### PR TITLE
Fix incompatibility with Bison >= 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,10 @@ addons:
   # for Mac builds, we use Homebrew
   homebrew:
     packages:
-      - flex
+      - bison
       - boost
       - cmake
+      - flex
       - python@3
     update: true
 
@@ -56,15 +57,12 @@ addons:
 # Install dependencies / setup Spack
 #=============================================================================
 before_install:
-  # default bison in homebrew is now 3.5 but nmodl currently does not build with bison 3.5
   # brew installed flex and bison is not in $PATH
   # unlink python2 and use python3 as it's required for nmodl
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
         export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
         brew unlink python@2;
         brew link --overwrite python;
-        curl -L "https://homebrew.bintray.com/bottles/bison-3.4.2.mojave.bottle.tar.gz" -o bison-3.4.2.mojave.bottle.tar.gz;
-        brew install file://$(pwd)/bison-3.4.2.mojave.bottle.tar.gz;
     else
         pyenv global $PYTHON_VERSION;
         ls /usr/bin/;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,10 +35,7 @@ jobs:
   - checkout: self
     submodules: true
   - script: |
-      brew install flex cmake python@3
-      # default bison in homebrew is now 3.5 but nmodl currently does not build with bison 3.5
-      curl -L "https://homebrew.bintray.com/bottles/bison-3.4.2.mojave.bottle.tar.gz" -o bison-3.4.2.mojave.bottle.tar.gz
-      brew install file://$(pwd)/bison-3.4.2.mojave.bottle.tar.gz
+      brew install flex bison cmake python@3
       python3 -m pip install -U pip setuptools
       python3 -m pip install --user 'Jinja2>=2.9.3' 'PyYAML>=3.13' pytest 'sympy>=1.3'
     displayName: 'Install Depdendencies'

--- a/src/lexer/main_c.cpp
+++ b/src/lexer/main_c.cpp
@@ -25,7 +25,7 @@
 
 using namespace fmt::literals;
 using namespace nmodl;
