### PR TITLE
Implement loop unroll visitor

### DIFF
--- a/src/language/templates/lookup_visitor.cpp
+++ b/src/language/templates/lookup_visitor.cpp
@@ -25,7 +25,7 @@ void AstLookupVisitor::visit_{{ node.class_name|snake_case }}({{ node.class_name
 {% endfor %}
 
 
-std::vector<std::shared_ptr<ast::AST>> AstLookupVisitor::lookup(Program* node, std::vector<AstNodeType>& _types) {
+std::vector<std::shared_ptr<ast::AST>> AstLookupVisitor::lookup(AST* node, std::vector<AstNodeType>& _types) {
     nodes.clear();
     types = _types;
     node->accept(this);
@@ -33,7 +33,7 @@ std::vector<std::shared_ptr<ast::AST>> AstLookupVisitor::lookup(Program* node, s
 }
 
 
-std::vector<std::shared_ptr<ast::AST>> AstLookupVisitor::lookup(Program* node, AstNodeType type) {
+std::vector<std::shared_ptr<ast::AST>> AstLookupVisitor::lookup(AST* node, AstNodeType type) {
     nodes.clear();
     types.clear();
     types.push_back(type);

--- a/src/language/templates/lookup_visitor.hpp
+++ b/src/language/templates/lookup_visitor.hpp
@@ -34,9 +34,9 @@ class AstLookupVisitor : public Visitor {
 
         AstLookupVisitor(const std::vector<ast::AstNodeType>& types) : types(types) {}
 
-        std::vector<std::shared_ptr<ast::AST>> lookup(ast::Program* node, ast::AstNodeType type);
+        std::vector<std::shared_ptr<ast::AST>> lookup(ast::AST* node, ast::AstNodeType type);
 
-        std::vector<std::shared_ptr<ast::AST>> lookup(ast::Program* node, std::vector<ast::AstNodeType>& types);
+        std::vector<std::shared_ptr<ast::AST>> lookup(ast::AST* node, std::vector<ast::AstNodeType>& types);
 
         const std::vector<std::shared_ptr<ast::AST>>& get_nodes() const noexcept {
             return nodes;

--- a/src/language/templates/pyvisitor.cpp
+++ b/src/language/templates/pyvisitor.cpp
@@ -93,8 +93,8 @@ void init_visitor_module(py::module& m) {
         .def(py::init<ast::AstNodeType>())
         .def("get_nodes", &AstLookupVisitor::get_nodes)
         .def("clear", &AstLookupVisitor::clear)
-        .def("lookup", (std::vector<std::shared_ptr<ast::AST>> (AstLookupVisitor::*)(ast::Program*, ast::AstNodeType)) &AstLookupVisitor::lookup)
-        .def("lookup", (std::vector<std::shared_ptr<ast::AST>> (AstLookupVisitor::*)(ast::Program*, std::vector<ast::AstNodeType>&)) &AstLookupVisitor::lookup)
+        .def("lookup", (std::vector<std::shared_ptr<ast::AST>> (AstLookupVisitor::*)(ast::AST*, ast::AstNodeType)) &AstLookupVisitor::lookup)
+        .def("lookup", (std::vector<std::shared_ptr<ast::AST>> (AstLookupVisitor::*)(ast::AST*, std::vector<ast::AstNodeType>&)) &AstLookupVisitor::lookup)
     {% for node in nodes %}
         .def("visit_{{ node.class_name | snake_case }}", &AstLookupVisitor::visit_{{ node.class_name | snake_case }})
         {% if loop.last -%};{% endif %}

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -29,6 +29,7 @@
 #include "visitors/kinetic_block_visitor.hpp"
 #include "visitors/local_var_rename_visitor.hpp"
 #include "visitors/localize_visitor.hpp"
+#include "visitors/loop_unroll_visitor.hpp"
 #include "visitors/nmodl_visitor.hpp"
 #include "visitors/perf_visitor.hpp"
 #include "visitors/sympy_conductance_visitor.hpp"
@@ -80,6 +81,9 @@ int main(int argc, const char* argv[]) {
 
     /// true if inlining at nmodl level to be done
     bool nmodl_inline(false);
+
+    /// true if unroll at nmodl level to be done
+    bool nmodl_unroll(false);
 
     /// true if perform constant folding at nmodl level to be done
     bool nmodl_const_folding(false);
@@ -156,6 +160,7 @@ int main(int argc, const char* argv[]) {
 
     auto passes_opt = app.add_subcommand("passes", "Analyse/Optimization passes")->ignore_case();
     passes_opt->add_flag("--inline", nmodl_inline, "Perform inlining at NMODL level")->ignore_case();
+    passes_opt->add_flag("--unroll", nmodl_unroll, "Perform loop unroll at NMODL level")->ignore_case();
     passes_opt->add_flag("--const-folding", nmodl_const_folding, "Perform constant folding at NMODL level")->ignore_case();
     passes_opt->add_flag("--localize", localize, "Convert RANGE variables to LOCAL")->ignore_case();
     passes_opt->add_flag("--localize-verbatim", localize_verbatim, "Convert RANGE variables to LOCAL even if verbatim block exist")->ignore_case();
@@ -266,6 +271,14 @@ int main(int argc, const char* argv[]) {
             logger->info("Running nmodl constant folding visitor");
             ConstantFolderVisitor().visit_program(ast.get());
             ast_to_nmodl(ast.get(), filepath("constfold"));
+        }
+
+        if (nmodl_unroll) {
+            logger->info("Running nmodl loop unroll visitor");
+            LoopUnrollVisitor().visit_program(ast.get());
+            ConstantFolderVisitor().visit_program(ast.get());
+            ast_to_nmodl(ast.get(), filepath("unroll"));
+            SymtabVisitor(update_symtab).visit_program(ast.get());
         }
 
         if (nmodl_inline) {

--- a/src/visitors/CMakeLists.txt
+++ b/src/visitors/CMakeLists.txt
@@ -16,6 +16,8 @@ set(VISITOR_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/local_var_rename_visitor.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/localize_visitor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/localize_visitor.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/loop_unroll_visitor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/loop_unroll_visitor.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/nmodl_visitor_helper.ipp
     ${CMAKE_CURRENT_SOURCE_DIR}/perf_visitor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/perf_visitor.hpp

--- a/src/visitors/constant_folder_visitor.cpp
+++ b/src/visitors/constant_folder_visitor.cpp
@@ -6,6 +6,8 @@
  *************************************************************************/
 
 #include "visitors/constant_folder_visitor.hpp"
+#include "utils/logger.hpp"
+#include "visitors/visitor_utils.hpp"
 
 
 namespace nmodl {
@@ -107,7 +109,7 @@ void ConstantFolderVisitor::visit_wrapped_expression(ast::WrappedExpression* nod
     /// first expression which is wrapped
     auto expr = node->get_expression();
 
-    /// if wrapped expressesion is parentheses
+    /// if wrapped expression is parentheses
     bool is_parentheses = false;
 
     /// opposite to visit_paren_expression, we might have
@@ -155,6 +157,8 @@ void ConstantFolderVisitor::visit_wrapped_expression(ast::WrappedExpression* nod
         return;
     }
 
+    std::string nmodl_before = to_nmodl(binary_expr.get());
+
     /// compute the value of expression
     auto value = compute(get_value(lhs), op, get_value(rhs));
 
@@ -166,6 +170,9 @@ void ConstantFolderVisitor::visit_wrapped_expression(ast::WrappedExpression* nod
     } else {
         node->set_expression(std::make_shared<ast::Float>(value));
     }
+
+    std::string nmodl_after = to_nmodl(node->get_expression().get());
+    logger->debug("ConstantFolderVisitor : expression {} folded to {}", nmodl_before, nmodl_after);
 }
 
 }  // namespace nmodl

--- a/src/visitors/kinetic_block_visitor.cpp
+++ b/src/visitors/kinetic_block_visitor.cpp
@@ -59,7 +59,8 @@ void KineticBlockVisitor::visit_conserve(ast::Conserve* node) {
     // NOTE! CONSERVE statement "implicitly takes into account COMPARTMENT factors on LHS"
     // see p244 of NEURON book
     // need to ensure that we do this in the same way: presumably need
-    // to either multiply or divide state vars on LHS of conserve statement by their COMPARTMENT factors?
+    // to either multiply or divide state vars on LHS of conserve statement by their COMPARTMENT
+    // factors?
     logger->debug("KineticBlockVisitor :: CONSERVE statement ignored (for now): {} = {}",
                   to_nmodl(node->get_react().get()), to_nmodl(node->get_expr().get()));
     statements_to_remove.insert(node);
@@ -102,7 +103,7 @@ void KineticBlockVisitor::visit_react_var_name(ast::ReactVarName* node) {
     // react_var_name node contains var_name and integer
     // var_name is the state variable which we convert to an index
     // integer is the value to be added to the stochiometric matrix at this index
-    if(in_reaction_statement){
+    if (in_reaction_statement) {
         auto varname = node->get_node_name();
         int count = node->get_value() ? node->get_value()->eval() : 1;
         process_reac_var(varname, count);

--- a/src/visitors/loop_unroll_visitor.cpp
+++ b/src/visitors/loop_unroll_visitor.cpp
@@ -1,0 +1,164 @@
+/*************************************************************************
+ * Copyright (C) 2018-2019 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#include "visitors/loop_unroll_visitor.hpp"
+#include "parser/c11_driver.hpp"
+#include "utils/logger.hpp"
+#include "visitors/lookup_visitor.hpp"
+#include "visitors/visitor_utils.hpp"
+
+
+namespace nmodl {
+
+/**
+ * \class IndexRemover
+ * \brief Helper visitor to replace index of array variable with integer
+ *
+ * When loop is unrolled, the index variable like `i` :
+ *
+ *   ca[i] <-> ca[i+1]
+ *
+ * has type `Name` in the AST. This needs to be replaced with `Integer`
+ * for optimizations like constant folding. This pass look at name and
+ * binary expressions under index variables.
+ */
+class IndexRemover: public AstVisitor {
+  private:
+    /// index variable name
+    std::string index;
+
+    /// integer value of index variable
+    int value;
+
+    /// true if we are visiting index variable
+    bool under_indexed_name = false;
+
+  public:
+    IndexRemover(std::string index, int value)
+        : index(index)
+        , value(value) {}
+
+    /// if expression we are visiting is `Name` then return new `Integer` node
+    std::shared_ptr<ast::Expression> replace_for_name(const std::shared_ptr<ast::Expression> node) {
+        if (node->is_name()) {
+            auto name = std::dynamic_pointer_cast<ast::Name>(node);
+            if (name->get_node_name() == index) {
+                return std::make_shared<ast::Integer>(value, nullptr);
+            }
+        }
+        return node;
+    }
+
+    virtual void visit_binary_expression(ast::BinaryExpression* node) override {
+        node->visit_children(this);
+        if (under_indexed_name) {
+            /// first recursively replaces childrens
+            /// replace lhs & rhs if they have matching index variable
+            auto lhs = replace_for_name(node->get_lhs());
+            auto rhs = replace_for_name(node->get_rhs());
+            node->set_lhs(std::move(lhs));
+            node->set_rhs(std::move(rhs));
+        }
+    }
+
+    virtual void visit_indexed_name(ast::IndexedName* node) override {
+        under_indexed_name = true;
+        node->visit_children(this);
+        /// once all children are replaced, do the same for index
+        auto length = replace_for_name(node->get_length());
+        node->set_length(std::move(length));
+        under_indexed_name = false;
+    }
+};
+
+
+/// return underlying expression wrapped by WrappedExpression
+static std::shared_ptr<ast::Expression> unwrap(const std::shared_ptr<ast::Expression>& expr) {
+    if (expr && expr->is_wrapped_expression()) {
+        auto e = std::dynamic_pointer_cast<ast::WrappedExpression>(expr);
+        return e->get_expression();
+    }
+    return expr;
+}
+
+
+/**
+ * Unroll given for loop
+ *
+ * @param node From loop node in the AST
+ * @return expression statement represeing unrolled loop if successfull otherwise nullptr
+ */
+static std::shared_ptr<ast::ExpressionStatement> unroll_for_loop(
+    const std::shared_ptr<ast::FromStatement> node) {
+    /// loop can be in the form of `FROM i=(0) TO (10)`
+    /// so first unwrap all elements of the loop
+    const auto from = unwrap(node->get_from());
+    const auto to = unwrap(node->get_to());
+    const auto increment = unwrap(node->get_increment());
+
+    /// we can unroll if iteration space of the loop is known
+    /// after constant folding start, end and increment must be known
+    if (!from->is_integer() || !to->is_integer() ||
+        (increment != nullptr && !increment->is_integer())) {
+        return nullptr;
+    }
+
+    int start = std::dynamic_pointer_cast<ast::Integer>(from)->eval();
+    int end = std::dynamic_pointer_cast<ast::Integer>(to)->eval();
+    int step = 1;
+    if (increment != nullptr) {
+        step = std::dynamic_pointer_cast<ast::Integer>(increment)->eval();
+    }
+
+    ast::StatementVector statements;
+    std::string index_var = node->get_node_name();
+    for (int i = start; i <= end; i += step) {
+        /// duplicate loop body and copy all statements to new vector
+        auto new_block = node->get_statement_block()->clone();
+        IndexRemover(index_var, i).visit_statement_block(new_block);
+        statements.insert(statements.end(), new_block->statements.begin(),
+                          new_block->statements.end());
+        delete new_block;
+    }
+
+    /// create new statement representing unrolled loop
+    auto block = new ast::StatementBlock(std::move(statements));
+    return std::make_shared<ast::ExpressionStatement>(block);
+}
+
+
+/**
+ * Parse verbatim blocks and rename variable if it is used.
+ */
+void LoopUnrollVisitor::visit_statement_block(ast::StatementBlock* node) {
+    node->visit_children(this);
+
+    for (auto iter = node->statements.begin(); iter != node->statements.end(); iter++) {
+        if ((*iter)->is_from_statement()) {
+            auto statement = std::dynamic_pointer_cast<ast::FromStatement>((*iter));
+
+            /// check if any verbatim block exists
+            auto verbatim_blocks = AstLookupVisitor().lookup(statement.get(),
+                                                             ast::AstNodeType::VERBATIM);
+            if (!verbatim_blocks.empty()) {
+                logger->debug("LoopUnrollVisitor : can not unroll because of verbatim block");
+                continue;
+            }
+
+            /// unroll loop, replace current statement on successfull unroll
+            auto new_statement = unroll_for_loop(statement);
+            if (new_statement != nullptr) {
+                (*iter) = new_statement;
+                std::string before = to_nmodl(statement.get());
+                std::string after = to_nmodl(new_statement.get());
+                logger->debug("LoopUnrollVisitor : \n {} \n unrolled to \n {}", before, after);
+            }
+        }
+    }
+}
+
+}  // namespace nmodl

--- a/src/visitors/loop_unroll_visitor.hpp
+++ b/src/visitors/loop_unroll_visitor.hpp
@@ -1,0 +1,55 @@
+/*************************************************************************
+ * Copyright (C) 2018-2019 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#pragma once
+
+#include <string>
+
+#include "ast/ast.hpp"
+#include "symtab/symbol_table.hpp"
+#include "visitors/ast_visitor.hpp"
+
+
+namespace nmodl {
+
+/**
+ * \class LoopUnrollVisitor
+ * \brief Unroll for loop in the AST
+ *
+ * Derivative and kinetic blocks have for loop with coupled set of ODEs :
+ *
+ * DEFINE NANN 4
+ * KINETIC state {
+ *    FROM i=0 TO NANN-2 {
+ *		~ ca[i] <-> ca[i+1] (DFree*frat[i+1]*1(um), DFree*frat[i+1]*1(um))
+ *    }
+ * }
+ *
+ * To solve these ODEs with SymPy, we need to get all ODEs from such loops.
+ * This visitor unroll such loops and insert new expression statement in
+ * the AST :
+ *
+ * KINETIC state {
+ *   {
+ *       ~ ca[0] <-> ca[0+1] (DFree*frat[0+1]*1(um), DFree*frat[0+1]*1(um))
+ *       ~ ca[1] <-> ca[1+1] (DFree*frat[1+1]*1(um), DFree*frat[1+1]*1(um))
+ *       ~ ca[2] <-> ca[2+1] (DFree*frat[2+1]*1(um), DFree*frat[2+1]*1(um))
+ *   }
+ * }
+ *
+ * Note that the index `0+1` is not expanded to `1` because we do not run
+ * constant folder pass within this loop (but could be easily done).
+ */
+
+class LoopUnrollVisitor: public AstVisitor {
+  public:
+    LoopUnrollVisitor() = default;
+
+    virtual void visit_statement_block(ast::StatementBlock* node) override;
+};
+
+}  // namespace nmodl

--- a/test/visitor/visitor.cpp
+++ b/test/visitor/visitor.cpp
@@ -25,6 +25,7 @@
 #include "visitors/local_var_rename_visitor.hpp"
 #include "visitors/localize_visitor.hpp"
 #include "visitors/lookup_visitor.hpp"
+#include "visitors/loop_unroll_visitor.hpp"
 #include "visitors/nmodl_visitor.hpp"
 #include "visitors/perf_visitor.hpp"
 #include "visitors/rename_visitor.hpp"
@@ -3651,6 +3652,145 @@ TEST_CASE("Constant Folding Visitor") {
             THEN("successfully folds and keep other statements untouched") {
                 auto result = run_constant_folding_visitor(nmodl_text);
                 REQUIRE(reindent_text(result) == reindent_text(expected_text));
+            }
+        }
+    }
+}
+
+
+//=============================================================================
+// Loop unroll tests
+//=============================================================================
+
+std::string run_loop_unroll_visitor(const std::string& text) {
+    NmodlDriver driver;
+    driver.parse_string(text);
+    auto ast = driver.ast();
+
+    SymtabVisitor().visit_program(ast.get());
+    ConstantFolderVisitor().visit_program(ast.get());
+    LoopUnrollVisitor().visit_program(ast.get());
+    ConstantFolderVisitor().visit_program(ast.get());
+    return to_nmodl(ast.get(), {AstNodeType::DEFINE});
+}
+
+TEST_CASE("Loop Unroll visitor") {
+    SECTION("Successful unrolls with constant folding") {
+        GIVEN("A loop with known iteration space") {
+            std::string input_nmodl = R"(
+            DEFINE N 2
+            PROCEDURE rates() {
+                LOCAL x[N]
+                FROM i=0 TO N {
+                    x[i] = x[i] + 11
+                }
+                FROM i=(0+(0+1)) TO (N+2-1) {
+                    x[(i+0)] = x[i+1] + 11
+                }
+            }
+            KINETIC state {
+                FROM i=1 TO N+1 {
+                    ~ ca[i] <-> ca[i+1] (DFree*frat[i+1]*1(um), DFree*frat[i+1]*1(um))
+                }
+            }
+        )";
+            std::string output_nmodl = R"(
+            PROCEDURE rates() {
+                LOCAL x[N]
+                {
+                    x[0] = x[0]+11
+                    x[1] = x[1]+11
+                    x[2] = x[2]+11
+                }
+                {
+                    x[1] = x[2]+11
+                    x[2] = x[3]+11
+                    x[3] = x[4]+11
+                }
+            }
+
+            KINETIC state {
+                {
+                    ~ ca[1] <-> ca[2] (DFree*frat[2]*1(um), DFree*frat[2]*1(um))
+                    ~ ca[2] <-> ca[3] (DFree*frat[3]*1(um), DFree*frat[3]*1(um))
+                    ~ ca[3] <-> ca[4] (DFree*frat[4]*1(um), DFree*frat[4]*1(um))
+                }
+            }
+        )";
+            THEN("Loop body gets correctly unrolled") {
+                auto result = run_loop_unroll_visitor(input_nmodl);
+                REQUIRE(reindent_text(output_nmodl) == reindent_text(result));
+            }
+        }
+
+        GIVEN("A nested loop") {
+            std::string input_nmodl = R"(
+            DEFINE N 1
+            PROCEDURE rates() {
+                LOCAL x[N]
+                FROM i=0 TO N {
+                    FROM j=1 TO N+1 {
+                        x[i] = x[i+j] + 1
+                    }
+                }
+            }
+        )";
+            std::string output_nmodl = R"(
+            PROCEDURE rates() {
+                LOCAL x[N]
+                {
+                    {
+                        x[0] = x[1]+1
+                        x[0] = x[2]+1
+                    }
+                    {
+                        x[1] = x[2]+1
+                        x[1] = x[3]+1
+                    }
+                }
+            }
+        )";
+            THEN("Loop get unrolled recursively") {
+                auto result = run_loop_unroll_visitor(input_nmodl);
+                REQUIRE(reindent_text(output_nmodl) == reindent_text(result));
+            }
+        }
+
+
+        GIVEN("Loop with verbatim and unknown iteration space") {
+            std::string input_nmodl = R"(
+            DEFINE N 1
+            PROCEDURE rates() {
+                LOCAL x[N]
+                FROM i=((0+0)) TO (((N+0))) {
+                    FROM j=1 TO k {
+                        x[i] = x[i+k] + 1
+                    }
+                }
+                FROM i=0 TO N {
+                    VERBATIM ENDVERBATIM
+                }
+            }
+        )";
+            std::string output_nmodl = R"(
+            PROCEDURE rates() {
+                LOCAL x[N]
+                {
+                    FROM j = 1 TO k {
+                        x[0] = x[0+k]+1
+                    }
+                    FROM j = 1 TO k {
+                        x[1] = x[1+k]+1
+                    }
+                }
+                FROM i = 0 TO N {
+                    VERBATIM ENDVERBATIM
+                }
+            }
+        )";
+            THEN("Only some loops get unrolled") {
+                auto result = run_loop_unroll_visitor(input_nmodl);
+                REQUIRE(reindent_text(output_nmodl) == reindent_text(result));
             }
         }
     }


### PR DESCRIPTION
  -  perform unroll for loops with know iteration count
  -  do not unroll if verbatim block exist
  -  add tests and new command line option

 - [x] Update implementation notes/docs
 - [x] Add tests
 - [x] ~~To be safe, enable unroll only in kinetic, derivative block or if ODEs are used~~ doesnt seem like necessary at the moment

Resolves #74