### PR TITLE
[DRAFT] : Updates to C and ispc visitors :

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3378,13 +3378,15 @@ void CodegenCVisitor::print_net_send_buffering() {
 }
 
 
-void CodegenCVisitor::print_net_receive() {
+void CodegenCVisitor::print_net_receive_kernel() {
     if (!net_receive_required()) {
         return;
     }
+    codegen = true;
+    printing_net_receive = true;
     auto node = info.net_receive_node;
 
-    /// rename arguments but need to see if they are actually used
+    /// rename arguments if same name is used
     auto parameters = node->get_parameters();
     for (auto& parameter: parameters) {
         auto name = parameter->get_node_name();
@@ -3395,39 +3397,43 @@ void CodegenCVisitor::print_net_receive() {
         }
     }
 
-    codegen = true;
-    printing_net_receive = true;
-    std::string function_name = method_name("net_receive_kernel");
-    std::string function_arguments = "double t, Point_process* pnt, int weight_index, double flag";
+    std::string name = method_name("net_receive_kernel");
+    std::string arguments = "double t, Point_process* pnt, int weight_index, double flag";
 
     if (info.artificial_cell) {
-        function_name = method_name("net_receive");
-        function_arguments = "Point_process* pnt, int weight_index, double flag";
+        name = method_name("net_receive");
+        arguments = "Point_process* pnt, int weight_index, double flag";
     }
 
-    /// net receive kernel
     printer->add_newline(2);
-    printer->start_block("static void {}({}) "_format(function_name, function_arguments));
+    printer->start_block("static void {}({}) "_format(name, arguments));
     print_net_receive_common_code(node);
-
     if (info.artificial_cell) {
         printer->add_line("double t = nt->_t;");
     }
-
     printer->add_line("{} = t;"_format(get_variable_name("tsave")));
-
     printer->add_indent();
     node->get_statement_block()->accept(this);
     printer->add_newline();
     printer->end_block();
     printer->add_newline();
 
-    /// net receive function
+    printing_net_receive = false;
+    codegen = false;
+}
+
+
+void CodegenCVisitor::print_net_receive() {
+    if (!net_receive_required()) {
+        return;
+    }
+    codegen = true;
+    printing_net_receive = true;
     if (!info.artificial_cell) {
-        function_name = method_name("net_receive");
-        function_arguments = "Point_process* pnt, int weight_index, double flag";
+        std::string name = method_name("net_receive");
+        std::string arguments = "Point_process* pnt, int weight_index, double flag";
         printer->add_newline(2);
-        printer->start_block("static void {}({}) "_format(function_name, function_arguments));
+        printer->start_block("static void {}({}) "_format(name, arguments));
         printer->add_line("NrnThread* nt = nrn_threads + pnt->_tid;");
         printer->add_line("Memb_list* ml = get_memb_list(nt);");
         printer->add_line("NetReceiveBuffer_t* nrb = ml->_net_receive_buffer;");
@@ -3835,6 +3841,7 @@ void CodegenCVisitor::print_compute_functions() {
     print_net_send_buffering();
     print_watch_activate();
     print_watch_check();
+    print_net_receive_kernel();
     print_net_receive();
     print_net_receive_buffering();
     print_nrn_init();

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -796,6 +796,10 @@ class CodegenCVisitor: public AstVisitor {
     void print_net_receive_buffering();
 
 
+    /// net_receive kernel function definition
+    void print_net_receive_kernel();
+
+
     /// net_receive function definition
     void print_net_receive();
 

--- a/src/codegen/codegen_cuda_visitor.cpp
+++ b/src/codegen/codegen_cuda_visitor.cpp
@@ -158,7 +158,7 @@ void CodegenCudaVisitor::print_compute_functions() {
     }
 
     print_net_send_buffering();
-    print_net_receive();
+    print_net_receive_kernel();
     print_net_receive_buffering();
     print_nrn_cur();
     print_nrn_state();

--- a/src/codegen/codegen_cuda_visitor.hpp
+++ b/src/codegen/codegen_cuda_visitor.hpp
@@ -43,6 +43,7 @@ class CodegenCudaVisitor: public CodegenCVisitor {
     /// setup method for setting matrix shadow vectors
     void print_rhs_d_shadow_variables() override;
 
+
     /// if reduction block in nrn_cur required
     bool nrn_cur_reduction_loop_required() override;
 

--- a/src/codegen/codegen_ispc_visitor.hpp
+++ b/src/codegen/codegen_ispc_visitor.hpp
@@ -30,7 +30,6 @@ class CodegenIspcVisitor: public CodegenCVisitor {
     /// common includes : standard c/c++, coreneuron and backend specific
     void print_backend_includes() override;
 
-    /*
     /// update to matrix elements with/without shadow vectors
     void print_nrn_cur_matrix_shadow_update() override;
 
@@ -42,9 +41,12 @@ class CodegenIspcVisitor: public CodegenCVisitor {
     /// setup method for setting matrix shadow vectors
     void print_rhs_d_shadow_variables() override;
 
+
     /// if reduction block in nrn_cur required
     bool nrn_cur_reduction_loop_required() override;
-    */
+
+
+    /// helper data structure for ispc backend
     void print_ispc_helper_ds();
 
 

--- a/src/codegen/coreneuron_ispc.hpp
+++ b/src/codegen/coreneuron_ispc.hpp
@@ -1,0 +1,94 @@
+/// list of data structures required for ISPC backend
+/// added here just as placeholder
+
+typedef int Datum;
+
+struct ThreadDatum {
+    int i;
+    double* pval;
+    void* _pvoid;
+};
+
+struct NetReceiveBuffer_t {
+    int* _displ;
+    int* _nrb_index;
+
+    int* _pnt_index;
+    int* _weight_index;
+    double* _nrb_t;
+    double* _nrb_flag;
+    int _cnt;
+    int _displ_cnt;
+    int _size;
+    int _pnt_offset;
+};
+
+struct NetSendBuffer_t {
+    int* _sendtype;
+    int* _vdata_index;
+    int* _pnt_index;
+    int* _weight_index;
+    double* _nsb_t;
+    double* _nsb_flag;
+    int _cnt;
+    int _size;
+    int reallocated;
+};
+
+struct Memb_list {
+    int* nodeindices;
+    int* _permute;
+    double* data;
+    Datum* pdata;
+    ThreadDatum* _thread;
+    NetReceiveBuffer_t* _net_receive_buffer;
+    NetSendBuffer_t* _net_send_buffer;
+    int nodecount;
+    int _nodecount_padded;
+    void* instance; // this is of type hh_Instance
+};
+
+typedef struct Point_process {
+    int _i_instance;
+    short _type;
+    short _tid;
+} Point_process;
+
+struct NrnThread {
+    double _t;
+    double _dt;
+    double cj;
+
+    Memb_list** _ml_list;
+    Point_process* pntprocs;
+    double* weights;
+
+    int n_pntproc, n_presyn, n_input_presyn, n_netcon, n_weight;
+
+    int ncell;
+    int end;
+    int id;
+
+    size_t _ndata, _nidata, _nvdata;
+    double* _data;
+    int* _idata;
+
+    double* _actual_rhs;
+    double* _actual_d;
+    double* _actual_a;
+    double* _actual_b;
+    double* _actual_v;
+    double* _actual_area;
+    double* _actual_diam;
+    double* _shadow_rhs;
+    double* _shadow_d;
+    int* _v_parent_index;
+    int* _permute;
+
+    int shadow_rhs_cnt;
+    int compute_gpu;
+    int stream_id;
+    int _net_send_buffer_size;
+    int _net_send_buffer_cnt;
+    int* _net_send_buffer;
+};


### PR DESCRIPTION
    - split net_receive printing routine into two parts
      so that backends can only print compute kernels
    - update ispc backend for atomic operations in nrn_cur
    - added placeholder data structures from coreneuron
