### PR TITLE
Bug fix for setup.py install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ import sysconfig
 from distutils.version import LooseVersion
 
 from distutils.cmd import Command
+from distutils.dir_util import copy_tree
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 from setuptools.command.test import test
@@ -113,6 +114,9 @@ class CMakeBuild(build_ext):
         subprocess.check_call(
             ["cmake", "--build", "."] + build_args, cwd=self.build_temp
         )
+
+        # copy nmodl module with shared library to extension directory
+        copy_tree(os.path.join(self.build_temp, 'nmodl'), extdir)
 
 class NMODLTest(test):
     """Custom disutils command that acts like as a replacement


### PR DESCRIPTION
  - python setup.py was installing nmodl module with
    all python files but not shared library
  - it was working fine in the past but somewhere distutils
     behaviour changed? Anyway, use build/nmodl directory
     where we built complete nmodl module and copy that to
     extension directory

@ramcdougal : could you please checkout this branch and re-execute `python setup.py install` or `pip install` and see if you see shared library module is correctly copied?

On my Mac I see:

```
$ python3.7 setup.py install --home=/Users/kumbhar/nmodl-install-37
....

$ → tree /Users/kumbhar/nmodl-install-37
/Users/kumbhar/nmodl-install-37
├── bin
│   └── isympy
└── lib
    └── python
        └── NMODL-0.2-py3.7-macosx-10.9-x86_64.egg
            ├── EGG-INFO
            │   ├── PKG-INFO
            │   ├── SOURCES.txt
            │   ├── dependency_links.txt
            │   ├── native_libs.txt
            │   ├── not-zip-safe
            │   ├── requires.txt
            │   └── top_level.txt
            └── nmodl
                ├── __init__.py
                ├── __init__.pyc
                ├── __pycache__
                │   ├── __init__.cpython-37.pyc
                │   ├── ast.cpython-37.pyc
                │   ├── config.cpython-37.pyc
                │   ├── dsl.cpython-37.pyc
                │   ├── ode.cpython-37.pyc
                │   ├── symtab.cpython-37.pyc
                │   └── visitor.cpython-37.pyc
                ├── _nmodl.cpython-37m-darwin.so
                ├── ast.py
                ├── config.py
                ├── dsl.py
                ├── ext
                │   ├── example
                │   │   ├── exp2syn.mod
                │   │   ├── expsyn.mod
                │   │   ├── hh.mod
                │   │   └── passive.mod
                │   └── viz
                │       ├── css
                │       │   └── tree.css
                │       ├── index.html
                │       └── js
                │           ├── d3.min.js
                │           └── tree.js
                ├── ode.py
                ├── symtab.py
                └── visitor.py

12 directories, 33 files
```