### PR TITLE
Remove virtual from set_parent_for_children (issue #295)

### DIFF
--- a/src/language/templates/ast/ast.cpp
+++ b/src/language/templates/ast/ast.cpp
@@ -73,10 +73,6 @@ void Ast::set_parent(Ast* p) {
     parent = p;
 }
 
-void Ast::set_parent_in_children() {
-    throw std::runtime_error("set_parent_in_children not implemented");
-}
-
 
     {% for node in nodes %}
 

--- a/src/language/templates/ast/ast.hpp
+++ b/src/language/templates/ast/ast.hpp
@@ -348,14 +348,6 @@ struct Ast: public std::enable_shared_from_this<Ast> {
    * \ref Check Ast::parent for more information
    */
   virtual void set_parent(Ast* p);
-
-  /**
-   *\brief Set this object as parent for all the children
-   *
-   * This should be called in every object (with children) constructor
-   * to set the parents.
-   */
-  virtual void set_parent_in_children();
 };
 
 /** @} */  // end of ast_class

--- a/src/language/templates/ast/ast.hpp
+++ b/src/language/templates/ast/ast.hpp
@@ -706,6 +706,7 @@ struct Ast: public std::enable_shared_from_this<Ast> {
         {% endif %}
 
         {% if node.children %}
+      private:
             /**
              *\brief Set this object as parent for all the children
              *

--- a/src/language/templates/ast/ast.hpp
+++ b/src/language/templates/ast/ast.hpp
@@ -715,11 +715,13 @@ struct Ast: public std::enable_shared_from_this<Ast> {
 
         {% if node.children %}
             /**
-             * \brief Set parents in children
+             *\brief Set this object as parent for all the children
              *
-             * Usually called in constructors
+             * This should be called in every object (with children) constructor
+             * to set parents. Since it is called only in the constructors it
+             * should not be virtual to avoid ambiguities (issue #295).
              */
-            virtual void set_parent_in_children() override;
+            void set_parent_in_children();
         {% endif %}
     };
 


### PR DESCRIPTION
set_parent_for_children is called only in the constructors. The
virtual keyword unnecessary and generates only confusion. 
Check issue #295 for more info