### PR TITLE
Safety mechanism for SympyConductance visitor (resolves #29) 

### DIFF
--- a/src/language/templates/lookup_visitor.hpp
+++ b/src/language/templates/lookup_visitor.hpp
@@ -34,6 +34,8 @@ class AstLookupVisitor : public Visitor {
             types.push_back(type);
         }
 
+        AstLookupVisitor(std::vector<ast::AstNodeType> types) : types(types) {}
+
         std::vector<std::shared_ptr<ast::AST>> lookup(ast::Program* node, ast::AstNodeType type);
 
         std::vector<std::shared_ptr<ast::AST>> lookup(ast::Program* node, std::vector<ast::AstNodeType>& types);


### PR DESCRIPTION
  - if breakpoint block contains if-elseif-else block then
    do not insert conductance statement
  - add constructor in lookup visitor to accept vector of ast types