### PR TITLE
Improve prototype of Ast node getters and ctors

### DIFF
--- a/src/language/node_info.py
+++ b/src/language/node_info.py
@@ -18,19 +18,20 @@ We should properties like is_enum, data_type, is_symbol, is_global etc.
 """
 
 # yapf: disable
-BASE_TYPES = {"short",
-              "int",
-              "float",
-              "double",
-              "std::string",
-              "BinaryOp",
-              "UnaryOp",
-              "ReactionOp",
-              "FirstLastType",
-              "QueueType",
-              "BAType",
-              "UnitStateType",
-              }
+INTEGRAL_TYPES = {"short",
+                  "int",
+                  "float",
+                  "double",
+                  "BinaryOp",
+                  "UnaryOp",
+                  "ReactionOp",
+                  "FirstLastType",
+                  "QueueType",
+                  "BAType",
+                  "UnitStateType",
+                  }
+
+BASE_TYPES = {"std::string" } | INTEGRAL_TYPES
 
 # base types which are enums
 ENUM_BASE_TYPES = {"BinaryOp",

--- a/src/language/templates/ast/node_class.template
+++ b/src/language/templates/ast/node_class.template
@@ -64,8 +64,10 @@ class {{ node.class_name }} : public {{ node.base_class }} {
 
   /// \}
 
+  {% if node.is_base_block_node or node.is_number_node %}
   /// \name Not implemented
   /// \{
+  {% endif %}
 
   {% if node.is_base_block_node %}
     virtual const ArgumentVector& get_parameters() const {
@@ -79,7 +81,7 @@ class {{ node.class_name }} : public {{ node.base_class }} {
     }
   {% endif %}
 
-  /// \}
+  {{ "/// \}" if node.is_base_block_node or node.is_number_node else "" }}
 
   /**
    * \brief Check if the ast node is an instance of ast::{{ node.class_name }}
@@ -220,8 +222,10 @@ class {{ node.class_name }} : public {{ node.base_class }} {
 
   /// \}
 
+  {% if node.has_setters %}
   /// \name Setters
   /// \{
+  {% endif %}
 
   {% if node.is_name_node %}
     /**
@@ -274,7 +278,7 @@ class {{ node.class_name }} : public {{ node.base_class }} {
     {{ child.get_setter_method_declaration(node.class_name) }}
   {% endfor %}
 
-  /// \}
+  {{ "/// \}" if node.has_setters else "" }}
 
   /// \name Visitor
   /// \{

--- a/src/lexer/nmodl.ll
+++ b/src/lexer/nmodl.ll
@@ -231,7 +231,7 @@ ELSE                    {
                                   * as integer with token as it's name. Otherwise return it as
                                   * regular name token. */
                                 else if (driver.is_defined_var(yytext)) {
-                                    auto value = driver.get_defined_var_value(yytext);
+                                    const auto& value = driver.get_defined_var_value(yytext);
                                     return integer_symbol(value, loc, yytext);
                                 } else {
                                     return name_symbol(yytext, loc);


### PR DESCRIPTION
This pull-request brings minor improvements to the generated Ast classes:

* Node constructors: use `const&` for not integral types
* Remove empty Doxygen groups, for instance
   ```c++
   /// \name Setters
   /// \{

   /// \}
   ```
* Node `get_xxx` methods:
  * mark them `noexcept`
  * return by value instead of reference for integral types, for instance:
  ```diff
         /**
	-     * \brief Getter (const ref) for member variable \ref Integer.value
	+     * \brief Getter for member variable \ref Integer.value
	      */
	-    const int& get_value() const {
	+    int get_value() const noexcept {
	         return value;
	     }
   ```