### PR TITLE
Handle code generation for INITIAL block under NET_RECEIVE

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(testvisitor
                visitor/sympy_conductance.cpp
                visitor/sympy_solver.cpp
                visitor/units.cpp
+               visitor/var_usage.cpp
                visitor/verbatim.cpp)
 add_executable(testprinter printer/printer.cpp)
 add_executable(testsymtab symtab/symbol_table.cpp)

--- a/test/visitor/var_usage.cpp
+++ b/test/visitor/var_usage.cpp
@@ -33,7 +33,9 @@ SCENARIO("Searching for variable name using VarUsageVisitor", "[visitor][var_usa
             DERIVATIVE states {
                 tau = 11.1
                 exp(tau)
+            {
                 h' = h + 2 + n
+            }
             }
         )";
 

--- a/test/visitor/var_usage.cpp
+++ b/test/visitor/var_usage.cpp
@@ -1,0 +1,93 @@
+/*************************************************************************
+ * Copyright (C) 2018-2019 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#include "catch/catch.hpp"
+
+#include "parser/nmodl_driver.hpp"
+#include "test/utils/test_utils.hpp"
+#include "visitors/var_usage_visitor.hpp"
+
+using namespace nmodl;
+using namespace visitor;
+
+//=============================================================================
+// Variable usage visitor tests
+//=============================================================================
+
+bool run_var_usage_visitor(std::shared_ptr<ast::Node> node, const std::string& variable) {
+    return VarUsageVisitor().variable_used(node.get(), variable);
+}
+
+SCENARIO("Searching for variable name using VarUsageVisitor", "[visitor][var_usage]") {
+    auto to_ast = [](const std::string& text) {
+        parser::NmodlDriver driver;
+        return driver.parse_string(text);
+    };
+
+    GIVEN("A simple NMODL block") {
+        std::string nmodl_text = R"(
+            DERIVATIVE states {
+                tau = 11.1
+                exp(tau)
+                h' = h + 2 + n
+            }
+        )";
+
+        auto ast = to_ast(nmodl_text);
+        auto node = ast->blocks[0];
+
+        WHEN("Looking for existing variable") {
+            THEN("Can find variables") {
+                REQUIRE(run_var_usage_visitor(node, "tau"));
+                REQUIRE(run_var_usage_visitor(node, "h"));
+                REQUIRE(run_var_usage_visitor(node, "n"));
+            }
+        }
+
+        WHEN("Looking for missing variable") {
+            THEN("Can not find variable") {
+                REQUIRE_FALSE(run_var_usage_visitor(node, "tauu"));
+                REQUIRE_FALSE(run_var_usage_visitor(node, "my_var"));
+            }
+        }
+    }
+
+    GIVEN("A nested NMODL block") {
+        std::string nmodl_text = R"(
+            NET_RECEIVE (weight,weight_AMPA, weight_NMDA, R){
+                LOCAL result
+                weight_AMPA = weight
+                weight_NMDA = weight * NMDA_ratio
+                INITIAL {
+                    R = 1
+                    u = u0
+                    {
+                        tsyn = t
+                    }
+                }
+            }
+        )";
+
+        auto ast = to_ast(nmodl_text);
+        auto node = ast->blocks[0];
+
+        WHEN("Looking for existing variable in outer block") {
+            THEN("Can find variables") {
+                REQUIRE(run_var_usage_visitor(node, "weight"));
+                REQUIRE(run_var_usage_visitor(node, "NMDA_ratio"));
+            }
+        }
+
+        WHEN("Looking for existing variable in inner block") {
+            THEN("Can find variables") {
+                REQUIRE(run_var_usage_visitor(node, "R"));
+                REQUIRE(run_var_usage_visitor(node, "u0"));
+                REQUIRE(run_var_usage_visitor(node, "tsyn"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
  - variables under INITIAL block were not correctly handle
  - bug fix: if all parameters were not used correctly, variable
    from weight index was not correctly used
  - added unit tests for VarUsageVisitor

Todo

- [x]  cleanup code generation so that net_receieve and net_init are
         handled similarly (specifically (*var_name) syntax)
- [x] test DetAmpa and DetGaba mod files

Fixes #239