### PR TITLE
Remove the jinja macro "override(node)"

### DIFF
--- a/src/ast/ast_common.hpp
+++ b/src/ast/ast_common.hpp
@@ -18,7 +18,6 @@
 #include <memory>
 #include <string>
 
-
 #include "ast/ast_decl.hpp"
 #include "lexer/modtoken.hpp"
 #include "symtab/symbol_table.hpp"

--- a/src/ast/ast_common.hpp
+++ b/src/ast/ast_common.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 
+
 #include "ast/ast_decl.hpp"
 #include "lexer/modtoken.hpp"
 #include "symtab/symbol_table.hpp"

--- a/src/language/templates/ast/ast.hpp
+++ b/src/language/templates/ast/ast.hpp
@@ -32,10 +32,7 @@
     {% if node.is_abstract %} virtual {% endif %}
 {% endmacro %}
 
-{# add override qualifier if node is not an abstract class #}
-{% macro override(node) %}
-    {% if not node.is_abstract %} override {% endif %}
-{% endmacro %}
+
 
 
 namespace nmodl {
@@ -202,7 +199,7 @@ namespace ast {
          *
          * @return pointer to token if exist otherwise nullptr
          */
-        {{ virtual(node) }}ModToken* get_token(){{ override(node) }} {
+        {{ virtual(node) }}ModToken* get_token() override {
             return token.get();
         }
         {% endif %}
@@ -258,7 +255,7 @@ namespace ast {
          *
          * \sa Ast::get_node_type_name Ast::get_node_name
          */
-        {{ virtual(node) }}void set_name(std::string name){{ override(node) }} {
+        {{ virtual(node) }}void set_name(std::string name) {
             value->set(name);
         }
         {% endif %}

--- a/src/language/templates/ast/ast.hpp
+++ b/src/language/templates/ast/ast.hpp
@@ -255,7 +255,7 @@ namespace ast {
          *
          * \sa Ast::get_node_type_name Ast::get_node_name
          */
-        {{ virtual(node) }}void set_name(std::string name) {
+        {{ virtual(node) }}void set_name(std::string name) override {
             value->set(name);
         }
         {% endif %}
@@ -389,4 +389,3 @@ namespace ast {
 
 }  // namespace ast
 }  // namespace nmodl
-


### PR DESCRIPTION
override(node) is a macro to add override only where needed and
copied from virtual(node). However, override is required also
for derived classes were virtual is not needed (we do not want
a virtual table). It was used only for get_token and set_name,
2 methods that are in ast_commons and, thus, must be always
overridden. For these reasons override is actually superflous
and does not print "override" for LinearBlock where it should
(because LinearBlock is a virtual class still). Removing it
and hardcoding override in the 2 functions erases the problem
and simplifies the code.