### PR TITLE
kinetic block improvements

### DIFF
--- a/nmodl/ode.py
+++ b/nmodl/ode.py
@@ -128,13 +128,13 @@ def _sympify_eqs(eq_strings, state_vars, vars):
         var_name, sympy_object = _var_to_sympy(var)
         sympy_vars[var_name] = sympy_object
 
-    # parse state vars using above sympy objects
+    # parse state vars & eqs using above sympy objects
     sympy_state_vars = []
     for state_var in state_vars:
         sympy_state_vars.append(sp.sympify(state_var, locals=sympy_vars))
     eqs = [
-        sp.sympify(eq.split("=", 1)[1], locals=sympy_vars)
-        - sp.sympify(eq.split("=", 1)[0], locals=sympy_vars)
+        (sp.sympify(eq.split("=", 1)[1], locals=sympy_vars)
+        - sp.sympify(eq.split("=", 1)[0], locals=sympy_vars)).expand()
         for eq in eq_strings
     ]
     return eqs, sympy_state_vars, sympy_vars
@@ -193,6 +193,7 @@ def solve_lin_system(eq_strings, vars, constants, small_system=False, do_cse=Fal
         # large linear system: construct and return matrix J, vector F such that
         # J X = F is the linear system to be solved for X by e.g. LU factorization
         matJ, vecF = sp.linear_eq_to_matrix(eqs, state_vars)
+
         # construct vector F
         for i, expr in enumerate(vecF):
             code.append(f"F[{i}] = {sp.ccode(expr.simplify().evalf())}")

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -259,13 +259,6 @@ int main(int argc, const char* argv[]) {
             ast_to_nmodl(ast.get(), filepath("verbatim_rename"));
         }
 
-        {
-            logger->info("Running KINETIC block visitor");
-            KineticBlockVisitor().visit_program(ast.get());
-            SymtabVisitor(update_symtab).visit_program(ast.get());
-            ast_to_nmodl(ast.get(), filepath("kinetic"));
-        }
-
         /// once we start modifying (especially removing) older constructs
         /// from ast then we should run symtab visitor in update mode so
         /// that old symbols (e.g. prime variables) are not lost
@@ -305,6 +298,13 @@ int main(int argc, const char* argv[]) {
             LocalVarRenameVisitor().visit_program(ast.get());
             SymtabVisitor(update_symtab).visit_program(ast.get());
             ast_to_nmodl(ast.get(), filepath("localize"));
+        }
+
+        {
+            logger->info("Running KINETIC block visitor");
+            KineticBlockVisitor().visit_program(ast.get());
+            SymtabVisitor(update_symtab).visit_program(ast.get());
+            ast_to_nmodl(ast.get(), filepath("kinetic"));
         }
 
         if (sympy_conductance) {

--- a/src/visitors/visitor_utils.cpp
+++ b/src/visitors/visitor_utils.cpp
@@ -127,12 +127,15 @@ void remove_statements_from_block(ast::StatementBlock* block,
 std::set<std::string> get_global_vars(Program* node) {
     std::set<std::string> vars;
     if (auto* symtab = node->get_symbol_table()) {
-        NmodlType property =
-            NmodlType::global_var | NmodlType::range_var | NmodlType::param_assign |
-            NmodlType::extern_var | NmodlType::prime_name | NmodlType::dependent_def |
-            NmodlType::read_ion_var | NmodlType::write_ion_var | NmodlType::nonspecific_cur_var |
-            NmodlType::electrode_cur_var | NmodlType::section_var | NmodlType::constant_var |
-            NmodlType::extern_neuron_variable | NmodlType::state_var | NmodlType::factor_def;
+        // NB: local_var included here as locals can be declared at global scope
+        NmodlType property = NmodlType::global_var | NmodlType::local_var | NmodlType::range_var |
+                             NmodlType::param_assign | NmodlType::extern_var |
+                             NmodlType::prime_name | NmodlType::dependent_def |
+                             NmodlType::read_ion_var | NmodlType::write_ion_var |
+                             NmodlType::nonspecific_cur_var | NmodlType::electrode_cur_var |
+                             NmodlType::section_var | NmodlType::constant_var |
+                             NmodlType::extern_neuron_variable | NmodlType::state_var |
+                             NmodlType::factor_def;
         for (const auto& globalvar: symtab->get_variables_with_properties(property)) {
             std::string var_name = globalvar->get_name();
             if (globalvar->is_array()) {

--- a/test/visitor/visitor.cpp
+++ b/test/visitor/visitor.cpp
@@ -2846,7 +2846,7 @@ SCENARIO("SympySolver visitor: derivimplicit or sparse", "[sympy][derivimplicit]
                 }{
                     X[0] = m
                 }{
-                    F[0] = (-dt*(X[0]-mInf)+mTau*(-X[0]+old_m))/mTau
+                    F[0] = (-X[0]*dt+dt*mInf+mTau*(-X[0]+old_m))/mTau
                     J[0] = -(dt+mTau)/mTau
                 }{
                     m = X[0]
@@ -3026,8 +3026,8 @@ SCENARIO("SympySolver visitor: derivimplicit or sparse", "[sympy][derivimplicit]
                 }{
                     X[0] = W[0]
                 }{
-                    F[0] = -X[0]+dt*(-X[0]*A[0]+X[0]*B[0]+3*A[1])+old_W_0
-                    J[0] = -dt*(A[0]-B[0])-1
+                    F[0] = -X[0]*dt*A[0]+X[0]*dt*B[0]-X[0]+3*dt*A[1]+old_W_0
+                    J[0] = -dt*A[0]+dt*B[0]-1
                 }{
                     W[0] = X[0]
                 }{
@@ -3070,9 +3070,9 @@ SCENARIO("SympySolver visitor: derivimplicit or sparse", "[sympy][derivimplicit]
                     X[1] = h
                     X[2] = n
                 }{
-                    F[0] = (-dt*(X[0]+3*X[1]*mtau-minf)+mtau*(-X[0]+old_m))/mtau
-                    F[1] = (dt*(pow(X[0], 2)*htau-X[1]+hinf)+htau*(-X[1]+old_h))/htau
-                    F[2] = (-dt*(X[2]-ninf)+ntau*(-X[2]+old_n))/ntau
+                    F[0] = (-X[0]*dt+dt*minf+mtau*(-X[0]-3*X[1]*dt+old_m))/mtau
+                    F[1] = (-X[1]*dt+dt*hinf+htau*(pow(X[0], 2)*dt-X[1]+old_h))/htau
+                    F[2] = (-X[2]*dt+dt*ninf+ntau*(-X[2]+old_n))/ntau
                     J[0] = -(dt+mtau)/mtau
                     J[3] = -3*dt
                     J[6] = 0
@@ -3128,8 +3128,8 @@ SCENARIO("SympySolver visitor: derivimplicit or sparse", "[sympy][derivimplicit]
                     X[0] = m
                     X[1] = h
                 }{
-                    F[0] = (-dt*(X[0]-minf)+mtau*(-X[0]+old_m))/mtau
-                    F[1] = (dt*(pow(X[0], 2)*htau-X[1]+hinf)+htau*(-X[1]+old_h))/htau
+                    F[0] = (-X[0]*dt+dt*minf+mtau*(-X[0]+old_m))/mtau
+                    F[1] = (-X[1]*dt+dt*hinf+htau*(pow(X[0], 2)*dt-X[1]+old_h))/htau
                     J[0] = -(dt+mtau)/mtau
                     J[2] = 0
                     J[1] = 2*X[0]*dt
@@ -3151,8 +3151,8 @@ SCENARIO("SympySolver visitor: derivimplicit or sparse", "[sympy][derivimplicit]
                     X[0] = m
                     X[1] = h
                 }{
-                    F[0] = (dt*(pow(X[0], 2)*htau-X[1]+hinf)+htau*(-X[1]+old_h))/htau
-                    F[1] = (dt*(-X[0]+X[1]*mtau+minf)+mtau*(-X[0]+old_m))/mtau
+                    F[0] = (-X[1]*dt+dt*hinf+htau*(pow(X[0], 2)*dt-X[1]+old_h))/htau
+                    F[1] = (-X[0]*dt+dt*minf+mtau*(-X[0]+X[1]*dt+old_m))/mtau
                     J[0] = 2*X[0]*dt
                     J[2] = -(dt+htau)/htau
                     J[1] = -(dt+mtau)/mtau


### PR DESCRIPTION
  - moved kinetic block visitor after loop unrolling pass
  - added `local_var` type to `get_global_vars`, as local vars can be at global scope
  - added `.expand()` to `_sympify_eqs()`, (implicitly) required / assumed to have been done already by sympy routine `linear_eq_to_matrix()`
  - updated tests due to above change