### PR TITLE
Fix code generator dependencies

### DIFF
--- a/src/language/code_generator.cmake
+++ b/src/language/code_generator.cmake
@@ -9,6 +9,7 @@ set(CODE_GENERATOR_JINJA_FILES
     ${PROJECT_SOURCE_DIR}/src/language/templates/ast/ast.hpp
     ${PROJECT_SOURCE_DIR}/src/language/templates/ast/ast_decl.hpp
     ${PROJECT_SOURCE_DIR}/src/language/templates/ast/node.hpp
+    ${PROJECT_SOURCE_DIR}/src/language/templates/ast/node_class.template
     ${PROJECT_SOURCE_DIR}/src/language/templates/pybind/pyast.cpp
     ${PROJECT_SOURCE_DIR}/src/language/templates/pybind/pyast.hpp
     ${PROJECT_SOURCE_DIR}/src/language/templates/pybind/pysymtab.cpp

--- a/src/language/code_generator.py
+++ b/src/language/code_generator.py
@@ -126,6 +126,8 @@ class CodeGenerator(
         outputs = dict()
         for task in tasks:
             inputs.add(task.input.relative_to(self.jinja_templates_dir))
+            for dep in task.extradeps:
+                inputs.add(dep.relative_to(self.jinja_templates_dir))
             dir, name = task.output.relative_to(self.base_dir).parts
             outputs.setdefault(dir, []).append(name)
 
@@ -158,7 +160,7 @@ class CodeGenerator(
         extradeps = collections.defaultdict(
             list,
             {
-                self.jinja_templates_dir / "ast" / "ast.hpp": [node_class_tpl],
+                self.jinja_templates_dir / "ast" / "all.hpp": [node_class_tpl],
                 node_hpp_tpl: [node_class_tpl],
             },
         )


### PR DESCRIPTION
Unit ast headers and `all.hpp` are now rebuilt when
template `node_class.template` is modified.

It involves 2 fixes:
* It is the Jinja template `all.hpp` that includes `node_class.template`, not `ast.hpp`
* Jinja tasks extra dependencies are now declared at CMake level