### PR TITLE
Consistently use spdlog (and internal fmt)

### DIFF
--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -5,8 +5,6 @@
  * Lesser General Public License. See top-level LICENSE file for details.
  *************************************************************************/
 
-#include <fmt/format.h>
-
 #include "codegen/codegen_acc_visitor.hpp"
 
 

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -22,12 +22,11 @@
 #include <string>
 #include <utility>
 
-#include <fmt/format.h>
-
 #include "codegen/codegen_info.hpp"
 #include "codegen/codegen_naming.hpp"
 #include "printer/code_printer.hpp"
 #include "symtab/symbol_table.hpp"
+#include "utils/logger.hpp"
 #include "visitors/ast_visitor.hpp"
 
 

--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -9,10 +9,9 @@
 #include <cmath>
 #include <set>
 
-#include <fmt/format.h>
-
 #include "codegen/codegen_helper_visitor.hpp"
 #include "codegen/codegen_naming.hpp"
+#include "utils/logger.hpp"
 #include "visitors/lookup_visitor.hpp"
 #include "visitors/rename_visitor.hpp"
 

--- a/src/language/templates/visitors/checkparent_visitor.cpp
+++ b/src/language/templates/visitors/checkparent_visitor.cpp
@@ -12,9 +12,9 @@
 #include "visitors/checkparent_visitor.hpp"
 
 #include <string>
-#include <fmt/format.h>
 
 #include "ast/ast.hpp"
+#include "utils/logger.hpp"
 
 namespace nmodl {
 namespace visitor {

--- a/src/symtab/symbol.cpp
+++ b/src/symtab/symbol.cpp
@@ -5,10 +5,8 @@
  * Lesser General Public License. See top-level LICENSE file for details.
  *************************************************************************/
 
-#include <fmt/format.h>
-
 #include "symtab/symbol.hpp"
-
+#include "utils/logger.hpp"
 
 using namespace fmt::literals;
 

--- a/src/utils/common_utils.hpp
+++ b/src/utils/common_utils.hpp
@@ -60,15 +60,16 @@ T remove_extension(T const& filename) {
  * \todo Remove this after move to manylinux2010 platform.
  */
 #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) < 40900
-template<typename T>
-typename std::vector<T>::iterator
-const_iter_cast(std::vector<T>& v, typename std::vector<T>::const_iterator iter) {
+template <typename T>
+typename std::vector<T>::iterator const_iter_cast(std::vector<T>& v,
+                                                  typename std::vector<T>::const_iterator iter) {
     return v.begin() + (iter - v.cbegin());
 }
 #else
-template<typename T>
-typename std::vector<T>::const_iterator
-const_iter_cast(const std::vector<T>& /*v*/, typename std::vector<T>::const_iterator iter) {
+template <typename T>
+typename std::vector<T>::const_iterator const_iter_cast(
+    const std::vector<T>& /*v*/,
+    typename std::vector<T>::const_iterator iter) {
     return iter;
 }
 #endif


### PR DESCRIPTION
  - spdlog ships it's internal fmt library
  - user header only target is not desirable at the moment
    due to link library required for some targets
  - we now udpated fmt and spdlog to have same fmt 6.2.0
  - use spdlog consistently to avoid inclusion of incompatible
    headers
 - #330 got introduced in 809d68de3f476db53569b277f553c62097fa25e5

fixes #330  