### PR TITLE
Fix declaration of dt_saved_value in ISPC backend

### DIFF
--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -63,6 +63,36 @@ void CodegenIspcVisitor::visit_var_name(ast::VarName& node) {
     CodegenCVisitor::visit_var_name(node);
 }
 
+void CodegenIspcVisitor::visit_local_list_statement(ast::LocalListStatement& node) {
+    if (!codegen) {
+        return;
+    }
+    auto type = CodegenCVisitor::local_var_type() + " ";
+    printer->add_text(type);
+    auto local_variables = node.get_variables();
+    std::string separator = ", ";
+    std::set<std::string> uniform_variables;
+    for (auto iter = local_variables.begin(); iter != local_variables.end(); iter++) {
+        if ((*iter)->get_node_name().find("dt_") != std::string::npos) {
+            uniform_variables.insert((*iter)->get_node_name());
+            continue;
+        }
+        printer->add_text((*iter)->get_node_name());
+        if (!separator.empty() && !utils::is_last(iter, local_variables)) {
+            printer->add_text(separator);
+        }
+    }
+    printer->add_text(";");
+    printer->add_newline();
+    type = CodegenCVisitor::local_var_type() + " uniform ";
+    printer->add_text(type);
+    for (auto iter = uniform_variables.begin(); iter != uniform_variables.end(); iter++) {
+        printer->add_text(*iter);
+        if (!separator.empty() && !utils::is_last(iter, uniform_variables)) {
+            printer->add_text(separator);
+        }
+    }
+}
 
 /****************************************************************************************/
 /*                      Routines must be overloaded in backend                          */

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -70,12 +70,13 @@ void CodegenIspcVisitor::visit_local_list_statement(ast::LocalListStatement& nod
     auto type = CodegenCVisitor::local_var_type() + " ";
     printer->add_text(type);
     auto local_variables = node.get_variables();
-    std::string separator = ", ";
     std::set<std::string> uniform_variables;
     auto dt_saved_value_exists = false;
 
     /// Remove dt_saved_value from local_variables if it exists
-    for(auto it_local_variables = local_variables.begin(); it_local_variables < local_variables.end(); ++it_local_variables) {
+    for (auto it_local_variables = local_variables.begin();
+         it_local_variables < local_variables.end();
+         ++it_local_variables) {
         if ((*it_local_variables)->get_node_name() == "dt_saved_value") {
             local_variables.erase(it_local_variables);
             dt_saved_value_exists = true;

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -67,6 +67,10 @@ void CodegenIspcVisitor::visit_local_list_statement(ast::LocalListStatement& nod
     if (!codegen) {
         return;
     }
+    /// Correct indentation
+    printer->add_newline();
+    printer->add_indent();
+
     /// Name of the variable _dt given by
     /// nmodl::visitor::SteadystateVisitor::create_steadystate_block()
     const std::string steadystate_dt_variable_name = "dt_saved_value";
@@ -95,7 +99,9 @@ void CodegenIspcVisitor::visit_local_list_statement(ast::LocalListStatement& nod
     /// Print dt_saved_value as uniform
     if (dt_saved_value_exists) {
         printer->add_text(";");
+        /// Correct indentation
         printer->add_newline();
+        printer->add_indent();
 
         type = CodegenCVisitor::local_var_type() + " uniform ";
         printer->add_text(type + steadystate_dt_variable_name);

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -72,25 +72,27 @@ void CodegenIspcVisitor::visit_local_list_statement(ast::LocalListStatement& nod
     auto local_variables = node.get_variables();
     std::string separator = ", ";
     std::set<std::string> uniform_variables;
-    for (auto iter = local_variables.begin(); iter != local_variables.end(); iter++) {
-        if ((*iter)->get_node_name().find("dt_") != std::string::npos) {
-            uniform_variables.insert((*iter)->get_node_name());
-            continue;
-        }
-        printer->add_text((*iter)->get_node_name());
-        if (!separator.empty() && !utils::is_last(iter, local_variables)) {
-            printer->add_text(separator);
+    auto dt_saved_value_exists = false;
+
+    /// Remove dt_saved_value from local_variables if it exists
+    for(auto it_local_variables = local_variables.begin(); it_local_variables < local_variables.end(); ++it_local_variables) {
+        if ((*it_local_variables)->get_node_name() == "dt_saved_value") {
+            local_variables.erase(it_local_variables);
+            dt_saved_value_exists = true;
+            break;
         }
     }
-    printer->add_text(";");
-    printer->add_newline();
-    type = CodegenCVisitor::local_var_type() + " uniform ";
-    printer->add_text(type);
-    for (auto iter = uniform_variables.begin(); iter != uniform_variables.end(); iter++) {
-        printer->add_text(*iter);
-        if (!separator.empty() && !utils::is_last(iter, uniform_variables)) {
-            printer->add_text(separator);
-        }
+
+    /// Print the local_variables like normally
+    CodegenCVisitor::print_vector_elements(local_variables, ", ");
+
+    /// Print dt_saved_value as uniform
+    if (dt_saved_value_exists) {
+        printer->add_text(";");
+        printer->add_newline();
+
+        type = CodegenCVisitor::local_var_type() + " uniform ";
+        printer->add_text(type + "dt_saved_value");
     }
 }
 

--- a/src/codegen/codegen_ispc_visitor.hpp
+++ b/src/codegen/codegen_ispc_visitor.hpp
@@ -233,6 +233,7 @@ class CodegenIspcVisitor: public CodegenCVisitor {
     void visit_function_call(ast::FunctionCall& node) override;
     void visit_var_name(ast::VarName& node) override;
     void visit_program(ast::Program& node) override;
+    void visit_local_list_statement(ast::LocalListStatement& node) override;
 };
 
 /** @} */  // end of codegen_backends


### PR DESCRIPTION
- `dt_saved_value` should be defined as uniform in the ISPC backend while other variables should be varying (simply double)
- Fixes #329 