### PR TITLE
Fix/ispc atomics

### DIFF
--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1415,7 +1415,7 @@ class CodegenCVisitor: public visitor::AstVisitor {
      * Print block / loop for statement requiring reduction
      *
      */
-    void print_shadow_reduction_block_begin();
+    virtual void print_shadow_reduction_block_begin();
 
 
     /**

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -188,6 +188,21 @@ void CodegenIspcVisitor::print_get_memb_list() {
 }
 
 
+void CodegenIspcVisitor::print_atomic_op(const std::string& lhs,
+                                         const std::string& op,
+                                         const std::string& rhs) {
+    std::string function;
+    if (op == "+") {
+        function = "atomic_add_local";
+    } else if (op == "-") {
+        function = "atomic_subtract_local";
+    } else {
+        throw std::runtime_error("ISPC backend error : {} not supported"_format(op));
+    }
+    printer->add_line("{}(&{}, {});"_format(function, lhs, rhs));
+}
+
+
 void CodegenIspcVisitor::print_nrn_cur_matrix_shadow_reduction() {
     auto rhs_op = operator_for_rhs();
     auto d_op = operator_for_d();

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -173,10 +173,8 @@ void CodegenIspcVisitor::print_nrn_cur_matrix_shadow_update() {
     auto rhs_op = operator_for_rhs();
     auto d_op = operator_for_d();
     if (info.point_process) {
-        stringutils::remove_character(rhs_op, '=');
-        stringutils::remove_character(d_op, '=');
-        print_atomic_op("vec_rhs[node_id]", rhs_op, "rhs");
-        print_atomic_op("vec_d[node_id]", d_op, "g");
+        printer->add_line("shadow_rhs[id] = rhs;");
+        printer->add_line("shadow_d[id] = g;");
     } else {
         printer->add_line("vec_rhs[node_id] {} rhs;"_format(rhs_op));
         printer->add_line("vec_d[node_id] {} g;"_format(d_op));
@@ -219,17 +217,35 @@ void CodegenIspcVisitor::print_get_memb_list() {
 
 
 void CodegenIspcVisitor::print_nrn_cur_matrix_shadow_reduction() {
-    // do nothing
+    auto rhs_op = operator_for_rhs();
+    auto d_op = operator_for_d();
+    if (info.point_process) {
+        printer->start_block("programIndex == 0");
+        printer->add_line("uniform int node_id = node_index[id];");
+        print_atomic_reduction_pragma();
+        printer->add_line("vec_rhs[node_id] {} shadow_rhs[id];"_format(rhs_op));
+        print_atomic_reduction_pragma();
+        printer->add_line("vec_d[node_id] {} shadow_d[id];"_format(d_op));
+        printer->end_block(1);
+    }
+}
+
+
+void CodegenIspcVisitor::print_shadow_reduction_block_begin() {
+    printer->start_block("for (uniform int id = start; id < end; id++) ");
 }
 
 
 void CodegenIspcVisitor::print_rhs_d_shadow_variables() {
-    // do nothing
+    if (info.point_process) {
+        printer->add_line("double* uniform shadow_rhs = nt->{};"_format(naming::NTHREAD_RHS_SHADOW));
+        printer->add_line("double* uniform shadow_d = nt->{};"_format(naming::NTHREAD_D_SHADOW));
+    }
 }
 
 
 bool CodegenIspcVisitor::nrn_cur_reduction_loop_required() {
-    return false;
+    return info.point_process;
 }
 
 

--- a/src/codegen/codegen_ispc_visitor.hpp
+++ b/src/codegen/codegen_ispc_visitor.hpp
@@ -28,7 +28,6 @@ namespace codegen {
  * \brief %Visitor for printing C code with ISPC backend
  */
 class CodegenIspcVisitor: public CodegenCVisitor {
-    void print_atomic_op(const std::string& lhs, const std::string& op, const std::string& rhs);
 
     /// ast nodes which are not compatible with ISPC target
     const std::vector<ast::AstNodeType> incompatible_node_types{
@@ -81,10 +80,6 @@ class CodegenIspcVisitor: public CodegenCVisitor {
 
     /// common includes : standard c/c++, coreneuron and backend specific
     void print_backend_includes() override;
-
-
-    /// update to matrix elements with/without shadow vectors
-    void print_nrn_cur_matrix_shadow_update() override;
 
 
     /// reduction to matrix elements from shadow vectors

--- a/src/codegen/codegen_ispc_visitor.hpp
+++ b/src/codegen/codegen_ispc_visitor.hpp
@@ -29,6 +29,19 @@ namespace codegen {
  */
 class CodegenIspcVisitor: public CodegenCVisitor {
 
+    /**
+     * Prints an ISPC atomic operation
+     *
+     * \note This is currently not used because of performance issues on KNL. Instead reduction
+     * operations are serialized.
+     *
+     * \param lhs Reduction left-hand-side operand
+     * \param op  Reducation operation. Currently only \c += and \c -= are supported
+     * \param rhs Reduction right-hand-side operand
+     */
+    void print_atomic_op(const std::string& lhs, const std::string& op, const std::string& rhs);
+
+
     /// ast nodes which are not compatible with ISPC target
     const std::vector<ast::AstNodeType> incompatible_node_types{
         ast::AstNodeType::VERBATIM,

--- a/src/codegen/codegen_ispc_visitor.hpp
+++ b/src/codegen/codegen_ispc_visitor.hpp
@@ -91,6 +91,13 @@ class CodegenIspcVisitor: public CodegenCVisitor {
     void print_nrn_cur_matrix_shadow_reduction() override;
 
 
+    /**
+     * Print block / loop for statement requiring reduction
+     *
+     */
+    void print_shadow_reduction_block_begin() override;
+
+
     /// setup method for setting matrix shadow vectors
     void print_rhs_d_shadow_variables() override;
 


### PR DESCRIPTION
Added a serialized reduction update to replace the ISPC atomic reduction operations. This fixes the performance regression from #137.