### PR TITLE
Replace raw pointers by references

### DIFF
--- a/src/ast/ast_common.hpp
+++ b/src/ast/ast_common.hpp
@@ -208,13 +208,13 @@ struct Ast: public std::enable_shared_from_this<Ast> {
      *       to visit the node itself in the visitor.
      *
      * \code{.cpp}
-     *   void IndexedName::accept(visitor::Visitor* v) override {
-     *       v->visit_indexed_name(this);
+     *   void IndexedName::accept(visitor::Visitor& v) override {
+     *       v.visit_indexed_name(this);
      *   }
      * \endcode
      *
      */
-    virtual void accept(visitor::Visitor* v) = 0;
+    virtual void accept(visitor::Visitor& v) = 0;
 
     /**
      * \brief Visit children i.e. member of AST node using provided visitor
@@ -228,13 +228,13 @@ struct Ast: public std::enable_shared_from_this<Ast> {
      *       ast::IndexedName node children are visited instead of node itself.
      *
      * \code{.cpp}
-     * void IndexedName::visit_children(visitor::Visitor* v) {
+     * void IndexedName::visit_children(visitor::Visitor& v) {
      *    name->accept(v);
      *    length->accept(v);
      * }
      * \endcode
      */
-    virtual void visit_children(visitor::Visitor* v) = 0;
+    virtual void visit_children(visitor::Visitor& v) = 0;
 
     /**
      * \brief Create a copy of the current node

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1822,7 +1822,7 @@ void CodegenCVisitor::print_vector_elements(const std::vector<T>& elements,
                                             const std::string& prefix) {
     for (auto iter = elements.begin(); iter != elements.end(); iter++) {
         printer->add_text(prefix);
-        (*iter)->accept(this);
+        (*iter)->accept(*this);
         if (!separator.empty() && !utils::is_last(iter, elements)) {
             printer->add_text(separator);
         }

--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -440,7 +440,7 @@ void CodegenHelperVisitor::visit_initial_block(InitialBlock* node) {
     } else {
         info.initial_node = node;
     }
-    node->visit_children(this);
+    node->visit_children(*this);
 }
 
 
@@ -448,14 +448,14 @@ void CodegenHelperVisitor::visit_net_receive_block(NetReceiveBlock* node) {
     under_net_receive_block = true;
     info.net_receive_node = node;
     info.num_net_receive_parameters = node->get_parameters().size();
-    node->visit_children(this);
+    node->visit_children(*this);
     under_net_receive_block = false;
 }
 
 
 void CodegenHelperVisitor::visit_derivative_block(DerivativeBlock* node) {
     under_derivative_block = true;
-    node->visit_children(this);
+    node->visit_children(*this);
     under_derivative_block = false;
 }
 
@@ -468,20 +468,20 @@ void CodegenHelperVisitor::visit_derivimplicit_callback(ast::DerivimplicitCallba
 void CodegenHelperVisitor::visit_breakpoint_block(BreakpointBlock* node) {
     under_breakpoint_block = true;
     info.breakpoint_node = node;
-    node->visit_children(this);
+    node->visit_children(*this);
     under_breakpoint_block = false;
 }
 
 
 void CodegenHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock* node) {
     info.nrn_state_block = node;
-    node->visit_children(this);
+    node->visit_children(*this);
 }
 
 
 void CodegenHelperVisitor::visit_procedure_block(ast::ProcedureBlock* node) {
     info.procedures.push_back(node);
-    node->visit_children(this);
+    node->visit_children(*this);
     if (table_statement_used) {
         table_statement_used = false;
         info.functions_with_table.push_back(node);
@@ -491,7 +491,7 @@ void CodegenHelperVisitor::visit_procedure_block(ast::ProcedureBlock* node) {
 
 void CodegenHelperVisitor::visit_function_block(ast::FunctionBlock* node) {
     info.functions.push_back(node);
-    node->visit_children(this);
+    node->visit_children(*this);
     if (table_statement_used) {
         table_statement_used = false;
         info.functions_with_table.push_back(node);
@@ -547,7 +547,7 @@ void CodegenHelperVisitor::visit_conductance_hint(ConductanceHint* node) {
 void CodegenHelperVisitor::visit_statement_block(ast::StatementBlock* node) {
     auto statements = node->get_statements();
     for (auto& statement: statements) {
-        statement->accept(this);
+        statement->accept(*this);
         if (under_derivative_block && assign_lhs &&
             (assign_lhs->is_name() || assign_lhs->is_var_name())) {
             auto name = assign_lhs->get_node_name();
@@ -577,8 +577,8 @@ void CodegenHelperVisitor::visit_binary_expression(BinaryExpression* node) {
     if (node->get_op().eval() == "=") {
         assign_lhs = node->get_lhs();
     }
-    node->get_lhs()->accept(this);
-    node->get_rhs()->accept(this);
+    node->get_lhs()->accept(*this);
+    node->get_rhs()->accept(*this);
 }
 
 
@@ -594,7 +594,7 @@ void CodegenHelperVisitor::visit_watch(ast::Watch* node) {
 
 void CodegenHelperVisitor::visit_watch_statement(ast::WatchStatement* node) {
     info.watch_statements.push_back(node);
-    node->visit_children(this);
+    node->visit_children(*this);
 }
 
 
@@ -618,7 +618,7 @@ void CodegenHelperVisitor::visit_program(ast::Program* node) {
             info.top_verbatim_blocks.push_back(block.get());
         }
     }
-    node->visit_children(this);
+    node->visit_children(*this);
     find_range_variables();
     find_non_range_variables();
     find_ion_variables();
@@ -627,7 +627,7 @@ void CodegenHelperVisitor::visit_program(ast::Program* node) {
 
 
 codegen::CodegenInfo CodegenHelperVisitor::analyze(ast::Program* node) {
-    node->accept(this);
+    node->accept(*this);
     return info;
 }
 

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -57,9 +57,9 @@ void CodegenIspcVisitor::visit_var_name(ast::VarName* node) {
         return;
     }
     auto celsius_rename = RenameVisitor("celsius", "ispc_celsius");
-    node->accept(&celsius_rename);
+    node->accept(celsius_rename);
     auto pi_rename = RenameVisitor("PI", "ISPC_PI");
-    node->accept(&pi_rename);
+    node->accept(pi_rename);
     CodegenCVisitor::visit_var_name(node);
 }
 

--- a/src/language/templates/ast/ast.cpp
+++ b/src/language/templates/ast/ast.cpp
@@ -22,7 +22,7 @@ namespace ast {
     /// {{node.class_name}} member functions definition
     ///
 
-    void {{ node.class_name }}::visit_children(visitor::Visitor* v) {
+    void {{ node.class_name }}::visit_children(visitor::Visitor& v) {
     {% for child in node.non_base_members %}
         {% if child.is_vector %}
         /// visit each element of vector

--- a/src/language/templates/ast/ast.hpp
+++ b/src/language/templates/ast/ast.hpp
@@ -267,7 +267,7 @@ namespace ast {
         /**
          * \brief Set token for the current ast node
          */
-        void set_token(ModToken& tok) { token = std::shared_ptr<ModToken>(new ModToken(tok)); }
+        void set_token(ModToken& tok) { token = std::make_shared<ModToken>(tok); }
         {% endif %}
 
         {% if node.is_symtab_needed %}

--- a/src/language/templates/ast/ast.hpp
+++ b/src/language/templates/ast/ast.hpp
@@ -317,7 +317,7 @@ namespace ast {
          *
          * \sa Ast::visit_children for example.
          */
-        {{ virtual(node) }} void visit_children (visitor::Visitor* v) override;
+        {{ virtual(node) }} void visit_children (visitor::Visitor& v) override;
 
         /**
          * \brief accept (or visit) the current AST node using provided visitor
@@ -330,8 +330,8 @@ namespace ast {
          *
          * \sa Ast::accept for example.
          */
-        {{ virtual(node) }} void accept(visitor::Visitor* v) override {
-            v->visit_{{ node.class_name | snake_case }}(this);
+        {{ virtual(node) }} void accept(visitor::Visitor& v) override {
+            v.visit_{{ node.class_name | snake_case }}(this);
         }
 
         /// \}

--- a/src/language/templates/pybind/pyast.cpp
+++ b/src/language/templates/pybind/pyast.cpp
@@ -234,7 +234,7 @@ void init_ast_module(py::module& m) {
             std::stringstream ss;
             JSONVisitor v(ss);
             v.compact_json(true);
-            n.accept(&v);
+            n.accept(v);
             return ss.str();
         });
 

--- a/src/language/templates/pybind/pyast.hpp
+++ b/src/language/templates/pybind/pyast.hpp
@@ -46,7 +46,7 @@ using namespace ast;
  */
 struct PyAst: public Ast {
 
-    void visit_children(visitor::Visitor* v) override {
+    void visit_children(visitor::Visitor& v) override {
         PYBIND11_OVERLOAD_PURE(void,            /// Return type
                                Ast,             /// Parent class
                                visit_children,  /// Name of function in C++ (must match Python name)
@@ -54,7 +54,7 @@ struct PyAst: public Ast {
         );
     }
 
-    void accept(visitor::Visitor* v) override {
+    void accept(visitor::Visitor& v) override {
         PYBIND11_OVERLOAD_PURE(void, Ast, accept, v);
     }
 

--- a/src/language/templates/visitors/ast_visitor.cpp
+++ b/src/language/templates/visitors/ast_visitor.cpp
@@ -15,7 +15,7 @@ using namespace ast;
 
 {% for node in nodes %}
 void AstVisitor::visit_{{ node.class_name|snake_case }}({{ node.class_name }}* node) {
-    node->visit_children(this);
+    node->visit_children(*this);
 }
 
 {% endfor %}

--- a/src/language/templates/visitors/json_visitor.cpp
+++ b/src/language/templates/visitors/json_visitor.cpp
@@ -20,7 +20,7 @@ void JSONVisitor::visit_{{ node.class_name|snake_case }}({{ node.class_name }}* 
     if (embed_nmodl) {
         printer->add_block_property("nmodl", to_nmodl(node));
     }
-    node->visit_children(this);
+    node->visit_children(*this);
     {% if node.is_data_type_node %}
             {% if node.is_integer_node %}
     if(!node->get_macro()) {

--- a/src/language/templates/visitors/lookup_visitor.cpp
+++ b/src/language/templates/visitors/lookup_visitor.cpp
@@ -20,7 +20,7 @@ void AstLookupVisitor::visit_{{ node.class_name|snake_case }}({{ node.class_name
     if(std::find(types.begin(), types.end(), type) != types.end()) {
         nodes.push_back(node->get_shared_ptr());
     }
-    node->visit_children(this);
+    node->visit_children(*this);
 }
 
 {% endfor %}
@@ -29,7 +29,7 @@ void AstLookupVisitor::visit_{{ node.class_name|snake_case }}({{ node.class_name
 std::vector<std::shared_ptr<ast::Ast>> AstLookupVisitor::lookup(Ast* node, std::vector<AstNodeType>& _types) {
     nodes.clear();
     types = _types;
-    node->accept(this);
+    node->accept(*this);
     return nodes;
 }
 
@@ -37,13 +37,13 @@ std::vector<std::shared_ptr<ast::Ast>> AstLookupVisitor::lookup(Ast* node, AstNo
     nodes.clear();
     types.clear();
     types.push_back(type);
-    node->accept(this);
+    node->accept(*this);
     return nodes;
 }
 
 std::vector<std::shared_ptr<ast::Ast>> AstLookupVisitor::lookup(Ast* node) {
     nodes.clear();
-    node->accept(this);
+    node->accept(*this);
     return nodes;
 }
 

--- a/src/language/templates/visitors/nmodl_visitor.cpp
+++ b/src/language/templates/visitors/nmodl_visitor.cpp
@@ -69,7 +69,7 @@ using namespace ast;
         printer->add_element(op);
     {% else %}
         {% call guard(child.prefix, child.suffix) %}
-        node->get_{{ child.varname }}(){{ "->" if child.is_pointer_node else "." }}accept(this);
+        node->get_{{ child.varname }}(){{ "->" if child.is_pointer_node else "." }}accept(*this);
         {% endcall %}
     {%- endif %}
 {%- endmacro -%}

--- a/src/visitors/constant_folder_visitor.cpp
+++ b/src/visitors/constant_folder_visitor.cpp
@@ -76,7 +76,7 @@ static double compute(double lhs, ast::BinaryOp op, double rhs) {
  *  parenthesis_exp => binary_expression => ...
  */
 void ConstantFolderVisitor::visit_paren_expression(ast::ParenExpression* node) {
-    node->visit_children(this);
+    node->visit_children(*this);
     auto expr = node->get_expression();
     if (expr->is_wrapped_expression()) {
         auto e = std::dynamic_pointer_cast<ast::WrappedExpression>(expr);
@@ -105,7 +105,7 @@ void ConstantFolderVisitor::visit_paren_expression(ast::ParenExpression* node) {
  * }
  */
 void ConstantFolderVisitor::visit_wrapped_expression(ast::WrappedExpression* node) {
-    node->visit_children(this);
+    node->visit_children(*this);
 
     /// first expression which is wrapped
     auto expr = node->get_expression();

--- a/src/visitors/defuse_analyze_visitor.cpp
+++ b/src/visitors/defuse_analyze_visitor.cpp
@@ -183,7 +183,7 @@ DUState DUChain::eval() {
 
 void DefUseAnalyzeVisitor::visit_unsupported_node(ast::Node* node) {
     unsupported_node = true;
-    node->visit_children(this);
+    node->visit_children(*this);
     unsupported_node = false;
 }
 
@@ -196,7 +196,7 @@ void DefUseAnalyzeVisitor::visit_function_call(ast::FunctionCall* node) {
     std::string function_name = node->get_node_name();
     auto symbol = global_symtab->lookup_in_scope(function_name);
     if (symbol == nullptr || symbol->is_external_variable()) {
-        node->visit_children(this);
+        node->visit_children(*this);
     } else {
         visit_unsupported_node(node);
     }
@@ -209,7 +209,7 @@ void DefUseAnalyzeVisitor::visit_statement_block(ast::StatementBlock* node) {
     }
 
     symtab_stack.push(current_symtab);
-    node->visit_children(this);
+    node->visit_children(*this);
     symtab_stack.pop();
     current_symtab = symtab_stack.top();
 }
@@ -218,11 +218,11 @@ void DefUseAnalyzeVisitor::visit_statement_block(ast::StatementBlock* node) {
  *  and hence not necessary to keep track of assignment operator using stack.
  */
 void DefUseAnalyzeVisitor::visit_binary_expression(ast::BinaryExpression* node) {
-    node->get_rhs()->visit_children(this);
+    node->get_rhs()->visit_children(*this);
     if (node->get_op().get_value() == ast::BOP_ASSIGN) {
         visiting_lhs = true;
     }
-    node->get_lhs()->visit_children(this);
+    node->get_lhs()->visit_children(*this);
     visiting_lhs = false;
 }
 
@@ -237,10 +237,10 @@ void DefUseAnalyzeVisitor::visit_if_statement(ast::IfStatement* node) {
     /// visiting if sub-block
     auto last_chain = current_chain;
     start_new_chain(DUState::IF);
-    node->get_condition()->accept(this);
+    node->get_condition()->accept(*this);
     auto block = node->get_statement_block();
     if (block) {
-        block->accept(this);
+        block->accept(*this);
     }
     current_chain = last_chain;
 
@@ -322,7 +322,7 @@ void DefUseAnalyzeVisitor::process_variable(const std::string& name, int index) 
 void DefUseAnalyzeVisitor::visit_with_new_chain(ast::Node* node, DUState state) {
     auto last_chain = current_chain;
     start_new_chain(state);
-    node->visit_children(this);
+    node->visit_children(*this);
     current_chain = last_chain;
 }
 
@@ -344,7 +344,7 @@ DUChain DefUseAnalyzeVisitor::analyze(ast::Ast* node, const std::string& name) {
 
     /// analyze given node
     symtab_stack.push(current_symtab);
-    node->visit_children(this);
+    node->visit_children(*this);
     symtab_stack.pop();
 
     return usage;

--- a/src/visitors/inline_visitor.cpp
+++ b/src/visitors/inline_visitor.cpp
@@ -94,7 +94,7 @@ void InlineVisitor::inline_arguments(StatementBlock* inlined_block,
 
         /// variables in cloned block needs to be renamed
         RenameVisitor visitor(old_name, new_name);
-        inlined_block->visit_children(&visitor);
+        inlined_block->visit_children(visitor);
 
         auto lhs = new VarName(name->clone(), nullptr, nullptr);
         auto rhs = caller_expressions.at(counter)->clone();
@@ -159,7 +159,7 @@ bool InlineVisitor::inline_function_call(ast::Block* callee,
     /// function definition has function name as return value. we have to rename
     /// it with new variable name
     RenameVisitor visitor(function_name, new_varname);
-    inlined_block->visit_children(&visitor);
+    inlined_block->visit_children(visitor);
 
     /// \todo Have to re-run symtab visitor pass to update symbol table
     inlined_block->set_symbol_table(nullptr);
@@ -189,7 +189,7 @@ bool InlineVisitor::inline_function_call(ast::Block* callee,
 
 void InlineVisitor::visit_function_call(FunctionCall* node) {
     /// argument can be function call itself
-    node->visit_children(this);
+    node->visit_children(*this);
 
     std::string function_name = node->get_name()->get_node_name();
     auto symbol = program_symtab->lookup_in_scope(function_name);
@@ -205,7 +205,7 @@ void InlineVisitor::visit_function_call(FunctionCall* node) {
     }
 
     /// first inline called function
-    function_definition->visit_children(this);
+    function_definition->visit_children(*this);
 
     bool inlined = false;
 
@@ -244,7 +244,7 @@ void InlineVisitor::visit_statement_block(StatementBlock* node) {
     for (auto& statement: statements) {
         caller_statement = statement;
         statement_stack.push(statement);
-        caller_statement->visit_children(this);
+        caller_statement->visit_children(*this);
         statement_stack.pop();
     }
 
@@ -293,7 +293,7 @@ void InlineVisitor::visit_statement_block(StatementBlock* node) {
  *  also replaced with new variable node from the inlining result.
  */
 void InlineVisitor::visit_wrapped_expression(WrappedExpression* node) {
-    node->visit_children(this);
+    node->visit_children(*this);
     auto e = node->get_expression();
     if (e->is_function_call()) {
         auto expression = static_cast<FunctionCall*>(e.get());
@@ -309,7 +309,7 @@ void InlineVisitor::visit_program(Program* node) {
     if (program_symtab == nullptr) {
         throw std::runtime_error("Program node doesn't have symbol table");
     }
-    node->visit_children(this);
+    node->visit_children(*this);
 }
 
 }  // namespace visitor

--- a/src/visitors/kinetic_block_visitor.cpp
+++ b/src/visitors/kinetic_block_visitor.cpp
@@ -115,7 +115,7 @@ void KineticBlockVisitor::visit_conserve(ast::Conserve* node) {
 
     in_conserve_statement = true;
     // construct equation to replace ODE in conserve_equation_str
-    node->visit_children(this);
+    node->visit_children(*this);
     in_conserve_statement = false;
 
     conserve_equation_str = to_nmodl(node->get_expr().get()) + conserve_equation_str;
@@ -273,7 +273,7 @@ void KineticBlockVisitor::visit_reaction_statement(ast::ReactionStatement* node)
     // add the corresponding integer to the new row in the matrix
     in_reaction_statement = true;
     in_reaction_statement_lhs = true;
-    node->visit_children(this);
+    node->visit_children(*this);
     in_reaction_statement = false;
 
     // generate fluxes
@@ -334,13 +334,13 @@ void KineticBlockVisitor::visit_wrapped_expression(ast::WrappedExpression* node)
             node->set_expression(std::move(expr));
         }
     }
-    node->visit_children(this);
+    node->visit_children(*this);
 }
 
 void KineticBlockVisitor::visit_statement_block(ast::StatementBlock* node) {
     auto prev_statement_block = current_statement_block;
     current_statement_block = node;
-    node->visit_children(this);
+    node->visit_children(*this);
     // remove processed statements from current statement block
     remove_statements_from_block(current_statement_block, statements_to_remove);
     current_statement_block = prev_statement_block;
@@ -363,7 +363,7 @@ void KineticBlockVisitor::visit_kinetic_block(ast::KineticBlock* node) {
     i_statement = 0;
 
     // construct stoichiometric matrices and fluxes
-    node->visit_children(this);
+    node->visit_children(*this);
 
     // number of reaction statements
     int Ni = static_cast<int>(rate_eqs.k_f.size());
@@ -461,7 +461,7 @@ void KineticBlockVisitor::visit_program(ast::Program* node) {
     }
 
     // replace reaction statements within each kinetic block with equivalent ODEs
-    node->visit_children(this);
+    node->visit_children(*this);
 
     // change KINETIC blocks -> DERIVATIVE blocks
     auto blocks = node->get_blocks();

--- a/src/visitors/local_var_rename_visitor.cpp
+++ b/src/visitors/local_var_rename_visitor.cpp
@@ -34,7 +34,7 @@ void LocalVarRenameVisitor::visit_statement_block(ast::StatementBlock* node) {
 
     // first need to process all children : perform recursively from innermost block
     for (const auto& item: node->get_statements()) {
-        item->visit_children(this);
+        item->visit_children(*this);
     }
 
     /// go back to previous block in hierarchy

--- a/src/visitors/loop_unroll_visitor.cpp
+++ b/src/visitors/loop_unroll_visitor.cpp
@@ -55,7 +55,7 @@ class IndexRemover: public AstVisitor {
     }
 
     virtual void visit_binary_expression(ast::BinaryExpression* node) override {
-        node->visit_children(this);
+        node->visit_children(*this);
         if (under_indexed_name) {
             /// first recursively replaces childrens
             /// replace lhs & rhs if they have matching index variable
@@ -68,7 +68,7 @@ class IndexRemover: public AstVisitor {
 
     virtual void visit_indexed_name(ast::IndexedName* node) override {
         under_indexed_name = true;
-        node->visit_children(this);
+        node->visit_children(*this);
         /// once all children are replaced, do the same for index
         auto length = replace_for_name(node->get_length());
         node->set_length(std::move(length));
@@ -137,7 +137,7 @@ static std::shared_ptr<ast::ExpressionStatement> unroll_for_loop(
  * Parse verbatim blocks and rename variable if it is used.
  */
 void LoopUnrollVisitor::visit_statement_block(ast::StatementBlock* node) {
-    node->visit_children(this);
+    node->visit_children(*this);
 
     for (auto iter = node->statements.begin(); iter != node->statements.end(); iter++) {
         if ((*iter)->is_from_statement()) {

--- a/src/visitors/neuron_solve_visitor.cpp
+++ b/src/visitors/neuron_solve_visitor.cpp
@@ -30,14 +30,14 @@ void NeuronSolveVisitor::visit_solve_block(ast::SolveBlock* node) {
 void NeuronSolveVisitor::visit_derivative_block(ast::DerivativeBlock* node) {
     derivative_block_name = node->get_name()->get_node_name();
     derivative_block = true;
-    node->visit_children(this);
+    node->visit_children(*this);
     derivative_block = false;
 }
 
 
 void NeuronSolveVisitor::visit_diff_eq_expression(ast::DiffEqExpression* node) {
     differential_equation = true;
-    node->visit_children(this);
+    node->visit_children(*this);
     differential_equation = false;
 }
 
@@ -100,7 +100,7 @@ void NeuronSolveVisitor::visit_binary_expression(ast::BinaryExpression* node) {
 
 void NeuronSolveVisitor::visit_program(ast::Program* node) {
     program_symtab = node->get_symbol_table();
-    node->visit_children(this);
+    node->visit_children(*this);
 }
 
 }  // namespace visitor

--- a/src/visitors/nmodl_visitor_helper.ipp
+++ b/src/visitors/nmodl_visitor_helper.ipp
@@ -33,7 +33,7 @@ void NmodlPrintVisitor::visit_element(const std::vector<T>& elements,
             printer->add_indent();
         }
 
-        (*iter)->accept(this);
+        (*iter)->accept(*this);
 
         /// print separator (e.g. comma, space)
         if (!separator.empty() && !utils::is_last(iter, elements)) {

--- a/src/visitors/perf_visitor.cpp
+++ b/src/visitors/perf_visitor.cpp
@@ -97,12 +97,12 @@ void PerfVisitor::visit_binary_expression(ast::BinaryExpression* node) {
         visiting_lhs_expression = true;
     }
 
-    node->get_lhs()->accept(this);
+    node->get_lhs()->accept(*this);
 
     /// lhs is done (rhs is read only)
     visiting_lhs_expression = false;
 
-    node->get_rhs()->accept(this);
+    node->get_rhs()->accept(*this);
 }
 
 /// add performance stats to json printer
@@ -124,7 +124,7 @@ void PerfVisitor::add_perf_to_printer(PerfStat& perf) {
 void PerfVisitor::measure_performance(ast::Ast* node) {
     start_measurement = true;
 
-    node->visit_children(this);
+    node->visit_children(*this);
 
     PerfStat perf;
     while (!children_blocks_perf.empty()) {
@@ -176,7 +176,7 @@ void PerfVisitor::visit_function_call(ast::FunctionCall* node) {
         } else if (name == "pow") {
             current_block_perf.n_pow++;
         }
-        node->visit_children(this);
+        node->visit_children(*this);
 
         auto symbol = current_symtab->lookup_in_scope(name);
         auto method_property = NmodlType::procedure_block | NmodlType::function_block;
@@ -193,26 +193,26 @@ void PerfVisitor::visit_function_call(ast::FunctionCall* node) {
 /// every variable used is of type name, update counters
 void PerfVisitor::visit_name(ast::Name* node) {
     update_memory_ops(node->get_node_name());
-    node->visit_children(this);
+    node->visit_children(*this);
 }
 
 /// prime name derived from identifier and hence need to be handled here
 void PerfVisitor::visit_prime_name(ast::PrimeName* node) {
     update_memory_ops(node->get_node_name());
-    node->visit_children(this);
+    node->visit_children(*this);
 }
 
 void PerfVisitor::visit_if_statement(ast::IfStatement* node) {
     if (start_measurement) {
         current_block_perf.n_if++;
-        node->visit_children(this);
+        node->visit_children(*this);
     }
 }
 
 void PerfVisitor::visit_else_if_statement(ast::ElseIfStatement* node) {
     if (start_measurement) {
         current_block_perf.n_elif++;
-        node->visit_children(this);
+        node->visit_children(*this);
     }
 }
 
@@ -318,7 +318,7 @@ void PerfVisitor::visit_program(ast::Program* node) {
         printer->push_block("BlockPerf");
     }
 
-    node->visit_children(this);
+    node->visit_children(*this);
     std::string title = "Total Performance Statistics";
     total_perf.title = title;
     total_perf.print(stream);
@@ -353,7 +353,7 @@ void PerfVisitor::visit_statement_block(ast::StatementBlock* node) {
     /// new block perf starts from zero
     current_block_perf = PerfStat();
 
-    node->visit_children(this);
+    node->visit_children(*this);
 
     /// add performance of all visited children
     total_perf = total_perf + current_block_perf;
@@ -371,7 +371,7 @@ void PerfVisitor::visit_statement_block(ast::StatementBlock* node) {
 /// statement block (in theory)
 void PerfVisitor::visit_solve_block(ast::SolveBlock* node) {
     under_solve_block = true;
-    node->visit_children(this);
+    node->visit_children(*this);
     under_solve_block = false;
 }
 
@@ -391,7 +391,7 @@ void PerfVisitor::visit_unary_expression(ast::UnaryExpression* node) {
             throw std::logic_error("Unary operator not handled in perf visitor");
         }
     }
-    node->visit_children(this);
+    node->visit_children(*this);
 }
 
 /** Certain statements / symbols needs extra check while measuring

--- a/src/visitors/rename_visitor.cpp
+++ b/src/visitors/rename_visitor.cpp
@@ -27,7 +27,7 @@ void RenameVisitor::visit_name(ast::Name* node) {
  * by parser. To be safe we are only renaming prime variable.
  */
 void RenameVisitor::visit_prime_name(ast::PrimeName* node) {
-    node->visit_children(this);
+    node->visit_children(*this);
 }
 
 /**

--- a/src/visitors/solve_block_visitor.cpp
+++ b/src/visitors/solve_block_visitor.cpp
@@ -15,7 +15,7 @@ namespace visitor {
 
 void SolveBlockVisitor::visit_breakpoint_block(ast::BreakpointBlock* node) {
     in_breakpoint_block = true;
-    node->visit_children(this);
+    node->visit_children(*this);
     in_breakpoint_block = false;
 }
 
@@ -64,7 +64,7 @@ ast::SolutionExpression* SolveBlockVisitor::create_solution_expression(
  * @param node Ast node for SOLVE statement in the mod file
  */
 void SolveBlockVisitor::visit_expression_statement(ast::ExpressionStatement* node) {
-    node->visit_children(this);
+    node->visit_children(*this);
     if (node->get_expression()->is_solve_block()) {
         auto solve_block = dynamic_cast<ast::SolveBlock*>(node->get_expression().get());
         auto sol_expr = create_solution_expression(solve_block);
@@ -78,7 +78,7 @@ void SolveBlockVisitor::visit_expression_statement(ast::ExpressionStatement* nod
 
 void SolveBlockVisitor::visit_program(ast::Program* node) {
     symtab = node->get_symbol_table();
-    node->visit_children(this);
+    node->visit_children(*this);
     /// add new node NrnState with solve blocks from breakpoint block
     if (!nrn_state_solve_statements.empty()) {
         auto nrn_state = new ast::NrnStateBlock(nrn_state_solve_statements);

--- a/src/visitors/sympy_conductance_visitor.cpp
+++ b/src/visitors/sympy_conductance_visitor.cpp
@@ -41,7 +41,7 @@ using symtab::syminfo::NmodlType;
  */
 static bool conductance_statement_possible(ast::BreakpointBlock* node) {
     AstLookupVisitor v({AstNodeType::IF_STATEMENT, AstNodeType::VERBATIM});
-    node->accept(&v);
+    node->accept(v);
     return v.get_nodes().empty();
 }
 
@@ -216,7 +216,7 @@ void SympyConductanceVisitor::visit_breakpoint_block(ast::BreakpointBlock* node)
     }
     // visit BREAKPOINT block statements
     under_breakpoint_block = true;
-    node->visit_children(this);
+    node->visit_children(*this);
     under_breakpoint_block = false;
 
     // lookup USEION and NONSPECIFIC statements from NEURON block
@@ -249,7 +249,7 @@ void SympyConductanceVisitor::visit_program(ast::Program* node) {
     use_ion_nodes = ast_lookup_visitor.lookup(node, AstNodeType::USEION);
     nonspecific_nodes = ast_lookup_visitor.lookup(node, AstNodeType::NONSPECIFIC);
 
-    node->visit_children(this);
+    node->visit_children(*this);
 }
 
 }  // namespace visitor

--- a/src/visitors/sympy_solver_visitor.cpp
+++ b/src/visitors/sympy_solver_visitor.cpp
@@ -532,7 +532,7 @@ void SympySolverVisitor::visit_derivative_block(ast::DerivativeBlock* node) {
     // visit each differential equation:
     //  - for CNEXP or EULER, each equation is independent & is replaced with its solution
     //  - otherwise, each equation is added to eq_system
-    node->visit_children(this);
+    node->visit_children(*this);
 
     if (eq_system_is_valid && !eq_system.empty()) {
         // solve system of ODEs in eq_system
@@ -596,7 +596,7 @@ void SympySolverVisitor::visit_lin_equation(ast::LinEquation* node) {
     last_expression_statement = current_expression_statement;
     logger->debug("SympySolverVisitor :: adding linear eq: {}", lin_eq);
     collect_state_vars = true;
-    node->visit_children(this);
+    node->visit_children(*this);
     collect_state_vars = false;
 }
 
@@ -607,7 +607,7 @@ void SympySolverVisitor::visit_linear_block(ast::LinearBlock* node) {
     init_block_data(node);
 
     // collect linear equations
-    node->visit_children(this);
+    node->visit_children(*this);
 
     if (eq_system_is_valid && !eq_system.empty()) {
         solve_linear_system();
@@ -624,7 +624,7 @@ void SympySolverVisitor::visit_non_lin_equation(ast::NonLinEquation* node) {
     last_expression_statement = current_expression_statement;
     logger->debug("SympySolverVisitor :: adding non-linear eq: {}", non_lin_eq);
     collect_state_vars = true;
-    node->visit_children(this);
+    node->visit_children(*this);
     collect_state_vars = false;
 }
 
@@ -635,7 +635,7 @@ void SympySolverVisitor::visit_non_linear_block(ast::NonLinearBlock* node) {
     init_block_data(node);
 
     // collect non-linear equations
-    node->visit_children(this);
+    node->visit_children(*this);
 
     if (eq_system_is_valid && !eq_system.empty()) {
         solve_non_linear_system();
@@ -645,14 +645,14 @@ void SympySolverVisitor::visit_non_linear_block(ast::NonLinearBlock* node) {
 void SympySolverVisitor::visit_expression_statement(ast::ExpressionStatement* node) {
     auto prev_expression_statement = current_expression_statement;
     current_expression_statement = node;
-    node->visit_children(this);
+    node->visit_children(*this);
     current_expression_statement = prev_expression_statement;
 }
 
 void SympySolverVisitor::visit_statement_block(ast::StatementBlock* node) {
     auto prev_statement_block = current_statement_block;
     current_statement_block = node;
-    node->visit_children(this);
+    node->visit_children(*this);
     current_statement_block = prev_statement_block;
 }
 
@@ -696,7 +696,7 @@ void SympySolverVisitor::visit_program(ast::Program* node) {
         }
     }
 
-    node->visit_children(this);
+    node->visit_children(*this);
 }
 
 }  // namespace visitor

--- a/src/visitors/symtab_visitor_helper.hpp
+++ b/src/visitors/symtab_visitor_helper.hpp
@@ -127,7 +127,7 @@ void SymtabVisitor::setup_symbol(ast::Node* node, NmodlType property) {
 
     /// visit children, most likely variables are already
     /// leaf nodes, not necessary to visit
-    node->visit_children(this);
+    node->visit_children(*this);
 }
 
 
@@ -187,7 +187,7 @@ void SymtabVisitor::setup_symbol_table(ast::Ast* node, const std::string& name, 
     }
 
     /// look for all children blocks recursively
-    node->visit_children(this);
+    node->visit_children(*this);
 
     /// existing nmodl block
     modsymtab->leave_scope();

--- a/src/visitors/units_visitor.cpp
+++ b/src/visitors/units_visitor.cpp
@@ -22,7 +22,7 @@ namespace visitor {
 
 void UnitsVisitor::visit_program(ast::Program* node) {
     units_driver.parse_file(units_dir);
-    node->visit_children(this);
+    node->visit_children(*this);
 }
 
 /**

--- a/src/visitors/var_usage_visitor.cpp
+++ b/src/visitors/var_usage_visitor.cpp
@@ -24,7 +24,7 @@ void VarUsageVisitor::visit_name(ast::Name* node) {
 bool VarUsageVisitor::variable_used(ast::Node* node, std::string name) {
     used = false;
     var_name = std::move(name);
-    node->visit_children(this);
+    node->visit_children(*this);
     return used;
 }
 

--- a/src/visitors/verbatim_var_rename_visitor.cpp
+++ b/src/visitors/verbatim_var_rename_visitor.cpp
@@ -29,7 +29,7 @@ void VerbatimVarRenameVisitor::visit_statement_block(ast::StatementBlock* node) 
 
     // first need to process all children : perform recursively from innermost block
     for (const auto& item: node->get_statements()) {
-        item->accept(this);
+        item->accept(*this);
     }
 
     /// go back to previous block in hierarchy

--- a/src/visitors/visitor_utils.cpp
+++ b/src/visitors/visitor_utils.cpp
@@ -165,7 +165,7 @@ bool calls_function(ast::Ast* node, const std::string& name) {
 std::string to_nmodl(ast::Ast* node, const std::set<ast::AstNodeType>& exclude_types) {
     std::stringstream stream;
     visitor::NmodlPrintVisitor v(stream, exclude_types);
-    node->accept(&v);
+    node->accept(v);
     return stream.str();
 }
 
@@ -176,7 +176,7 @@ std::string to_json(ast::Ast* node, bool compact, bool expand, bool add_nmodl) {
     v.compact_json(compact);
     v.add_nmodl(add_nmodl);
     v.expand_keys(expand);
-    node->accept(&v);
+    node->accept(v);
     v.flush();
     return stream.str();
 }

--- a/test/visitor/lookup.cpp
+++ b/test/visitor/lookup.cpp
@@ -65,7 +65,7 @@ SCENARIO("Searching for ast nodes using AstLookupVisitor", "[visitor][lookup]") 
 
             THEN("Can find NEURON block") {
                 AstLookupVisitor v(AstNodeType::NEURON_BLOCK);
-                ast->accept(&v);
+                ast->accept(v);
                 auto nodes = v.get_nodes();
                 REQUIRE(nodes.size() == 1);
 


### PR DESCRIPTION
This is a first attempt to make the use of pointers and references more consistent and clean. For now we replace some raw pointer access with references, especially when working with the visitors.
In a future PR we should address the many unnecessary shared_ptr and replace them with unique_ptr and consider accessing elements only by reference when the receiver does not participate in the object's lifetime.