### PR TITLE
Bugfix: CONSERVE statement OUTSIDE of a KINETIC block -> seg. fault

### DIFF
--- a/src/visitors/kinetic_block_visitor.hpp
+++ b/src/visitors/kinetic_block_visitor.hpp
@@ -109,6 +109,9 @@ class KineticBlockVisitor: public AstVisitor {
     /// true if we are visiting a CONSERVE statement
     bool in_conserve_statement = false;
 
+    /// true if we are visiting a KINETIC block
+    bool in_kinetic_block = false;
+
     /// conserve statement equation as string
     std::string conserve_equation_str;
 


### PR DESCRIPTION
Related to [issue 280](https://github.com/BlueBrain/nmodl/issues/280)

Solution: added a flag in the KineticBlockVisitor that inhibit
visit_* functions in case we are not visiting a kinetic block.