### PR TITLE
Avoid including ast/ast.hpp in visitor class declarations.

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3525,7 +3525,7 @@ static void rename_net_receive_arguments(ast::NetReceiveBlock& net_receive_node,
 
 
 void CodegenCVisitor::print_net_init() {
-    auto node = info.net_receive_initial_node;
+    const auto node = info.net_receive_initial_node;
     if (node == nullptr) {
         return;
     }
@@ -3677,7 +3677,7 @@ void CodegenCVisitor::print_net_receive_kernel() {
     }
     codegen = true;
     printing_net_receive = true;
-    auto node = info.net_receive_node;
+    const auto node = info.net_receive_node;
 
     // rename net_receive arguments used in the block itself
     rename_net_receive_arguments(*info.net_receive_node, *node);

--- a/src/language/templates/ast/ast_decl.hpp
+++ b/src/language/templates/ast/ast_decl.hpp
@@ -23,6 +23,7 @@ namespace ast {
 
 /// forward declaration of ast nodes
 
+class Ast;
 {% for node in nodes %}
 class {{ node.class_name }};
 {% endfor %}

--- a/src/language/templates/visitors/ast_visitor.cpp
+++ b/src/language/templates/visitors/ast_visitor.cpp
@@ -11,6 +11,8 @@
 
 #include "visitors/ast_visitor.hpp"
 
+#include "ast/ast.hpp"
+
 
 namespace nmodl {
 namespace visitor {

--- a/src/language/templates/visitors/ast_visitor.hpp
+++ b/src/language/templates/visitors/ast_visitor.hpp
@@ -20,7 +20,6 @@
  * \brief \copybrief nmodl::visitor::AstVisitor
  */
 
-#include "ast/ast.hpp"
 #include "visitors/visitor.hpp"
 
 

--- a/src/language/templates/visitors/checkparent_visitor.cpp
+++ b/src/language/templates/visitors/checkparent_visitor.cpp
@@ -9,10 +9,12 @@
 /// THIS FILE IS GENERATED AT BUILD TIME AND SHALL NOT BE EDITED.
 ///
 
+#include "visitors/checkparent_visitor.hpp"
+
 #include <string>
 #include <fmt/format.h>
 
-#include "visitors/checkparent_visitor.hpp"
+#include "ast/ast.hpp"
 
 namespace nmodl {
 namespace visitor {

--- a/src/language/templates/visitors/lookup_visitor.cpp
+++ b/src/language/templates/visitors/lookup_visitor.cpp
@@ -9,8 +9,11 @@
 /// THIS FILE IS GENERATED AT BUILD TIME AND SHALL NOT BE EDITED.
 ///
 
-#include <algorithm>
 #include "visitors/lookup_visitor.hpp"
+
+#include <algorithm>
+
+#include "ast/ast.hpp"
 
 
 namespace nmodl {

--- a/src/language/templates/visitors/lookup_visitor.hpp
+++ b/src/language/templates/visitors/lookup_visitor.hpp
@@ -16,7 +16,6 @@
  * \brief \copybrief nmodl::visitor::AstLookupVisitor
  */
 
-#include "ast/ast.hpp"
 #include "visitors/visitor.hpp"
 
 namespace nmodl {

--- a/src/language/templates/visitors/nmodl_visitor.hpp
+++ b/src/language/templates/visitors/nmodl_visitor.hpp
@@ -18,7 +18,7 @@
 
 #include <set>
 
-#include "ast/ast.hpp"
+#include "visitors/visitor.hpp"
 #include "printer/nmodl_printer.hpp"
 
 namespace nmodl {

--- a/src/language/templates/visitors/visitor.hpp
+++ b/src/language/templates/visitors/visitor.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "ast/ast_decl.hpp"
 
 namespace nmodl {
 /// Implementation of different AST visitors

--- a/src/printer/decl.hpp
+++ b/src/printer/decl.hpp
@@ -1,0 +1,21 @@
+/*************************************************************************
+ * Copyright (C) 2018-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#pragma once
+
+/**
+ * \file
+ * \brief Forward references of symbols defined in namespace nmodl::printer
+ */
+
+namespace nmodl {
+namespace printer {
+
+class JSONPrinter;
+
+}
+}  // namespace nmodl

--- a/src/printer/json_printer.hpp
+++ b/src/printer/json_printer.hpp
@@ -69,14 +69,14 @@ class JSONPrinter {
     const std::string child_key = "children";
 
   public:
-    JSONPrinter(const std::string& filename);
+    explicit JSONPrinter(const std::string& filename);
 
     /// By default dump output to std::cout
     JSONPrinter()
         : result(new std::ostream(std::cout.rdbuf())) {}
 
     // Dump output to stringstream
-    JSONPrinter(std::ostream& os)
+    explicit JSONPrinter(std::ostream& os)
         : result(new std::ostream(os.rdbuf())) {}
 
     ~JSONPrinter() {

--- a/src/symtab/decl.hpp
+++ b/src/symtab/decl.hpp
@@ -1,0 +1,20 @@
+/*************************************************************************
+ * Copyright (C) 2018-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#pragma once
+
+/// \file
+/// \brief Forward declarations of symbols in namespace nmodl::symtab
+
+namespace nmodl {
+namespace symtab {
+
+class Symbol;
+class SymbolTable;
+
+}  // namespace symtab
+}  // namespace nmodl

--- a/src/utils/perf_stat.cpp
+++ b/src/utils/perf_stat.cpp
@@ -73,13 +73,13 @@ void PerfStat::print(std::stringstream& stream) {
     table.print(stream);
 }
 
-std::vector<std::string> PerfStat::keys() {
+std::vector<std::string> PerfStat::keys() const {
     return {"+",       "-",       "x",          "/",          "exp",     "log",     "GM-R(T)",
             "GM-R(U)", "GM-W(T)", "GM-W(U)",    "CM-R(T)",    "CM-R(U)", "CM-W(T)", "CM-W(U)",
             "LM-R(T)", "LM-W(T)", "calls(ext)", "calls(int)", "compare", "unary",   "conditional"};
 }
 
-std::vector<std::string> PerfStat::values() {
+std::vector<std::string> PerfStat::values() const {
     std::vector<std::string> row;
 
     int compares = n_gt + n_lt + n_ge + n_le + n_ne + n_ee;

--- a/src/utils/perf_stat.hpp
+++ b/src/utils/perf_stat.hpp
@@ -13,7 +13,8 @@
  */
 
 #include <sstream>
-
+#include <string>
+#include <vector>
 
 namespace nmodl {
 namespace utils {
@@ -100,9 +101,9 @@ struct PerfStat {
 
     void print(std::stringstream& stream);
 
-    std::vector<std::string> keys();
+    std::vector<std::string> keys() const;
 
-    std::vector<std::string> values();
+    std::vector<std::string> values() const;
 };
 
 /** @} */  // end of utils

--- a/src/visitors/constant_folder_visitor.hpp
+++ b/src/visitors/constant_folder_visitor.hpp
@@ -19,8 +19,6 @@
 #include <stack>
 #include <string>
 
-#include "ast/ast.hpp"
-#include "utils/logger.hpp"
 #include "visitors/ast_visitor.hpp"
 
 

--- a/src/visitors/defuse_analyze_visitor.cpp
+++ b/src/visitors/defuse_analyze_visitor.cpp
@@ -55,7 +55,7 @@ std::ostream& operator<<(std::ostream& os, DUState state) {
 }
 
 /// DUInstance to JSON string
-void DUInstance::print(JSONPrinter& printer) {
+void DUInstance::print(JSONPrinter& printer) const {
     if (children.empty()) {
         printer.add_node(to_string(state));
     } else {
@@ -68,7 +68,7 @@ void DUInstance::print(JSONPrinter& printer) {
 }
 
 /// DUChain to JSON string
-std::string DUChain::to_string(bool compact) {
+std::string DUChain::to_string(bool compact) const {
     std::stringstream stream;
     JSONPrinter printer(stream);
     printer.compact_json(compact);

--- a/src/visitors/defuse_analyze_visitor.cpp
+++ b/src/visitors/defuse_analyze_visitor.cpp
@@ -5,10 +5,13 @@
  * Lesser General Public License. See top-level LICENSE file for details.
  *************************************************************************/
 
+#include "visitors/defuse_analyze_visitor.hpp"
+
 #include <algorithm>
 #include <utility>
 
-#include "visitors/defuse_analyze_visitor.hpp"
+#include "ast/ast.hpp"
+#include "utils/logger.hpp"
 
 namespace nmodl {
 namespace visitor {
@@ -128,7 +131,6 @@ DUState DUInstance::sub_block_eval() {
 DUState DUInstance::conditional_block_eval() {
     DUState result = DUState::NONE;
     bool block_with_none = false;
-    bool block_non_def_cdef = false;
 
     for (auto& chain: children) {
         auto child_state = chain.eval();
@@ -181,9 +183,9 @@ DUState DUChain::eval() {
     return result;
 }
 
-void DefUseAnalyzeVisitor::visit_unsupported_node(ast::Node* node) {
+void DefUseAnalyzeVisitor::visit_unsupported_node(ast::Node& node) {
     unsupported_node = true;
-    node->visit_children(*this);
+    node.visit_children(*this);
     unsupported_node = false;
 }
 
@@ -198,7 +200,7 @@ void DefUseAnalyzeVisitor::visit_function_call(ast::FunctionCall& node) {
     if (symbol == nullptr || symbol->is_external_variable()) {
         node.visit_children(*this);
     } else {
-        visit_unsupported_node(&node);
+        visit_unsupported_node(node);
     }
 }
 
@@ -246,12 +248,12 @@ void DefUseAnalyzeVisitor::visit_if_statement(ast::IfStatement& node) {
 
     /// visiting else if sub-blocks
     for (const auto& item: node.get_elseifs()) {
-        visit_with_new_chain(item.get(), DUState::ELSEIF);
+        visit_with_new_chain(*item, DUState::ELSEIF);
     }
 
     /// visiting else sub-block
     if (node.get_elses()) {
-        visit_with_new_chain(node.get_elses().get(), DUState::ELSE);
+        visit_with_new_chain(*node.get_elses(), DUState::ELSE);
     }
 
     /// restore to previous chain
@@ -269,6 +271,73 @@ void DefUseAnalyzeVisitor::visit_verbatim(ast::Verbatim& node) {
         current_chain->push_back(DUInstance(DUState::U));
     }
 }
+
+/// unsupported statements : we aren't sure how to handle this "yet" and
+/// hence variables used in any of the below statements are handled separately
+
+void DefUseAnalyzeVisitor::visit_reaction_statement(ast::ReactionStatement& node) {
+    visit_unsupported_node(node);
+}
+
+void DefUseAnalyzeVisitor::visit_non_lin_equation(ast::NonLinEquation& node) {
+    visit_unsupported_node(node);
+}
+
+void DefUseAnalyzeVisitor::visit_lin_equation(ast::LinEquation& node) {
+    visit_unsupported_node(node);
+}
+
+void DefUseAnalyzeVisitor::visit_partial_boundary(ast::PartialBoundary& node) {
+    visit_unsupported_node(node);
+}
+
+void DefUseAnalyzeVisitor::visit_from_statement(ast::FromStatement& node) {
+    visit_unsupported_node(node);
+}
+
+void DefUseAnalyzeVisitor::visit_conserve(ast::Conserve& node) {
+    visit_unsupported_node(node);
+}
+
+void DefUseAnalyzeVisitor::visit_var_name(ast::VarName& node) {
+    const std::string& variable = to_nmodl(node);
+    process_variable(variable);
+}
+
+void DefUseAnalyzeVisitor::visit_name(ast::Name& node) {
+    const std::string& variable = to_nmodl(node);
+    process_variable(variable);
+}
+
+void DefUseAnalyzeVisitor::visit_indexed_name(ast::IndexedName& node) {
+    const auto& name = node.get_node_name();
+    const auto& length = node.get_length();
+
+    /// index should be an integer (e.g. after constant folding)
+    /// if this is not the case and then we can't determine exact
+    /// def-use chain
+    if (!length->is_integer()) {
+        /// check if variable name without index part is same
+        auto variable_name_prefix = variable_name.substr(0, variable_name.find('['));
+        if (name == variable_name_prefix) {
+            update_defuse_chain(variable_name_prefix);
+            const std::string& text = to_nmodl(node);
+            nmodl::logger->info("index used to access variable is not known : {} ", text);
+        }
+        return;
+    }
+    auto index = std::dynamic_pointer_cast<ast::Integer>(length);
+    process_variable(name, index->eval());
+}
+
+/// statements / nodes that should not be used for def-use chain analysis
+
+void DefUseAnalyzeVisitor::visit_conductance_hint(ast::ConductanceHint& /*node*/) {}
+
+void DefUseAnalyzeVisitor::visit_local_list_statement(ast::LocalListStatement& /*node*/) {}
+
+void DefUseAnalyzeVisitor::visit_argument(ast::Argument& /*node*/) {}
+
 
 /**
  * Update the Def-Use chain for given variable
@@ -319,10 +388,10 @@ void DefUseAnalyzeVisitor::process_variable(const std::string& name, int index) 
     }
 }
 
-void DefUseAnalyzeVisitor::visit_with_new_chain(ast::Node* node, DUState state) {
+void DefUseAnalyzeVisitor::visit_with_new_chain(ast::Node& node, DUState state) {
     auto last_chain = current_chain;
     start_new_chain(state);
-    node->visit_children(*this);
+    node.visit_children(*this);
     current_chain = last_chain;
 }
 
@@ -331,7 +400,7 @@ void DefUseAnalyzeVisitor::start_new_chain(DUState state) {
     current_chain = &current_chain->back().children;
 }
 
-DUChain DefUseAnalyzeVisitor::analyze(ast::Ast* node, const std::string& name) {
+DUChain DefUseAnalyzeVisitor::analyze(ast::Ast& node, const std::string& name) {
     /// re-initialize state
     variable_name = name;
     visiting_lhs = false;
@@ -339,12 +408,12 @@ DUChain DefUseAnalyzeVisitor::analyze(ast::Ast* node, const std::string& name) {
     unsupported_node = false;
 
     /// new chain
-    DUChain usage(node->get_node_type_name());
+    DUChain usage(node.get_node_type_name());
     current_chain = &usage.chain;
 
     /// analyze given node
     symtab_stack.push(current_symtab);
-    node->visit_children(*this);
+    node.visit_children(*this);
     symtab_stack.pop();
 
     return usage;

--- a/src/visitors/defuse_analyze_visitor.hpp
+++ b/src/visitors/defuse_analyze_visitor.hpp
@@ -180,7 +180,7 @@ class DUChain {
  * in any of the if-elseif-else part then it is considered as "used". And
  * this is done recursively from innermost level to the top.
  */
-class DefUseAnalyzeVisitor: public AstVisitor {
+class DefUseAnalyzeVisitor: protected AstVisitor {
   private:
     /// symbol table containing global variables
     symtab::SymbolTable* global_symtab = nullptr;
@@ -231,8 +231,12 @@ class DefUseAnalyzeVisitor: public AstVisitor {
     void visit_statement_block(ast::StatementBlock& node) override;
     void visit_verbatim(ast::Verbatim& node) override;
 
-    /// unsupported statements : we aren't sure how to handle this "yet" and
-    /// hence variables used in any of the below statements are handled separately
+    /**
+     * /\name unsupported statements
+     * we aren't sure how to handle this "yet" and hence variables
+     * used in any of the below statements are handled separately
+     * \{
+     */
 
     void visit_reaction_statement(ast::ReactionStatement& node) override;
 
@@ -252,13 +256,21 @@ class DefUseAnalyzeVisitor: public AstVisitor {
 
     void visit_indexed_name(ast::IndexedName& node) override;
 
-    /// statements / nodes that should not be used for def-use chain analysis
+    /** \} */
+
+    /**
+     * /\name statements
+     * nodes that should not be used for def-use chain analysis
+     * \{
+     */
 
     void visit_conductance_hint(ast::ConductanceHint& node) override;
 
     void visit_local_list_statement(ast::LocalListStatement& node) override;
 
     void visit_argument(ast::Argument& node) override;
+
+    /** \} */
 
     /// compute def-use chain for a variable within the node
     DUChain analyze(ast::Ast& node, const std::string& name);

--- a/src/visitors/defuse_analyze_visitor.hpp
+++ b/src/visitors/defuse_analyze_visitor.hpp
@@ -93,7 +93,7 @@ class DUInstance {
     /// evaluate global usage i.e. with [D,U] states of children
     DUState conditional_block_eval();
 
-    void print(printer::JSONPrinter& printer);
+    void print(printer::JSONPrinter& printer) const;
 };
 
 
@@ -117,7 +117,7 @@ class DUChain {
     DUState eval();
 
     /// return json representation
-    std::string to_string(bool compact = true);
+    std::string to_string(bool compact = true) const;
 };
 
 

--- a/src/visitors/defuse_analyze_visitor.hpp
+++ b/src/visitors/defuse_analyze_visitor.hpp
@@ -15,10 +15,7 @@
 #include <map>
 #include <stack>
 
-#include "ast/ast.hpp"
 #include "printer/json_printer.hpp"
-#include "symtab/symbol_table.hpp"
-#include "utils/logger.hpp"
 #include "visitors/ast_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
 
@@ -214,8 +211,8 @@ class DefUseAnalyzeVisitor: public AstVisitor {
     void process_variable(const std::string& name, int index);
 
     void update_defuse_chain(const std::string& name);
-    void visit_unsupported_node(ast::Node* node);
-    void visit_with_new_chain(ast::Node* node, DUState state);
+    void visit_unsupported_node(ast::Node& node);
+    void visit_with_new_chain(ast::Node& node, DUState state);
     void start_new_chain(DUState state);
 
   public:
@@ -237,71 +234,34 @@ class DefUseAnalyzeVisitor: public AstVisitor {
     /// unsupported statements : we aren't sure how to handle this "yet" and
     /// hence variables used in any of the below statements are handled separately
 
-    void visit_reaction_statement(ast::ReactionStatement& node) override {
-        visit_unsupported_node(&node);
-    }
+    void visit_reaction_statement(ast::ReactionStatement& node) override;
 
-    void visit_non_lin_equation(ast::NonLinEquation& node) override {
-        visit_unsupported_node(&node);
-    }
+    void visit_non_lin_equation(ast::NonLinEquation& node) override;
 
-    void visit_lin_equation(ast::LinEquation& node) override {
-        visit_unsupported_node(&node);
-    }
+    void visit_lin_equation(ast::LinEquation& node) override;
 
-    void visit_partial_boundary(ast::PartialBoundary& node) override {
-        visit_unsupported_node(&node);
-    }
+    void visit_partial_boundary(ast::PartialBoundary& node) override;
 
-    void visit_from_statement(ast::FromStatement& node) override {
-        visit_unsupported_node(&node);
-    }
+    void visit_from_statement(ast::FromStatement& node) override;
 
-    void visit_conserve(ast::Conserve& node) override {
-        visit_unsupported_node(&node);
-    }
+    void visit_conserve(ast::Conserve& node) override;
 
-    void visit_var_name(ast::VarName& node) override {
-        const std::string& variable = to_nmodl(node);
-        process_variable(variable);
-    }
+    void visit_var_name(ast::VarName& node) override;
 
-    void visit_name(ast::Name& node) override {
-        const std::string& variable = to_nmodl(node);
-        process_variable(variable);
-    }
+    void visit_name(ast::Name& node) override;
 
-    void visit_indexed_name(ast::IndexedName& node) override {
-        const auto& name = node.get_node_name();
-        const auto& length = node.get_length();
-
-        /// index should be an integer (e.g. after constant folding)
-        /// if this is not the case and then we can't determine exact
-        /// def-use chain
-        if (!length->is_integer()) {
-            /// check if variable name without index part is same
-            auto variable_name_prefix = variable_name.substr(0, variable_name.find('['));
-            if (name == variable_name_prefix) {
-                update_defuse_chain(variable_name_prefix);
-                const std::string& text = to_nmodl(node);
-                nmodl::logger->info("index used to access variable is not known : {} ", text);
-            }
-            return;
-        }
-        auto index = std::dynamic_pointer_cast<ast::Integer>(length);
-        process_variable(name, index->eval());
-    }
+    void visit_indexed_name(ast::IndexedName& node) override;
 
     /// statements / nodes that should not be used for def-use chain analysis
 
-    void visit_conductance_hint(ast::ConductanceHint& /*node*/) override {}
+    void visit_conductance_hint(ast::ConductanceHint& node) override;
 
-    void visit_local_list_statement(ast::LocalListStatement& /*node*/) override {}
+    void visit_local_list_statement(ast::LocalListStatement& node) override;
 
-    void visit_argument(ast::Argument& /*node*/) override {}
+    void visit_argument(ast::Argument& node) override;
 
     /// compute def-use chain for a variable within the node
-    DUChain analyze(ast::Ast* node, const std::string& name);
+    DUChain analyze(ast::Ast& node, const std::string& name);
 };
 
 /** @} */  // end of visitor_classes

--- a/src/visitors/inline_visitor.cpp
+++ b/src/visitors/inline_visitor.cpp
@@ -6,7 +6,12 @@
  *************************************************************************/
 
 #include "visitors/inline_visitor.hpp"
+
+#include "ast/ast.hpp"
 #include "parser/c11_driver.hpp"
+#include "visitors/local_var_rename_visitor.hpp"
+#include "visitors/rename_visitor.hpp"
+#include "visitors/visitor_utils.hpp"
 
 
 namespace nmodl {
@@ -14,9 +19,9 @@ namespace visitor {
 
 using namespace ast;
 
-bool InlineVisitor::can_inline_block(StatementBlock* block) {
+bool InlineVisitor::can_inline_block(StatementBlock& block) {
     bool to_inline = true;
-    const auto& statements = block->get_statements();
+    const auto& statements = block.get_statements();
     for (const auto& statement: statements) {
         /// inlining is disabled if function/procedure contains table or lag statement
         if (statement->is_table_statement() || statement->is_lag_statement()) {
@@ -120,7 +125,7 @@ bool InlineVisitor::inline_function_call(ast::Block* callee,
     const auto& function_name = callee->get_node_name();
 
     /// do nothing if we can't inline given procedure/function
-    if (!can_inline_block(callee->get_statement_block().get())) {
+    if (!can_inline_block(*callee->get_statement_block())) {
         std::cerr << "Can not inline function call to " + function_name << '\n';
         return false;
     }

--- a/src/visitors/inline_visitor.hpp
+++ b/src/visitors/inline_visitor.hpp
@@ -15,13 +15,8 @@
 #include <map>
 #include <stack>
 
-#include "ast/ast.hpp"
-#include "symtab/symbol_table.hpp"
+#include "symtab/decl.hpp"
 #include "visitors/ast_visitor.hpp"
-#include "visitors/local_var_rename_visitor.hpp"
-#include "visitors/rename_visitor.hpp"
-#include "visitors/visitor_utils.hpp"
-
 
 namespace nmodl {
 namespace visitor {
@@ -164,7 +159,7 @@ class InlineVisitor: public AstVisitor {
     std::map<std::string, int> inlined_variables;
 
     /// true if given statement block can be inlined
-    bool can_inline_block(ast::StatementBlock* block);
+    bool can_inline_block(ast::StatementBlock& block);
 
     /// true if statement can be replaced with inlined body
     /// this is possible for standalone function/procedure call as statement

--- a/src/visitors/kinetic_block_visitor.hpp
+++ b/src/visitors/kinetic_block_visitor.hpp
@@ -12,14 +12,13 @@
  * \brief \copybrief nmodl::visitor::KineticBlockVisitor
  */
 
-#include "ast/ast.hpp"
-#include "visitors/ast_visitor.hpp"
-#include "visitors/visitor_utils.hpp"
 #include <map>
 #include <memory>
 #include <set>
 #include <string>
 #include <vector>
+
+#include "visitors/ast_visitor.hpp"
 
 namespace nmodl {
 namespace visitor {

--- a/src/visitors/local_var_rename_visitor.hpp
+++ b/src/visitors/local_var_rename_visitor.hpp
@@ -72,7 +72,7 @@ class LocalVarRenameVisitor: public AstVisitor {
 
   public:
     LocalVarRenameVisitor() = default;
-    virtual void visit_statement_block(ast::StatementBlock& node) override;
+    void visit_statement_block(ast::StatementBlock& node) override;
 };
 
 /** @} */  // end of visitor_classes

--- a/src/visitors/local_var_rename_visitor.hpp
+++ b/src/visitors/local_var_rename_visitor.hpp
@@ -15,8 +15,7 @@
 #include <map>
 #include <stack>
 
-#include "ast/ast.hpp"
-#include "symtab/symbol_table.hpp"
+#include "symtab/decl.hpp"
 #include "visitors/ast_visitor.hpp"
 
 namespace nmodl {

--- a/src/visitors/localize_visitor.hpp
+++ b/src/visitors/localize_visitor.hpp
@@ -13,16 +13,9 @@
  */
 
 #include <map>
-#include <stack>
 
-#include "ast/ast.hpp"
-#include "printer/json_printer.hpp"
-#include "symtab/symbol_table.hpp"
-#include "utils/logger.hpp"
+#include "symtab/decl.hpp"
 #include "visitors/ast_visitor.hpp"
-#include "visitors/local_var_rename_visitor.hpp"
-#include "visitors/rename_visitor.hpp"
-#include "visitors/visitor_utils.hpp"
 
 
 namespace nmodl {
@@ -94,11 +87,11 @@ class LocalizeVisitor: public AstVisitor {
 
     symtab::SymbolTable* program_symtab = nullptr;
 
-    std::vector<std::string> variables_to_optimize();
+    std::vector<std::string> variables_to_optimize() const;
 
-    bool node_for_def_use_analysis(ast::Node* node);
+    bool node_for_def_use_analysis(const ast::Node& node) const;
 
-    bool is_solve_procedure(ast::Node* node);
+    bool is_solve_procedure(const ast::Node& node) const;
 
   public:
     LocalizeVisitor() = default;
@@ -106,7 +99,7 @@ class LocalizeVisitor: public AstVisitor {
     explicit LocalizeVisitor(bool ignore_verbatim)
         : ignore_verbatim(ignore_verbatim) {}
 
-    virtual void visit_program(ast::Program& node) override;
+    void visit_program(ast::Program& node) override;
 };
 
 /** @} */  // end of visitor_classes

--- a/src/visitors/loop_unroll_visitor.hpp
+++ b/src/visitors/loop_unroll_visitor.hpp
@@ -14,8 +14,6 @@
 
 #include <string>
 
-#include "ast/ast.hpp"
-#include "symtab/symbol_table.hpp"
 #include "visitors/ast_visitor.hpp"
 
 namespace nmodl {

--- a/src/visitors/neuron_solve_visitor.hpp
+++ b/src/visitors/neuron_solve_visitor.hpp
@@ -12,9 +12,10 @@
  * \brief \copybrief nmodl::visitor::NeuronSolveVisitor
  */
 
+#include <map>
 #include <string>
 
-#include "ast/ast.hpp"
+#include "symtab/decl.hpp"
 #include "visitors/ast_visitor.hpp"
 
 

--- a/src/visitors/nmodl_visitor_helper.ipp
+++ b/src/visitors/nmodl_visitor_helper.ipp
@@ -9,6 +9,8 @@
 
 #include "visitors/nmodl_visitor.hpp"
 
+#include "visitors/visitor_utils.hpp"
+
 
 namespace nmodl {
 namespace visitor {

--- a/src/visitors/perf_visitor.cpp
+++ b/src/visitors/perf_visitor.cpp
@@ -5,9 +5,12 @@
  * Lesser General Public License. See top-level LICENSE file for details.
  *************************************************************************/
 
+#include "visitors/perf_visitor.hpp"
+
 #include <utility>
 
-#include "visitors/perf_visitor.hpp"
+#include "ast/ast.hpp"
+#include "printer/json_printer.hpp"
 
 
 namespace nmodl {
@@ -21,6 +24,11 @@ using utils::PerfStat;
 
 PerfVisitor::PerfVisitor(const std::string& filename)
     : printer(new JSONPrinter(filename)) {}
+
+void PerfVisitor::compact_json(bool flag) {
+    printer->compact_json(flag);
+}
+
 
 /// count math operations from all binary expressions
 void PerfVisitor::visit_binary_expression(ast::BinaryExpression& node) {
@@ -333,6 +341,95 @@ void PerfVisitor::visit_program(ast::Program& node) {
     current_symtab = node.get_symbol_table();
     count_variables();
     print_memory_usage();
+}
+
+void PerfVisitor::visit_plot_block(ast::PlotBlock& node) {
+    measure_performance(&node);
+}
+
+/// skip initial block under net_receive block
+void PerfVisitor::visit_initial_block(ast::InitialBlock& node) {
+    if (!under_net_receive_block) {
+        measure_performance(&node);
+    }
+}
+
+void PerfVisitor::visit_constructor_block(ast::ConstructorBlock& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_destructor_block(ast::DestructorBlock& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_derivative_block(ast::DerivativeBlock& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_linear_block(ast::LinearBlock& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_non_linear_block(ast::NonLinearBlock& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_discrete_block(ast::DiscreteBlock& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_partial_block(ast::PartialBlock& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_function_table_block(ast::FunctionTableBlock& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_function_block(ast::FunctionBlock& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_procedure_block(ast::ProcedureBlock& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_net_receive_block(ast::NetReceiveBlock& node) {
+    under_net_receive_block = true;
+    measure_performance(&node);
+    under_net_receive_block = false;
+}
+
+void PerfVisitor::visit_breakpoint_block(ast::BreakpointBlock& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_terminal_block(ast::TerminalBlock& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_before_block(ast::BeforeBlock& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_after_block(ast::AfterBlock& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_ba_block(ast::BABlock& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_for_netcon(ast::ForNetcon& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_kinetic_block(ast::KineticBlock& node) {
+    measure_performance(&node);
+}
+
+void PerfVisitor::visit_match_block(ast::MatchBlock& node) {
+    measure_performance(&node);
 }
 
 /** Blocks like function can have multiple statement blocks and

--- a/src/visitors/perf_visitor.hpp
+++ b/src/visitors/perf_visitor.hpp
@@ -12,11 +12,12 @@
  * \brief \copybrief nmodl::visitor::PerfVisitor
  */
 
+#include <map>
 #include <set>
 #include <stack>
 
-#include "printer/json_printer.hpp"
-#include "symtab/symbol_table.hpp"
+#include "printer/decl.hpp"
+#include "symtab/decl.hpp"
 #include "utils/perf_stat.hpp"
 #include "visitors/ast_visitor.hpp"
 
@@ -151,9 +152,7 @@ class PerfVisitor: public AstVisitor {
 
     explicit PerfVisitor(const std::string& filename);
 
-    void compact_json(bool flag) {
-        printer->compact_json(flag);
-    }
+    void compact_json(bool flag);
 
     utils::PerfStat get_total_perfstat() const noexcept {
         return total_perf;
@@ -199,94 +198,48 @@ class PerfVisitor: public AstVisitor {
 
     void visit_program(ast::Program& node) override;
 
-    void visit_plot_block(ast::PlotBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_plot_block(ast::PlotBlock& node) override;
 
     /// skip initial block under net_receive block
-    void visit_initial_block(ast::InitialBlock& node) override {
-        if (!under_net_receive_block) {
-            measure_performance(&node);
-        }
-    }
+    void visit_initial_block(ast::InitialBlock& node) override;
 
-    void visit_constructor_block(ast::ConstructorBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_constructor_block(ast::ConstructorBlock& node) override;
 
-    void visit_destructor_block(ast::DestructorBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_destructor_block(ast::DestructorBlock& node) override;
 
-    void visit_derivative_block(ast::DerivativeBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_derivative_block(ast::DerivativeBlock& node) override;
 
-    void visit_linear_block(ast::LinearBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_linear_block(ast::LinearBlock& node) override;
 
-    void visit_non_linear_block(ast::NonLinearBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_non_linear_block(ast::NonLinearBlock& node) override;
 
-    void visit_discrete_block(ast::DiscreteBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_discrete_block(ast::DiscreteBlock& node) override;
 
-    void visit_partial_block(ast::PartialBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_partial_block(ast::PartialBlock& node) override;
 
-    void visit_function_table_block(ast::FunctionTableBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_function_table_block(ast::FunctionTableBlock& node) override;
 
-    void visit_function_block(ast::FunctionBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_function_block(ast::FunctionBlock& node) override;
 
-    void visit_procedure_block(ast::ProcedureBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_procedure_block(ast::ProcedureBlock& node) override;
 
-    void visit_net_receive_block(ast::NetReceiveBlock& node) override {
-        under_net_receive_block = true;
-        measure_performance(&node);
-        under_net_receive_block = false;
-    }
+    void visit_net_receive_block(ast::NetReceiveBlock& node) override;
 
-    void visit_breakpoint_block(ast::BreakpointBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_breakpoint_block(ast::BreakpointBlock& node) override;
 
-    void visit_terminal_block(ast::TerminalBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_terminal_block(ast::TerminalBlock& node) override;
 
-    void visit_before_block(ast::BeforeBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_before_block(ast::BeforeBlock& node) override;
 
-    void visit_after_block(ast::AfterBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_after_block(ast::AfterBlock& node) override;
 
-    void visit_ba_block(ast::BABlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_ba_block(ast::BABlock& node) override;
 
-    void visit_for_netcon(ast::ForNetcon& node) override {
-        measure_performance(&node);
-    }
+    void visit_for_netcon(ast::ForNetcon& node) override;
 
-    void visit_kinetic_block(ast::KineticBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_kinetic_block(ast::KineticBlock& node) override;
 
-    void visit_match_block(ast::MatchBlock& node) override {
-        measure_performance(&node);
-    }
+    void visit_match_block(ast::MatchBlock& node) override;
 
     /// certain constructs needs to be excluded from usage counting
     /// and hence need to provide empty implementations
@@ -301,7 +254,7 @@ class PerfVisitor: public AstVisitor {
 
     void visit_valence(ast::Valence& /*node*/) override {}
 
-    void print(std::ostream& ss) {
+    void print(std::ostream& ss) const {
         ss << stream.str();
     }
 };

--- a/src/visitors/rename_visitor.cpp
+++ b/src/visitors/rename_visitor.cpp
@@ -6,6 +6,8 @@
  *************************************************************************/
 
 #include "visitors/rename_visitor.hpp"
+
+#include "ast/ast.hpp"
 #include "parser/c11_driver.hpp"
 
 

--- a/src/visitors/rename_visitor.hpp
+++ b/src/visitors/rename_visitor.hpp
@@ -14,8 +14,6 @@
 
 #include <string>
 
-#include "ast/ast.hpp"
-#include "symtab/symbol_table.hpp"
 #include "visitors/ast_visitor.hpp"
 
 
@@ -55,12 +53,12 @@ class RenameVisitor: public AstVisitor {
     RenameVisitor() = default;
 
     RenameVisitor(std::string old_name, std::string new_name)
-        : var_name(old_name)
-        , new_var_name(new_name) {}
+        : var_name(std::move(old_name))
+        , new_var_name(std::move(new_name)) {}
 
     void set(std::string old_name, std::string new_name) {
-        var_name = old_name;
-        new_var_name = new_name;
+        var_name = std::move(old_name);
+        new_var_name = std::move(new_name);
     }
 
     void enable_verbatim(bool state) {

--- a/src/visitors/solve_block_visitor.cpp
+++ b/src/visitors/solve_block_visitor.cpp
@@ -6,6 +6,8 @@
  *************************************************************************/
 
 #include "visitors/solve_block_visitor.hpp"
+
+#include "ast/ast.hpp"
 #include "codegen/codegen_naming.hpp"
 #include "utils/logger.hpp"
 #include "visitors/lookup_visitor.hpp"

--- a/src/visitors/solve_block_visitor.hpp
+++ b/src/visitors/solve_block_visitor.hpp
@@ -12,8 +12,7 @@
  * \brief \copybrief nmodl::visitor::SolveBlockVisitor
  */
 
-#include "ast/ast.hpp"
-#include "symtab/symbol_table.hpp"
+#include "symtab/decl.hpp"
 #include "visitors/ast_visitor.hpp"
 
 namespace nmodl {

--- a/src/visitors/steadystate_visitor.hpp
+++ b/src/visitors/steadystate_visitor.hpp
@@ -12,9 +12,7 @@
  * \brief \copybrief nmodl::visitor::SteadystateVisitor
  */
 
-#include "ast/ast.hpp"
 #include "visitors/ast_visitor.hpp"
-#include "visitors/visitor_utils.hpp"
 
 namespace nmodl {
 namespace visitor {

--- a/src/visitors/sympy_conductance_visitor.cpp
+++ b/src/visitors/sympy_conductance_visitor.cpp
@@ -5,13 +5,17 @@
  * Lesser General Public License. See top-level LICENSE file for details.
  *************************************************************************/
 
+#include "visitors/sympy_conductance_visitor.hpp"
+
 #include <algorithm>
 #include <iostream>
 
+#include <pybind11/embed.h>
+
+#include "ast/ast.hpp"
 #include "symtab/symbol.hpp"
 #include "utils/logger.hpp"
 #include "visitors/lookup_visitor.hpp"
-#include "visitors/sympy_conductance_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
 
 
@@ -165,6 +169,11 @@ void SympyConductanceVisitor::lookup_nonspecific_statements() {
         }
     }
 }
+
+std::string SympyConductanceVisitor::to_nmodl_for_sympy(ast::Ast& node) {
+    return to_nmodl(node, {ast::AstNodeType::UNIT, ast::AstNodeType::UNIT_DEF});
+}
+
 
 void SympyConductanceVisitor::lookup_useion_statements() {
     // add USEION statements to i_name map between write vars and names

--- a/src/visitors/sympy_conductance_visitor.cpp
+++ b/src/visitors/sympy_conductance_visitor.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 
 #include <pybind11/embed.h>
+#include <pybind11/stl.h>
 
 #include "ast/ast.hpp"
 #include "symtab/symbol.hpp"

--- a/src/visitors/sympy_conductance_visitor.hpp
+++ b/src/visitors/sympy_conductance_visitor.hpp
@@ -16,17 +16,10 @@
 #include <set>
 #include <vector>
 
-#include <pybind11/embed.h>
-#include <pybind11/stl.h>
-
-#include "ast/ast.hpp"
-#include "symtab/symbol.hpp"
 #include "visitors/ast_visitor.hpp"
-#include "visitors/lookup_visitor.hpp"
-#include "visitors/visitor_utils.hpp"
-
 
 namespace nmodl {
+
 namespace visitor {
 
 /**
@@ -96,9 +89,7 @@ class SympyConductanceVisitor: public AstVisitor {
     void lookup_useion_statements();
     void lookup_nonspecific_statements();
 
-    static std::string to_nmodl_for_sympy(ast::Ast& node) {
-        return to_nmodl(node, {ast::AstNodeType::UNIT, ast::AstNodeType::UNIT_DEF});
-    }
+    static std::string to_nmodl_for_sympy(ast::Ast& node);
 
   public:
     SympyConductanceVisitor() = default;

--- a/src/visitors/sympy_solver_visitor.cpp
+++ b/src/visitors/sympy_solver_visitor.cpp
@@ -7,6 +7,8 @@
 
 #include <iostream>
 
+#include <pybind11/pytypes.h>
+
 #include "codegen/codegen_naming.hpp"
 #include "symtab/symbol.hpp"
 #include "utils/logger.hpp"
@@ -115,7 +117,7 @@ ast::StatementVector::const_iterator SympySolverVisitor::get_solution_location_i
  * expression statement and hence we try to look inside if it's really a
  * variable declaration.
  */
-static bool is_local_statement(std::shared_ptr<ast::Statement> statement) {
+static bool is_local_statement(const std::shared_ptr<ast::Statement>& statement) {
     if (statement->is_local_list_statement()) {
         return true;
     }

--- a/src/visitors/sympy_solver_visitor.hpp
+++ b/src/visitors/sympy_solver_visitor.hpp
@@ -177,9 +177,9 @@ class SympySolverVisitor: public AstVisitor {
     int SMALL_LINEAR_SYSTEM_MAX_STATES;
 
   public:
-    SympySolverVisitor(bool use_pade_approx = false,
-                       bool elimination = true,
-                       int SMALL_LINEAR_SYSTEM_MAX_STATES = 3)
+    explicit SympySolverVisitor(bool use_pade_approx = false,
+                                bool elimination = true,
+                                int SMALL_LINEAR_SYSTEM_MAX_STATES = 3)
         : use_pade_approx(use_pade_approx)
         , elimination(elimination)
         , SMALL_LINEAR_SYSTEM_MAX_STATES(SMALL_LINEAR_SYSTEM_MAX_STATES){};

--- a/src/visitors/units_visitor.hpp
+++ b/src/visitors/units_visitor.hpp
@@ -16,7 +16,6 @@
 #include <string>
 #include <vector>
 
-#include "ast/ast.hpp"
 #include "parser/unit_driver.hpp"
 #include "visitors/ast_visitor.hpp"
 #include "visitors/visitor_utils.hpp"

--- a/src/visitors/var_usage_visitor.cpp
+++ b/src/visitors/var_usage_visitor.cpp
@@ -9,6 +9,8 @@
 
 #include <utility>
 
+#include "ast/ast.hpp"
+
 
 namespace nmodl {
 namespace visitor {

--- a/src/visitors/var_usage_visitor.hpp
+++ b/src/visitors/var_usage_visitor.hpp
@@ -32,7 +32,7 @@ namespace visitor {
  * \todo Check if macro is considered as variable
  */
 
-class VarUsageVisitor: public AstVisitor {
+class VarUsageVisitor: protected AstVisitor {
   private:
     /// variable to check usage
     std::string var_name;

--- a/src/visitors/var_usage_visitor.hpp
+++ b/src/visitors/var_usage_visitor.hpp
@@ -14,7 +14,6 @@
 
 #include <string>
 
-#include "ast/ast.hpp"
 #include "visitors/ast_visitor.hpp"
 
 

--- a/src/visitors/verbatim_var_rename_visitor.cpp
+++ b/src/visitors/verbatim_var_rename_visitor.cpp
@@ -6,6 +6,8 @@
  *************************************************************************/
 
 #include "visitors/verbatim_var_rename_visitor.hpp"
+
+#include "ast/ast.hpp"
 #include "parser/c11_driver.hpp"
 #include "src/utils/logger.hpp"
 

--- a/test/visitor/defuse_analyze.cpp
+++ b/test/visitor/defuse_analyze.cpp
@@ -40,9 +40,9 @@ std::vector<DUChain> run_defuse_visitor(const std::string& text, const std::stri
 
     /// analyse only derivative blocks in this test
     auto blocks = AstLookupVisitor().lookup(*ast, AstNodeType::DERIVATIVE_BLOCK);
+    chains.reserve(blocks.size());
     for (auto& block: blocks) {
-        auto node = block.get();
-        chains.push_back(v.analyze(node, variable));
+        chains.push_back(v.analyze(*block, variable));
     }
 
     // check that, after visitor rearrangement, parents are still up-to-date

--- a/test/visitor/kinetic_block.cpp
+++ b/test/visitor/kinetic_block.cpp
@@ -15,6 +15,7 @@
 #include "visitors/lookup_visitor.hpp"
 #include "visitors/loop_unroll_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"
+#include "visitors/visitor_utils.hpp"
 
 using namespace nmodl;
 using namespace visitor;

--- a/test/visitor/misc.cpp
+++ b/test/visitor/misc.cpp
@@ -13,6 +13,7 @@
 #include "visitors/inline_visitor.hpp"
 #include "visitors/localize_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"
+#include "visitors/visitor_utils.hpp"
 
 using namespace nmodl;
 using namespace visitor;

--- a/test/visitor/steadystate.cpp
+++ b/test/visitor/steadystate.cpp
@@ -9,15 +9,14 @@
 
 #include "parser/nmodl_driver.hpp"
 #include "test/utils/test_utils.hpp"
+#include "visitors/checkparent_visitor.hpp"
 #include "visitors/constant_folder_visitor.hpp"
 #include "visitors/kinetic_block_visitor.hpp"
 #include "visitors/lookup_visitor.hpp"
 #include "visitors/loop_unroll_visitor.hpp"
-//#include "visitors/nmodl_visitor.hpp"
 #include "visitors/steadystate_visitor.hpp"
-//#include "visitors/sympy_solver_visitor.hpp"
-#include "visitors/checkparent_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"
+#include "visitors/visitor_utils.hpp"
 
 using namespace nmodl;
 using namespace visitor;

--- a/test/visitor/sympy_conductance.cpp
+++ b/test/visitor/sympy_conductance.cpp
@@ -16,6 +16,7 @@
 #include "visitors/lookup_visitor.hpp"
 #include "visitors/sympy_conductance_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"
+#include "visitors/visitor_utils.hpp"
 
 using namespace nmodl;
 using namespace visitor;


### PR DESCRIPTION
Changes in visitor classes:
* declarations only use Ast node forward declarations
* do not inline virtual member functions and move the definitions in .cpp