### PR TITLE
reduce number of object copies in AstLookupVisitor

### DIFF
--- a/src/language/templates/lookup_visitor.hpp
+++ b/src/language/templates/lookup_visitor.hpp
@@ -30,17 +30,15 @@ class AstLookupVisitor : public Visitor {
 
         AstLookupVisitor() = default;
 
-        AstLookupVisitor(ast::AstNodeType type) {
-            types.push_back(type);
-        }
+        AstLookupVisitor(ast::AstNodeType type) : types{type} {}
 
-        AstLookupVisitor(std::vector<ast::AstNodeType> types) : types(types) {}
+        AstLookupVisitor(const std::vector<ast::AstNodeType>& types) : types(types) {}
 
         std::vector<std::shared_ptr<ast::AST>> lookup(ast::Program* node, ast::AstNodeType type);
 
         std::vector<std::shared_ptr<ast::AST>> lookup(ast::Program* node, std::vector<ast::AstNodeType>& types);
 
-        std::vector<std::shared_ptr<ast::AST>> get_nodes() {
+        const std::vector<std::shared_ptr<ast::AST>>& get_nodes() const noexcept {
             return nodes;
         }
 


### PR DESCRIPTION
      - use list initializer in constructor
      - pass `std::vector` parameter in constructor as const reference
      - `AstLookupVisitor::get_nodes` now returns a const reference
        instead of a copy.