### PR TITLE
Fixes for integrating sympy based solvers with CoreNEURON

### DIFF
--- a/src/nmodl/CMakeLists.txt
+++ b/src/nmodl/CMakeLists.txt
@@ -11,6 +11,11 @@ add_executable(nmodl ${NMODL_SOURCE_FILES})
 target_link_libraries(nmodl printer codegen visitor symtab util lexer)
 
 # =============================================================================
+# Add dependency with nmodl pytnon module (for consumer projects)
+# =============================================================================
+add_dependencies(nmodl _nmodl)
+
+# =============================================================================
 # Install executable
 # =============================================================================
 install(TARGETS nmodl DESTINATION bin)

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -55,7 +55,7 @@ add_custom_command(OUTPUT ${NMODL_PYTHON_FILES_OUT}
 # =============================================================================
 # Copy python binding components into build directory
 # =============================================================================
-file(GLOB NMODL_PYTHON_HELPER_FILES "${PROJECT_BINARY_DIR}/nmodl/*.py")
+file(GLOB NMODL_PYTHON_HELPER_FILES "${NMODL_PROJECT_SOURCE_DIR}/nmodl/*.py")
 file(COPY ${NMODL_PYTHON_HELPER_FILES} DESTINATION ${CMAKE_BINARY_DIR}/lib/python/nmodl/)
 
 # =============================================================================

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -56,9 +56,9 @@ add_custom_command(OUTPUT ${NMODL_PYTHON_FILES_OUT}
 # Copy python binding components into build directory
 # =============================================================================
 file(GLOB NMODL_PYTHON_HELPER_FILES "${PROJECT_BINARY_DIR}/nmodl/*.py")
-file(COPY ${NMODL_PYTHON_HELPER_FILES} DESTINATION ${CMAKE_BINARY_DIR}/lib/python/)
+file(COPY ${NMODL_PYTHON_HELPER_FILES} DESTINATION ${CMAKE_BINARY_DIR}/lib/python/nmodl/)
 
 # =============================================================================
 # Install python binding components
 # =============================================================================
-install(DIRECTORY ${CMAKE_BINARY_DIR}/lib DESTINATION lib)
+install(DIRECTORY ${CMAKE_BINARY_DIR}/lib/ DESTINATION lib)

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -3,6 +3,9 @@
 # =============================================================================
 set_source_files_properties(${AUTO_GENERATED_FILES} PROPERTIES GENERATED TRUE)
 
+# build nmodl python module under lib/python/nmodl
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/python/nmodl)
+
 foreach(file ast.py dsl.py ode.py symtab.py visitor.py __init__.py)
   list(APPEND NMODL_PYTHON_FILES_IN ${NMODL_PROJECT_SOURCE_DIR}/nmodl/${file})
   list(APPEND NMODL_PYTHON_FILES_OUT ${PROJECT_BINARY_DIR}/nmodl/${file})
@@ -50,7 +53,12 @@ add_custom_command(OUTPUT ${NMODL_PYTHON_FILES_OUT}
                    COMMENT "-- COPYING NMODL PYTHON FILES --")
 
 # =============================================================================
+# Copy python binding components into build directory
+# =============================================================================
+file(GLOB NMODL_PYTHON_HELPER_FILES "${PROJECT_BINARY_DIR}/nmodl/*.py")
+file(COPY ${NMODL_PYTHON_HELPER_FILES} DESTINATION ${CMAKE_BINARY_DIR}/lib/python/)
+
+# =============================================================================
 # Install python binding components
 # =============================================================================
-install(TARGETS _nmodl DESTINATION lib/python/nmodl)
-install(DIRECTORY ${PROJECT_BINARY_DIR}/nmodl DESTINATION lib/python/ FILES_MATCHING PATTERN "*.py")
+install(DIRECTORY ${CMAKE_BINARY_DIR}/lib DESTINATION lib)

--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -8,9 +8,12 @@ set(SOLVER_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/newton/newton.hpp)
 # =============================================================================
 
 # =============================================================================
-# Install headers
+# Install solver headers and Eigen dependency headers
 # =============================================================================
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/newton
         DESTINATION include
         FILES_MATCHING
         PATTERN "*.h*")
+
+install(DIRECTORY ${NMODL_PROJECT_SOURCE_DIR}/ext/eigen/Eigen
+        DESTINATION include)

--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -4,16 +4,13 @@
 set(SOLVER_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/newton/newton.hpp)
 
 # =============================================================================
-# Solver target for dependencies (only headers for now)
+# Copy necessary headers to build directory
 # =============================================================================
+file(GLOB NMODL_SOLVER_HEADER_FILES "${CMAKE_CURRENT_SOURCE_DIR}/newton/*.h*")
+file(COPY ${NMODL_SOLVER_HEADER_FILES} DESTINATION ${CMAKE_BINARY_DIR}/include/newton/)
+file(COPY ${NMODL_PROJECT_SOURCE_DIR}/ext/eigen/Eigen DESTINATION ${CMAKE_BINARY_DIR}/include/)
 
 # =============================================================================
-# Install solver headers and Eigen dependency headers
+# Install solver headers and eigen from include
 # =============================================================================
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/newton
-        DESTINATION include
-        FILES_MATCHING
-        PATTERN "*.h*")
-
-install(DIRECTORY ${NMODL_PROJECT_SOURCE_DIR}/ext/eigen/Eigen
-        DESTINATION include)
+install(DIRECTORY ${CMAKE_BINARY_DIR}/include DESTINATION include)

--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -13,4 +13,4 @@ file(COPY ${NMODL_PROJECT_SOURCE_DIR}/ext/eigen/Eigen DESTINATION ${CMAKE_BINARY
 # =============================================================================
 # Install solver headers and eigen from include
 # =============================================================================
-install(DIRECTORY ${CMAKE_BINARY_DIR}/include DESTINATION include)
+install(DIRECTORY ${CMAKE_BINARY_DIR}/include/ DESTINATION include)


### PR DESCRIPTION
* Install newton solver and related header dependencies
* Build libraries and prepare headers in CMAKE_BINARY_DIR
