### PR TITLE
First attempt to develop an override checker in jinja2 templates

### DIFF
--- a/src/language/code_generator.py
+++ b/src/language/code_generator.py
@@ -58,8 +58,11 @@ if clang_format_file.exists():
 
 env = jinja2.Environment(loader=jinja2.FileSystemLoader(str(templates_dir)),
                          trim_blocks=True,
-                         lstrip_blocks=True)
+                         lstrip_blocks=True,
+                         extensions=['jinja2.ext.do'])
+
 env.filters['snake_case'] = utils.to_snake_case
+env.globals['inherit_signatures'] = utils.inherit_signatures
 
 updated_files = []
 

--- a/src/language/code_generator.py
+++ b/src/language/code_generator.py
@@ -62,7 +62,7 @@ env = jinja2.Environment(loader=jinja2.FileSystemLoader(str(templates_dir)),
                          extensions=['jinja2.ext.do'])
 
 env.filters['snake_case'] = utils.to_snake_case
-env.globals['inherit_signatures'] = utils.inherit_signatures
+env.globals['inherit_member_signatures'] = utils.inherit_member_signatures
 
 updated_files = []
 

--- a/src/language/nodes.py
+++ b/src/language/nodes.py
@@ -279,7 +279,7 @@ class ChildNode(BaseNode):
                 """
 
         if self.is_base_type_node:
-            signature = check_override(class_name, f"""void {setter_method}({setter_type} {self.varname})""", node_members_signatures)
+            signature = check_override(f"""void {setter_method}({setter_type} {self.varname})""", class_name, node_members_signatures)
             return f"""
                        /**
                         * \\brief Setter for member variable \\ref {class_name}.{self.varname}
@@ -287,14 +287,14 @@ class ChildNode(BaseNode):
                        {signature} {body}
                     """
         else:
-            signature_rvalue = check_override(class_name, f"""void {setter_method}({setter_type}&& {self.varname})""", node_members_signatures)
-            signature = check_override(class_name, f"""void {setter_method}({setter_type}& {self.varname})""", node_members_signatures)
+            signature_rvalue = check_override(f"""void {setter_method}({setter_type}&& {self.varname})""", class_name, node_members_signatures)
+            signature = check_override(f"""void {setter_method}(const {setter_type}& {self.varname})""", class_name, node_members_signatures)
             return f"""
                        /**
                         * \\brief Setter for member variable \\ref {class_name}.{self.varname} (rvalue reference)
                         */
                        {signature_rvalue} {body}
-                       
+
                        /**
                         * \\brief Setter for member variable \\ref {class_name}.{self.varname}
                         */

--- a/src/language/templates/ast/ast.hpp
+++ b/src/language/templates/ast/ast.hpp
@@ -33,7 +33,7 @@
 {% endmacro %}
 
 
-
+{% set node_members_signatures = {} %}
 
 namespace nmodl {
 namespace ast {
@@ -51,6 +51,9 @@ namespace ast {
      * {{- node.get_description() -}}
      */
     class {{ node.class_name }} : public {{ node.base_class }} {
+
+    {% do inherit_signatures(node.class_name, node.base_class, node_members_signatures) %}
+
     {% if node.private_members() %}
       private:
         {% for member in node.private_members() %}
@@ -72,6 +75,8 @@ namespace ast {
         {{ member[0] }} {{ member[1] }} = {{ member[2] }};
         {% endif %}
         {% endfor %}
+
+
 
 
         /// \name Ctor & dtor
@@ -295,7 +300,7 @@ namespace ast {
 
         {# doxygen for these methods is handled by nodes.py #}
         {% for child in node.children %}
-        {{ child.get_setter_method(node.class_name) }}
+        {{ child.get_setter_method(node.class_name, node_members_signatures) }}
         {% endfor %}
 
         /// \}

--- a/src/language/templates/ast/ast.hpp
+++ b/src/language/templates/ast/ast.hpp
@@ -52,7 +52,7 @@ namespace ast {
      */
     class {{ node.class_name }} : public {{ node.base_class }} {
 
-    {% do inherit_signatures(node.class_name, node.base_class, node_members_signatures) %}
+    {% do inherit_member_signatures(node.class_name, node.base_class, node_members_signatures) %}
 
     {% if node.private_members() %}
       private:

--- a/src/language/utils.py
+++ b/src/language/utils.py
@@ -18,3 +18,22 @@ def camel_case_to_underscore(name):
 def to_snake_case(name):
     """convert string from 'AaaBbbbCccDdd' -> 'aaa_bbbb_ccc_ddd'"""
     return camel_case_to_underscore(name).lower()
+
+
+def check_override(node_name, signature, node_members_signatures):
+    add = ""
+    if node_name in node_members_signatures :
+        # print(node_members_signatures[node_name])
+        if signature in node_members_signatures[node_name]:
+
+            add = " override "
+        else:
+            node_members_signatures[node_name].add(signature)
+    else :
+        node_members_signatures[node_name] = {signature}
+
+    return signature + add
+
+def inherit_signatures(child, parent, node_members_signatures):
+    if parent in node_members_signatures :
+        node_members_signatures[child] = node_members_signatures[parent]

--- a/src/language/utils.py
+++ b/src/language/utils.py
@@ -20,10 +20,9 @@ def to_snake_case(name):
     return camel_case_to_underscore(name).lower()
 
 
-def check_override(node_name, signature, node_members_signatures):
+def check_override(signature, node_name, node_members_signatures):
     add = ""
     if node_name in node_members_signatures :
-        # print(node_members_signatures[node_name])
         if signature in node_members_signatures[node_name]:
 
             add = " override "
@@ -34,6 +33,6 @@ def check_override(node_name, signature, node_members_signatures):
 
     return signature + add
 
-def inherit_signatures(child, parent, node_members_signatures):
+def inherit_member_signatures(child, parent, node_members_signatures):
     if parent in node_members_signatures :
         node_members_signatures[child] = node_members_signatures[parent]


### PR DESCRIPTION
some compilers (i.e. PGI) complain if there is no override keyword for overriding member functions. This addition to the code adds the "override" keyword in case the signature is already present in the base classes. For now it is added only for setters functions (that do not present overrides) so I could not test it. I need to find a suitable function that is not present in ast_common, is declared in a virtual class, and overridden in a derived one. Suggestions are welcome!