### PR TITLE
Fix incompatibility issues with manylinux1 platform

### DIFF
--- a/cmake/CompilerHelper.cmake
+++ b/cmake/CompilerHelper.cmake
@@ -1,8 +1,8 @@
 # minimal check for c++11 compliant gnu compiler
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion OUTPUT_VARIABLE GCC_VERSION)
-  if(NOT (GCC_VERSION VERSION_GREATER 4.9 OR GCC_VERSION VERSION_EQUAL 4.9))
-    message(FATAL_ERROR "${PROJECT_NAME} requires g++ >= 4.9 (for c++11 support)")
+  if(NOT (GCC_VERSION VERSION_GREATER 4.8.2 OR GCC_VERSION VERSION_EQUAL 4.8.2))
+    message(FATAL_ERROR "${PROJECT_NAME} requires g++ >= 4.8.2 (for C++11 support)")
   endif()
 endif()
 

--- a/ext/json/json.hpp
+++ b/ext/json/json.hpp
@@ -63,7 +63,7 @@ SOFTWARE.
         #error "unsupported Clang version - see https://github.com/nlohmann/json#supported-compilers"
     #endif
 #elif defined(__GNUC__) && !(defined(__ICC) || defined(__INTEL_COMPILER))
-    #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40900
+    #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40802
         #error "unsupported GCC version - see https://github.com/nlohmann/json#supported-compilers"
     #endif
 #endif

--- a/src/language/nodes.py
+++ b/src/language/nodes.py
@@ -245,13 +245,16 @@ class ChildNode(BaseNode):
                           * \\brief Erase member to {self.varname}
                           */
                          {self.class_name}Vector::const_iterator erase_{to_snake_case(self.class_name)}({self.class_name}Vector::const_iterator first) {{
-                            return {self.varname}.erase(first);
+                            auto first_it = const_iter_cast({self.varname}, first);
+                            return {self.varname}.erase(first_it);
                          }}
                          /**
                           * \\brief Erase members to {self.varname}
                           */
                          {self.class_name}Vector::const_iterator erase_{to_snake_case(self.class_name)}({self.class_name}Vector::const_iterator first, {self.class_name}Vector::const_iterator last) {{
-                            return {self.varname}.erase(first, last);
+                            auto first_it = const_iter_cast({self.varname}, first);
+                            auto last_it = const_iter_cast({self.varname}, last);
+                            return {self.varname}.erase(first_it, last_it);
                          }}
 
                          /**
@@ -259,22 +262,24 @@ class ChildNode(BaseNode):
                           */
                          {self.class_name}Vector::const_iterator insert_{to_snake_case(self.class_name)}({self.class_name}Vector::const_iterator position, const std::shared_ptr<{self.class_name}>& n) {{
                              {set_parent}
-
-                            return {self.varname}.insert(position, n);
+                            auto pos_it = const_iter_cast({self.varname}, position);
+                            return {self.varname}.insert(pos_it, n);
                          }}
                          /**
                           * \\brief Insert members to {self.varname}
                           */
