### PR TITLE
Fixed small issue in code generation

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -2297,7 +2297,7 @@ void CodegenCVisitor::print_coreneuron_includes() {
     printer->add_line("#include <coreneuron/nrniv/ivocvect.h>");
     printer->add_line("#include <coreneuron/mech/mod2c_core_thread.h>");
     printer->add_line("#include <coreneuron/scopmath_core/newton_struct.h>");
-    printer->add_line("#include <_kinderiv.h>");
+    printer->add_line("#include \"_kinderiv.h\"");
     if (info.eigen_newton_solver_exist) {
         printer->add_line("#include <newton/newton.hpp>");
     }


### PR DESCRIPTION
the generated code was including _kinderiv.h as a system-dependent lib
rather than as a local include. This broke compatibility with mod2c and
coreneuron.