### PR TITLE
sanity: remove backticks, default to $(…)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ install:
 script:
   - echo "------- Build, Test and Install -------"
   - mkdir build && cd build
-  - cmake .. -DPYTHON_EXECUTABLE=`which python3` -DCMAKE_INSTALL_PREFIX=$HOME/nmodl
+  - cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl
   - make -j 2
   - make test
   - make install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
       mkdir -p $(Build.Repository.LocalPath)/build
       cd $(Build.Repository.LocalPath)/build
       cmake --version 
-      cmake .. -DPYTHON_EXECUTABLE=`which python3.7` -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=Release
+      cmake .. -DPYTHON_EXECUTABLE=$(which python3.7) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=Release
       make -j 2
       make test
     env:
@@ -51,7 +51,7 @@ jobs:
       export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
       mkdir -p $(Build.Repository.LocalPath)/build
       cd $(Build.Repository.LocalPath)/build
-      cmake .. -DPYTHON_EXECUTABLE=`which python3` -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo
       make -j 2
       make test
     displayName: 'Build and Run Tests'

--- a/docker/recipe/entrypoint
+++ b/docker/recipe/entrypoint
@@ -14,7 +14,7 @@ if [ "x$GROUP_ID" = x -o "x$USER_ID" = x ] ;then
 fi
 
 # Create fake user
-CUR_GROUP=`grep ":${GROUP_ID}:" /etc/group | cut -d: -f1`
+CUR_GROUP=$(grep ":${GROUP_ID}:" /etc/group | cut -d: -f1)
 if [ "x$CUR_GROUP" != x ] ;then
     groupmod --new-name dummy "$CUR_GROUP"
 else


### PR DESCRIPTION
This is POSIX compatible, should work everywhere and is cleaner to
read/modify since it is a proper delimiter and can be nested.