### PR TITLE
Backend specific zero initialisation of ion variable

### DIFF
--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -624,6 +624,14 @@ class CodegenCVisitor: public AstVisitor {
     void print_ion_var_structure();
 
 
+    /// constructor of ion variables
+    virtual void print_ion_var_constructor(const std::vector<std::string>& members);
+
+
+    /// print ion variable
+    virtual void print_ion_variable();
+
+
     /// return floating point type for given range variable symbol
     std::string get_range_var_float_type(const SymbolType& symbol);
 

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -474,6 +474,17 @@ void CodegenIspcVisitor::print_ispc_globals() {
 }
 
 
+void CodegenIspcVisitor::print_ion_var_constructor(const std::vector<std::string>& members) {
+    /// no constructor for ispc
+}
+
+
+void CodegenIspcVisitor::print_ion_variable() {
+    /// c syntax to zero initialize struct
+    printer->add_line("IonCurVar ionvar = {0};");
+}
+
+
 /****************************************************************************************/
 /*                    Main code printing entry points and wrappers                      */
 /****************************************************************************************/

--- a/src/codegen/codegen_ispc_visitor.hpp
+++ b/src/codegen/codegen_ispc_visitor.hpp
@@ -142,6 +142,12 @@ class CodegenIspcVisitor: public CodegenCVisitor {
     void print_net_receive_buffering_wrapper();
 
 
+    void print_ion_var_constructor(const std::vector<std::string>& members) override;
+
+
+    void print_ion_variable() override;
+
+
     /// entry point to code generation
     void print_codegen_routines() override;
 

--- a/src/printer/code_printer.cpp
+++ b/src/printer/code_printer.cpp
@@ -47,10 +47,10 @@ void CodePrinter::add_text(const std::string& text) {
     *result << text;
 }
 
-void CodePrinter::add_line(const std::string& text) {
+void CodePrinter::add_line(const std::string& text, int num_new_lines) {
     add_indent();
     *result << text;
-    add_newline();
+    add_newline(num_new_lines);
 }
 
 void CodePrinter::add_multi_line(const std::string& text) {

--- a/src/printer/code_printer.hpp
+++ b/src/printer/code_printer.hpp
@@ -52,7 +52,7 @@ class CodePrinter {
 
     void add_text(const std::string&);
 
-    void add_line(const std::string&);
+    void add_line(const std::string&, int num_new_lines = 1);
 
     void add_multi_line(const std::string&);
 


### PR DESCRIPTION
      - c++  backend should have constructor for member initialization
      - c backend (e.g. ispc) uses C syntax for zero initialization

    Resolves #125