### PR TITLE
Add version to executables and cleanup visitor client

### DIFF
--- a/nmodl/__init__.py
+++ b/nmodl/__init__.py
@@ -1,0 +1,1 @@
+from ._nmodl import __version__

--- a/src/lexer/main_c.cpp
+++ b/src/lexer/main_c.cpp
@@ -8,17 +8,23 @@
 #include <fstream>
 
 #include "CLI/CLI.hpp"
+#include "fmt/format.h"
+
 #include "lexer/c11_lexer.hpp"
 #include "parser/c11_driver.hpp"
 #include "utils/logger.hpp"
+#include "version/version.h"
 
 /**
  * Example of standalone lexer program for C codes that
  * demonstrate use of CLexer and CDriver classes.
  */
 
+using namespace fmt::literals;
+using namespace nmodl;
+
 int main(int argc, const char* argv[]) {
-    CLI::App app{"C-Lexer : Standalone Lexer for C Code"};
+    CLI::App app{"C-Lexer : Standalone Lexer for C Code({})"_format(version::to_string())};
 
     std::vector<std::string> files;
     app.add_option("file", files, "One or more C files to process")

--- a/src/lexer/main_nmodl.cpp
+++ b/src/lexer/main_nmodl.cpp
@@ -9,10 +9,13 @@
 #include <streambuf>
 
 #include "CLI/CLI.hpp"
+#include "fmt/format.h"
+
 #include "ast/ast.hpp"
 #include "lexer/nmodl_lexer.hpp"
 #include "parser/nmodl_driver.hpp"
 #include "utils/logger.hpp"
+#include "version/version.h"
 
 /**
  * Stand alone lexer program for NMODL. This demonstrate basic
@@ -21,6 +24,7 @@
  * location.
  */
 
+using namespace fmt::literals;
 using namespace nmodl;
 
 using parser::NmodlDriver;
@@ -111,7 +115,7 @@ void tokenize(const std::string& mod_text) {
 
 
 int main(int argc, const char* argv[]) {
-    CLI::App app{"NMODL-Lexer : Standalone Lexer for NMODL Code"};
+    CLI::App app{"NMODL-Lexer : Standalone Lexer for NMODL Code({})"_format(version::to_string())};
 
     std::vector<std::string> mod_files;
     std::vector<std::string> mod_texts;

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -21,6 +21,7 @@
 #include "parser/nmodl_driver.hpp"
 #include "utils/common_utils.hpp"
 #include "utils/logger.hpp"
+#include "version/version.h"
 #include "visitors/ast_visitor.hpp"
 #include "visitors/cnexp_solve_visitor.hpp"
 #include "visitors/constant_folder_visitor.hpp"
@@ -43,7 +44,8 @@ using namespace codegen;
 using nmodl::parser::NmodlDriver;
 
 int main(int argc, const char* argv[]) {
-    CLI::App app{"NMODL : Source-to-Source Code Generation Framework"};
+    CLI::App app{
+        "NMODL : Source-to-Source Code Generation Framework [{}]"_format(version::to_string())};
 
     /// list of mod files to process
     std::vector<std::string> mod_files;

--- a/src/parser/main_c.cpp
+++ b/src/parser/main_c.cpp
@@ -8,16 +8,22 @@
 #include <fstream>
 
 #include "CLI/CLI.hpp"
+#include "fmt/format.h"
+
 #include "parser/c11_driver.hpp"
 #include "utils/logger.hpp"
+#include "version/version.h"
 
 /**
  * Standalone parser program for C. This demonstrate basic
  * usage of parser and driver class.
  */
 
+using namespace fmt::literals;
+using namespace nmodl;
+
 int main(int argc, const char* argv[]) {
-    CLI::App app{"C-Parser : Standalone Parser for C Code"};
+    CLI::App app{"C-Parser : Standalone Parser for C Code({})"_format(version::to_string())};
 
     std::vector<std::string> files;
     app.add_option("file", files, "One or more C files to process")
@@ -27,11 +33,11 @@ int main(int argc, const char* argv[]) {
     CLI11_PARSE(app, argc, argv);
 
     for (const auto& f: files) {
-        nmodl::logger->info("Processing {}", f);
+        logger->info("Processing {}", f);
         std::ifstream file(f);
 
         /// driver object creates lexer and parser
-        nmodl::parser::CDriver driver;
+        parser::CDriver driver;
         driver.set_verbose(true);
 
         /// just call parser method

--- a/src/parser/main_nmodl.cpp
+++ b/src/parser/main_nmodl.cpp
@@ -7,16 +7,22 @@
 
 
 #include "CLI/CLI.hpp"
+#include "fmt/format.h"
+
 #include "parser/nmodl_driver.hpp"
 #include "utils/logger.hpp"
+#include "version/version.h"
 
 /**
  * Standalone parser program for NMODL. This demonstrate
  * basic usage of parser and driver classes.
  */
 
+using namespace fmt::literals;
+using namespace nmodl;
+
 int main(int argc, const char* argv[]) {
-    CLI::App app{"NMODL-Parser : Standalone Parser for NMODL"};
+    CLI::App app{"NMODL-Parser : Standalone Parser for NMODL({})"_format(version::to_string())};
 
     std::vector<std::string> mod_files;
     std::vector<std::string> mod_texts;
@@ -26,16 +32,16 @@ int main(int argc, const char* argv[]) {
 
     CLI11_PARSE(app, argc, argv);
 
-    nmodl::parser::NmodlDriver driver;
+    parser::NmodlDriver driver;
     driver.set_verbose(true);
 
     for (const auto& f: mod_files) {
-        nmodl::logger->info("Processing file : {}", f);
+        logger->info("Processing file : {}", f);
         driver.parse_file(f);
     }
 
     for (const auto& text: mod_texts) {
-        nmodl::logger->info("Processing text : {}", text);
+        logger->info("Processing text : {}", text);
         driver.parse_string(text);
     }
 

--- a/src/pybind/pynmodl.cpp
+++ b/src/pybind/pynmodl.cpp
@@ -14,6 +14,7 @@
 
 #include "parser/nmodl_driver.hpp"
 #include "pybind/pybind_utils.hpp"
+#include "version/version.h"
 #include "visitors/visitor_utils.hpp"
 
 namespace py = pybind11;
@@ -41,6 +42,9 @@ void init_ast_module(py::module& m);
 void init_symtab_module(py::module& m);
 
 PYBIND11_MODULE(_nmodl, m_nmodl) {
+    m_nmodl.doc() = "NMODL : Source-to-Source Code Generation Framework";
+    m_nmodl.attr("__version__") = nmodl::version::NMODL_VERSION;
+
     py::class_<PyDriver> nmodl_driver(m_nmodl, "NmodlDriver");
 
     // todo : what has changed ? fix this!

--- a/src/version/version.h
+++ b/src/version/version.h
@@ -13,8 +13,8 @@ namespace nmodl {
 struct version {
     static const std::string GIT_REVISION;
     static const std::string NMODL_VERSION;
-    std::string to_string() {
-        return NMODL_VERSION + " [" + GIT_REVISION + "]";
+    static std::string to_string() {
+        return NMODL_VERSION + " " + GIT_REVISION;
     }
 };
 }  // namespace nmodl

--- a/src/visitors/kinetic_block_visitor.cpp
+++ b/src/visitors/kinetic_block_visitor.cpp
@@ -59,7 +59,8 @@ void KineticBlockVisitor::visit_conserve(ast::Conserve* node) {
     // NOTE! CONSERVE statement "implicitly takes into account COMPARTMENT factors on LHS"
     // see p244 of NEURON book
     // need to ensure that we do this in the same way: presumably need
-    // to either multiply or divide state vars on LHS of conserve statement by their COMPARTMENT factors?
+    // to either multiply or divide state vars on LHS of conserve statement by their COMPARTMENT
+    // factors?
     logger->debug("KineticBlockVisitor :: CONSERVE statement ignored (for now): {} = {}",
                   to_nmodl(node->get_react().get()), to_nmodl(node->get_expr().get()));
     statements_to_remove.insert(node);
@@ -102,7 +103,7 @@ void KineticBlockVisitor::visit_react_var_name(ast::ReactVarName* node) {
     // react_var_name node contains var_name and integer
     // var_name is the state variable which we convert to an index
     // integer is the value to be added to the stochiometric matrix at this index
-    if(in_reaction_statement){
+    if (in_reaction_statement) {
         auto varname = node->get_node_name();
         int count = node->get_value() ? node->get_value()->eval() : 1;
         process_reac_var(varname, count);

--- a/src/visitors/main.cpp
+++ b/src/visitors/main.cpp
@@ -8,21 +8,31 @@
 #include <sstream>
 
 #include "CLI/CLI.hpp"
+#include "fmt/format.h"
+#include "pybind11/embed.h"
+
 #include "parser/nmodl_driver.hpp"
 #include "utils/logger.hpp"
+#include "version/version.h"
 #include "visitors/ast_visitor.hpp"
 #include "visitors/cnexp_solve_visitor.hpp"
+#include "visitors/constant_folder_visitor.hpp"
 #include "visitors/inline_visitor.hpp"
 #include "visitors/json_visitor.hpp"
+#include "visitors/kinetic_block_visitor.hpp"
 #include "visitors/local_var_rename_visitor.hpp"
 #include "visitors/localize_visitor.hpp"
 #include "visitors/nmodl_visitor.hpp"
 #include "visitors/perf_visitor.hpp"
+#include "visitors/sympy_conductance_visitor.hpp"
+#include "visitors/sympy_solver_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"
 #include "visitors/verbatim_var_rename_visitor.hpp"
 #include "visitors/verbatim_visitor.hpp"
 
+
 using namespace nmodl;
+using namespace fmt::literals;
 
 /**
  * Standalone visitor program for NMODL. This demonstrate basic
@@ -30,169 +40,74 @@ using namespace nmodl;
  **/
 
 int main(int argc, const char* argv[]) {
-    CLI::App app{"NMODL Visitor : Runs standalone visitor classes"};
+    CLI::App app{
+        "NMODL Visitor : Runs standalone visitor classes({})"_format(version::to_string())};
 
     bool verbose = false;
     std::vector<std::string> files;
 
-    app.add_flag("-v,--verbose", verbose, "Show intermediate output");
+    app.add_flag("-v,--verbose", verbose, "Enable debug log level");
     app.add_option("-f,--file,file", files, "One or more MOD files to process")
         ->required()
         ->check(CLI::ExistingFile);
 
     CLI11_PARSE(app, argc, argv);
 
-    for (const auto& filename: files) {
-        nmodl::logger->info("Processing {}", filename);
+    if (verbose) {
+        logger->set_level(spdlog::level::debug);
+    }
 
-        std::string mod_filename = remove_extension(base_name(filename));
+    struct VisitorInfo {
+        std::shared_ptr<Visitor> v;
+        std::string id;
+        std::string description;
+    };
+
+    std::vector<VisitorInfo> visitors = {
+        {std::make_shared<AstVisitor>(), "astvis", "AstVisitor"},
+        {std::make_shared<SymtabVisitor>(), "symtab", "SymtabVisitor"},
+        {std::make_shared<JSONVisitor>(), "json", "JSONVisitor"},
+        {std::make_shared<VerbatimVisitor>(), "verbatim", "VerbatimVisitor"},
+        {std::make_shared<VerbatimVarRenameVisitor>(), "verbatim-rename",
+         "VerbatimVarRenameVisitor"},
+        {std::make_shared<KineticBlockVisitor>(), "kinetic-rewrite", "KineticBlockVisitor"},
+        {std::make_shared<ConstantFolderVisitor>(), "const-fold", "ConstantFolderVisitor"},
+        {std::make_shared<InlineVisitor>(), "cnexp", "InlineVisitor"},
+        {std::make_shared<LocalVarRenameVisitor>(), "local-rename", "LocalVarRenameVisitor"},
+        {std::make_shared<SymtabVisitor>(), "symtab", "SymtabVisitor"},
+        {std::make_shared<SympyConductanceVisitor>(), "sympy-cond", "SympyConductanceVisitor"},
+        {std::make_shared<SymtabVisitor>(), "symtab", "SymtabVisitor"},
+        {std::make_shared<SympySolverVisitor>(), "sympy-solve", "SympySolverVisitor"},
+        {std::make_shared<CnexpSolveVisitor>(), "cnexp", "CnexpSolveVisitor"},
+        {std::make_shared<LocalizeVisitor>(), "localize", "LocalizeVisitor"},
+        {std::make_shared<PerfVisitor>(), "perf", "PerfVisitor"},
+    };
+
+    pybind11::initialize_interpreter();
+
+    for (const auto& filename: files) {
+        logger->info("Processing {}", filename);
+
+        std::string mod_file = remove_extension(base_name(filename));
 
         /// driver object that creates lexer and parser
-        nmodl::parser::NmodlDriver driver;
+        parser::NmodlDriver driver;
         driver.parse_file(filename);
 
         /// shared_ptr to ast constructed from parsing nmodl file
-        auto ast = driver.ast();
+        auto ast = driver.ast().get();
 
-        {
-            AstVisitor v;
-            v.visit_program(ast.get());
-            std::cout << "----AST VISITOR FINISHED----" << std::endl;
-        }
-
-        {
-            /// constructor takes true/false argument for printing blocks
-            VerbatimVisitor v;
-            v.visit_program(ast.get());
-            std::cout << "----VERBATIM VISITOR FINISHED----" << std::endl;
-        }
-
-        {
-            std::stringstream ss;
-            JSONVisitor v(ss);
-            v.visit_program(ast.get());
-            if (verbose) {
-                std::cout << "RESULT OF JSON VISITOR : " << std::endl << ss.str();
-            }
-            std::cout << "----JSON VISITOR FINISHED----" << std::endl;
-        }
-
-        {
-            SymtabVisitor v(false);
-            v.visit_program(ast.get());
-        }
-
-        {
-            std::stringstream stream;
-            auto symtab = ast->get_model_symbol_table();
-            symtab->print(stream);
-            std::cout << stream.str();
-            std::cout << "----SYMTAB VISITOR FINISHED----" << std::endl;
-        }
-
-        {
-            VerbatimVarRenameVisitor v;
-            v.visit_program(ast.get());
-        }
-
-        {
-            NmodlPrintVisitor v(mod_filename + ".nmodl.verbrename.mod");
-            v.visit_program(ast.get());
-        }
-
-        {
-            NmodlPrintVisitor v(mod_filename + ".nmodl.mod");
-            v.visit_program(ast.get());
-        }
-
-        {
-            CnexpSolveVisitor v;
-            v.visit_program(ast.get());
-            std::cout << "----CNEXP SOLVE VISITOR FINISHED----" << std::endl;
-        }
-
-        {
-            NmodlPrintVisitor v(mod_filename + ".nmodl.cnexp.mod");
-            v.visit_program(ast.get());
-        }
-
-
-        {
-            InlineVisitor v;
-            v.visit_program(ast.get());
-        }
-
-
-        {
-            NmodlPrintVisitor v(mod_filename + ".nmodl.cnexp.in.mod");
-            v.visit_program(ast.get());
-        }
-
-        {
-            LocalVarRenameVisitor v;
-            v.visit_program(ast.get());
-            std::cout << "----LOCAL VAR RENAME VISITOR FINISHED----" << std::endl;
-        }
-
-        {
-            NmodlPrintVisitor v(mod_filename + ".nmodl.cnexp.in.ren.mod");
-            v.visit_program(ast.get());
-        }
-
-        {
-            SymtabVisitor v(true);
-            v.visit_program(ast.get());
-        }
-
-        {
-            /// for benchmarking/plotting purpose we want to enable unsafe mode
-            bool ignore_verbatim = true;
-            LocalizeVisitor v(ignore_verbatim);
-            v.visit_program(ast.get());
-        }
-
-        {
-            NmodlPrintVisitor v(mod_filename + ".nmodl.cnexp.in.ren.loc.mod");
-            v.visit_program(ast.get());
-        }
-
-        {
-            LocalVarRenameVisitor v;
-            v.visit_program(ast.get());
-        }
-
-        {
-            SymtabVisitor v(true);
-            v.visit_program(ast.get());
-        }
-
-        {
-            std::stringstream stream;
-            auto symtab = ast->get_model_symbol_table();
-            symtab->print(stream);
-            std::cout << stream.str();
-            std::cout << "----SYMTAB VISITOR FINISHED----" << std::endl;
-        }
-
-        {
-            NmodlPrintVisitor v(mod_filename + ".nmodl.cnexp.in.ren.loc.ren.mod");
-            v.visit_program(ast.get());
-        }
-
-        {
-            PerfVisitor v(mod_filename + ".perf.json");
-            v.visit_program(ast.get());
-
-            auto symtab = ast->get_symbol_table();
-            std::stringstream ss;
-            symtab->print(ss, 0);
-            std::cout << ss.str();
-
-            ss.str("");
-            v.print(ss);
-            std::cout << ss.str() << std::endl;
-            std::cout << "----PERF VISITOR FINISHED----" << std::endl;
+        /// run all visitors and generate mod file after each run
+        for (const auto& visitor: visitors) {
+            logger->info("Running {}", visitor.description);
+            visitor.v->visit_program(ast);
+            std::string file = mod_file + "." + visitor.id + ".mod";
+            NmodlPrintVisitor(file).visit_program(ast);
+            logger->info("NMODL visitor generated {}", file);
         }
     }
+
+    pybind11::finalize_interpreter();
+
     return 0;
 }


### PR DESCRIPTION
  - python nmodl module now have __version__ for documentation, Resolves #69
  - update all executables to print version, git commit with build time version
  - cleanup visitor client to run all visitors easily