### PR TITLE
Code generation fixes for OpenACC backend

### DIFF
--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -28,7 +28,7 @@ class CodegenAccVisitor: public CodegenCVisitor {
 
 
     /// ivdep like annotation for channel iterations
-    void print_channel_iteration_block_parallel_hint() override;
+    void print_channel_iteration_block_parallel_hint(BlockType type) override;
 
 
     /// atomic update pragma for reduction statements
@@ -62,6 +62,12 @@ class CodegenAccVisitor: public CodegenCVisitor {
     /// if reduction block in nrn_cur required
     bool nrn_cur_reduction_loop_required() override;
 
+
+    /// create global variable on the device
+    void print_global_variable_device_create_annotation() override;
+
+    /// update global variable from host to the device
+    void print_global_variable_device_update_annotation() override;
 
   public:
     CodegenAccVisitor(std::string mod_file,

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -680,6 +680,14 @@ class CodegenCVisitor: public AstVisitor {
     void print_global_variable_setup();
 
 
+    /// pragma annotation to create global variables on the device
+    virtual void print_global_variable_device_create_annotation();
+
+
+    /// pragma annotation to update global variables from host to the device
+    virtual void print_global_variable_device_update_annotation();
+
+
     /// setup method for allocation of shadow vectors
     void print_shadow_vector_setup();
 
@@ -729,7 +737,7 @@ class CodegenCVisitor: public AstVisitor {
 
 
     /// ivdep like annotation for channel iterations
-    virtual void print_channel_iteration_block_parallel_hint();
+    virtual void print_channel_iteration_block_parallel_hint(BlockType type);
 
 
     /// annotations like "acc enter data present(...)" for main kernel
@@ -741,7 +749,7 @@ class CodegenCVisitor: public AstVisitor {
 
 
     /// backend specific channel instance iteration block start
-    virtual void print_channel_iteration_block_begin();
+    virtual void print_channel_iteration_block_begin(BlockType type);
 
 
     /// backend specific channel instance iteration block end

--- a/src/codegen/codegen_cuda_visitor.cpp
+++ b/src/codegen/codegen_cuda_visitor.cpp
@@ -107,7 +107,7 @@ void CodegenCudaVisitor::print_nrn_cur_matrix_shadow_update() {
  * For GPU backend its thread id less than total channel instances. Below we
  * assume we launch 1-d grid.
  */
-void CodegenCudaVisitor::print_channel_iteration_block_begin() {
+void CodegenCudaVisitor::print_channel_iteration_block_begin(BlockType type) {
     printer->add_line("int id = blockIdx.x * blockDim.x + threadIdx.x;");
     printer->start_block("if (id < end) ");
 }

--- a/src/codegen/codegen_cuda_visitor.hpp
+++ b/src/codegen/codegen_cuda_visitor.hpp
@@ -51,7 +51,7 @@ class CodegenCudaVisitor: public CodegenCVisitor {
 
 
     /// backend specific channel instance iteration block start
-    void print_channel_iteration_block_begin() override;
+    void print_channel_iteration_block_begin(BlockType type) override;
 
 
     /// backend specific channel instance iteration block end

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -180,7 +180,7 @@ void CodegenIspcVisitor::print_channel_iteration_tiling_block_begin(BlockType ty
  *
  * Use ispc foreach loop
  */
-void CodegenIspcVisitor::print_channel_iteration_block_begin() {
+void CodegenIspcVisitor::print_channel_iteration_block_begin(BlockType type) {
     printer->start_block("foreach (id = start ... end)");
 }
 

--- a/src/codegen/codegen_ispc_visitor.hpp
+++ b/src/codegen/codegen_ispc_visitor.hpp
@@ -80,7 +80,7 @@ class CodegenIspcVisitor: public CodegenCVisitor {
 
 
     /// backend specific channel instance iteration block start
-    void print_channel_iteration_block_begin() override;
+    void print_channel_iteration_block_begin(BlockType type) override;
 
 
     /// backend specific channel iteration bounds

--- a/src/codegen/codegen_omp_visitor.cpp
+++ b/src/codegen/codegen_omp_visitor.cpp
@@ -72,7 +72,7 @@ void CodegenOmpVisitor::print_channel_iteration_tiling_block_end() {
  *      for(int id=0; id<nodecount; id++) {
  *
  */
-void CodegenOmpVisitor::print_channel_iteration_block_parallel_hint() {
+void CodegenOmpVisitor::print_channel_iteration_block_parallel_hint(BlockType type) {
     printer->add_line("#pragma omp simd");
 }
 

--- a/src/codegen/codegen_omp_visitor.hpp
+++ b/src/codegen/codegen_omp_visitor.hpp
@@ -48,7 +48,7 @@ class CodegenOmpVisitor: public CodegenCVisitor {
 
 
     /// ivdep like annotation for channel iterations
-    void print_channel_iteration_block_parallel_hint() override;
+    void print_channel_iteration_block_parallel_hint(BlockType type) override;
 
 
     /// atomic update pragma for reduction statements

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -359,17 +359,6 @@ int main(int argc, const char* argv[]) {
         {
             auto mem_layout = layout == "aos" ? codegen::LayoutType::aos : codegen::LayoutType::soa;
 
-            if (c_backend) {
-                logger->info("Running C backend code generator");
-                CodegenCVisitor visitor(modfile, output_dir, mem_layout, data_type);
-                visitor.visit_program(ast.get());
-            }
-
-            if (omp_backend) {
-                logger->info("Running OpenMP backend code generator");
-                CodegenOmpVisitor visitor(modfile, output_dir, mem_layout, data_type);
-                visitor.visit_program(ast.get());
-            }
 
             if (ispc_backend) {
                 logger->info("Running ISPC backend code generator");
@@ -377,9 +366,21 @@ int main(int argc, const char* argv[]) {
                 visitor.visit_program(ast.get());
             }
 
-            if (oacc_backend) {
+            else if (oacc_backend) {
                 logger->info("Running OpenACC backend code generator");
                 CodegenAccVisitor visitor(modfile, output_dir, mem_layout, data_type);
+                visitor.visit_program(ast.get());
+            }
+
+            else if (omp_backend) {
+                logger->info("Running OpenMP backend code generator");
+                CodegenOmpVisitor visitor(modfile, output_dir, mem_layout, data_type);
+                visitor.visit_program(ast.get());
+            }
+
+            else if (c_backend) {
+                logger->info("Running C backend code generator");
+                CodegenCVisitor visitor(modfile, output_dir, mem_layout, data_type);
                 visitor.visit_program(ast.get());
             }
 


### PR DESCRIPTION
  - pragma acc parallel loop needs present clause with the
     list of arrays used in the loop body
  - include cuda_runtime_api.h header
  - avoid running host backends simultaenously, see  #128
  - disable openacc annoitation for artificial cells
  - copy global variables structure at the start and delete
     then at the time of cleanup

Resolves #101