-                         template <class InputIterator>
-                         void insert_{to_snake_case(self.class_name)}({self.class_name}Vector::const_iterator position, InputIterator first, InputIterator last) {{
+                         template <class NodeType, class InputIterator>
+                         void insert_{to_snake_case(self.class_name)}({self.class_name}Vector::const_iterator position, NodeType& to, InputIterator first, InputIterator last) {{
 
                              for (auto it = first; it != last; ++it) {{
                                  auto& n = *it;
                                  //set parents
                                  {set_parent}
                               }}
-
-                            {self.varname}.insert(position, first, last);
+                             auto pos_it = const_iter_cast({self.varname}, position);
+                             auto first_it = const_iter_cast(to, first);
+                             auto last_it = const_iter_cast(to, last);
+                             {self.varname}.insert(pos_it, first_it, last_it);
                          }}
 
                          /**

--- a/src/language/templates/ast/ast.hpp
+++ b/src/language/templates/ast/ast.hpp
@@ -36,8 +36,7 @@
     {% if node.is_abstract %} virtual {% endif %}
 {% endmacro %}
 
-
-
+using nmodl::utils::const_iter_cast;
 
 namespace nmodl {
 namespace ast {

--- a/src/language/templates/pybind/pyast.cpp
+++ b/src/language/templates/pybind/pyast.cpp
@@ -165,7 +165,7 @@ static const char* eval_method = R"(
 namespace py = pybind11;
 using namespace nmodl::ast;
 using nmodl::visitor::JSONVisitor;
-using pybind11::literals::operator""_a;
+using namespace pybind11::literals;
 
 
 void init_ast_module(py::module& m) {

--- a/src/language/templates/pybind/pysymtab.cpp
+++ b/src/language/templates/pybind/pysymtab.cpp
@@ -62,7 +62,7 @@ static const char* symtabvisitor_class = R"(
 
 
 namespace py = pybind11;
-using pybind11::literals::operator""_a;
+using namespace pybind11::literals;
 
 using namespace nmodl;
 using namespace symtab;

--- a/src/language/templates/pybind/pyvisitor.cpp
+++ b/src/language/templates/pybind/pyvisitor.cpp
@@ -85,7 +85,7 @@ static const char* sympy_solver_visitor_class = R"(
 }  // namespace nmodl
 
 
-using pybind11::literals::operator""_a;
+using namespace pybind11::literals;
 namespace py = pybind11;
 
 

--- a/src/pybind/pynmodl.cpp
+++ b/src/pybind/pynmodl.cpp
@@ -28,7 +28,7 @@
 
 
 namespace py = pybind11;
-using pybind11::literals::operator""_a;
+using namespace pybind11::literals;
 
 
 namespace nmodl {

--- a/src/utils/common_utils.hpp
+++ b/src/utils/common_utils.hpp
@@ -48,6 +48,32 @@ T remove_extension(T const& filename) {
     return p > 0 && p != T::npos ? filename.substr(0, p) : filename;
 }
 
+/**
+ * Retrun non-const iterator corresponding to the const_iterator in a vector
+ *
+ * Some old compilers like GCC v4.8.2  has C++11 support but missing erase and insert
+ * with const_iterator implementation. This is a workaround to handle build issues with
+ * such compilers especially on manylnux1 platform.
+ *
+ * See bug report : https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57158
+ *
+ * \todo Remove this after move to manylinux2010 platform.
+ */
+#if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40900
+template<typename T>
+typename std::vector<T>::iterator
+const_iter_cast(std::vector<T>& v, typename std::vector<T>::const_iterator iter) {
+    return v.begin() + (iter - v.cbegin());
+}
+#else
+template<typename T>
+typename std::vector<T>::const_iterator
+const_iter_cast(const std::vector<T>& /*v*/, typename std::vector<T>::const_iterator iter) {
+    return iter;
+}
+#endif
+
+
 /// Given directory path, create sub-directories
 bool make_path(const std::string& path);
 

--- a/src/utils/common_utils.hpp
+++ b/src/utils/common_utils.hpp
@@ -49,7 +49,7 @@ T remove_extension(T const& filename) {
 }
 
 /**
- * Retrun non-const iterator corresponding to the const_iterator in a vector
+ * Return non-const iterator corresponding to the const_iterator in a vector
  *
  * Some old compilers like GCC v4.8.2  has C++11 support but missing erase and insert
  * with const_iterator implementation. This is a workaround to handle build issues with

--- a/src/visitors/inline_visitor.cpp
+++ b/src/visitors/inline_visitor.cpp
@@ -273,7 +273,7 @@ void InlineVisitor::visit_statement_block(StatementBlock& node) {
     for (auto& element: inlined_statements) {
         auto it = std::find(statements.begin(), statements.end(), element.first);
         if (it != statements.end()) {
-            node.insert_statement(it, element.second.begin(), element.second.end());
+            node.insert_statement(it, element.second, element.second.begin(), element.second.end());
             element.second.clear();
         }
     }


### PR DESCRIPTION
#### Motivation
We would like to ship nmodl with NEURON manylinux1 wheel during upcoming release 8.0 

#### Changes
- manylinux1 platform provides gcc 4.8.2 for wider compatibility
- gcc 4.8.2 is first gnu compiler supporting `almost all` C++11
  except that it lacks `const_iterator` overload for std::vector::erase
  and std::vector::insert
- in this PR we introduce const_iter_cast thar turns const iterator
  into non-const-iterator to have minimal changes to the code base
- change the compatibility to gcc 4.8.2 for cmake as well as json library
- change `pybind11::literals::operator""_a` to `namespace pybind11::literals`
  as documented in https://pybind11.readthedocs.io/en/stable/basics.html#keyword-arguments

fixes #319

#### Considerations
* This PR is **not an attempt** to bind to the oldest compiler
* We have [started investigation to upgrade to new gcc](https://github.com/neuronsimulator/nrn/issues/511) (e.g. v7 or v8) under manylinux platfor. This should happen soon after 8.0 release.
* For this 8.0 relate, NEURON wheel infrastructure is setup with manylinux1 and would be good to have current nmodl ship with NEURON
* As the changes are minimal here, it won't be a big deal to get this in.