### PR TITLE
Bug fixes in codegen for traub model mod files

### DIFF
--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -624,5 +624,21 @@ codegen::CodegenInfo CodegenHelperVisitor::analyze(ast::Program* node) {
     return info;
 }
 
+void CodegenHelperVisitor::visit_linear_block(ast::LinearBlock* node) {
+    info.vectorize = false;
+}
+
+void CodegenHelperVisitor::visit_non_linear_block(ast::NonLinearBlock* node) {
+    info.vectorize = false;
+}
+
+void CodegenHelperVisitor::visit_discrete_block(ast::DiscreteBlock* node) {
+    info.vectorize = false;
+}
+
+void CodegenHelperVisitor::visit_partial_block(ast::PartialBlock* node) {
+    info.vectorize = false;
+}
+
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/codegen_helper_visitor.hpp
+++ b/src/codegen/codegen_helper_visitor.hpp
@@ -92,6 +92,10 @@ class CodegenHelperVisitor: public AstVisitor {
     void visit_table_statement(ast::TableStatement* node) override;
     void visit_program(ast::Program* node) override;
     void visit_nrn_state_block(ast::NrnStateBlock* node) override;
+    void visit_linear_block(ast::LinearBlock* node) override;
+    void visit_non_linear_block(ast::NonLinearBlock* node) override;
+    void visit_discrete_block(ast::DiscreteBlock* node) override;
+    void visit_partial_block(ast::PartialBlock* node) override;
 };
 
 }  // namespace codegen

--- a/src/codegen/codegen_info.cpp
+++ b/src/codegen/codegen_info.cpp
@@ -6,6 +6,7 @@
  *************************************************************************/
 
 #include "codegen/codegen_info.hpp"
+#include "visitors/lookup_visitor.hpp"
 
 
 namespace nmodl {
@@ -86,6 +87,19 @@ bool CodegenInfo::derivimplicit_coreneuron_solver() {
     return !derivimplicit_callbacks.empty();
 }
 
+/**
+ * Check if NrnState node in the AST has EigenSolverBlock node
+ *
+ * @return True if EigenSolverBlock exist in the node
+ */
+bool CodegenInfo::nrn_state_has_eigen_solver_block() const {
+    if (nrn_state_block == nullptr) {
+        return false;
+    }
+    return !AstLookupVisitor()
+                .lookup(nrn_state_block, ast::AstNodeType::EIGEN_NEWTON_SOLVER_BLOCK)
+                .empty();
+}
 
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/codegen_info.hpp
+++ b/src/codegen/codegen_info.hpp
@@ -133,7 +133,11 @@ struct CodegenInfo {
     /// name of the suffix
     std::string mod_suffix;
 
-    /// if mod file is vectorizable (always true for coreneuron)
+    /// true if mod file is vectorizable (which should be always true for coreneuron)
+    /// But there are some blocks like LINEAR are not thread safe in neuron or mod2c
+    /// context. In this case vectorize is used to determine number of float variable
+    /// in the data array (e.g. v). For such non thread methods or blocks vectorize is
+    /// false.
     bool vectorize = true;
 
     /// if mod file is thread safe (always true for coreneuron)
@@ -364,6 +368,9 @@ struct CodegenInfo {
     bool derivimplicit_coreneuron_solver();
 
     bool function_uses_table(std::string& name) const;
+
+    /// true if EigenNewtonSolver is used in nrn_state block
+    bool nrn_state_has_eigen_solver_block() const;
 };
 
 }  // namespace codegen

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -259,11 +259,6 @@ int main(int argc, const char* argv[]) {
             ast_to_nmodl(ast.get(), filepath("verbatim_rename"));
         }
 
-        /// once we start modifying (especially removing) older constructs
-        /// from ast then we should run symtab visitor in update mode so
-        /// that old symbols (e.g. prime variables) are not lost
-        update_symtab = true;
-
         if (nmodl_const_folding) {
             logger->info("Running nmodl constant folding visitor");
             ConstantFolderVisitor().visit_program(ast.get());
@@ -277,6 +272,21 @@ int main(int argc, const char* argv[]) {
             ast_to_nmodl(ast.get(), filepath("unroll"));
             SymtabVisitor(update_symtab).visit_program(ast.get());
         }
+
+        /// note that we can not symtab visitor in update mode as we
+        /// replace kinetic block with derivative block of same name
+        /// in global scope
+        {
+            logger->info("Running KINETIC block visitor");
+            KineticBlockVisitor().visit_program(ast.get());
+            SymtabVisitor(update_symtab).visit_program(ast.get());
+            ast_to_nmodl(ast.get(), filepath("kinetic"));
+        }
+
+        /// once we start modifying (especially removing) older constructs
+        /// from ast then we should run symtab visitor in update mode so
+        /// that old symbols (e.g. prime variables) are not lost
+        update_symtab = true;
 
         if (nmodl_inline) {
             logger->info("Running nmodl inline visitor");
@@ -298,13 +308,6 @@ int main(int argc, const char* argv[]) {
             LocalVarRenameVisitor().visit_program(ast.get());
             SymtabVisitor(update_symtab).visit_program(ast.get());
             ast_to_nmodl(ast.get(), filepath("localize"));
-        }
-
-        {
-            logger->info("Running KINETIC block visitor");
-            KineticBlockVisitor().visit_program(ast.get());
-            SymtabVisitor(update_symtab).visit_program(ast.get());
-            ast_to_nmodl(ast.get(), filepath("kinetic"));
         }
 
         if (sympy_conductance) {


### PR DESCRIPTION
  - print F which is often alias to faraday
  - has_local_statement to is_local_statement check so that it is more robust in case of inlining
  - add missing pnodecount argument to newton functor