### PR TITLE
Use the newly introduced function in coreneuron to set net_receive

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -2656,7 +2656,7 @@ void CodegenCVisitor::print_mechanism_register() {
             method_name("net_buf_receive")));
     }
     if (info.num_net_receive_parameters != 0) {
-        auto net_recv_init_arg = "NULL";
+        auto net_recv_init_arg = "nullptr";
         if (info.net_receive_initial_node != nullptr) {
             net_recv_init_arg = "net_init";
         }

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -2656,11 +2656,13 @@ void CodegenCVisitor::print_mechanism_register() {
             method_name("net_buf_receive")));
     }
     if (info.num_net_receive_parameters != 0) {
-        printer->add_line("pnt_receive[mech_type] = {};"_format(method_name("net_receive")));
-        printer->add_line("pnt_receive_size[mech_type] = num_net_receive_args();");
+        auto net_recv_init_arg = "NULL";
         if (info.net_receive_initial_node != nullptr) {
-            printer->add_line("pnt_receive_init[mech_type] = net_init;");
+            net_recv_init_arg = "net_init";
         }
+        auto pnt_recline = "set_pnt_receive(mech_type, {}, {}, num_net_receive_args());"_format(
+            method_name("net_receive"), net_recv_init_arg);
+        printer->add_line(pnt_recline);
     }
     if (info.net_event_used || info.net_send_used) {
         printer->add_line("hoc_register_net_send_buffering(mech_type);");


### PR DESCRIPTION
This is necessary because we want to for now keep generated code free of
the more complex changes of data encapsulation in coreneuron.

This PR follows
https://github.com/BlueBrain/CoreNeuron/pull/203