### PR TITLE
Fix codegen issues and update travis CI for CoreNEURON tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ addons:
     packages:
       - flex
       - bison
+      - libboost-all-dev
       - cmake
       - python3-dev
       - python3-pip
@@ -45,6 +46,7 @@ addons:
     packages:
       - flex
       - bison
+      - boost
       - cmake
       - python@3
 
@@ -79,6 +81,18 @@ script:
   - make -j 2
   - make test
   - make install
+
+#=============================================================================
+# Build CoreNEURON and run tests
+#=============================================================================
+after_success:
+  - echo "------- Build and Test CoreNEURON -------"
+  - cd $HOME
+  - git clone --recursive https://github.com/BlueBrain/CoreNeuron.git
+  - mkdir CoreNeuron/build && cd CoreNeuron/build
+  - cmake .. -DENABLE_MPI=OFF -DENABLE_NMODL=ON -DNMODL_ROOT=$HOME/nmodl -DNMODL_EXTRA_FLAGS="passes --verbatim-rename --inline sympy --analytic"
+  - make -j
+  - make test
 
 #=============================================================================
 # Notifications

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -259,14 +259,10 @@ int main(int argc, const char* argv[]) {
         }
 
         {
-            // make sure to run perf visitor because code generator
-            // looks for read/write counts const/non-const declaration
-            PerfVisitor().visit_program(ast.get());
-        }
-
-        {
             // Compatibility Checking
             logger->info("Running code compatibility checker");
+            // run perfvisitor to update read/wrie counts
+            PerfVisitor().visit_program(ast.get());
             // If there is an incompatible construct and code generation is not forced exit NMODL
             if (CodegenCompatibilityVisitor().find_unhandled_ast_nodes(ast.get()) &&
                 !force_codegen) {
@@ -390,6 +386,12 @@ int main(int argc, const char* argv[]) {
             auto file = scratch_dir + "/" + modfile + ".perf.json";
             logger->info("Writing performance statistics to {}", file);
             PerfVisitor(file).visit_program(ast.get());
+        }
+
+        {
+            // make sure to run perf visitor because code generator
+            // looks for read/write counts const/non-const declaration
+            PerfVisitor().visit_program(ast.get());
         }
 
         {


### PR DESCRIPTION
  - #196 introduced regression in the sense that the perfvisitor
    was not running just before codegen. Because of this, read/write
    count was not updated resulting in const/non-const issues.
  - update travis configuration so that coreneuron is built and run
    on every PR to avoid issues like above

fixes #226 #227