### PR TITLE
Rename context to eq_context for compatibility with Bison v3.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,14 @@ matrix:
         - MATRIX_EVAL="CXX=c++"
 
 #=============================================================================
+# Cache directories
+#=============================================================================
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/Library/Caches/Homebrew
+
+#=============================================================================
 # Common Packages
 #=============================================================================
 addons:
@@ -48,7 +56,6 @@ addons:
   # for Mac builds, we use Homebrew
   homebrew:
     packages:
-      - bison
       - boost
       - cmake
       - flex
@@ -61,7 +68,9 @@ addons:
 before_install:
   # brew installed flex and bison is not in $PATH
   # unlink python2 and use python3 as it's required for nmodl
+  # install older bison because of #314
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+        brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/187c0d5/Formula/bison.rb;
         export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
         brew unlink python@2;
         brew link --overwrite python;

--- a/src/parser/diffeq.yy
+++ b/src/parser/diffeq.yy
@@ -40,7 +40,7 @@
 
 /** add extra arguments to yyparse() and yylexe() methods */
 %parse-param {class DiffeqLexer& scanner}
-%parse-param {diffeq::DiffEqContext& context}
+%parse-param {diffeq::DiffEqContext& eq_context}
 %lex-param   {diffeq::DiffEqScanner &scanner }
 
 /** use variant based implementation of semantic values */
