### PR TITLE
Directly construct *Visitors instead of constructing and assigning #171

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ addons:
       - boost
       - cmake
       - python@3
+      update: true
 
 #=============================================================================
 # Install dependencies / setup Spack

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -56,9 +56,9 @@ void CodegenIspcVisitor::visit_var_name(ast::VarName* node) {
     if (!codegen) {
         return;
     }
-    auto celsius_rename = RenameVisitor("celsius", "ispc_celsius");
+    RenameVisitor celsius_rename("celsius", "ispc_celsius");
     node->accept(celsius_rename);
-    auto pi_rename = RenameVisitor("PI", "ISPC_PI");
+    RenameVisitor pi_rename("PI", "ISPC_PI");
     node->accept(pi_rename);
     CodegenCVisitor::visit_var_name(node);
 }
@@ -641,7 +641,7 @@ void CodegenIspcVisitor::print_backend_compute_routine_decl() {
 }
 
 void CodegenIspcVisitor::determine_target() {
-    auto node_lv = AstLookupVisitor(incompatible_node_types);
+    AstLookupVisitor node_lv(incompatible_node_types);
 
     if (info.initial_node) {
         emit_fallback[BlockType::Initial] =
@@ -679,7 +679,7 @@ void CodegenIspcVisitor::move_procs_to_wrapper() {
     auto nameset = std::set<std::string>();
 
     auto populate_nameset = [&nameset](ast::Block* block) {
-        auto name_lv = AstLookupVisitor(ast::AstNodeType::NAME);
+        AstLookupVisitor name_lv(ast::AstNodeType::NAME);
         if (block) {
             auto names = name_lv.lookup(block);
             for (const auto& name: names) {
@@ -691,7 +691,7 @@ void CodegenIspcVisitor::move_procs_to_wrapper() {
     populate_nameset(info.nrn_state_block);
     populate_nameset(info.breakpoint_node);
 
-    auto node_lv = AstLookupVisitor(incompatible_node_types);
+    AstLookupVisitor node_lv(incompatible_node_types);
     auto target_procedures = std::vector<ast::ProcedureBlock*>();
     for (auto it = info.procedures.begin(); it != info.procedures.end(); it++) {
         auto procname = (*it)->get_name()->get_node_name();

--- a/src/lexer/modl.h
+++ b/src/lexer/modl.h
@@ -20,7 +20,7 @@
  */
 
 /// bit masks for block types where integration method are used
-#define DERF 01000
-#define KINF 02000
-#define LINF 0200000
+#define DERF  01000
+#define KINF  02000
+#define LINF  0200000
 #define NLINF 04000

--- a/src/visitors/sympy_solver_visitor.cpp
+++ b/src/visitors/sympy_solver_visitor.cpp
@@ -44,7 +44,7 @@ void SympySolverVisitor::init_block_data(ast::Node* node) {
             vars.insert(var_name);
         }
     }
-    auto lv = AstLookupVisitor(ast::AstNodeType::FUNCTION_CALL);
+    AstLookupVisitor lv(ast::AstNodeType::FUNCTION_CALL);
     for (const auto& call: lv.lookup(node->get_statement_block().get())) {
         function_calls.insert(call->get_node_name());
     }

--- a/src/visitors/visitor_utils.cpp
+++ b/src/visitors/visitor_utils.cpp
@@ -150,7 +150,7 @@ std::set<std::string> get_global_vars(Program* node) {
 
 
 bool calls_function(ast::Ast* node, const std::string& name) {
-    auto lv = AstLookupVisitor(ast::AstNodeType::FUNCTION_CALL);
+    AstLookupVisitor lv(ast::AstNodeType::FUNCTION_CALL);
     for (const auto& f: lv.lookup(node)) {
         if (std::dynamic_pointer_cast<ast::FunctionCall>(f)->get_node_name() == name) {
             return true;

--- a/test/lexer/tokens.cpp
+++ b/test/lexer/tokens.cpp
@@ -75,7 +75,9 @@ TokenType token_type(const std::string& name) {
         break;
     }
 
-    default: { auto value = sym.value.as<ModToken>(); }
+    default: {
+        auto value = sym.value.as<ModToken>();
+    }
     }
 
     return token;


### PR DESCRIPTION
- i.e.: "auto lv = AstLookupVisitor(bla bla)" ->
        "AstLookupVisitor lv(bla bla)"
- "make clang-format cmake-format" slightly changed 2 more files