### PR TITLE
remove INDEPENDENT from compatibility_visitor checks (issue #303)

### DIFF
--- a/src/codegen/codegen_compatibility_visitor.cpp
+++ b/src/codegen/codegen_compatibility_visitor.cpp
@@ -41,8 +41,6 @@ const std::map<ast::AstNodeType, CodegenCompatibilityVisitor::FunctionPointer>
           &CodegenCompatibilityVisitor::return_error_without_name<ConstructorBlock>},
          {AstNodeType::DESTRUCTOR_BLOCK,
           &CodegenCompatibilityVisitor::return_error_without_name<DestructorBlock>},
-         {AstNodeType::INDEPENDENT_BLOCK,
-          &CodegenCompatibilityVisitor::return_error_without_name<IndependentBlock>},
          {AstNodeType::SOLVE_BLOCK,
           &CodegenCompatibilityVisitor::return_error_if_solve_method_is_unhandled},
          {AstNodeType::GLOBAL_VAR, &CodegenCompatibilityVisitor::return_error_global_var},

--- a/src/codegen/codegen_compatibility_visitor.hpp
+++ b/src/codegen/codegen_compatibility_visitor.hpp
@@ -37,6 +37,9 @@ using namespace ast;
 /**
  * \class CodegenCompatibilityVisitor
  * \brief %Visitor for printing compatibility issues of the mod file
+ *
+ * INDEPENDENT_BLOCK is ignored (no error raised) as stated in:
+ * https://www.neuron.yale.edu/neuron/static/py_doc/modelspec/programmatic/mechanisms/nmodl.html
  */
 class CodegenCompatibilityVisitor: public visitor::AstVisitor {
     /// Typedef for defining FunctionPointer that points to the


### PR DESCRIPTION
Independent should not be supported by NMODL as stated in:

https://www.neuron.yale.edu/neuron/static/py_doc/modelspec/programmatic/mechanisms/nmodl.html

Thus, the error can (and should be) dropped.