@@ -115,7 +115,7 @@
  */
 
 top             : expression                {
-                                                context.solution.b = "-(" + context.solution.b + ")/(" + context.solution.a + ")";
+                                                eq_context.solution.b = "-(" + eq_context.solution.b + ")/(" + eq_context.solution.a + ")";
                                             }
                 | error                     {
                                                 throw std::runtime_error("Invalid differential equation");
@@ -131,63 +131,63 @@ expression      : e                         { $$ = $1; }
 
 
 e               : ATOM                      {
-                                                context.solution = Term($1, context.state_variable());
-                                                $$ = context.solution;
+                                                eq_context.solution = Term($1, eq_context.state_variable());
+                                                $$ = eq_context.solution;
                                             }
 
                 | "(" e ")"                 {
-                                                context.solution = Term();
-                                                context.solution.expr = "(" + $2.expr + ")";
+                                                eq_context.solution = Term();
+                                                eq_context.solution.expr = "(" + $2.expr + ")";
 
                                                 if($2.deriv_nonzero())
-                                                    context.solution.deriv = "(" + $2.deriv + ")";
+                                                    eq_context.solution.deriv = "(" + $2.deriv + ")";
                                                 if($2.a_nonzero())
-                                                    context.solution.a = "(" + $2.a + ")";
+                                                    eq_context.solution.a = "(" + $2.a + ")";
                                                 if($2.b_nonzero())
-                                                    context.solution.b = "(" + $2.b + ")";
+                                                    eq_context.solution.b = "(" + $2.b + ")";
 
-                                                $$ = context.solution;
+                                                $$ = eq_context.solution;
                                             }
 
                 | ATOM "(" arglist ")"      {
-                                                context.solution = Term();
-                                                context.solution.expr = $1 +  "(" + $3.expr + ")";
-                                                context.solution.b = $1 + "(" + $3.expr + ")";
-                                                $$ = context.solution;
+                                                eq_context.solution = Term();
+                                                eq_context.solution.expr = $1 +  "(" + $3.expr + ")";
+                                                eq_context.solution.b = $1 + "(" + $3.expr + ")";
+                                                $$ = eq_context.solution;
                                             }
 
                 | "-" e %prec UNARYMINUS    {
-                                                context.solution = Term();
-                                                context.solution.expr = "-" + $2.expr;
+                                                eq_context.solution = Term();
+                                                eq_context.solution.expr = "-" + $2.expr;
 
                                                 if($2.deriv_nonzero())
-                                                    context.solution.deriv = "-" + $2.deriv;
+                                                    eq_context.solution.deriv = "-" + $2.deriv;
                                                 if($2.a_nonzero())
-                                                    context.solution.a = "-" + $2.a;
+                                                    eq_context.solution.a = "-" + $2.a;
                                                 if($2.b_nonzero())
-                                                    context.solution.b = "-" +$2.b;
+                                                    eq_context.solution.b = "-" +$2.b;
 
-                                                $$ = context.solution;
+                                                $$ = eq_context.solution;
                                             }
 
                 | e "+" e                   {
-                                                context.solution = eval_derivative<MathOp::add>($1, $3, context.deriv_invalid, context.eqn_invalid);
-                                                $$ = context.solution;
+                                                eq_context.solution = eval_derivative<MathOp::add>($1, $3, eq_context.deriv_invalid, eq_context.eqn_invalid);
+                                                $$ = eq_context.solution;
                                             }
 
                 | e "-" e                   {
-                                                context.solution = eval_derivative<MathOp::sub>($1, $3, context.deriv_invalid, context.eqn_invalid);
-                                                $$ = context.solution;
+                                                eq_context.solution = eval_derivative<MathOp::sub>($1, $3, eq_context.deriv_invalid, eq_context.eqn_invalid);
+                                                $$ = eq_context.solution;
                                             }
 
                 | e "*" e                   {
-                                                context.solution = eval_derivative<MathOp::mul>($1, $3, context.deriv_invalid, context.eqn_invalid);
-                                                $$ = context.solution;
+                                                eq_context.solution = eval_derivative<MathOp::mul>($1, $3, eq_context.deriv_invalid, eq_context.eqn_invalid);
+                                                $$ = eq_context.solution;
                 }
 
                 | e "/" e                   {
-                                                context.solution = eval_derivative<MathOp::div>($1, $3, context.deriv_invalid, context.eqn_invalid);
-                                                $$ = context.solution;
+                                                eq_context.solution = eval_derivative<MathOp::div>($1, $3, eq_context.deriv_invalid, eq_context.eqn_invalid);
+                                                $$ = eq_context.solution;
 
                                             }
                 ;
@@ -199,29 +199,29 @@ arglist         : /*nothing*/               { $$ = Term("", "0.0", "0.0", ""); }
                 | arg                       { $$ = $1; }
 
                 | arglist arg               {
-                                                context.solution.expr = $1.expr + " " + $2.expr;
-                                                context.solution.b    = $1.expr + " " + $2.expr;
-                                                $$ = context.solution;
+                                                eq_context.solution.expr = $1.expr + " " + $2.expr;
+                                                eq_context.solution.b    = $1.expr + " " + $2.expr;
+                                                $$ = eq_context.solution;
                                             }
 
                 | arglist "," arg           {
-                                                context.solution.expr = $1.expr + "," + $3.expr;
-                                                context.solution.b    = $1.expr + "," + $3.expr;
-                                                $$ = context.solution;
+                                                eq_context.solution.expr = $1.expr + "," + $3.expr;
+                                                eq_context.solution.b    = $1.expr + "," + $3.expr;
+                                                $$ = eq_context.solution;
                                             }
                 ;
 
 
 
 arg             : e                         {
-                                                context.solution = Term();
-                                                context.solution.expr = $1.expr;
-                                                context.solution.b = $1.expr;
+                                                eq_context.solution = Term();
+                                                eq_context.solution.expr = $1.expr;
+                                                eq_context.solution.b = $1.expr;
                                                 if($1.deriv_nonzero()) {
-                                                    context.deriv_invalid = true;
-                                                    context.eqn_invalid = true;
+                                                    eq_context.deriv_invalid = true;
+                                                    eq_context.eqn_invalid = true;
                                                 }
-                                                $$ = context.solution;
+                                                $$ = eq_context.solution;
                                             }
                 ;
 

--- a/src/parser/diffeq_driver.cpp
+++ b/src/parser/diffeq_driver.cpp
@@ -48,14 +48,14 @@ std::string DiffeqDriver::solve_equation(std::string& state,
                                          bool& cnexp_possible,
                                          bool debug) {
     std::istringstream in(rhs);
-    diffeq::DiffEqContext context(state, order, rhs, method);
+    diffeq::DiffEqContext eq_context(state, order, rhs, method);
     DiffeqLexer scanner(&in);
-    DiffeqParser parser(scanner, context);
+    DiffeqParser parser(scanner, eq_context);
     parser.parse();
     if (debug) {
-        context.print();
+        eq_context.print();
     }
-    return context.get_solution(cnexp_possible);
+    return eq_context.get_solution(cnexp_possible);
 }
 
 /// \todo Instead of using neuron like api, we need to refactor


### PR DESCRIPTION
 - upcoming bison release 3.6.0 will have new type called `class context`
 - this will conflict with the variable name used in differential
   equation parser and hence we rename it.