### PR TITLE
Ast generated code: fix template members / move definitions in compilation unit

### DIFF
--- a/src/language/code_generator.cmake
+++ b/src/language/code_generator.cmake
@@ -10,6 +10,7 @@ set(CODE_GENERATOR_JINJA_FILES
     ${PROJECT_SOURCE_DIR}/src/language/templates/ast/ast_decl.hpp
     ${PROJECT_SOURCE_DIR}/src/language/templates/ast/node.hpp
     ${PROJECT_SOURCE_DIR}/src/language/templates/ast/node_class.template
+    ${PROJECT_SOURCE_DIR}/src/language/templates/ast/node_class_inline_definition.template
     ${PROJECT_SOURCE_DIR}/src/language/templates/pybind/pyast.cpp
     ${PROJECT_SOURCE_DIR}/src/language/templates/pybind/pyast.hpp
     ${PROJECT_SOURCE_DIR}/src/language/templates/pybind/pysymtab.cpp

--- a/src/language/node_info.py
+++ b/src/language/node_info.py
@@ -171,10 +171,3 @@ UNIT_BLOCK = "UnitBlock"
 ORDER_VAR_NAME = "order"
 BINARY_OPERATOR_NAME = "op"
 # yapf: enable
-
-# those are the header file names that have circular dependencies in the NMODL
-# language abstract class definition. This means that the header file that fully
-# defines a class should be included in the beginning of the all.hpp file
-# because another class is depending on it, while in the NMODL language abstract
-# class definition the first class is defined after the dependent one
-CIRCULAR_DEPENDECIES = {"assigned_definition"}

--- a/src/language/templates/ast/all.hpp
+++ b/src/language/templates/ast/all.hpp
@@ -24,7 +24,9 @@
 {% for node in nodes %}
 #ifndef {{ node.cpp_fence }}
 #define {{ node.cpp_fence }}
+{% if node.has_template_methods %}
 #define {{ node.cpp_fence }}_INLINE_DEFINITION_REQUIRED
+{% endif %}
 {% include "ast/node_class.template" %}
 #endif // !{{ node.cpp_fence }}
 {% endfor %}

--- a/src/language/templates/ast/all.hpp
+++ b/src/language/templates/ast/all.hpp
@@ -20,13 +20,25 @@
  */
 
 #include "ast/ast.hpp"
-{% for header in node_info.CIRCULAR_DEPENDECIES %}
-#include "ast/{{header}}.hpp"
-{% endfor %}
 
 {% for node in nodes %}
 #ifndef {{ node.cpp_fence }}
 #define {{ node.cpp_fence }}
+#define {{ node.cpp_fence }}_INLINE_DEFINITION_REQUIRED
 {% include "ast/node_class.template" %}
 #endif // !{{ node.cpp_fence }}
 {% endfor %}
+
+{# add inline definitions of template member methods #}
+namespace nmodl {
+namespace ast {
+{% for node in nodes %}
+{%- if node.has_template_methods %}
+#ifdef {{ node.cpp_fence }}_INLINE_DEFINITION_REQUIRED
+  {% include "ast/node_class_inline_definition.template" %}
+#endif  // !{{ node.cpp_fence }}_INLINE_DEFINITION_REQUIRED
+
+{% endif %}
+{%- endfor %}
+}  // namespace ast
+}  // namespace nmodl

--- a/src/language/templates/ast/ast.cpp
+++ b/src/language/templates/ast/ast.cpp
@@ -81,6 +81,8 @@ void Ast::set_parent(Ast* p) {
     ///
 
     {% for child in node.children %}
+      {{ child.get_add_methods_definition(node) }}
+
       {{ child.get_node_name_method_definition(node) }}
     {% endfor %}
 

--- a/src/language/templates/ast/node_class.template
+++ b/src/language/templates/ast/node_class.template
@@ -212,7 +212,7 @@ class {{ node.class_name }} : public {{ node.base_class }} {
 
   {# doxygen for these methods is handled by nodes.py #}
   {% for child in node.children %}
-    {{ child.get_add_methods() }}
+    {{ child.get_add_methods_declaration() }}
 
     {{ child.get_node_name_method_declaration() }}
 
@@ -373,6 +373,10 @@ class {{ node.class_name }} : public {{ node.base_class }} {
 };
 
 /** @} */  // end of ast_class
+
+{% if render_ast_all is not defined %}
+{% include "ast/node_class_inline_definition.template" %}
+{% endif %}
 
 }  // namespace ast
 }  // namespace nmodl

--- a/src/language/templates/ast/node_class_inline_definition.template
+++ b/src/language/templates/ast/node_class_inline_definition.template
@@ -1,0 +1,8 @@
+{#
+   this Jinja template is not used to directly generate
+   a file but included by other templates.
+#}
+{# doxygen for these methods is handled by nodes.py #}
+{% for child in node.children %}
+  {{ child.get_add_methods_inline_definition(node) }}
+{% endfor %}

--- a/test/unit/visitor/local_to_assigned.cpp
+++ b/test/unit/visitor/local_to_assigned.cpp
@@ -1,0 +1,80 @@
+/*************************************************************************
+ * Copyright (C) 2018-2019 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#include "catch/catch.hpp"
+
+#include "ast/program.hpp"
+#include "parser/nmodl_driver.hpp"
+#include "test/unit/utils/nmodl_constructs.hpp"
+#include "visitors/local_var_visitor.hpp"
+#include "visitors/lookup_visitor.hpp"
+#include "visitors/nmodl_visitor.hpp"
+#include "visitors/perf_visitor.hpp"
+#include "visitors/symtab_visitor.hpp"
+
+using namespace nmodl;
+using namespace visitor;
+using namespace test_utils;
+
+using ast::AstNodeType;
+using nmodl::parser::NmodlDriver;
+using symtab::syminfo::NmodlType;
+
+//=============================================================================
+// GlobalToRange visitor tests
+//=============================================================================
+
+std::shared_ptr<ast::Program> run_local_to_assigned_visitor(const std::string& text) {
+    std::map<std::string, std::string> rval;
+    NmodlDriver driver;
+    auto ast = driver.parse_string(text);
+
+    SymtabVisitor().visit_program(*ast);
+    PerfVisitor().visit_program(*ast);
+    LocalToAssignedVisitor().visit_program(*ast);
+    SymtabVisitor().visit_program(*ast);
+    return ast;
+}
+
+SCENARIO("LOCAL to ASSIGNED variable transformer", "[visitor][localtoassigned]") {
+    GIVEN("mod file with LOCAL variables that are written") {
+        std::string input_nmodl = R"(
+            NEURON {
+                SUFFIX test
+            }
+            LOCAL x, y, z
+            INITIAL {
+                x = 1
+            }
+            BREAKPOINT {
+                z = 2
+            }
+        )";
+        auto ast = run_local_to_assigned_visitor(input_nmodl);
+        auto symtab = ast->get_symbol_table();
+        THEN("LOCAL variables that are written are turned to ASSIGNED") {
+            /// check for all ASSIGNED variables : old ones + newly converted ones
+            auto vars = symtab->get_variables_with_properties(NmodlType::assigned_definition);
+            REQUIRE(vars.size() == 2);
+
+            /// x and z should be converted from LOCAL to ASSIGNED
+            auto x = symtab->lookup("x");
+            REQUIRE(x != nullptr);
+            REQUIRE(x->has_any_property(NmodlType::assigned_definition) == true);
+            REQUIRE(x->has_any_property(NmodlType::local_var) == false);
+            auto z = symtab->lookup("z");
+            REQUIRE(z != nullptr);
+            REQUIRE(z->has_any_property(NmodlType::assigned_definition) == true);
+            REQUIRE(z->has_any_property(NmodlType::local_var) == false);
+        }
+        THEN("LOCAL variables that are read only remain LOCAL") {
+            auto vars = symtab->get_variables_with_properties(NmodlType::local_var);
+            REQUIRE(vars.size() == 1);
+            REQUIRE(vars[0]->get_name() == "y");
+        }
+    }
+}


### PR DESCRIPTION
Ast generated code: fix template members / move definitions in compilation unit

* In `ast/all.hpp` the definition of template member functions are
now after the definition of all Ast classes.
* The definition of some member methods has been moved in `ast/ast.cpp`
compilation units instead of inlining them.