### PR TITLE
CONSERVE statements processing (issues #280, #284)

### DIFF
--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -356,7 +356,13 @@ int main(int argc, const char* argv[]) {
             logger->info("Running KINETIC block visitor");
             KineticBlockVisitor().visit_program(ast.get());
             SymtabVisitor(update_symtab).visit_program(ast.get());
-            ast_to_nmodl(ast.get(), filepath("kinetic"));
+            const auto filename = filepath("kinetic");
+            ast_to_nmodl(ast.get(), filename);
+            if (nmodl_ast) {
+                logger->warn(
+                    "{} may present non-standard CONSERVE statements in DERIVATIVE blocks. In this case, use it only for debugging/developing"_format(
+                        filename));
+            }
         }
 
         {

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -354,13 +354,14 @@ int main(int argc, const char* argv[]) {
         /// in global scope
         {
             logger->info("Running KINETIC block visitor");
-            KineticBlockVisitor().visit_program(ast.get());
+            auto kineticBlockVisitor = KineticBlockVisitor();
+            kineticBlockVisitor.visit_program(ast.get());
             SymtabVisitor(update_symtab).visit_program(ast.get());
             const auto filename = filepath("kinetic");
             ast_to_nmodl(ast.get(), filename);
-            if (nmodl_ast) {
+            if (nmodl_ast && kineticBlockVisitor.get_conserve_statement_count()) {
                 logger->warn(
-                    "{} may present non-standard CONSERVE statements in DERIVATIVE blocks. In this case, use it only for debugging/developing"_format(
+                    "{} presents non-standard CONSERVE statements in DERIVATIVE blocks. Use it only for debugging/developing"_format(
                         filename));
             }
         }

--- a/src/visitors/kinetic_block_visitor.cpp
+++ b/src/visitors/kinetic_block_visitor.cpp
@@ -12,6 +12,7 @@
 #include "utils/logger.hpp"
 #include "utils/string_utils.hpp"
 #include "visitor_utils.hpp"
+#include "visitors/lookup_visitor.hpp"
 
 
 namespace nmodl {
@@ -365,7 +366,7 @@ void KineticBlockVisitor::visit_kinetic_block(ast::KineticBlock* node) {
     additive_terms = std::vector<std::string>(state_var_count);
     i_statement = 0;
 
-    // construct stoichiometric matrices and fluxes
+    // construct stochiometric matrices and fluxes
     node->visit_children(*this);
 
     // number of reaction statements
@@ -463,8 +464,13 @@ void KineticBlockVisitor::visit_program(ast::Program* node) {
         }
     }
 
+    auto kineticBlockNodes = AstLookupVisitor().lookup(node, ast::AstNodeType::KINETIC_BLOCK);
     // replace reaction statements within each kinetic block with equivalent ODEs
-    node->visit_children(*this);
+    for (const auto& ii: kineticBlockNodes) {
+        ii->accept(*this);
+    }
+
+    //    node->visit_children(*this);
 
     // change KINETIC blocks -> DERIVATIVE blocks
     auto blocks = node->get_blocks();

--- a/src/visitors/kinetic_block_visitor.cpp
+++ b/src/visitors/kinetic_block_visitor.cpp
@@ -470,8 +470,6 @@ void KineticBlockVisitor::visit_program(ast::Program* node) {
         ii->accept(*this);
     }
 
-    //    node->visit_children(*this);
-
     // change KINETIC blocks -> DERIVATIVE blocks
     auto blocks = node->get_blocks();
     for (auto* kinetic_block: kinetic_blocks) {

--- a/src/visitors/kinetic_block_visitor.cpp
+++ b/src/visitors/kinetic_block_visitor.cpp
@@ -102,6 +102,7 @@ std::shared_ptr<ast::Expression> create_expr(const std::string& str_expr) {
 }
 
 void KineticBlockVisitor::visit_conserve(ast::Conserve* node) {
+    ++conserve_statement_count;
     // rewrite CONSERVE statement in form x = ...
     // where x was the last state var on LHS, and whose ODE should later be replaced with this
     // equation note: CONSERVE statement "implicitly takes into account COMPARTMENT factors on LHS"
@@ -429,6 +430,7 @@ void KineticBlockVisitor::visit_kinetic_block(ast::KineticBlock* node) {
 }
 
 void KineticBlockVisitor::visit_program(ast::Program* node) {
+    conserve_statement_count = 0;
     statements_to_remove.clear();
     current_statement_block = nullptr;
 

--- a/src/visitors/kinetic_block_visitor.hpp
+++ b/src/visitors/kinetic_block_visitor.hpp
@@ -109,6 +109,9 @@ class KineticBlockVisitor: public AstVisitor {
     /// true if we are visiting a CONSERVE statement
     bool in_conserve_statement = false;
 
+    /// counts the number of CONSERVE statements in Kinetic blocks
+    int conserve_statement_count = 0;
+
     /// conserve statement equation as string
     std::string conserve_equation_str;
 
@@ -132,6 +135,9 @@ class KineticBlockVisitor: public AstVisitor {
 
   public:
     KineticBlockVisitor() = default;
+    inline int get_conserve_statement_count() const {
+        return conserve_statement_count;
+    }
 
     void visit_wrapped_expression(ast::WrappedExpression* node) override;
     void visit_reaction_operator(ast::ReactionOperator* node) override;


### PR DESCRIPTION
- Bugfix (issue #284): conserve statements in derivative blocks are not corrupt anymore
- Bugfix (issue #280): KineticBlockVisitor visits only kinetic blocks (no more seg. fault)
- Added a warning to enlight the user that the nmodl printed in between the KineticBlockVisitor and the SympyBlockVisitor, in presence of CONSERVE statements, is not standard (for example it does not work in mod2c). It should be used only for debugging/developing