### PR TITLE
OpenACC backend fixes

### DIFF
--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -32,15 +32,17 @@ namespace codegen {
  *
  */
 void CodegenAccVisitor::print_channel_iteration_block_parallel_hint(BlockType type) {
-    if (!info.artificial_cell) {
-        std::string present_clause = "present(node_index, data, voltage, indexes, thread";
-
-        if (type == BlockType::Equation) {
-            present_clause += ", vec_rhs, vec_d";
-        }
-        present_clause += ")";
-        printer->add_line("#pragma acc parallel loop {}"_format(present_clause));
+    if (info.artificial_cell || info.eigen_newton_solver_exist || info.eigen_linear_solver_exist) {
+        return;
     }
+
+    std::string present_clause = "present(node_index, data, voltage, indexes, thread";
+
+    if (type == BlockType::Equation) {
+        present_clause += ", vec_rhs, vec_d";
+    }
+    present_clause += ")";
+    printer->add_line("#pragma acc parallel loop {}"_format(present_clause));
 }
 
 

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -47,7 +47,7 @@ void CodegenAccVisitor::print_channel_iteration_block_parallel_hint(BlockType ty
         }
     }
     present_clause += ")";
-    printer->add_line("#pragma acc parallel loop {}"_format(present_clause));
+    printer->add_line("#pragma acc parallel loop {} async(nt->stream_id)"_format(present_clause));
 }
 
 

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -32,7 +32,7 @@ namespace codegen {
  *
  */
 void CodegenAccVisitor::print_channel_iteration_block_parallel_hint(BlockType type) {
-    if (info.artificial_cell || info.eigen_newton_solver_exist || info.eigen_linear_solver_exist) {
+    if (info.artificial_cell) {
         return;
     }
 

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -36,10 +36,15 @@ void CodegenAccVisitor::print_channel_iteration_block_parallel_hint(BlockType ty
         return;
     }
 
-    std::string present_clause = "present(node_index, data, voltage, indexes, thread";
+    std::string present_clause = "present(inst";
 
-    if (type == BlockType::Equation) {
-        present_clause += ", vec_rhs, vec_d";
+    if (type == BlockType::NetReceive) {
+        present_clause += ", nrb";
+    } else {
+        present_clause += ", node_index, data, voltage, indexes, thread";
+        if (type == BlockType::Equation) {
+            present_clause += ", vec_rhs, vec_d";
+        }
     }
     present_clause += ")";
     printer->add_line("#pragma acc parallel loop {}"_format(present_clause));

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -159,5 +159,12 @@ void CodegenAccVisitor::print_global_variable_device_update_annotation() {
     }
 }
 
+std::string CodegenAccVisitor::get_variable_device_pointer(std::string variable, std::string type) {
+    if (info.artificial_cell) {
+        return variable;
+    }
+    return "({}) acc_deviceptr({})"_format(type, variable);
+}
+
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -79,6 +79,9 @@ class CodegenAccVisitor: public CodegenCVisitor {
     /// update global variable from host to the device
     void print_global_variable_device_update_annotation() override;
 
+    std::string get_variable_device_pointer(std::string variable, std::string type) override;
+
+
   public:
     CodegenAccVisitor(std::string mod_file,
                       std::string output_dir,

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -2540,9 +2540,6 @@ void CodegenCVisitor::print_mechanism_register() {
     printer->add_line("/** register channel with the simulator */");
     printer->start_block("void _{}_reg() "_format(info.mod_file));
 
-    // allocate global variables
-    printer->add_line("setup_global_variables();");
-
     // type related information
     auto mech_type = get_variable_name("mech_type");
     auto suffix = add_escape_quote(info.mod_suffix);
@@ -2572,6 +2569,9 @@ void CodegenCVisitor::print_mechanism_register() {
         printer->add_line(type + " = nrn_get_mechtype(" + name + ");");
     }
     printer->add_newline();
+
+    // allocate global variables as ion types are now set
+    printer->add_line("setup_global_variables();");
 
     /*
      *  If threads are used then memory is allocated in setup_global_variables.

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3509,6 +3509,7 @@ void CodegenCVisitor::print_get_memb_list() {
 
 void CodegenCVisitor::print_net_receive_loop_begin() {
     printer->add_line("int count = nrb->_displ_cnt;");
+    print_channel_iteration_block_parallel_hint(BlockType::NetReceive);
     printer->start_block("for (int i = 0; i < count; i++)");
 }
 
@@ -3528,6 +3529,8 @@ void CodegenCVisitor::print_net_receive_buffering(bool need_mech_inst) {
     print_get_memb_list();
 
     auto net_receive = method_name("net_receive_kernel");
+
+    print_kernel_data_present_annotation_block_begin();
 
     printer->add_line(
         "NetReceiveBuffer_t* {}nrb = ml->_net_receive_buffer;"_format(ptr_type_qualifier()));
@@ -3557,6 +3560,7 @@ void CodegenCVisitor::print_net_receive_buffering(bool need_mech_inst) {
     printer->add_line("nrb->_displ_cnt = 0;");
     printer->add_line("nrb->_cnt = 0;");
 
+    print_kernel_data_present_annotation_block_end();
     printer->end_block(1);
 }
 

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1585,6 +1585,12 @@ class CodegenCVisitor: public visitor::AstVisitor {
     virtual void print_wrapper_routines();
 
 
+    /**
+     * Get device variable pointer for corresponding host variable
+     */
+    virtual std::string get_variable_device_pointer(std::string variable, std::string type);
+
+
     CodegenCVisitor(std::string mod_filename,
                     std::string output_dir,
                     LayoutType layout,

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -223,7 +223,8 @@ void CodegenIspcVisitor::print_shadow_reduction_block_begin() {
 
 void CodegenIspcVisitor::print_rhs_d_shadow_variables() {
     if (info.point_process) {
-        printer->add_line("double* uniform shadow_rhs = nt->{};"_format(naming::NTHREAD_RHS_SHADOW));
+        printer->add_line(
+            "double* uniform shadow_rhs = nt->{};"_format(naming::NTHREAD_RHS_SHADOW));
         printer->add_line("double* uniform shadow_d = nt->{};"_format(naming::NTHREAD_D_SHADOW));
     }
 }

--- a/src/codegen/codegen_ispc_visitor.hpp
+++ b/src/codegen/codegen_ispc_visitor.hpp
@@ -28,7 +28,6 @@ namespace codegen {
  * \brief %Visitor for printing C code with ISPC backend
  */
 class CodegenIspcVisitor: public CodegenCVisitor {
-
     /**
      * Prints an ISPC atomic operation
      *


### PR DESCRIPTION
OpenACC backend now works with Ring test and channel benchmark
using explicit memory transfer from CoreNEURON.
  - setup_global_variables after ion types are set
  - net_receive offloaded to GPU
  - async clause added to all `acc parallel loop` execution
  - all instance variables get device pointer in OpenACC backend