-
+using Token = parser::CParser::token;
 
 void scan_c_code(std::istream& in) {
     nmodl::parser::CDriver driver;
@@ -34,8 +34,8 @@ void scan_c_code(std::istream& in) {
     /// parse C file and print token until EOF
     while (true) {
         auto sym = scanner.next_token();
-        auto token = sym.token();
-        if (token == nmodl::parser::CParser::token::END) {
+        auto token_type = sym.type_get();
+        if (token_type == parser::CParser::by_type(Token::END).type_get()) {
             break;
         }
         std::cout << sym.value.as<std::string>() << std::endl;

--- a/src/lexer/main_nmodl.cpp
+++ b/src/lexer/main_nmodl.cpp
@@ -45,73 +45,64 @@ void tokenize(const std::string& mod_text) {
     /// lexer instance with stream to read-in tokens
     NmodlLexer scanner(driver, &in);
 
+    auto get_token_type = [](TokenType token) {
+        return parser::NmodlParser::by_type(token).type_get();
+    };
+
     /// parse nmodl text and print token until EOF
     while (true) {
         SymbolType sym = scanner.next_token();
-        TokenType token = sym.token();
+        auto token_type = sym.type_get();
 
-        if (token == Token::END) {
+        if (token_type == get_token_type(Token::END)) {
             break;
         }
 
-        /** Lexer returns different ast types base on token type. We
+        /**
+         * Lexer returns different ast types base on token type. We
          * retrieve token object from each instance and print it.
-         * Note that value is of ast type i.e. ast::Name* etc. */
-        switch (token) {
+         * Note that value is of ast type i.e. ast::Name* etc.
+         */
         /// token with name ast class
-        case Token::NAME:
-        case Token::METHOD:
-        case Token::SUFFIX:
-        case Token::VALENCE:
-        case Token::DEL:
-        case Token::DEL2: {
+        if (token_type == get_token_type(Token::NAME) ||
+            token_type == get_token_type(Token::METHOD) ||
+            token_type == get_token_type(Token::SUFFIX) ||
+            token_type == get_token_type(Token::VALENCE) ||
+            token_type == get_token_type(Token::DEL) || token_type == get_token_type(Token::DEL2)) {
             auto value = sym.value.as<ast::Name>();
             std::cout << *(value.get_token()) << std::endl;
-            break;
         }
-
         /// token with prime ast class
-        case Token::PRIME: {
+        else if (token_type == get_token_type(Token::PRIME)) {
             auto value = sym.value.as<ast::PrimeName>();
             std::cout << *(value.get_token()) << std::endl;
-            break;
         }
-
         /// token with integer ast class
-        case Token::INTEGER: {
+        else if (token_type == get_token_type(Token::INTEGER)) {
             auto value = sym.value.as<ast::Integer>();
             std::cout << *(value.get_token()) << std::endl;
-            break;
         }
-
         /// token with double/float ast class
-        case Token::REAL: {
+        else if (token_type == get_token_type(Token::REAL)) {
             auto value = sym.value.as<ast::Double>();
             std::cout << *(value.get_token()) << std::endl;
-            break;
         }
-
         /// token with string ast class
-        case Token::STRING: {
+        else if (token_type == get_token_type(Token::STRING)) {
             auto value = sym.value.as<ast::String>();
             std::cout << *(value.get_token()) << std::endl;
-            break;
         }
-
         /// token with string data type
-        case Token::VERBATIM:
-        case Token::BLOCK_COMMENT:
-        case Token::LINE_PART: {
+        else if (token_type == get_token_type(Token::VERBATIM) ||
+                 token_type == get_token_type(Token::BLOCK_COMMENT) ||
+                 token_type == get_token_type(Token::LINE_PART)) {
             auto str = sym.value.as<std::string>();
             std::cout << str << std::endl;
-            break;
         }
-
         /// all remaining tokens has ModToken* as a vaue
-        default: {
+        else {
             auto token = sym.value.as<ModToken>();
             std::cout << token << std::endl;
-        }
         }
     }
 }

--- a/src/lexer/main_units.cpp
+++ b/src/lexer/main_units.cpp
@@ -22,6 +22,7 @@
 
 using namespace fmt::literals;
 using namespace nmodl;
+using Token = parser::UnitParser::token;
 
 int main(int argc, const char* argv[]) {
     CLI::App app{"Unit-Lexer : Standalone Lexer for Units({})"_format(Version::to_string())};
@@ -42,8 +43,8 @@ int main(int argc, const char* argv[]) {
         /// parse Units file and print token until EOF
         while (true) {
             auto sym = scanner.next_token();
-            auto token = sym.token();
-            if (token == nmodl::parser::UnitParser::token::END) {
+            auto token_type = sym.type_get();
+            if (token_type == parser::UnitParser::by_type(Token::END).type_get()) {
                 break;
             }
             std::cout << sym.value.as<std::string>() << std::endl;

--- a/src/parser/c11_driver.cpp
+++ b/src/parser/c11_driver.cpp
@@ -69,8 +69,8 @@ void CDriver::scan_string(std::string& text) {
     this->parser = &parser;
     while (true) {
         auto sym = lexer->next_token();
-        auto token = sym.token();
-        if (token == CParser::token::END) {
+        auto token_type = sym.type_get();
+        if (token_type == CParser::by_type(CParser::token::END).type_get()) {
             break;
         }
     }

--- a/src/parser/diffeq_context.cpp
+++ b/src/parser/diffeq_context.cpp
@@ -77,8 +77,8 @@ std::string DiffEqContext::get_expr_for_nonlinear() {
     /// scan entire expression
     while (true) {
         auto sym = scanner.next_token();
-        auto token = sym.token();
-        if (token == DiffeqParser::token::END) {
+        auto token_type = sym.type_get();
+        if (token_type == DiffeqParser::by_type(DiffeqParser::token::END).type_get()) {
             break;
         }
         /// extract value of the token and check if it is a token

--- a/src/parser/unit_driver.cpp
+++ b/src/parser/unit_driver.cpp
@@ -64,8 +64,8 @@ void UnitDriver::scan_string(std::string& text) {
     this->parser = &parser;
     while (true) {
         auto sym = lexer->next_token();
-        auto token = sym.token();
-        if (token == UnitParser::token::END) {
+        auto token_type = sym.type_get();
+        if (token_type == UnitParser::by_type(UnitParser::token::END).type_get()) {
             break;
         }
     }

--- a/src/parser/verbatim.yy
+++ b/src/parser/verbatim.yy
@@ -20,7 +20,7 @@
 %}
 
 /** print out verbose error instead of just message 'syntax error' */
-%error-verbose
+%define parse.error verbose
 
 /** make a reentrant parser */
 %pure-parser

--- a/test/lexer/tokens.cpp
+++ b/test/lexer/tokens.cpp
@@ -23,8 +23,9 @@ using Token = NmodlParser::token;
 using TokenType = NmodlParser::token_type;
 using SymbolType = NmodlParser::symbol_type;
 
-/// just retrieve token type from lexer
-TokenType token_type(const std::string& name) {
+
+/// retrieve token type from lexer and check if it's of given type
+bool check_token_type(const std::string& name, TokenType type) {
     std::istringstream ss(name);
     std::istream& in = ss;
 
@@ -32,104 +33,112 @@ TokenType token_type(const std::string& name) {
     NmodlLexer scanner(driver, &in);
 
     SymbolType sym = scanner.next_token();
-    TokenType token = sym.token();
+    int token_type = sym.type_get();
 
-    /** Lexer returns raw pointers for some AST types
+    auto get_token_type = [](TokenType token) {
+        return parser::NmodlParser::by_type(token).type_get();
+    };
+
+    /**
+     * Lexer returns raw pointers for some AST types
      * and we need to clean-up memory for those.
-     * Todo: add tests later for checking values */
-    switch (token) {
-    case Token::NAME:
-    case Token::METHOD:
-    case Token::SUFFIX:
-    case Token::VALENCE:
-    case Token::DEL:
-    case Token::DEL2: {
+     * Todo: add tests later for checking values
+     */
+    // clang-format off
+    if (token_type == get_token_type(Token::NAME) ||
+        token_type == get_token_type(Token::METHOD) ||
+        token_type == get_token_type(Token::SUFFIX) ||
+        token_type == get_token_type(Token::VALENCE) ||
+        token_type == get_token_type(Token::DEL) ||
+        token_type == get_token_type(Token::DEL2)) {
         auto value = sym.value.as<ast::Name>();
-        break;
+        REQUIRE(value.get_node_name() != "");
     }
-
-    case Token::PRIME: {
+    // clang-format on
+    // prime variable
+    else if (token_type == get_token_type(Token::PRIME)) {
         auto value = sym.value.as<ast::PrimeName>();
-        break;
+        REQUIRE(value.get_node_name() != "");
     }
-
-    case Token::INTEGER: {
+    // integer constant
+    else if (token_type == get_token_type(Token::INTEGER)) {
         auto value = sym.value.as<ast::Integer>();
-        break;
+        REQUIRE(value.get_value() != 0);
     }
-
-    case Token::REAL: {
+    // float constant
+    else if (token_type == get_token_type(Token::REAL)) {
         auto value = sym.value.as<ast::Double>();
-        break;
+        REQUIRE(value.get_value() != 0);
     }
-
-    case Token::STRING: {
+    // const char*
+    else if (token_type == get_token_type(Token::STRING)) {
         auto value = sym.value.as<ast::String>();
-        break;
+        REQUIRE(value.get_value() != "");
     }
-
-    case Token::VERBATIM:
-    case Token::BLOCK_COMMENT:
-    case Token::LINE_PART: {
+    // string block representation verbatim or block comment
+    else if (token_type == get_token_type(Token::VERBATIM) ||
+             token_type == get_token_type(Token::BLOCK_COMMENT) ||
+             token_type == get_token_type(Token::LINE_PART)) {
         auto value = sym.value.as<std::string>();
-        break;
+        REQUIRE(value != "");
     }
-
-    default: {
+    // rest of the tokens
+    else {
         auto value = sym.value.as<ModToken>();
-    }
+        REQUIRE(value.text() != "");
     }
 
-    return token;
+    return sym.type_get() == get_token_type(type);
 }
 
 TEST_CASE("NMODL Lexer returning valid token types", "[Lexer]") {
     SECTION("Some keywords") {
-        REQUIRE(token_type("VERBATIM Hello ENDVERBATIM") == Token::VERBATIM);
-        REQUIRE(token_type("INITIAL") == Token::INITIAL1);
-        REQUIRE(token_type("SOLVE") == Token::SOLVE);
+        REQUIRE(check_token_type("VERBATIM Hello ENDVERBATIM", Token::VERBATIM));
+        REQUIRE(check_token_type("INITIAL", Token::INITIAL1));
+        REQUIRE(check_token_type("SOLVE", Token::SOLVE));
     }
 
     SECTION("NMODL language keywords and constructs") {
-        REQUIRE(token_type(" h' = (hInf-h)/hTau\n") == Token::PRIME);
-        REQUIRE(token_type("while") == Token::WHILE);
-        REQUIRE(token_type("if") == Token::IF);
-        REQUIRE(token_type("else") == Token::ELSE);
-        REQUIRE(token_type("WHILE") == Token::WHILE);
-        REQUIRE(token_type("IF") == Token::IF);
-        REQUIRE(token_type("ELSE") == Token::ELSE);
-        REQUIRE(token_type("REPRESENTS NCIT:C17145") == Token::REPRESENTS);
+        REQUIRE(check_token_type(" h' = (hInf-h)/hTau\n", Token::PRIME));
+        REQUIRE(check_token_type("while", Token::WHILE));
+        REQUIRE(check_token_type("if", Token::IF));
+        REQUIRE(check_token_type("else", Token::ELSE));
+        REQUIRE(check_token_type("WHILE", Token::WHILE));
+        REQUIRE(check_token_type("IF", Token::IF));
+        REQUIRE(check_token_type("ELSE", Token::ELSE));
+        REQUIRE(check_token_type("REPRESENTS NCIT:C17145", Token::REPRESENTS));
     }
 
     SECTION("Different number types") {
-        REQUIRE(token_type("123") == Token::INTEGER);
-        REQUIRE(token_type("123.32") == Token::REAL);
-        REQUIRE(token_type("1.32E+3") == Token::REAL);
-        REQUIRE(token_type("1.32e-3") == Token::REAL);
-        REQUIRE(token_type("32e-3") == Token::REAL);
-        REQUIRE(token_type("1e+23") == Token::REAL);
-        REQUIRE(token_type("1e-23") == Token::REAL);
+        REQUIRE(check_token_type("123", Token::INTEGER));
+        REQUIRE(check_token_type("123.32", Token::REAL));
+        REQUIRE(check_token_type("1.32E+3", Token::REAL));
+        REQUIRE(check_token_type("1.32e-3", Token::REAL));
+        REQUIRE(check_token_type("32e-3", Token::REAL));
+        REQUIRE(check_token_type("1e+23", Token::REAL));
+        REQUIRE(check_token_type("1e-23", Token::REAL));
+        REQUIRE_FALSE(check_token_type("124.11", Token::INTEGER));
     }
 
     SECTION("Name/Strings types") {
-        REQUIRE(token_type("neuron") == Token::NAME);
-        REQUIRE(token_type("\"Quoted String\"") == Token::STRING);
+        REQUIRE(check_token_type("neuron", Token::NAME));
+        REQUIRE(check_token_type("\"Quoted String\"", Token::STRING));
     }
 
     SECTION("Logical operator types") {
-        REQUIRE(token_type(">") == Token::GT);
-        REQUIRE(token_type(">=") == Token::GE);
-        REQUIRE(token_type("<") == Token::LT);
-        REQUIRE(token_type("==") == Token::EQ);
-        REQUIRE(token_type("!=") == Token::NE);
-        REQUIRE(token_type("<->") == Token::REACT1);
-        REQUIRE(token_type("~+") == Token::NONLIN1);
+        REQUIRE(check_token_type(">", Token::GT));
+        REQUIRE(check_token_type(">=", Token::GE));
+        REQUIRE(check_token_type("<", Token::LT));
+        REQUIRE(check_token_type("==", Token::EQ));
+        REQUIRE(check_token_type("!=", Token::NE));
+        REQUIRE(check_token_type("<->", Token::REACT1));
+        REQUIRE(check_token_type("~+", Token::NONLIN1));
     }
 
     SECTION("Brace types") {
-        REQUIRE(token_type("{") == Token::OPEN_BRACE);
-        REQUIRE(token_type("}") == Token::CLOSE_BRACE);
-        REQUIRE(token_type("(") == Token::OPEN_PARENTHESIS);
-        REQUIRE(token_type(")") != Token::OPEN_PARENTHESIS);
+        REQUIRE(check_token_type("{", Token::OPEN_BRACE));
+        REQUIRE(check_token_type("}", Token::CLOSE_BRACE));
+        REQUIRE(check_token_type("(", Token::OPEN_PARENTHESIS));
+        REQUIRE_FALSE(check_token_type(")", Token::OPEN_PARENTHESIS));
     }
 }

--- a/test/units/lexer.cpp
+++ b/test/units/lexer.cpp
@@ -22,50 +22,51 @@ using Token = UnitParser::token;
 using TokenType = UnitParser::token_type;
 using SymbolType = UnitParser::symbol_type;
 
-/// just retrieve token type from lexer
-TokenType token_type(const std::string& name) {
+/// retrieve token type from lexer and check if it's of given type
+bool check_token_type(const std::string& name, TokenType type) {
     std::istringstream ss(name);
     std::istream& in = ss;
 
     UnitDriver driver;
     UnitLexer scanner(driver, &in);
-    return scanner.next_token().token();
+    auto symbol = scanner.next_token();
+    return symbol.type_get() == UnitParser::by_type(type).type_get();
 }
 
 TEST_CASE("Unit Lexer tests for valid tokens", "[lexer][unit]") {
     SECTION("Tests for comments") {
-        REQUIRE(token_type("/ comment") == Token::COMMENT);
-        REQUIRE(token_type("/comment") == Token::COMMENT);
+        REQUIRE(check_token_type("/ comment", Token::COMMENT));
+        REQUIRE(check_token_type("/comment", Token::COMMENT));
     }
 
     SECTION("Tests for doubles") {
-        REQUIRE(token_type("27.52") == Token::DOUBLE);
-        REQUIRE(token_type("1.01325+5") == Token::DOUBLE);
-        REQUIRE(token_type("1") == Token::DOUBLE);
-        REQUIRE(token_type("-1.324e+10") == Token::DOUBLE);
-        REQUIRE(token_type("1-1") == Token::DOUBLE);
-        REQUIRE(token_type("1|100") == Token::FRACTION);
-        REQUIRE(token_type(".03") == Token::DOUBLE);
-        REQUIRE(token_type("12345e-2") == Token::DOUBLE);
-        REQUIRE(token_type("1|8.988e9") == Token::FRACTION);
+        REQUIRE(check_token_type("27.52", Token::DOUBLE));
+        REQUIRE(check_token_type("1.01325+5", Token::DOUBLE));
+        REQUIRE(check_token_type("1", Token::DOUBLE));
+        REQUIRE(check_token_type("-1.324e+10", Token::DOUBLE));
+        REQUIRE(check_token_type("1-1", Token::DOUBLE));
+        REQUIRE(check_token_type("1|100", Token::FRACTION));
+        REQUIRE(check_token_type(".03", Token::DOUBLE));
+        REQUIRE(check_token_type("12345e-2", Token::DOUBLE));
+        REQUIRE(check_token_type("1|8.988e9", Token::FRACTION));
     }
 
     SECTION("Tests for units") {
-        REQUIRE(token_type("*a*") == Token::BASE_UNIT);
-        REQUIRE(token_type("*k*") == Token::INVALID_BASE_UNIT);
-        REQUIRE(token_type("planck") == Token::NEW_UNIT);
-        REQUIRE(token_type("mse-1") == Token::NEW_UNIT);
-        REQUIRE(token_type("mA/cm2") == Token::NEW_UNIT);
-        REQUIRE(token_type(" m2") == Token::UNIT_POWER);
-        REQUIRE(token_type(" m") == Token::UNIT);
-        REQUIRE(token_type(" m_2") == Token::UNIT);
-        REQUIRE(token_type(" m_unit2") == Token::UNIT);
-        REQUIRE(token_type("yotta-") == Token::PREFIX);
+        REQUIRE(check_token_type("*a*", Token::BASE_UNIT));
+        REQUIRE(check_token_type("*k*", Token::INVALID_BASE_UNIT));
+        REQUIRE(check_token_type("planck", Token::NEW_UNIT));
+        REQUIRE(check_token_type("mse-1", Token::NEW_UNIT));
+        REQUIRE(check_token_type("mA/cm2", Token::NEW_UNIT));
+        REQUIRE(check_token_type(" m2", Token::UNIT_POWER));
+        REQUIRE(check_token_type(" m", Token::UNIT));
+        REQUIRE(check_token_type(" m_2", Token::UNIT));
+        REQUIRE(check_token_type(" m_unit2", Token::UNIT));
+        REQUIRE(check_token_type("yotta-", Token::PREFIX));
     }
 
     SECTION("Tests for special characters") {
-        REQUIRE(token_type("-") == Token::UNIT_PROD);
-        REQUIRE(token_type(" / ") == Token::DIVISION);
-        REQUIRE(token_type("\n") == Token::NEWLINE);
+        REQUIRE(check_token_type("-", Token::UNIT_PROD));
+        REQUIRE(check_token_type(" / ", Token::DIVISION));
+        REQUIRE(check_token_type("\n", Token::NEWLINE));
     }
 }


### PR DESCRIPTION
  - bison 3.5 released symbol_type::token () removed
  - we use c++ parsers with variant semantic values and
    symbol_type::token was used for unit testing as well
    as to decide if next token is EoF.
  - now we have to use symbol_type.type_get() and by_type(yytokentype)
    to compare the tokens
  - all comparisons with switch cases need to be converted
    to if-else because of non-constexpr by_type() function
    call (bison without C++17)
  - see bison bug report for details :
    https://lists.gnu.org/archive/html/bug-bison/2020-01/msg00001.html
  - remove older bison installation for CI

fixes #251