### PR TITLE
Introducing ConstVisitor

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -18,7 +18,6 @@
 #include "parser/c11_driver.hpp"
 #include "utils/logger.hpp"
 #include "utils/string_utils.hpp"
-#include "visitors/lookup_visitor.hpp"
 #include "visitors/rename_visitor.hpp"
 #include "visitors/var_usage_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
@@ -30,7 +29,6 @@ namespace codegen {
 
 using namespace ast;
 
-using visitor::AstLookupVisitor;
 using visitor::RenameVisitor;
 using visitor::VarUsageVisitor;
 
@@ -1402,10 +1400,7 @@ void CodegenCVisitor::print_function_prototypes() {
 static TableStatement* get_table_statement(ast::Block& node) {
     // TableStatementVisitor v;
 
-    AstLookupVisitor v(AstNodeType::TABLE_STATEMENT);
-    node.accept(v);
-
-    auto table_statements = v.get_nodes();
+    const auto& table_statements = collect_nodes(node, {AstNodeType::TABLE_STATEMENT});
 
     if (table_statements.size() != 1) {
         auto message =

--- a/src/codegen/codegen_compatibility_visitor.cpp
+++ b/src/codegen/codegen_compatibility_visitor.cpp
@@ -10,14 +10,13 @@
 #include "ast/all.hpp"
 #include "parser/c11_driver.hpp"
 #include "utils/logger.hpp"
-#include "visitors/lookup_visitor.hpp"
+#include "visitors/visitor_utils.hpp"
+
 
 using namespace fmt::literals;
 
 namespace nmodl {
 namespace codegen {
-
-using visitor::AstLookupVisitor;
 
 const std::map<ast::AstNodeType, CodegenCompatibilityVisitor::FunctionPointer>
     CodegenCompatibilityVisitor::unhandled_ast_types_func(
@@ -92,7 +91,7 @@ std::string CodegenCompatibilityVisitor::return_error_if_no_bbcore_read_write(
     ast::Ast& node,
     const std::shared_ptr<ast::Ast>& ast_node) {
     std::stringstream error_message_no_bbcore_read_write;
-    auto verbatim_nodes = AstLookupVisitor().lookup(node, AstNodeType::VERBATIM);
+    const auto& verbatim_nodes = collect_nodes(node, {AstNodeType::VERBATIM});
     auto found_bbcore_read = false;
     auto found_bbcore_write = false;
     for (const auto& it: verbatim_nodes) {
@@ -140,7 +139,7 @@ bool CodegenCompatibilityVisitor::find_unhandled_ast_nodes(Ast& node) {
     for (auto kv: unhandled_ast_types_func) {
         unhandled_ast_types.push_back(kv.first);
     }
-    unhandled_ast_nodes = AstLookupVisitor().lookup(node, unhandled_ast_types);
+    unhandled_ast_nodes = collect_nodes(node, unhandled_ast_types);
 
     std::stringstream ss;
     for (const auto& it: unhandled_ast_nodes) {

--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -12,7 +12,6 @@
 
 #include "ast/all.hpp"
 #include "codegen/codegen_naming.hpp"
-#include "visitors/lookup_visitor.hpp"
 
 
 namespace nmodl {

--- a/src/codegen/codegen_info.cpp
+++ b/src/codegen/codegen_info.cpp
@@ -8,13 +8,11 @@
 #include "codegen/codegen_info.hpp"
 
 #include "ast/all.hpp"
-#include "visitors/lookup_visitor.hpp"
+#include "visitors/visitor_utils.hpp"
 
 
 namespace nmodl {
 namespace codegen {
-
-using visitor::AstLookupVisitor;
 
 /// if any ion has write variable
 bool CodegenInfo::ion_has_write_variable() const {
@@ -100,9 +98,7 @@ bool CodegenInfo::nrn_state_has_eigen_solver_block() const {
     if (nrn_state_block == nullptr) {
         return false;
     }
-    return !AstLookupVisitor()
-                .lookup(*nrn_state_block, ast::AstNodeType::EIGEN_NEWTON_SOLVER_BLOCK)
-                .empty();
+    return !collect_nodes(*nrn_state_block, {ast::AstNodeType::EIGEN_NEWTON_SOLVER_BLOCK}).empty();
 }
 
 }  // namespace codegen

--- a/src/language/templates/ast/ast.cpp
+++ b/src/language/templates/ast/ast.cpp
@@ -109,7 +109,34 @@ void Ast::set_parent(Ast* p) {
     {% endfor %}
     }
 
+    void {{ node.class_name }}::visit_children(visitor::ConstVisitor& v) const {
+    {% for child in node.non_base_members %}
+        {% if child.is_vector %}
+        /// visit each element of vector
+        for (auto& item : this->{{ child.varname }}) {
+            item->accept(v);
+        }
+        {% elif child.optional %}
+        /// optional member could be nullptr
+        if (this->{{ child.varname }}) {
+            this->{{ child.varname }}->accept(v);
+        }
+        {% elif child.is_pointer_node %}
+        /// use -> for pointer member
+        {{ child.varname }}->accept(v);
+        {% else %}
+        /// use . for object member
+        {{ child.varname }}.accept(v);
+        {% endif %}
+        (void)v;
+    {% endfor %}
+    }
+
     void {{ node.class_name }}::accept(visitor::Visitor& v) {
+        v.visit_{{ node.class_name | snake_case }}(*this);
+    }
+
+    void {{ node.class_name }}::accept(visitor::ConstVisitor& v) const {
         v.visit_{{ node.class_name | snake_case }}(*this);
     }
 

--- a/src/language/templates/ast/ast.hpp
+++ b/src/language/templates/ast/ast.hpp
@@ -137,7 +137,7 @@ struct Ast: public std::enable_shared_from_this<Ast> {
    * statement can be returned as a std::string for printing to
    * text/json form.
    *
-   * @return name of the statement as a string
+   * \return name of the statement as a string
    *
    * \sa Ast::get_nmodl_name
    */
@@ -152,7 +152,7 @@ struct Ast: public std::enable_shared_from_this<Ast> {
    * accept allows to visit the current node itself using the concrete
    * visitor provided.
    *
-   * @param v Concrete visitor that will be used to recursively visit children
+   * \param v Concrete visitor that will be used to recursively visit children
    *
    * \note Below is an example of `accept` method implementation which shows how
    *       visitor method corresponding to ast::IndexedName node is called allowing
@@ -168,12 +168,19 @@ struct Ast: public std::enable_shared_from_this<Ast> {
   virtual void accept(visitor::Visitor& v) = 0;
 
   /**
+   * \brief Accept (or visit) the AST node using a given visitor
+   * \param v constant visitor visiting the AST node
+   * \ref accept(visitor::Visitor&);
+   */
+  virtual void accept(visitor::ConstVisitor& v) const = 0;
+
+  /**
    * \brief Visit children i.e. member of AST node using provided visitor
    *
    * Different nodes in the AST have different members (i.e. children). This method
    * recursively visits children using provided concrete visitor.
    *
-   * @param v Concrete visitor that will be used to recursively visit node
+   * \param v Concrete visitor that will be used to recursively visit node
    *
    * \note Below is an example of `visit_children` method implementation which shows
    *       ast::IndexedName node children are visited instead of node itself.
@@ -188,6 +195,11 @@ struct Ast: public std::enable_shared_from_this<Ast> {
   virtual void visit_children(visitor::Visitor& v) = 0;
 
   /**
+   * \copydoc visit_children(visitor::Visitor& v)
+   */
+  virtual void visit_children(visitor::ConstVisitor& v) const = 0;
+
+  /**
    * \brief Create a copy of the current node
    *
    * Recursively make a new copy/clone of the current node including
@@ -195,7 +207,7 @@ struct Ast: public std::enable_shared_from_this<Ast> {
    * passes like nmodl::visitor::InlineVisitor where nodes are cloned in the
    * ast.
    *
-   * @return pointer to the clone/copy of the current node
+   * \return pointer to the clone/copy of the current node
    */
   virtual Ast* clone() const;
 
@@ -212,7 +224,7 @@ struct Ast: public std::enable_shared_from_this<Ast> {
    * name. Note that this is different from ast node type name and not every
    * ast node has name.
    *
-   * @return name of the node as std::string
+   * \return name of the node as std::string
    *
    * \sa Ast::get_node_type_name
    */
@@ -225,7 +237,7 @@ struct Ast: public std::enable_shared_from_this<Ast> {
    * can insert new nodes in the ast as a solution of ODEs. In this case, we return
    * nullptr to store in the nmodl::symtab::SymbolTable.
    *
-   * @return pointer to token if exist otherwise nullptr
+   * \return pointer to token if exist otherwise nullptr
    */
   virtual const ModToken* get_token() const;
 
@@ -236,7 +248,7 @@ struct Ast: public std::enable_shared_from_this<Ast> {
    * symbol table. These nodes have nmodl::symtab::SymbolTable as member
    * and it can be accessed using this method.
    *
-   * @return pointer to the symbol table
+   * \return pointer to the symbol table
    *
    * \sa nmodl::symtab::SymbolTable nmodl::visitor::SymtabVisitor
    */
@@ -259,7 +271,7 @@ struct Ast: public std::enable_shared_from_this<Ast> {
    *
    * This method return enclosing statement block.
    *
-   * @return pointer to the statement block if exist
+   * \return pointer to the statement block if exist
    *
    * \sa ast::StatementBlock
    */
@@ -306,7 +318,7 @@ struct Ast: public std::enable_shared_from_this<Ast> {
 
   /**
    *\brief Check if the ast node is an instance of ast::Ast
-   * @return true if object of type ast::Ast
+   * \return true if object of type ast::Ast
    */
   virtual bool is_ast() const noexcept;
 

--- a/src/language/templates/ast/node_class.template
+++ b/src/language/templates/ast/node_class.template
@@ -293,7 +293,19 @@ class {{ node.class_name }} : public {{ node.base_class }} {
    *
    * \sa Ast::visit_children for example.
    */
-  {{ virtual(node) }} void visit_children (visitor::Visitor& v) override;
+  {{ virtual(node) }} void visit_children(visitor::Visitor& v) override;
+
+  /**
+   * \brief visit children i.e. member variables of current node using provided visitor
+   *
+   * Different nodes in the AST have different members (i.e. children). This method
+   * recursively visits children using provided visitor.
+   *
+   * \param v Concrete constant visitor that will be used to recursively visit children
+   *
+   * \sa Ast::visit_children for example.
+   */
+  {{ virtual(node) }} void visit_children(visitor::ConstVisitor& v) const override;
 
   /**
    * \brief accept (or visit) the current AST node using provided visitor
@@ -307,6 +319,11 @@ class {{ node.class_name }} : public {{ node.base_class }} {
    * \sa Ast::accept for example.
    */
   {{ virtual(node) }} void accept(visitor::Visitor& v) override;
+
+  /**
+   * \copydoc accept(visitor::Visitor&)
+   */
+  {{ virtual(node) }} void accept(visitor::ConstVisitor& v) const override;
 
   /// \}
 

--- a/src/language/templates/pybind/pyast.cpp
+++ b/src/language/templates/pybind/pyast.cpp
@@ -199,8 +199,9 @@ void init_ast_module(py::module& m) {
 
     py::class_<Ast, PyAst, std::shared_ptr<Ast>> ast_(m_ast, "Ast", docstring::ast_class);
     ast_.def(py::init<>())
-        .def("visit_children", &Ast::visit_children, "v"_a, docstring::visit_children_method)
-        .def("accept", &Ast::accept, "v"_a, docstring::accept_method)
+        .def("visit_children", static_cast<void (Ast::*)(visitor::Visitor&)>(&Ast::visit_children), "v"_a, docstring::visit_children_method)
+        .def("accept", static_cast<void (Ast::*)(visitor::Visitor&)>(&Ast::accept), "v"_a, docstring::accept_method)
+        .def("accept", static_cast<void (Ast::*)(visitor::ConstVisitor&) const>(&Ast::accept), "v"_a, docstring::accept_method)
         .def("get_node_type", &Ast::get_node_type, docstring::get_node_type_method)
         .def("get_node_type_name", &Ast::get_node_type_name, docstring::get_node_type_name_method)
         .def("get_node_name", &Ast::get_node_name, docstring::get_node_name_method)
@@ -258,8 +259,9 @@ void init_ast_module(py::module& m) {
     {% endif %}
     {% endfor %}
 
-    {{ var(node) }}.def("visit_children", &{{ node.class_name }}::visit_children, docstring::visit_children_method)
-    .def("accept", &{{ node.class_name }}::accept, docstring::accept_method)
+    {{ var(node) }}.def("visit_children", static_cast<void ({{ node.class_name }}::*)(visitor::Visitor&)>(&{{ node.class_name }}::visit_children), docstring::visit_children_method)
+    .def("accept", static_cast<void ({{ node.class_name }}::*)(visitor::Visitor&)>(&{{ node.class_name }}::accept), docstring::accept_method)
+    .def("accept", static_cast<void ({{ node.class_name }}::*)(visitor::ConstVisitor&) const>(&{{ node.class_name }}::accept), docstring::accept_method)
     .def("clone", &{{ node.class_name }}::clone, docstring::clone_method)
     .def("get_node_type", &{{ node.class_name }}::get_node_type, docstring::get_node_type_method)
     .def("get_node_type_name", &{{ node.class_name }}::get_node_type_name, docstring::get_node_type_name_method)

--- a/src/language/templates/pybind/pyast.hpp
+++ b/src/language/templates/pybind/pyast.hpp
@@ -28,16 +28,16 @@ using namespace ast;
  */
 
 /**
- * @defgroup nmodl_python Python Interface
- * @brief Python Bindings Implementation
+ * \defgroup nmodl_python Python Interface
+ * \brief Python Bindings Implementation
  */
 
 /**
  *
- * @defgroup ast_python AST Python Interface
- * @ingroup nmodl_python
- * @brief Ast classes for Python bindings
- * @{
+ * \defgroup ast_python AST Python Interface
+ * \ingroup nmodl_python
+ * \brief Ast classes for Python bindings
+ * \{
  */
 
 /**
@@ -58,10 +58,21 @@ struct PyAst: public Ast {
         );
     }
 
+    void visit_children(visitor::ConstVisitor& v) const override {
+        PYBIND11_OVERLOAD_PURE(void,            /// Return type
+                               Ast,             /// Parent class
+                               visit_children,  /// Name of function in C++ (must match Python name)
+                               v                /// Argument(s)
+        );
+    }
+
     void accept(visitor::Visitor& v) override {
         PYBIND11_OVERLOAD_PURE(void, Ast, accept, v);
     }
 
+    void accept(visitor::ConstVisitor& v) const override {
+        PYBIND11_OVERLOAD_PURE(void, Ast, accept, v);
+    }
 
     Ast* clone() const override {
         PYBIND11_OVERLOAD(Ast*, Ast, clone, );
@@ -128,5 +139,4 @@ struct PyAst: public Ast {
     {% endfor %}
 };
 
-/** @} */  // end of ast_python
-
+/** \} */  // end of ast_python

--- a/src/language/templates/pybind/pyvisitor.cpp
+++ b/src/language/templates/pybind/pyvisitor.cpp
@@ -112,6 +112,18 @@ void PyAstVisitor::visit_{{ node.class_name|snake_case }}(ast::{{ node.class_nam
     PYBIND11_OVERLOAD(void, AstVisitor, visit_{{ node.class_name|snake_case }}, node);
 }
 {% endfor %}
+
+{% for node in nodes %}
+void PyConstVisitor::visit_{{ node.class_name|snake_case }}(const ast::{{ node.class_name }}& node) {
+PYBIND11_OVERLOAD_PURE(void, ConstVisitor, visit_{{ node.class_name|snake_case }}, node);
+}
+{% endfor %}
+
+{% for node in nodes %}
+void PyConstAstVisitor::visit_{{ node.class_name|snake_case }}(const ast::{{ node.class_name }}& node) {
+PYBIND11_OVERLOAD(void, ConstAstVisitor, visit_{{ node.class_name|snake_case }}, node);
+}
+{% endfor %}
 // clang-format on
 
 
@@ -139,7 +151,7 @@ class PyNmodlPrintVisitor: private VisitorOStreamResources, public NmodlPrintVis
 
     // clang-format off
     {% for node in nodes %}
-    void visit_{{ node.class_name|snake_case }}(ast::{{ node.class_name }}& node) override {
+    void visit_{{ node.class_name|snake_case }}(const ast::{{ node.class_name }}& node) override {
         NmodlPrintVisitor::visit_{{ node.class_name|snake_case }}(node);
         flush();
     }
@@ -159,17 +171,34 @@ void init_visitor_module(py::module& m) {
         {% if loop.last -%};{% endif %}
     {% endfor %}  // clang-format on
 
+    py::class_<ConstVisitor, PyConstVisitor> const_visitor(m_visitor, "ConstVisitor", docstring::visitor_class);
+    const_visitor.def(py::init<>())
+    // clang-format off
+    {% for node in nodes %}
+    .def("visit_{{ node.class_name | snake_case }}", &ConstVisitor::visit_{{ node.class_name | snake_case }})
+    {% if loop.last -%};{% endif %}
+    {% endfor %}  // clang-format on
+
+    py::class_<ConstAstVisitor, ConstVisitor, PyConstAstVisitor>
+        const_ast_visitor(m_visitor, "ConstAstVisitor", docstring::ast_visitor_class);
+    const_ast_visitor.def(py::init<>())
+    // clang-format off
+    {% for node in nodes %}
+        .def("visit_{{ node.class_name | snake_case }}", &ConstAstVisitor::visit_{{ node.class_name | snake_case }})
+        {% if loop.last -%};{% endif %}
+    {% endfor %} // clang-format on
+
     py::class_<AstVisitor, Visitor, PyAstVisitor>
-        ast_visitor(m_visitor, "AstVisitor", docstring::ast_visitor_class);
+            ast_visitor(m_visitor, "AstVisitor", docstring::ast_visitor_class);
     ast_visitor.def(py::init<>())
     // clang-format off
     {% for node in nodes %}
-        .def("visit_{{ node.class_name | snake_case }}", &AstVisitor::visit_{{ node.class_name | snake_case }})
-        {% if loop.last -%};{% endif %}
+    .def("visit_{{ node.class_name | snake_case }}", &AstVisitor::visit_{{ node.class_name | snake_case }})
+    {% if loop.last -%};{% endif %}
     {% endfor %}
     // clang-format on
 
-    py::class_<PyNmodlPrintVisitor, Visitor>
+    py::class_<PyNmodlPrintVisitor, ConstVisitor>
         nmodl_visitor(m_visitor, "NmodlPrintVisitor", docstring::nmodl_print_visitor_class);
     nmodl_visitor.def(py::init<std::string>());
     nmodl_visitor.def(py::init<py::object>());
@@ -185,15 +214,10 @@ void init_visitor_module(py::module& m) {
     // clang-format off
     lookup_visitor.def(py::init<>())
         .def(py::init<ast::AstNodeType>())
-        .def("get_nodes", &AstLookupVisitor::get_nodes)
         .def("clear", &AstLookupVisitor::clear)
-        .def("lookup", (std::vector<std::shared_ptr<ast::Ast>> (AstLookupVisitor::*)(ast::Ast&)) &AstLookupVisitor::lookup)
-        .def("lookup", (std::vector<std::shared_ptr<ast::Ast>> (AstLookupVisitor::*)(ast::Ast&, ast::AstNodeType)) &AstLookupVisitor::lookup)
-        .def("lookup", (std::vector<std::shared_ptr<ast::Ast>> (AstLookupVisitor::*)(ast::Ast&, const std::vector<ast::AstNodeType>&)) &AstLookupVisitor::lookup)
-    {% for node in nodes %}
-        .def("visit_{{ node.class_name | snake_case }}", &AstLookupVisitor::visit_{{ node.class_name | snake_case }})
-        {% if loop.last -%};{% endif %}
-    {% endfor %}
+        .def("lookup", static_cast<const std::vector<std::shared_ptr<ast::Ast>>& (AstLookupVisitor::*)(ast::Ast&)>(&AstLookupVisitor::lookup))
+        .def("lookup", static_cast<const std::vector<std::shared_ptr<ast::Ast>>& (AstLookupVisitor::*)(ast::Ast&, ast::AstNodeType)>(&AstLookupVisitor::lookup))
+        .def("lookup", static_cast<const std::vector<std::shared_ptr<ast::Ast>>& (AstLookupVisitor::*)(ast::Ast&, const std::vector<ast::AstNodeType>&)>(&AstLookupVisitor::lookup));
 
     py::class_<ConstantFolderVisitor, AstVisitor> constant_folder_visitor(m_visitor, "ConstantFolderVisitor", docstring::constant_folder_visitor_class);
     constant_folder_visitor.def(py::init<>())

--- a/src/language/templates/pybind/pyvisitor.cpp
+++ b/src/language/templates/pybind/pyvisitor.cpp
@@ -214,6 +214,7 @@ void init_visitor_module(py::module& m) {
     // clang-format off
     lookup_visitor.def(py::init<>())
         .def(py::init<ast::AstNodeType>())
+        .def("get_nodes", &AstLookupVisitor::get_nodes)
         .def("clear", &AstLookupVisitor::clear)
         .def("lookup", static_cast<const std::vector<std::shared_ptr<ast::Ast>>& (AstLookupVisitor::*)(ast::Ast&)>(&AstLookupVisitor::lookup))
         .def("lookup", static_cast<const std::vector<std::shared_ptr<ast::Ast>>& (AstLookupVisitor::*)(ast::Ast&, ast::AstNodeType)>(&AstLookupVisitor::lookup))

--- a/src/language/templates/pybind/pyvisitor.hpp
+++ b/src/language/templates/pybind/pyvisitor.hpp
@@ -61,3 +61,38 @@ public:
     {% endfor %}
 };
 
+/**
+ * \brief Class mirroring nmodl::visitor::ConstVisitor for Python bindings
+ *
+ * \details \copydetails nmodl::visitor::ConstVisitor
+ *
+ * This class is used to interface nmodl::visitor::ConstVisitor with the Python
+ * world using `pybind11`.
+ */
+class PyConstVisitor : public ConstVisitor {
+public:
+    using ConstVisitor::ConstVisitor;
+
+    {% for node in nodes %}
+    void visit_{{ node.class_name|snake_case }}(const ast::{{ node.class_name }}& node) override;
+    {% endfor %}
+};
+
+
+/**
+ * \brief Class mirroring nmodl::visitor::ConstAstVisitor for Python bindings
+ *
+ * \details \copydetails nmodl::visitor::ConstAstVisitor
+ *
+ * This class is used to interface nmodl::visitor::ConstAstVisitor with the Python
+ * world using `pybind11`.
+ */
+class PyConstAstVisitor : public ConstAstVisitor {
+public:
+    using ConstAstVisitor::ConstAstVisitor;
+
+    {% for node in nodes %}
+    void visit_{{ node.class_name|snake_case }}(const ast::{{ node.class_name }}& node) override;
+    {% endfor %}
+};
+

--- a/src/language/templates/visitors/ast_visitor.cpp
+++ b/src/language/templates/visitors/ast_visitor.cpp
@@ -23,7 +23,12 @@ using namespace ast;
 void AstVisitor::visit_{{ node.class_name|snake_case }}({{ node.class_name }}& node) {
     node.visit_children(*this);
 }
+{% endfor %}
 
+{% for node in nodes %}
+void ConstAstVisitor::visit_{{ node.class_name|snake_case }}(const {{ node.class_name }}& node) {
+    node.visit_children(*this);
+}
 {% endfor %}
 
 }  // namespace visitor

--- a/src/language/templates/visitors/ast_visitor.hpp
+++ b/src/language/templates/visitors/ast_visitor.hpp
@@ -27,25 +27,31 @@ namespace nmodl {
 namespace visitor {
 
 /**
- * @ingroup visitor_classes
- * @{
+ * \ingroup visitor_classes
+ * \{
  */
 
 /**
  * \brief Concrete visitor for all AST classes
- *
- * This class defines interface for all concrete visitors implementation.
- * Note that this class only provides interface that could be implemented
- * by concrete visitors like ast::AstVisitor.
  */
-class AstVisitor : public Visitor {
+class AstVisitor: public Visitor {
   public:
     {% for node in nodes %}
     void visit_{{ node.class_name|snake_case }}(ast::{{ node.class_name }}& node) override;
     {% endfor %}
 };
 
-/** @} */  // end of visitor_classes
+/**
+ * \brief Concrete constant visitor for all AST classes
+ */
+class ConstAstVisitor: public ConstVisitor {
+  public:
+    {% for node in nodes %}
+    void visit_{{ node.class_name|snake_case }}(const ast::{{ node.class_name }}& node) override;
+    {% endfor %}
+};
+
+/** \} */  // end of visitor_classes
 
 }  // namespace visitor
 }  // namespace nmodl

--- a/src/language/templates/visitors/checkparent_visitor.cpp
+++ b/src/language/templates/visitors/checkparent_visitor.cpp
@@ -23,25 +23,25 @@ namespace test {
 using namespace fmt::literals;
 using namespace ast;
 
-int CheckParentVisitor::check_ast(Ast* node) {
+int CheckParentVisitor::check_ast(const Ast& node) {
 
     parent = nullptr;
 
-    node->accept(*this);
+    node.accept(*this);
 
     return 0;
 }
 
-void CheckParentVisitor::check_parent(ast::Ast* node) const {
+void CheckParentVisitor::check_parent(const ast::Ast& node) const {
     if (!parent) {
-        if (is_root_with_null_parent && node->get_parent()) {
+        if (is_root_with_null_parent && node.get_parent()) {
             const auto& parent_type = parent->get_node_type_name();
             throw std::runtime_error("root->parent: {} is set when it should be nullptr"_format(parent_type));
         }
     } else {
-        if (parent != node->get_parent()) {
-            std::string parent_type = (parent  == nullptr) ? "nullptr" : parent->get_node_type_name();
-            std::string node_parent_type = (node->get_parent() == nullptr) ? std::string("nullptr") : node->get_parent()->get_node_type_name();
+        if (parent != node.get_parent()) {
+            const std::string parent_type = (parent  == nullptr) ? "nullptr" : parent->get_node_type_name();
+            const std::string node_parent_type = (node.get_parent() == nullptr) ? "nullptr" : node.get_parent()->get_node_type_name();
             throw std::runtime_error("parent: {} and child->parent: {} missmatch"_format(parent_type, node_parent_type));
         }
     }
@@ -49,7 +49,9 @@ void CheckParentVisitor::check_parent(ast::Ast* node) const {
 
 
 {% for node in nodes %}
-void CheckParentVisitor::visit_{{ node.class_name|snake_case }}({{ node.class_name }}& node) {
+void CheckParentVisitor::visit_{{ node.class_name|snake_case }}(const {{ node.class_name }}& node) {
+    // check the node
+    check_parent(node);
 
     // Set this node as parent. and go down the tree
     parent = &node;

--- a/src/language/templates/visitors/checkparent_visitor.hpp
+++ b/src/language/templates/visitors/checkparent_visitor.hpp
@@ -42,12 +42,12 @@ namespace test {
  * the tree. Once all the children were checked we set the parent of the
  * current node as parent (it was checked before) and return.
  */
-class CheckParentVisitor : public AstVisitor {
+class CheckParentVisitor : public ConstAstVisitor {
     private:
         /**
         * \brief Keeps track of the parents while going down the tree
         */
-        ast::Ast* parent = nullptr;
+        const ast::Ast* parent = nullptr;
         /**
         * \brief Flag to activate the parent check on the root node
         *
@@ -55,32 +55,37 @@ class CheckParentVisitor : public AstVisitor {
         * root node, from which we start the visit, is the root node and
         * thus, it should have nullptr parent
         */
-        bool is_root_with_null_parent = false;
+        const bool is_root_with_null_parent = false;
+
+        /**
+         * \brief Check the parent, throw an error if not
+         */
+        void check_parent(const ast::Ast& node) const;
+
     public:
 
         /**
-        * \brief Standard constructor
-        *
-        * If is_root_with_null_parent is set to true, also the initial
-        * node is checked to be sure that is really the root (parent = nullptr)
-        */
-        CheckParentVisitor(const bool is_root_with_null_parent = true) {}
+         * \brief Standard constructor
+         *
+         * If \a is_root_with_null_parent is set to true, also the initial
+         * node is checked to be sure that is really the root (parent == nullptr)
+         */
+        CheckParentVisitor(bool is_root_with_null_parent = true)
+          : is_root_with_null_parent(is_root_with_null_parent) {}
 
         /**
-        * \brief A small wrapper to have a nicer call in parser.cpp
-        */
-        int check_ast(ast::Ast* node);
+         * \brief A small wrapper to have a nicer call in parser.cpp
+         * \return 0
+         */
+        int check_ast(const ast::Ast& node);
 
-        /**
-        * \brief Check the parent, throw an error if not
-        */
-        void check_parent(ast::Ast* node) const;
+    protected:
 
         {% for node in nodes %}
         /**
         * \brief Go through the tree while checking the parents
         */
-        void visit_{{ node.class_name|snake_case }}(ast::{{ node.class_name }}& node) override;
+        void visit_{{ node.class_name|snake_case }}(const ast::{{ node.class_name }}& node) override;
         {% endfor %}
 };
 

--- a/src/language/templates/visitors/json_visitor.cpp
+++ b/src/language/templates/visitors/json_visitor.cpp
@@ -20,7 +20,7 @@ namespace visitor {
 using namespace ast;
 
 {% for node in nodes %}
-void JSONVisitor::visit_{{ node.class_name|snake_case }}({{ node.class_name }}& node) {
+void JSONVisitor::visit_{{ node.class_name|snake_case }}(const {{ node.class_name }}& node) {
     {% if node.has_children() %}
     printer->push_block(node.get_node_type_name());
     if (embed_nmodl) {

--- a/src/language/templates/visitors/json_visitor.hpp
+++ b/src/language/templates/visitors/json_visitor.hpp
@@ -34,7 +34,7 @@ namespace visitor {
  * Convert AST into JSON form form using AST visitor. This is used
  * for debugging or visualization purpose.
  */
-class JSONVisitor: public AstVisitor {
+class JSONVisitor: public ConstAstVisitor {
   private:
     /// json printer
     std::unique_ptr<printer::JSONPrinter> printer;
@@ -49,28 +49,38 @@ class JSONVisitor: public AstVisitor {
     JSONVisitor(std::string filename)
         : printer(new printer::JSONPrinter(filename)) {}
 
-    JSONVisitor(std::stringstream& ss)
+    JSONVisitor(std::ostream& ss)
         : printer(new printer::JSONPrinter(ss)) {}
 
-    void flush() {
+    JSONVisitor& write(const ast::Program& program) {
+        visit_program(program);
+        return *this;
+    }
+
+    JSONVisitor& flush() {
         printer->flush();
+        return *this;
     }
 
-    void compact_json(bool flag) {
+    JSONVisitor& compact_json(bool flag) {
         printer->compact_json(flag);
+        return *this;
     }
 
-    void add_nmodl(bool flag) {
+    JSONVisitor& add_nmodl(bool flag) {
         embed_nmodl = flag;
+        return *this;
     }
 
-    void expand_keys(bool flag) {
+    JSONVisitor& expand_keys(bool flag) {
         printer->expand_keys(flag);
+        return *this;
     }
 
+  protected:
     // clang-format off
     {% for node in nodes %}
-    void visit_{{ node.class_name|snake_case }}(ast::{{ node.class_name }}& node) override;
+    void visit_{{ node.class_name|snake_case }}(const ast::{{ node.class_name }}& node) override;
     {% endfor %}
     // clang-format on
 };

--- a/src/language/templates/visitors/lookup_visitor.cpp
+++ b/src/language/templates/visitors/lookup_visitor.cpp
@@ -22,38 +22,47 @@ namespace visitor {
 using namespace ast;
 
 {% for node in nodes %}
-void AstLookupVisitor::visit_{{ node.class_name|snake_case }}({{ node.class_name }}& node) {
+template <typename DefaultVisitor>
+void MetaAstLookupVisitor<DefaultVisitor>::visit_{{ node.class_name|snake_case }}(typename visit_arg_trait<{{ node.class_name }}>::type& node) {
     const auto type = node.get_node_type();
     if (std::find(types.begin(), types.end(), type) != types.end()) {
         nodes.push_back(node.get_shared_ptr());
     }
     node.visit_children(*this);
 }
-
 {% endfor %}
 
-
-std::vector<std::shared_ptr<ast::Ast>> AstLookupVisitor::lookup(Ast& node, const std::vector<AstNodeType>& _types) {
-    nodes.clear();
-    types = _types;
+template <typename DefaultVisitor>
+const typename MetaAstLookupVisitor<DefaultVisitor>::nodes_t&
+MetaAstLookupVisitor<DefaultVisitor>::lookup(typename MetaAstLookupVisitor<DefaultVisitor>::ast_t& node,
+                                             const std::vector<AstNodeType>& t_types) {
+    clear();
+    this->types = t_types;
     node.accept(*this);
     return nodes;
 }
 
-std::vector<std::shared_ptr<ast::Ast>> AstLookupVisitor::lookup(Ast& node, AstNodeType type) {
-    nodes.clear();
-    types.clear();
-    types.push_back(type);
+template <typename DefaultVisitor>
+const typename MetaAstLookupVisitor<DefaultVisitor>::nodes_t&
+MetaAstLookupVisitor<DefaultVisitor>::lookup(typename MetaAstLookupVisitor<DefaultVisitor>::ast_t& node,
+                                             AstNodeType type) {
+    clear();
+    this->types.push_back(type);
     node.accept(*this);
     return nodes;
 }
 
-std::vector<std::shared_ptr<ast::Ast>> AstLookupVisitor::lookup(Ast& node) {
+template <typename DefaultVisitor>
+const typename MetaAstLookupVisitor<DefaultVisitor>::nodes_t&
+MetaAstLookupVisitor<DefaultVisitor>::lookup(typename MetaAstLookupVisitor<DefaultVisitor>::ast_t& node) {
     nodes.clear();
     node.accept(*this);
     return nodes;
 }
+
+// explicit template instantiation definitions
+template class MetaAstLookupVisitor<Visitor>;
+template class MetaAstLookupVisitor<ConstVisitor>;
 
 }  // namespace visitor
 }  // namespace nmodl
-

--- a/src/language/templates/visitors/lookup_visitor.hpp
+++ b/src/language/templates/visitors/lookup_visitor.hpp
@@ -22,55 +22,71 @@ namespace nmodl {
 namespace visitor {
 
 /**
- * @addtogroup visitor_classes
- * @{
+ * \addtogroup visitor_classes
+ * \{
  */
 
 /**
  * \class AstLookupVisitor
  * \brief %Visitor to find AST nodes based on their types
  */
-class AstLookupVisitor: public Visitor {
+template <typename DefaultVisitor>
+class MetaAstLookupVisitor: public DefaultVisitor {
+    static const bool is_const_visitor = std::is_same<ConstVisitor, DefaultVisitor>::value;
+  using ast_t = typename std::conditional<is_const_visitor, const ast::Ast, ast::Ast>::type;
+  using nodes_t = std::vector<std::shared_ptr<ast_t>>;
+
+  template <typename T>
+  struct identity {
+      using type = T;
+  };
+
+  template <typename T>
+  using visit_arg_trait = typename std::conditional<is_const_visitor, std::add_const<T>, identity<T>>::type;
+
   private:
     /// node types to search in the ast
     std::vector<ast::AstNodeType> types;
 
     /// matching nodes found in the ast
-    std::vector<std::shared_ptr<ast::Ast>> nodes;
+    std::vector<std::shared_ptr<ast_t>> nodes;
 
   public:
-    AstLookupVisitor() = default;
+    MetaAstLookupVisitor() = default;
 
-    AstLookupVisitor(ast::AstNodeType type)
+    MetaAstLookupVisitor(ast::AstNodeType type)
         : types{type} {}
 
-    AstLookupVisitor(const std::vector<ast::AstNodeType>& types)
+    MetaAstLookupVisitor(const std::vector<ast::AstNodeType>& types)
         : types(types) {}
 
-    std::vector<std::shared_ptr<ast::Ast>> lookup(ast::Ast& node);
+    const nodes_t& lookup(ast_t& node);
 
-    std::vector<std::shared_ptr<ast::Ast>> lookup(ast::Ast& node, ast::AstNodeType type);
+    const nodes_t& lookup(ast_t& node, ast::AstNodeType type);
 
-    std::vector<std::shared_ptr<ast::Ast>> lookup(ast::Ast& node,
-                                                  const std::vector<ast::AstNodeType>& types);
-
-    const std::vector<std::shared_ptr<ast::Ast>>& get_nodes() const noexcept {
-        return nodes;
-    }
+    const nodes_t& lookup(ast_t& node, const std::vector<ast::AstNodeType>& t_types);
 
     void clear() {
         types.clear();
         nodes.clear();
     }
 
+  protected:
     // clang-format off
     {% for node in nodes %}
-    void visit_{{ node.class_name|snake_case }}(ast::{{ node.class_name }}& node) override;
+    void visit_{{ node.class_name|snake_case }}(typename visit_arg_trait<ast::{{ node.class_name }}>::type& node) override;
     {% endfor %}
     // clang-format on
 };
 
-/** @} */  // end of visitor_classes
+using AstLookupVisitor = MetaAstLookupVisitor<Visitor>;
+using ConstAstLookupVisitor = MetaAstLookupVisitor<ConstVisitor>;
+
+// explicit template instantiation declarations
+extern template class MetaAstLookupVisitor<Visitor>;
+extern template class MetaAstLookupVisitor<ConstVisitor>;
+
+/** \} */  // end of visitor_classes
 
 }  // namespace visitor
 }  // namespace nmodl

--- a/src/language/templates/visitors/lookup_visitor.hpp
+++ b/src/language/templates/visitors/lookup_visitor.hpp
@@ -66,6 +66,10 @@ class MetaAstLookupVisitor: public DefaultVisitor {
 
     const nodes_t& lookup(ast_t& node, const std::vector<ast::AstNodeType>& t_types);
 
+    const nodes_t& get_nodes() const noexcept {
+        return nodes;
+    }
+
     void clear() {
         types.clear();
         nodes.clear();

--- a/src/language/templates/visitors/lookup_visitor.hpp
+++ b/src/language/templates/visitors/lookup_visitor.hpp
@@ -33,16 +33,17 @@ namespace visitor {
 template <typename DefaultVisitor>
 class MetaAstLookupVisitor: public DefaultVisitor {
     static const bool is_const_visitor = std::is_same<ConstVisitor, DefaultVisitor>::value;
-  using ast_t = typename std::conditional<is_const_visitor, const ast::Ast, ast::Ast>::type;
-  using nodes_t = std::vector<std::shared_ptr<ast_t>>;
 
-  template <typename T>
-  struct identity {
-      using type = T;
-  };
+    template <typename T>
+    struct identity {
+        using type = T;
+    };
 
-  template <typename T>
-  using visit_arg_trait = typename std::conditional<is_const_visitor, std::add_const<T>, identity<T>>::type;
+    template <typename T>
+    using visit_arg_trait =
+        typename std::conditional<is_const_visitor, std::add_const<T>, identity<T>>::type;
+    using ast_t = typename visit_arg_trait<ast::Ast>::type;
+    using nodes_t = std::vector<std::shared_ptr<ast_t>>;
 
   private:
     /// node types to search in the ast

--- a/src/language/templates/visitors/nmodl_visitor.cpp
+++ b/src/language/templates/visitors/nmodl_visitor.cpp
@@ -86,7 +86,7 @@ using namespace ast;
 
 
 {%- for node in nodes %}
-void NmodlPrintVisitor::visit_{{ node.class_name|snake_case}}({{ node.class_name }}& node) {
+void NmodlPrintVisitor::visit_{{ node.class_name|snake_case}}(const {{ node.class_name }}& node) {
     if (is_exclude_type(node.get_node_type())) {
         return;
     }

--- a/src/language/templates/visitors/nmodl_visitor.hpp
+++ b/src/language/templates/visitors/nmodl_visitor.hpp
@@ -49,7 +49,7 @@ class NmodlPrintVisitor: public ConstVisitor {
     NmodlPrintVisitor()
         : printer(new printer::NMODLPrinter()) {}
 
-    NmodlPrintVisitor(const std::string& filename)
+    NmodlPrintVisitor(std::string filename)
         : printer(new printer::NMODLPrinter(filename)) {}
 
     NmodlPrintVisitor(std::ostream& stream)

--- a/src/language/templates/visitors/nmodl_visitor.hpp
+++ b/src/language/templates/visitors/nmodl_visitor.hpp
@@ -25,15 +25,15 @@ namespace nmodl {
 namespace visitor {
 
 /**
- * @addtogroup visitor_classes
- * @{
+ * \addtogroup visitor_classes
+ * \{
  */
 
 /**
  * \class NmodlPrintVisitor
  * \brief %Visitor for printing AST back to NMODL
  */
-class NmodlPrintVisitor: public Visitor {
+class NmodlPrintVisitor: public ConstVisitor {
   private:
     std::unique_ptr<printer::NMODLPrinter> printer;
 
@@ -49,7 +49,7 @@ class NmodlPrintVisitor: public Visitor {
     NmodlPrintVisitor()
         : printer(new printer::NMODLPrinter()) {}
 
-    NmodlPrintVisitor(std::string filename)
+    NmodlPrintVisitor(const std::string& filename)
         : printer(new printer::NMODLPrinter(filename)) {}
 
     NmodlPrintVisitor(std::ostream& stream)
@@ -61,7 +61,7 @@ class NmodlPrintVisitor: public Visitor {
 
     // clang-format off
     {% for node in nodes %}
-    virtual void visit_{{ node.class_name|snake_case }}(ast::{{ node.class_name }}& node) override;
+    virtual void visit_{{ node.class_name|snake_case }}(const ast::{{ node.class_name }}& node) override;
     {% endfor %}
     // clang-format on
 
@@ -72,7 +72,7 @@ class NmodlPrintVisitor: public Visitor {
                        bool statement);
 };
 
-/** @} */  // end of visitor_classes
+/** \} */  // end of visitor_classes
 
 }  // namespace visitor
 }  // namespace nmodl

--- a/src/language/templates/visitors/visitor.hpp
+++ b/src/language/templates/visitors/visitor.hpp
@@ -18,13 +18,13 @@ namespace nmodl {
 namespace visitor {
 
 /**
- * @defgroup visitor Visitor Implementation
- * @brief All visitors related implementation details
+ * \defgroup visitor Visitor Implementation
+ * \brief All visitors related implementation details
  *
- * @defgroup visitor_classes Visitors
- * @ingroup visitor
- * @brief Different visitors implemented in NMODL
- * @{
+ * \defgroup visitor_classes Visitors
+ * \ingroup visitor
+ * \brief Different visitors implemented in NMODL
+ * \{
  */
 
 /**
@@ -32,23 +32,40 @@ namespace visitor {
  *
  * This class defines interface for all concrete visitors implementation.
  * Note that this class only provides interface that could be implemented
- * by oncrete visitors like ast::AstVisitor.
+ * by concrete visitors like ast::AstVisitor.
  *
  * \sa ast::AstVisitor
  */
 class Visitor {
+  public:
+    virtual ~Visitor() = default;
 
-    public:
-        virtual ~Visitor() = default;
+    {% for node in nodes %}
+      /// visit node of type ast::{{ node.class_name }}
+      virtual void visit_{{ node.class_name|snake_case }}(ast::{{ node.class_name }}& node) = 0;
+    {% endfor %}
+};
 
-        {% for node in nodes %}
-        /// visit node of type ast::{{ node.class_name }}
-        virtual void visit_{{ node.class_name|snake_case }}(ast::{{ node.class_name }}& node) = 0;
-        {% endfor %}
+/**
+ * \brief Abstract base class for all constant visitors implementation
+ *
+ * This class defines interface for all concrete constant visitors implementation.
+ * Note that this class only provides interface that could be implemented
+ * by concrete visitors like ast::ConstAstVisitor.
+ *
+ * \sa ast::ConstAstVisitor
+ */
+class ConstVisitor {
+  public:
+    virtual ~ConstVisitor() = default;
+
+    {% for node in nodes %}
+      /// visit node of type ast::{{ node.class_name }}
+      virtual void visit_{{ node.class_name|snake_case }}(const ast::{{ node.class_name }}& node) = 0;
+    {% endfor %}
 };
 
 }  // namespace visitor
 }  // namespace nmodl
 
-/** @} */  // end of visitor_classes
-
+/** \} */  // end of visitor_classes

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -364,7 +364,7 @@ int main(int argc, const char* argv[]) {
         if (json_ast) {
             logger->info("Writing AST into {}", file);
             auto file = scratch_dir + "/" + modfile + ".ast.json";
-            JSONVisitor(file).visit_program(*ast);
+            JSONVisitor(file).write(*ast);
         }
 
         if (verbatim_rename) {

--- a/src/parser/c11_driver.hpp
+++ b/src/parser/c11_driver.hpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -25,8 +26,8 @@ class CParser;
 class location;
 
 /**
- * @addtogroup parser
- * @{
+ * \addtogroup parser
+ * \{
  */
 
 /**
@@ -51,10 +52,10 @@ class CDriver {
     bool trace_parser = false;
 
     /// pointer to the lexer instance being used
-    CLexer* lexer = nullptr;
+    std::unique_ptr<CLexer> lexer;
 
     /// pointer to the parser instance being used
-    CParser* parser = nullptr;
+    std::unique_ptr<CParser> parser;
 
     /// print messages from lexer/parser
     bool verbose = false;
@@ -63,41 +64,42 @@ class CDriver {
     /// file or input stream name (used by scanner for position), see todo
     std::string streamname;
 
-    CDriver() = default;
+    CDriver();
     CDriver(bool strace, bool ptrace);
+    ~CDriver();
 
-    void error(const std::string& m);
+    void error(const std::string& m) const;
 
     bool parse_stream(std::istream& in);
     bool parse_string(const std::string& input);
     bool parse_file(const std::string& filename);
-    void scan_string(std::string& text);
+    void scan_string(const std::string& text);
     void add_token(const std::string&);
 
-    void error(const std::string& m, const location& l);
+    void error(const std::string& m, const location& l) const;
 
-    void set_verbose(bool b) {
+    void set_verbose(bool b) noexcept {
         verbose = b;
     }
 
-    bool is_verbose() const {
+    bool is_verbose() const noexcept {
         return verbose;
     }
 
-    bool is_typedef(std::string type) const {
+    bool is_typedef(const std::string& type) const noexcept {
         return typedefs.find(type) != typedefs.end();
     }
 
-    bool is_enum_constant(std::string constant) const {
+    bool is_enum_constant(const std::string& constant) const noexcept {
         return std::find(enum_constants.begin(), enum_constants.end(), constant) !=
                enum_constants.end();
     }
 
-    std::vector<std::string> all_tokens() const {
+    const std::vector<std::string>& all_tokens() const noexcept {
         return tokens;
     }
 
-    bool has_token(std::string token) {
+    bool has_token(const std::string& token) const noexcept {
         if (std::find(tokens.begin(), tokens.end(), token) != tokens.end()) {
             return true;
         }
@@ -105,7 +107,7 @@ class CDriver {
     }
 };
 
-/** @} */  // end of parser
+/** \} */  // end of parser
 
 }  // namespace parser
 }  // namespace nmodl

--- a/src/parser/nmodl.yy
+++ b/src/parser/nmodl.yy
@@ -2610,14 +2610,13 @@ threadsafe_var_list : NAME_PTR
  *  "empty" Verbatim parser which scan and return same string. */
 
 std::string parse_with_verbatim_parser(std::string str) {
-    auto is = new std::istringstream(str.c_str());
+    std::istringstream is(str.c_str());
 
-    VerbatimDriver extcontext(is);
+    VerbatimDriver extcontext(&is);
     Verbatim_parse(&extcontext);
 
     std::string ss(*(extcontext.result));
 
-    delete is;
     return ss;
 }
 

--- a/src/parser/nmodl_driver.cpp
+++ b/src/parser/nmodl_driver.cpp
@@ -54,11 +54,11 @@ std::shared_ptr<ast::Program> NmodlDriver::parse_string(const std::string& input
 }
 
 void NmodlDriver::error(const std::string& m, const class location& l) {
-    std::cerr << l << " : " << m << std::endl;
+    std::cerr << l << " : " << m << '\n';
 }
 
 void NmodlDriver::error(const std::string& m) {
-    std::cerr << m << std::endl;
+    std::cerr << m << '\n';
 }
 
 /// add macro definition and it's value (DEFINE keyword of nmodl)

--- a/src/pybind/pynmodl.cpp
+++ b/src/pybind/pynmodl.cpp
@@ -161,13 +161,13 @@ PYBIND11_MODULE(_nmodl, m_nmodl) {
              nmodl::docstring::driver_parse_stream)
         .def("get_ast", &nmodl::PyNmodlDriver::get_ast, nmodl::docstring::driver_ast);
 
-    m_nmodl.def(
-        "to_nmodl",
-        static_cast<std::string (*)(nmodl::ast::Ast&, const std::set<nmodl::ast::AstNodeType>&)>(
-            nmodl::to_nmodl),
-        "node"_a,
-        "exclude_types"_a = std::set<nmodl::ast::AstNodeType>(),
-        nmodl::docstring::to_nmodl);
+    m_nmodl.def("to_nmodl",
+                static_cast<std::string (*)(const nmodl::ast::Ast&,
+                                            const std::set<nmodl::ast::AstNodeType>&)>(
+                    nmodl::to_nmodl),
+                "node"_a,
+                "exclude_types"_a = std::set<nmodl::ast::AstNodeType>(),
+                nmodl::docstring::to_nmodl);
     m_nmodl.def("to_json",
                 nmodl::to_json,
                 "node"_a,

--- a/src/visitors/defuse_analyze_visitor.hpp
+++ b/src/visitors/defuse_analyze_visitor.hpp
@@ -86,13 +86,13 @@ class DUInstance {
         : state(state) {}
 
     /// analyze all children and return "effective" usage
-    DUState eval();
+    DUState eval() const;
 
     /// if, elseif and else evaluation
-    DUState sub_block_eval();
+    DUState sub_block_eval() const;
 
     /// evaluate global usage i.e. with [D,U] states of children
-    DUState conditional_block_eval();
+    DUState conditional_block_eval() const;
 
     void print(printer::JSONPrinter& printer) const;
 };
@@ -115,7 +115,7 @@ class DUChain {
         : name(std::move(name)) {}
 
     /// return "effective" usage of a variable
-    DUState eval();
+    DUState eval() const;
 
     /// return json representation
     std::string to_string(bool compact = true) const;
@@ -181,7 +181,7 @@ class DUChain {
  * in any of the if-elseif-else part then it is considered as "used". And
  * this is done recursively from innermost level to the top.
  */
-class DefUseAnalyzeVisitor: protected AstVisitor {
+class DefUseAnalyzeVisitor: protected ConstAstVisitor {
   private:
     /// symbol table containing global variables
     symtab::SymbolTable* global_symtab = nullptr;
@@ -212,25 +212,25 @@ class DefUseAnalyzeVisitor: protected AstVisitor {
     void process_variable(const std::string& name, int index);
 
     void update_defuse_chain(const std::string& name);
-    void visit_unsupported_node(ast::Node& node);
-    void visit_with_new_chain(ast::Node& node, DUState state);
+    void visit_unsupported_node(const ast::Node& node);
+    void visit_with_new_chain(const ast::Node& node, DUState state);
     void start_new_chain(DUState state);
 
   public:
     DefUseAnalyzeVisitor() = delete;
 
-    explicit DefUseAnalyzeVisitor(symtab::SymbolTable* symtab)
-        : global_symtab(symtab) {}
+    explicit DefUseAnalyzeVisitor(symtab::SymbolTable& symtab)
+        : global_symtab(&symtab) {}
 
-    DefUseAnalyzeVisitor(symtab::SymbolTable* symtab, bool ignore_verbatim)
-        : global_symtab(symtab)
+    DefUseAnalyzeVisitor(symtab::SymbolTable& symtab, bool ignore_verbatim)
+        : global_symtab(&symtab)
         , ignore_verbatim(ignore_verbatim) {}
 
-    void visit_binary_expression(ast::BinaryExpression& node) override;
-    void visit_if_statement(ast::IfStatement& node) override;
-    void visit_function_call(ast::FunctionCall& node) override;
-    void visit_statement_block(ast::StatementBlock& node) override;
-    void visit_verbatim(ast::Verbatim& node) override;
+    void visit_binary_expression(const ast::BinaryExpression& node) override;
+    void visit_if_statement(const ast::IfStatement& node) override;
+    void visit_function_call(const ast::FunctionCall& node) override;
+    void visit_statement_block(const ast::StatementBlock& node) override;
+    void visit_verbatim(const ast::Verbatim& node) override;
 
     /**
      * /\name unsupported statements
@@ -239,23 +239,23 @@ class DefUseAnalyzeVisitor: protected AstVisitor {
      * \{
      */
 
-    void visit_reaction_statement(ast::ReactionStatement& node) override;
+    void visit_reaction_statement(const ast::ReactionStatement& node) override;
 
-    void visit_non_lin_equation(ast::NonLinEquation& node) override;
+    void visit_non_lin_equation(const ast::NonLinEquation& node) override;
 
-    void visit_lin_equation(ast::LinEquation& node) override;
+    void visit_lin_equation(const ast::LinEquation& node) override;
 
-    void visit_partial_boundary(ast::PartialBoundary& node) override;
+    void visit_partial_boundary(const ast::PartialBoundary& node) override;
 
-    void visit_from_statement(ast::FromStatement& node) override;
+    void visit_from_statement(const ast::FromStatement& node) override;
 
-    void visit_conserve(ast::Conserve& node) override;
+    void visit_conserve(const ast::Conserve& node) override;
 
-    void visit_var_name(ast::VarName& node) override;
+    void visit_var_name(const ast::VarName& node) override;
 
-    void visit_name(ast::Name& node) override;
+    void visit_name(const ast::Name& node) override;
 
-    void visit_indexed_name(ast::IndexedName& node) override;
+    void visit_indexed_name(const ast::IndexedName& node) override;
 
     /** \} */
 
@@ -265,16 +265,16 @@ class DefUseAnalyzeVisitor: protected AstVisitor {
      * \{
      */
 
-    void visit_conductance_hint(ast::ConductanceHint& node) override;
+    void visit_conductance_hint(const ast::ConductanceHint& node) override;
 
-    void visit_local_list_statement(ast::LocalListStatement& node) override;
+    void visit_local_list_statement(const ast::LocalListStatement& node) override;
 
-    void visit_argument(ast::Argument& node) override;
+    void visit_argument(const ast::Argument& node) override;
 
     /** \} */
 
     /// compute def-use chain for a variable within the node
-    DUChain analyze(ast::Ast& node, const std::string& name);
+    DUChain analyze(const ast::Ast& node, const std::string& name);
 };
 
 /** @} */  // end of visitor_classes

--- a/src/visitors/global_var_visitor.cpp
+++ b/src/visitors/global_var_visitor.cpp
@@ -61,7 +61,7 @@ void GlobalToRangeVisitor::visit_neuron_block(ast::NeuronBlock& node) {
     /// insert new range variables replacing global ones
     if (!range_variables.empty()) {
         auto range_statement = new ast::Range(range_variables);
-        (*statement_block).emplace_back_statement(range_statement);
+        statement_block->emplace_back_statement(range_statement);
     }
 }
 

--- a/src/visitors/global_var_visitor.hpp
+++ b/src/visitors/global_var_visitor.hpp
@@ -23,8 +23,8 @@ namespace nmodl {
 namespace visitor {
 
 /**
- * @addtogroup visitor_classes
- * @{
+ * \addtogroup visitor_classes
+ * \{
  */
 
 /**
@@ -33,7 +33,7 @@ namespace visitor {
  *
  * Some of the existing mod files have GLOBAL variables that are updated in BREAKPOINT
  * or DERIVATIVE blocks. These variables have a single copy and works well when they
- * are read only. If such variables that are written as well, they result into race condition.
+ * are read only. If such variables are written as well, they result into race condition.
  * For example,
  *
  * \code{.mod}
@@ -51,7 +51,7 @@ namespace visitor {
  *      }
  * \endcode
  *
- * In above example, x will be simultaneously updated in case of vectorization. In NEURON,
+ * In above example, \a x will be simultaneously updated in case of vectorization. In NEURON,
  * such race condition is avoided by promoting these variables to thread variable (i.e. separate
  * copy per thread). In case of CoreNEURON, this is not sufficient because of vectorisation or
  * GPU execution. To address this issue, this visitor converts GLOBAL variables to RANGE variables
@@ -85,7 +85,7 @@ class GlobalToRangeVisitor: public AstVisitor {
     void visit_neuron_block(ast::NeuronBlock& node) override;
 };
 
-/** @} */  // end of visitor_classes
+/** \} */  // end of visitor_classes
 
 }  // namespace visitor
 }  // namespace nmodl

--- a/src/visitors/inline_visitor.cpp
+++ b/src/visitors/inline_visitor.cpp
@@ -20,7 +20,7 @@ namespace visitor {
 
 using namespace ast;
 
-bool InlineVisitor::can_inline_block(StatementBlock& block) {
+bool InlineVisitor::can_inline_block(const StatementBlock& block) const {
     bool to_inline = true;
     const auto& statements = block.get_statements();
     for (const auto& statement: statements) {

--- a/src/visitors/inline_visitor.hpp
+++ b/src/visitors/inline_visitor.hpp
@@ -22,8 +22,8 @@ namespace nmodl {
 namespace visitor {
 
 /**
- * @addtogroup visitor_classes
- * @{
+ * \addtogroup visitor_classes
+ * \{
  */
 
 /**
@@ -54,7 +54,7 @@ namespace visitor {
  * replacing tau and beta with local variables. Many mod files from BlueBrain
  * and other open source projects could be hugely benefited by inlining pass.
  * The goal of this pass is to implement procedure and function inlining in
- * the nmodl programs. After inlining we should be asble to translate AST back
+ * the nmodl programs. After inlining we should be able to translate AST back
  * to "transformed" nmodl program which can be compiled and run by NEURON or
  * CoreNEURON simulator.
  *
@@ -159,7 +159,7 @@ class InlineVisitor: public AstVisitor {
     std::map<std::string, int> inlined_variables;
 
     /// true if given statement block can be inlined
-    bool can_inline_block(ast::StatementBlock& block);
+    bool can_inline_block(const ast::StatementBlock& block) const;
 
     /// true if statement can be replaced with inlined body
     /// this is possible for standalone function/procedure call as statement
@@ -175,7 +175,7 @@ class InlineVisitor: public AstVisitor {
                               ast::FunctionCall& node,
                               ast::StatementBlock& caller);
 
-    /// add assignement statements into given statement block to inline arguments
+    /// add assignment statements into given statement block to inline arguments
     void inline_arguments(ast::StatementBlock& inlined_block,
                           const ast::ArgumentVector& callee_parameters,
                           const ast::ExpressionVector& caller_expressions);
@@ -196,7 +196,7 @@ class InlineVisitor: public AstVisitor {
     void visit_program(ast::Program& node) override;
 };
 
-/** @} */  // end of visitor_classes
+/** \} */  // end of visitor_classes
 
 }  // namespace visitor
 }  // namespace nmodl

--- a/src/visitors/kinetic_block_visitor.cpp
+++ b/src/visitors/kinetic_block_visitor.cpp
@@ -12,7 +12,6 @@
 #include "utils/logger.hpp"
 #include "utils/string_utils.hpp"
 #include "visitor_utils.hpp"
-#include "visitors/lookup_visitor.hpp"
 
 
 namespace nmodl {
@@ -466,7 +465,7 @@ void KineticBlockVisitor::visit_program(ast::Program& node) {
         }
     }
 
-    auto kineticBlockNodes = AstLookupVisitor().lookup(node, ast::AstNodeType::KINETIC_BLOCK);
+    const auto& kineticBlockNodes = collect_nodes(node, {ast::AstNodeType::KINETIC_BLOCK});
     // replace reaction statements within each kinetic block with equivalent ODEs
     for (const auto& ii: kineticBlockNodes) {
         ii->accept(*this);

--- a/src/visitors/kinetic_block_visitor.hpp
+++ b/src/visitors/kinetic_block_visitor.hpp
@@ -24,8 +24,8 @@ namespace nmodl {
 namespace visitor {
 
 /**
- * @addtogroup visitor_classes
- * @{
+ * \addtogroup visitor_classes
+ * \{
  */
 
 /**
@@ -149,7 +149,7 @@ class KineticBlockVisitor: public AstVisitor {
     void visit_program(ast::Program& node) override;
 };
 
-/** @} */  // end of visitor_classes
+/** \} */  // end of visitor_classes
 
 }  // namespace visitor
 }  // namespace nmodl

--- a/src/visitors/local_to_assigned_visitor.cpp
+++ b/src/visitors/local_to_assigned_visitor.cpp
@@ -42,7 +42,7 @@ void LocalToAssignedVisitor::visit_program(ast::Program& node) {
             top_level_node);
 
         for (const auto& local_variable: local_list_statement->get_variables()) {
-            auto variable_name = local_variable->get_node_name();
+            const auto& variable_name = local_variable->get_node_name();
             /// check if local variable is being updated in the mod file
             if (symbol_table->lookup(variable_name)->get_write_count() > 0) {
                 assigned_variables.emplace_back(
@@ -75,7 +75,7 @@ void LocalToAssignedVisitor::visit_program(ast::Program& node) {
         assigned_block = std::make_shared<ast::AssignedBlock>(assigned_variables);
         node.emplace_back_node(std::static_pointer_cast<ast::Node>(assigned_block));
     } else {
-        for (auto& assigned_variable: assigned_variables) {
+        for (const auto& assigned_variable: assigned_variables) {
             assigned_block->emplace_back_assigned_definition(assigned_variable);
         }
     }

--- a/src/visitors/local_to_assigned_visitor.hpp
+++ b/src/visitors/local_to_assigned_visitor.hpp
@@ -77,7 +77,7 @@ class LocalToAssignedVisitor: public AstVisitor {
     void visit_program(ast::Program& node) override;
 };
 
-/** @} */  // end of visitor_classes
+/** \} */  // end of visitor_classes
 
 }  // namespace visitor
 }  // namespace nmodl

--- a/src/visitors/local_var_rename_visitor.cpp
+++ b/src/visitors/local_var_rename_visitor.cpp
@@ -50,7 +50,7 @@ void LocalVarRenameVisitor::visit_statement_block(ast::StatementBlock& node) {
         parent_symtab = symtab->get_parent_table();
     }
 
-    auto variables = get_local_list_statement(node);
+    const auto& variables = get_local_list_statement(node);
 
     /// global blocks do not change (do no have parent symbol table)
     /// if no variables in the block then there is nothing to do

--- a/src/visitors/local_var_rename_visitor.hpp
+++ b/src/visitors/local_var_rename_visitor.hpp
@@ -22,8 +22,8 @@ namespace nmodl {
 namespace visitor {
 
 /**
- * @addtogroup visitor_classes
- * @{
+ * \addtogroup visitor_classes
+ * \{
  */
 
 /**
@@ -75,7 +75,7 @@ class LocalVarRenameVisitor: public AstVisitor {
     void visit_statement_block(ast::StatementBlock& node) override;
 };
 
-/** @} */  // end of visitor_classes
+/** \} */  // end of visitor_classes
 
 }  // namespace visitor
 }  // namespace nmodl

--- a/src/visitors/localize_visitor.hpp
+++ b/src/visitors/localize_visitor.hpp
@@ -22,8 +22,8 @@ namespace nmodl {
 namespace visitor {
 
 /**
- * @addtogroup visitor_classes
- * @{
+ * \addtogroup visitor_classes
+ * \{
  */
 
 /**
@@ -80,7 +80,7 @@ namespace visitor {
  *     variables. We need to have dead-code removal pass to eliminate unused procedures/
  *     functions before localizer pass.
  */
-class LocalizeVisitor: public AstVisitor {
+class LocalizeVisitor: public ConstAstVisitor {
   private:
     /// ignore verbatim blocks while localizing
     bool ignore_verbatim = false;
@@ -99,10 +99,10 @@ class LocalizeVisitor: public AstVisitor {
     explicit LocalizeVisitor(bool ignore_verbatim)
         : ignore_verbatim(ignore_verbatim) {}
 
-    void visit_program(ast::Program& node) override;
+    void visit_program(const ast::Program& node) override;
 };
 
-/** @} */  // end of visitor_classes
+/** \} */  // end of visitor_classes
 
 }  // namespace visitor
 }  // namespace nmodl

--- a/src/visitors/loop_unroll_visitor.cpp
+++ b/src/visitors/loop_unroll_visitor.cpp
@@ -10,7 +10,6 @@
 #include "ast/all.hpp"
 #include "parser/c11_driver.hpp"
 #include "utils/logger.hpp"
-#include "visitors/lookup_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
 
 
@@ -47,7 +46,7 @@ class IndexRemover: public AstVisitor {
 
     /// if expression we are visiting is `Name` then return new `Integer` node
     std::shared_ptr<ast::Expression> replace_for_name(
-        const std::shared_ptr<ast::Expression>& node) {
+        const std::shared_ptr<ast::Expression>& node) const {
         if (node->is_name()) {
             auto name = std::dynamic_pointer_cast<ast::Name>(node);
             if (name->get_node_name() == index) {
@@ -60,10 +59,10 @@ class IndexRemover: public AstVisitor {
     void visit_binary_expression(ast::BinaryExpression& node) override {
         node.visit_children(*this);
         if (under_indexed_name) {
-            /// first recursively replaces childrens
+            /// first recursively replaces children
             /// replace lhs & rhs if they have matching index variable
-            auto lhs = replace_for_name(node.get_lhs());
-            auto rhs = replace_for_name(node.get_rhs());
+            const auto& lhs = replace_for_name(node.get_lhs());
+            const auto& rhs = replace_for_name(node.get_rhs());
             node.set_lhs(std::move(lhs));
             node.set_rhs(std::move(rhs));
         }
@@ -73,7 +72,7 @@ class IndexRemover: public AstVisitor {
         under_indexed_name = true;
         node.visit_children(*this);
         /// once all children are replaced, do the same for index
-        auto length = replace_for_name(node.get_length());
+        const auto& length = replace_for_name(node.get_length());
         node.set_length(std::move(length));
         under_indexed_name = false;
     }
@@ -83,7 +82,7 @@ class IndexRemover: public AstVisitor {
 /// return underlying expression wrapped by WrappedExpression
 static std::shared_ptr<ast::Expression> unwrap(const std::shared_ptr<ast::Expression>& expr) {
     if (expr && expr->is_wrapped_expression()) {
-        auto e = std::dynamic_pointer_cast<ast::WrappedExpression>(expr);
+        const auto& e = std::dynamic_pointer_cast<ast::WrappedExpression>(expr);
         return e->get_expression();
     }
     return expr;
@@ -93,16 +92,16 @@ static std::shared_ptr<ast::Expression> unwrap(const std::shared_ptr<ast::Expres
 /**
  * Unroll given for loop
  *
- * @param node From loop node in the AST
- * @return expression statement represeing unrolled loop if successfull otherwise nullptr
+ * \param node From loop node in the AST
+ * \return expression statement representing unrolled loop if successful otherwise \a nullptr
  */
 static std::shared_ptr<ast::ExpressionStatement> unroll_for_loop(
     const std::shared_ptr<ast::FromStatement>& node) {
     /// loop can be in the form of `FROM i=(0) TO (10)`
     /// so first unwrap all elements of the loop
-    const auto from = unwrap(node->get_from());
-    const auto to = unwrap(node->get_to());
-    const auto increment = unwrap(node->get_increment());
+    const auto& from = unwrap(node->get_from());
+    const auto& to = unwrap(node->get_to());
+    const auto& increment = unwrap(node->get_increment());
 
     /// we can unroll if iteration space of the loop is known
     /// after constant folding start, end and increment must be known
@@ -122,7 +121,7 @@ static std::shared_ptr<ast::ExpressionStatement> unroll_for_loop(
     std::string index_var = node->get_node_name();
     for (int i = start; i <= end; i += step) {
         /// duplicate loop body and copy all statements to new vector
-        auto new_block = node->get_statement_block()->clone();
+        const auto& new_block = node->get_statement_block()->clone();
         IndexRemover(index_var, i).visit_statement_block(*new_block);
         statements.insert(statements.end(),
                           new_block->get_statements().begin(),
@@ -146,18 +145,17 @@ void LoopUnrollVisitor::visit_statement_block(ast::StatementBlock& node) {
 
     for (auto iter = statements.begin(); iter != statements.end(); ++iter) {
         if ((*iter)->is_from_statement()) {
-            auto statement = std::dynamic_pointer_cast<ast::FromStatement>((*iter));
+            const auto& statement = std::dynamic_pointer_cast<ast::FromStatement>((*iter));
 
             /// check if any verbatim block exists
-            auto verbatim_blocks = AstLookupVisitor().lookup(*statement,
-                                                             ast::AstNodeType::VERBATIM);
+            const auto& verbatim_blocks = collect_nodes(*statement, {ast::AstNodeType::VERBATIM});
             if (!verbatim_blocks.empty()) {
                 logger->debug("LoopUnrollVisitor : can not unroll because of verbatim block");
                 continue;
             }
 
             /// unroll loop, replace current statement on successfull unroll
-            auto new_statement = unroll_for_loop(statement);
+            const auto& new_statement = unroll_for_loop(statement);
             if (new_statement != nullptr) {
                 node.reset_statement(iter, new_statement);
 

--- a/src/visitors/loop_unroll_visitor.cpp
+++ b/src/visitors/loop_unroll_visitor.cpp
@@ -121,12 +121,12 @@ static std::shared_ptr<ast::ExpressionStatement> unroll_for_loop(
     std::string index_var = node->get_node_name();
     for (int i = start; i <= end; i += step) {
         /// duplicate loop body and copy all statements to new vector
-        const auto& new_block = node->get_statement_block()->clone();
+        const auto new_block = std::unique_ptr<ast::StatementBlock>(
+            node->get_statement_block()->clone());
         IndexRemover(index_var, i).visit_statement_block(*new_block);
         statements.insert(statements.end(),
                           new_block->get_statements().begin(),
                           new_block->get_statements().end());
-        delete new_block;
     }
 
     /// create new statement representing unrolled loop

--- a/src/visitors/loop_unroll_visitor.hpp
+++ b/src/visitors/loop_unroll_visitor.hpp
@@ -20,8 +20,8 @@ namespace nmodl {
 namespace visitor {
 
 /**
- * @addtogroup visitor_classes
- * @{
+ * \addtogroup visitor_classes
+ * \{
  */
 
 /**
@@ -63,7 +63,7 @@ class LoopUnrollVisitor: public AstVisitor {
     void visit_statement_block(ast::StatementBlock& node) override;
 };
 
-/** @} */  // end of visitor_classes
+/** \} */  // end of visitor_classes
 
 }  // namespace visitor
 }  // namespace nmodl

--- a/src/visitors/main.cpp
+++ b/src/visitors/main.cpp
@@ -57,7 +57,7 @@ void visit_program(const std::string& mod_file,
                    ast::Program& ast) {
     logger->info("Running {}", visitor.description);
     visitor.v->visit_program(ast);
-    const std::string file = mod_file + "." + visitor.id + ".mod";
+    const std::string file = "{}.{}.mod"_format(mod_file, visitor.id);
     NmodlPrintVisitor(file).visit_program(ast);
     logger->info("NMODL visitor generated {}", file);
 };

--- a/src/visitors/main.cpp
+++ b/src/visitors/main.cpp
@@ -15,6 +15,7 @@
 #include "pybind/pyembed.hpp"
 #include "utils/logger.hpp"
 #include "visitors/ast_visitor.hpp"
+#include "visitors/checkparent_visitor.hpp"
 #include "visitors/constant_folder_visitor.hpp"
 #include "visitors/inline_visitor.hpp"
 #include "visitors/json_visitor.hpp"
@@ -41,6 +42,26 @@ using namespace fmt::literals;
  * \brief Standalone program demonstrating usage of different visitors and driver classes.
  **/
 
+template <typename T>
+struct ClassInfo {
+    std::shared_ptr<T> v;
+    std::string id;
+    std::string description;
+};
+using VisitorInfo = ClassInfo<Visitor>;
+using ConstVisitorInfo = ClassInfo<ConstVisitor>;
+
+template <typename Visitor>
+void visit_program(const std::string& mod_file,
+                   const ClassInfo<Visitor>& visitor,
+                   ast::Program& ast) {
+    logger->info("Running {}", visitor.description);
+    visitor.v->visit_program(ast);
+    const std::string file = mod_file + "." + visitor.id + ".mod";
+    NmodlPrintVisitor(file).visit_program(ast);
+    logger->info("NMODL visitor generated {}", file);
+};
+
 int main(int argc, const char* argv[]) {
     CLI::App app{
         "NMODL Visitor : Runs standalone visitor classes({})"_format(Version::to_string())};
@@ -59,17 +80,9 @@ int main(int argc, const char* argv[]) {
         logger->set_level(spdlog::level::debug);
     }
 
-    struct VisitorInfo {
-        std::shared_ptr<Visitor> v;
-        std::string id;
-        std::string description;
-    };
-
-    std::vector<VisitorInfo> visitors = {
+    const std::vector<VisitorInfo> visitors = {
         {std::make_shared<AstVisitor>(), "astvis", "AstVisitor"},
         {std::make_shared<SymtabVisitor>(), "symtab", "SymtabVisitor"},
-        {std::make_shared<JSONVisitor>(), "json", "JSONVisitor"},
-        {std::make_shared<VerbatimVisitor>(), "verbatim", "VerbatimVisitor"},
         {std::make_shared<VerbatimVarRenameVisitor>(),
          "verbatim-rename",
          "VerbatimVarRenameVisitor"},
@@ -83,9 +96,15 @@ int main(int argc, const char* argv[]) {
          "SympyConductanceVisitor"},
         {std::make_shared<SympySolverVisitor>(), "sympy-solve", "SympySolverVisitor"},
         {std::make_shared<NeuronSolveVisitor>(), "neuron-solve", "NeuronSolveVisitor"},
-        {std::make_shared<LocalizeVisitor>(), "localize", "LocalizeVisitor"},
-        {std::make_shared<PerfVisitor>(), "perf", "PerfVisitor"},
         {std::make_shared<UnitsVisitor>(NrnUnitsLib::get_path()), "units", "UnitsVisitor"},
+    };
+
+    const std::vector<ConstVisitorInfo> const_visitors = {
+        {std::make_shared<JSONVisitor>(), "json", "JSONVisitor"},
+        {std::make_shared<test::CheckParentVisitor>(), "check-parent", "CheckParentVisitor"},
+        {std::make_shared<PerfVisitor>(), "perf", "PerfVisitor"},
+        {std::make_shared<LocalizeVisitor>(), "localize", "LocalizeVisitor"},
+        {std::make_shared<VerbatimVisitor>(), "verbatim", "VerbatimVisitor"},
     };
 
     nmodl::pybind_wrappers::EmbeddedPythonLoader::get_instance().api()->initialize_interpreter();
@@ -103,11 +122,10 @@ int main(int argc, const char* argv[]) {
 
         /// run all visitors and generate mod file after each run
         for (const auto& visitor: visitors) {
-            logger->info("Running {}", visitor.description);
-            visitor.v->visit_program(*ast);
-            const std::string file = mod_file + "." + visitor.id + ".mod";
-            NmodlPrintVisitor(file).visit_program(*ast);
-            logger->info("NMODL visitor generated {}", file);
+            visit_program(mod_file, visitor, *ast);
+        }
+        for (const auto& visitor: const_visitors) {
+            visit_program(mod_file, visitor, *ast);
         }
     }
 

--- a/src/visitors/neuron_solve_visitor.hpp
+++ b/src/visitors/neuron_solve_visitor.hpp
@@ -23,9 +23,9 @@ namespace nmodl {
 namespace visitor {
 
 /**
- * @addtogroup solver
- * @addtogroup visitor_classes
- * @{
+ * \addtogroup solver
+ * \addtogroup visitor_classes
+ * \{
  */
 
 /**
@@ -69,7 +69,7 @@ class NeuronSolveVisitor: public AstVisitor {
     void visit_program(ast::Program& node) override;
 };
 
-/** @} */  // end of visitor_classes
+/** \} */  // end of visitor_classes
 
 }  // namespace visitor
 }  // namespace nmodl

--- a/src/visitors/perf_visitor.cpp
+++ b/src/visitors/perf_visitor.cpp
@@ -31,7 +31,7 @@ void PerfVisitor::compact_json(bool flag) {
 
 
 /// count math operations from all binary expressions
-void PerfVisitor::visit_binary_expression(ast::BinaryExpression& node) {
+void PerfVisitor::visit_binary_expression(const ast::BinaryExpression& node) {
     bool assign_op = false;
 
     if (start_measurement) {
@@ -114,9 +114,9 @@ void PerfVisitor::visit_binary_expression(ast::BinaryExpression& node) {
 }
 
 /// add performance stats to json printer
-void PerfVisitor::add_perf_to_printer(PerfStat& perf) {
-    auto keys = perf.keys();
-    auto values = perf.values();
+void PerfVisitor::add_perf_to_printer(const PerfStat& perf) const {
+    const auto& keys = perf.keys();
+    const auto& values = perf.values();
     assert(keys.size() == values.size());
 
     for (size_t i = 0; i < keys.size(); i++) {
@@ -129,10 +129,10 @@ void PerfVisitor::add_perf_to_printer(PerfStat& perf) {
  *  all children visited, we get total performance by summing
  *  perfstat of all children.
  */
-void PerfVisitor::measure_performance(ast::Ast* node) {
+void PerfVisitor::measure_performance(const ast::Ast& node) {
     start_measurement = true;
 
-    node->visit_children(*this);
+    node.visit_children(*this);
 
     PerfStat perf;
     while (!children_blocks_perf.empty()) {
@@ -140,15 +140,15 @@ void PerfVisitor::measure_performance(ast::Ast* node) {
         children_blocks_perf.pop();
     }
 
-    auto symtab = node->get_symbol_table();
+    auto symtab = node.get_symbol_table();
     if (symtab == nullptr) {
         throw std::runtime_error("Perfvisitor : symbol table not setup for " +
-                                 node->get_node_type_name());
+                                 node.get_node_type_name());
     }
 
     auto name = symtab->name();
-    if (node->is_derivative_block()) {
-        name = node->get_node_type_name();
+    if (node.is_derivative_block()) {
+        name = node.get_node_type_name();
     }
 
     if (printer) {
@@ -172,7 +172,7 @@ void PerfVisitor::measure_performance(ast::Ast* node) {
 }
 
 /// count function calls and "most useful" or "commonly used" math functions
-void PerfVisitor::visit_function_call(ast::FunctionCall& node) {
+void PerfVisitor::visit_function_call(const ast::FunctionCall& node) {
     under_function_call = true;
 
     if (start_measurement) {
@@ -199,25 +199,25 @@ void PerfVisitor::visit_function_call(ast::FunctionCall& node) {
 }
 
 /// every variable used is of type name, update counters
-void PerfVisitor::visit_name(ast::Name& node) {
+void PerfVisitor::visit_name(const ast::Name& node) {
     update_memory_ops(node.get_node_name());
     node.visit_children(*this);
 }
 
 /// prime name derived from identifier and hence need to be handled here
-void PerfVisitor::visit_prime_name(ast::PrimeName& node) {
+void PerfVisitor::visit_prime_name(const ast::PrimeName& node) {
     update_memory_ops(node.get_node_name());
     node.visit_children(*this);
 }
 
-void PerfVisitor::visit_if_statement(ast::IfStatement& node) {
+void PerfVisitor::visit_if_statement(const ast::IfStatement& node) {
     if (start_measurement) {
         current_block_perf.n_if++;
         node.visit_children(*this);
     }
 }
 
-void PerfVisitor::visit_else_if_statement(ast::ElseIfStatement& node) {
+void PerfVisitor::visit_else_if_statement(const ast::ElseIfStatement& node) {
     if (start_measurement) {
         current_block_perf.n_elif++;
         node.visit_children(*this);
@@ -321,7 +321,7 @@ void PerfVisitor::print_memory_usage() {
     }
 }
 
-void PerfVisitor::visit_program(ast::Program& node) {
+void PerfVisitor::visit_program(const ast::Program& node) {
     if (printer) {
         printer->push_block("BlockPerf");
     }
@@ -343,100 +343,100 @@ void PerfVisitor::visit_program(ast::Program& node) {
     print_memory_usage();
 }
 
-void PerfVisitor::visit_plot_block(ast::PlotBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_plot_block(const ast::PlotBlock& node) {
+    measure_performance(node);
 }
 
 /// skip initial block under net_receive block
-void PerfVisitor::visit_initial_block(ast::InitialBlock& node) {
+void PerfVisitor::visit_initial_block(const ast::InitialBlock& node) {
     if (!under_net_receive_block) {
-        measure_performance(&node);
+        measure_performance(node);
     }
 }
 
-void PerfVisitor::visit_constructor_block(ast::ConstructorBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_constructor_block(const ast::ConstructorBlock& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_destructor_block(ast::DestructorBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_destructor_block(const ast::DestructorBlock& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_derivative_block(ast::DerivativeBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_derivative_block(const ast::DerivativeBlock& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_linear_block(ast::LinearBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_linear_block(const ast::LinearBlock& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_non_linear_block(ast::NonLinearBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_non_linear_block(const ast::NonLinearBlock& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_discrete_block(ast::DiscreteBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_discrete_block(const ast::DiscreteBlock& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_partial_block(ast::PartialBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_partial_block(const ast::PartialBlock& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_function_table_block(ast::FunctionTableBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_function_table_block(const ast::FunctionTableBlock& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_function_block(ast::FunctionBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_function_block(const ast::FunctionBlock& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_procedure_block(ast::ProcedureBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_procedure_block(const ast::ProcedureBlock& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_net_receive_block(ast::NetReceiveBlock& node) {
+void PerfVisitor::visit_net_receive_block(const ast::NetReceiveBlock& node) {
     under_net_receive_block = true;
-    measure_performance(&node);
+    measure_performance(node);
     under_net_receive_block = false;
 }
 
-void PerfVisitor::visit_breakpoint_block(ast::BreakpointBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_breakpoint_block(const ast::BreakpointBlock& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_terminal_block(ast::TerminalBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_terminal_block(const ast::TerminalBlock& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_before_block(ast::BeforeBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_before_block(const ast::BeforeBlock& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_after_block(ast::AfterBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_after_block(const ast::AfterBlock& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_ba_block(ast::BABlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_ba_block(const ast::BABlock& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_for_netcon(ast::ForNetcon& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_for_netcon(const ast::ForNetcon& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_kinetic_block(ast::KineticBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_kinetic_block(const ast::KineticBlock& node) {
+    measure_performance(node);
 }
 
-void PerfVisitor::visit_match_block(ast::MatchBlock& node) {
-    measure_performance(&node);
+void PerfVisitor::visit_match_block(const ast::MatchBlock& node) {
+    measure_performance(node);
 }
 
 /** Blocks like function can have multiple statement blocks and
  * blocks like net receive has nested initial blocks. Hence need
  * to maintain separate stack.
  */
-void PerfVisitor::visit_statement_block(ast::StatementBlock& node) {
+void PerfVisitor::visit_statement_block(const ast::StatementBlock& node) {
     /// starting new block, store current state
     blocks_perf.push(current_block_perf);
 
@@ -466,13 +466,13 @@ void PerfVisitor::visit_statement_block(ast::StatementBlock& node) {
 /// and hence could/should not be skipped completely
 /// we can't ignore the block because it could have associated
 /// statement block (in theory)
-void PerfVisitor::visit_solve_block(ast::SolveBlock& node) {
+void PerfVisitor::visit_solve_block(const ast::SolveBlock& node) {
     under_solve_block = true;
     node.visit_children(*this);
     under_solve_block = false;
 }
 
-void PerfVisitor::visit_unary_expression(ast::UnaryExpression& node) {
+void PerfVisitor::visit_unary_expression(const ast::UnaryExpression& node) {
     if (start_measurement) {
         auto value = node.get_op().get_value();
         switch (value) {
@@ -513,7 +513,7 @@ bool PerfVisitor::symbol_to_skip(const std::shared_ptr<Symbol>& symbol) {
     return skip;
 }
 
-bool PerfVisitor::is_local_variable(const std::shared_ptr<Symbol>& symbol) {
+bool PerfVisitor::is_local_variable(const std::shared_ptr<Symbol>& symbol) const {
     bool is_local = false;
     /// in the function when we write to function variable then consider it as local variable
     auto properties = NmodlType::local_var | NmodlType::argument | NmodlType::function_block;
@@ -523,7 +523,7 @@ bool PerfVisitor::is_local_variable(const std::shared_ptr<Symbol>& symbol) {
     return is_local;
 }
 
-bool PerfVisitor::is_constant_variable(const std::shared_ptr<Symbol>& symbol) {
+bool PerfVisitor::is_constant_variable(const std::shared_ptr<Symbol>& symbol) const {
     bool is_constant = false;
     auto properties = NmodlType::param_assign;
     if (symbol->has_any_property(properties)) {

--- a/src/visitors/perf_visitor.hpp
+++ b/src/visitors/perf_visitor.hpp
@@ -26,8 +26,8 @@ namespace nmodl {
 namespace visitor {
 
 /**
- * @addtogroup visitor_classes
- * @{
+ * \addtogroup visitor_classes
+ * \{
  */
 
 /**
@@ -55,7 +55,7 @@ namespace visitor {
  *       start_measurement, there should be "empty" ast visitor from
  *       which PerfVisitor should be inherited.
  */
-class PerfVisitor: public AstVisitor {
+class PerfVisitor: public ConstAstVisitor {
   private:
     /// symbol table of current block being visited
     symtab::SymbolTable* current_symtab = nullptr;
@@ -135,17 +135,17 @@ class PerfVisitor: public AstVisitor {
 
     bool symbol_to_skip(const std::shared_ptr<symtab::Symbol>& symbol);
 
-    bool is_local_variable(const std::shared_ptr<symtab::Symbol>& symbol);
+    bool is_local_variable(const std::shared_ptr<symtab::Symbol>& symbol) const;
 
-    bool is_constant_variable(const std::shared_ptr<symtab::Symbol>& symbol);
+    bool is_constant_variable(const std::shared_ptr<symtab::Symbol>& symbol) const;
 
     void count_variables();
 
-    void measure_performance(ast::Ast* node);
+    void measure_performance(const ast::Ast& node);
 
     void print_memory_usage();
 
-    void add_perf_to_printer(utils::PerfStat& perf);
+    void add_perf_to_printer(const utils::PerfStat& perf) const;
 
   public:
     PerfVisitor() = default;
@@ -154,7 +154,7 @@ class PerfVisitor: public AstVisitor {
 
     void compact_json(bool flag);
 
-    utils::PerfStat get_total_perfstat() const noexcept {
+    const utils::PerfStat& get_total_perfstat() const noexcept {
         return total_perf;
     }
 
@@ -178,88 +178,88 @@ class PerfVisitor: public AstVisitor {
         return num_state_variables;
     }
 
-    void visit_binary_expression(ast::BinaryExpression& node) override;
+    void visit_binary_expression(const ast::BinaryExpression& node) override;
 
-    void visit_function_call(ast::FunctionCall& node) override;
+    void visit_function_call(const ast::FunctionCall& node) override;
 
-    void visit_name(ast::Name& node) override;
+    void visit_name(const ast::Name& node) override;
 
-    void visit_prime_name(ast::PrimeName& node) override;
+    void visit_prime_name(const ast::PrimeName& node) override;
 
-    void visit_solve_block(ast::SolveBlock& node) override;
+    void visit_solve_block(const ast::SolveBlock& node) override;
 
-    void visit_statement_block(ast::StatementBlock& node) override;
+    void visit_statement_block(const ast::StatementBlock& node) override;
 
-    void visit_unary_expression(ast::UnaryExpression& node) override;
+    void visit_unary_expression(const ast::UnaryExpression& node) override;
 
-    void visit_if_statement(ast::IfStatement& node) override;
+    void visit_if_statement(const ast::IfStatement& node) override;
 
-    void visit_else_if_statement(ast::ElseIfStatement& node) override;
+    void visit_else_if_statement(const ast::ElseIfStatement& node) override;
 
-    void visit_program(ast::Program& node) override;
+    void visit_program(const ast::Program& node) override;
 
-    void visit_plot_block(ast::PlotBlock& node) override;
+    void visit_plot_block(const ast::PlotBlock& node) override;
 
     /// skip initial block under net_receive block
-    void visit_initial_block(ast::InitialBlock& node) override;
+    void visit_initial_block(const ast::InitialBlock& node) override;
 
-    void visit_constructor_block(ast::ConstructorBlock& node) override;
+    void visit_constructor_block(const ast::ConstructorBlock& node) override;
 
-    void visit_destructor_block(ast::DestructorBlock& node) override;
+    void visit_destructor_block(const ast::DestructorBlock& node) override;
 
-    void visit_derivative_block(ast::DerivativeBlock& node) override;
+    void visit_derivative_block(const ast::DerivativeBlock& node) override;
 
-    void visit_linear_block(ast::LinearBlock& node) override;
+    void visit_linear_block(const ast::LinearBlock& node) override;
 
-    void visit_non_linear_block(ast::NonLinearBlock& node) override;
+    void visit_non_linear_block(const ast::NonLinearBlock& node) override;
 
-    void visit_discrete_block(ast::DiscreteBlock& node) override;
+    void visit_discrete_block(const ast::DiscreteBlock& node) override;
 
-    void visit_partial_block(ast::PartialBlock& node) override;
+    void visit_partial_block(const ast::PartialBlock& node) override;
 
-    void visit_function_table_block(ast::FunctionTableBlock& node) override;
+    void visit_function_table_block(const ast::FunctionTableBlock& node) override;
 
-    void visit_function_block(ast::FunctionBlock& node) override;
+    void visit_function_block(const ast::FunctionBlock& node) override;
 
-    void visit_procedure_block(ast::ProcedureBlock& node) override;
+    void visit_procedure_block(const ast::ProcedureBlock& node) override;
 
-    void visit_net_receive_block(ast::NetReceiveBlock& node) override;
+    void visit_net_receive_block(const ast::NetReceiveBlock& node) override;
 
-    void visit_breakpoint_block(ast::BreakpointBlock& node) override;
+    void visit_breakpoint_block(const ast::BreakpointBlock& node) override;
 
-    void visit_terminal_block(ast::TerminalBlock& node) override;
+    void visit_terminal_block(const ast::TerminalBlock& node) override;
 
-    void visit_before_block(ast::BeforeBlock& node) override;
+    void visit_before_block(const ast::BeforeBlock& node) override;
 
-    void visit_after_block(ast::AfterBlock& node) override;
+    void visit_after_block(const ast::AfterBlock& node) override;
 
-    void visit_ba_block(ast::BABlock& node) override;
+    void visit_ba_block(const ast::BABlock& node) override;
 
-    void visit_for_netcon(ast::ForNetcon& node) override;
+    void visit_for_netcon(const ast::ForNetcon& node) override;
 
-    void visit_kinetic_block(ast::KineticBlock& node) override;
+    void visit_kinetic_block(const ast::KineticBlock& node) override;
 
-    void visit_match_block(ast::MatchBlock& node) override;
+    void visit_match_block(const ast::MatchBlock& node) override;
 
     /// certain constructs needs to be excluded from usage counting
     /// and hence need to provide empty implementations
 
-    void visit_conductance_hint(ast::ConductanceHint& /*node*/) override {}
+    void visit_conductance_hint(const ast::ConductanceHint& /*node*/) override {}
 
-    void visit_local_list_statement(ast::LocalListStatement& /*node*/) override {}
+    void visit_local_list_statement(const ast::LocalListStatement& /*node*/) override {}
 
-    void visit_suffix(ast::Suffix& /*node*/) override {}
+    void visit_suffix(const ast::Suffix& /*node*/) override {}
 
-    void visit_useion(ast::Useion& /*node*/) override {}
+    void visit_useion(const ast::Useion& /*node*/) override {}
 
-    void visit_valence(ast::Valence& /*node*/) override {}
+    void visit_valence(const ast::Valence& /*node*/) override {}
 
     void print(std::ostream& ss) const {
         ss << stream.str();
     }
 };
 
-/** @} */  // end of visitor_classes
+/** \} */  // end of visitor_classes
 
 }  // namespace visitor
 }  // namespace nmodl

--- a/src/visitors/rename_visitor.cpp
+++ b/src/visitors/rename_visitor.cpp
@@ -16,9 +16,9 @@
 namespace nmodl {
 namespace visitor {
 
-using nmodl::utils::UseNumbersInString;
 
-std::string RenameVisitor::new_name_generator(const std::string old_name) {
+std::string RenameVisitor::new_name_generator(const std::string& old_name) {
+
     std::string new_name;
     if (add_random_suffix) {
         if (renamed_variables.find(old_name) != renamed_variables.end()) {
@@ -46,7 +46,7 @@ std::string RenameVisitor::new_name_generator(const std::string old_name) {
 }
 
 /// rename matching variable
-void RenameVisitor::visit_name(ast::Name& node) {
+void RenameVisitor::visit_name(const ast::Name& node) {
     const auto& name = node.get_node_name();
     if (std::regex_match(name, var_name_regex)) {
         std::string new_name = new_name_generator(name);
@@ -63,40 +63,40 @@ void RenameVisitor::visit_name(ast::Name& node) {
  * macro. In practice this won't be an issue as we order is set
  * by parser. To be safe we are only renaming prime variable.
  */
-void RenameVisitor::visit_prime_name(ast::PrimeName& node) {
+void RenameVisitor::visit_prime_name(const ast::PrimeName& node) {
     node.visit_children(*this);
 }
 
 /**
  * Parse verbatim blocks and rename variable if it is used.
  */
-void RenameVisitor::visit_verbatim(ast::Verbatim& node) {
+void RenameVisitor::visit_verbatim(const ast::Verbatim& node) {
     if (!rename_verbatim) {
         return;
     }
 
     const auto& statement = node.get_statement();
-    auto text = statement->eval();
+    const auto& text = statement->eval();
     parser::CDriver driver;
 
     driver.scan_string(text);
     auto tokens = driver.all_tokens();
 
-    std::string result;
+    std::ostringstream result;
     for (auto& token: tokens) {
         if (std::regex_match(token, var_name_regex)) {
             /// Check if variable is already renamed and use the same naming otherwise add the
             /// new_name to the renamed_variables map
-            std::string new_name = new_name_generator(token);
-            result += new_name;
+            const std::string& new_name = new_name_generator(token);
+            result << new_name;
             logger->warn("RenameVisitor :: Renaming variable {} in VERBATIM block to {}",
                          token,
                          new_name);
         } else {
-            result += token;
+            result << token;
         }
     }
-    statement->set(result);
+    statement->set(result.str());
 }
 
 }  // namespace visitor

--- a/src/visitors/rename_visitor.cpp
+++ b/src/visitors/rename_visitor.cpp
@@ -18,7 +18,6 @@ namespace visitor {
 
 
 std::string RenameVisitor::new_name_generator(const std::string& old_name) {
-
     std::string new_name;
     if (add_random_suffix) {
         if (renamed_variables.find(old_name) != renamed_variables.end()) {

--- a/src/visitors/rename_visitor.hpp
+++ b/src/visitors/rename_visitor.hpp
@@ -23,8 +23,8 @@ namespace nmodl {
 namespace visitor {
 
 /**
- * @addtogroup visitor_classes
- * @{
+ * \addtogroup visitor_classes
+ * \{
  */
 
 /**
@@ -40,7 +40,7 @@ namespace visitor {
  *
  * \todo Add log/warning messages.
  */
-class RenameVisitor: public AstVisitor {
+class RenameVisitor: public ConstAstVisitor {
   private:
     /// ast::Ast* node
     std::shared_ptr<ast::Program> ast;
@@ -92,23 +92,23 @@ class RenameVisitor: public AstVisitor {
 
     /// Check if variable is already renamed and use the same naming otherwise add the new_name
     /// to the renamed_variables map
-    std::string new_name_generator(const std::string old_name);
+    std::string new_name_generator(const std::string& old_name);
 
     void set(std::string old_name, std::string new_name) {
         var_name_regex = std::move(old_name);
         new_var_name = std::move(new_name);
     }
 
-    void enable_verbatim(bool state) {
+    void enable_verbatim(bool state) noexcept {
         rename_verbatim = state;
     }
 
-    void visit_name(ast::Name& node) override;
-    void visit_prime_name(ast::PrimeName& node) override;
-    void visit_verbatim(ast::Verbatim& node) override;
+    void visit_name(const ast::Name& node) override;
+    void visit_prime_name(const ast::PrimeName& node) override;
+    void visit_verbatim(const ast::Verbatim& node) override;
 };
 
-/** @} */  // end of visitor_classes
+/** \} */  // end of visitor_classes
 
 }  // namespace visitor
 }  // namespace nmodl

--- a/src/visitors/solve_block_visitor.cpp
+++ b/src/visitors/solve_block_visitor.cpp
@@ -40,7 +40,7 @@ static bool has_sympy_solution(const ast::Ast& node) {
 ast::SolutionExpression* SolveBlockVisitor::create_solution_expression(
     ast::SolveBlock& solve_block) {
     /// find out the block that is going to solved
-    const std::string& block_name = solve_block.get_block_name()->get_node_name();
+    const auto& block_name = solve_block.get_block_name()->get_node_name();
     const auto& solve_node_symbol = symtab->lookup(block_name);
     assert(solve_node_symbol != nullptr);
     auto node_to_solve = solve_node_symbol->get_node();

--- a/src/visitors/solve_block_visitor.cpp
+++ b/src/visitors/solve_block_visitor.cpp
@@ -11,7 +11,7 @@
 
 #include "ast/all.hpp"
 #include "codegen/codegen_naming.hpp"
-#include "visitors/lookup_visitor.hpp"
+#include "visitor_utils.hpp"
 
 namespace nmodl {
 namespace visitor {
@@ -23,14 +23,14 @@ void SolveBlockVisitor::visit_breakpoint_block(ast::BreakpointBlock& node) {
 }
 
 /// check if given node contains sympy solution
-static bool has_sympy_solution(ast::Ast& node) {
-    return !AstLookupVisitor().lookup(node, ast::AstNodeType::EIGEN_NEWTON_SOLVER_BLOCK).empty();
+static bool has_sympy_solution(const ast::Ast& node) {
+    return !collect_nodes(node, {ast::AstNodeType::EIGEN_NEWTON_SOLVER_BLOCK}).empty();
 }
 
 /**
  * Create solution expression node that will be used for solve block
- * @param solve_block solve block used to describe node to solve and method
- * @return solution expression that will be used to replace the solve block
+ * \param solve_block solve block used to describe node to solve and method
+ * \return solution expression that will be used to replace the solve block
  *
  * Depending on the solver used, solve block is converted to solve expression statement
  * that will be used to replace solve block. Note that the blocks are clones instead of
@@ -40,8 +40,8 @@ static bool has_sympy_solution(ast::Ast& node) {
 ast::SolutionExpression* SolveBlockVisitor::create_solution_expression(
     ast::SolveBlock& solve_block) {
     /// find out the block that is going to solved
-    std::string block_name = solve_block.get_block_name()->get_node_name();
-    auto solve_node_symbol = symtab->lookup(block_name);
+    const std::string& block_name = solve_block.get_block_name()->get_node_name();
+    const auto& solve_node_symbol = symtab->lookup(block_name);
     assert(solve_node_symbol != nullptr);
     auto node_to_solve = solve_node_symbol->get_node();
 

--- a/src/visitors/solve_block_visitor.hpp
+++ b/src/visitors/solve_block_visitor.hpp
@@ -19,8 +19,8 @@ namespace nmodl {
 namespace visitor {
 
 /**
- * @addtogroup visitor_classes
- * @{
+ * \addtogroup visitor_classes
+ * \{
  */
 
 /**
@@ -50,7 +50,7 @@ class SolveBlockVisitor: public AstVisitor {
     void visit_program(ast::Program& node) override;
 };
 
-/** @} */  // end of visitor_classes
+/** \} */  // end of visitor_classes
 
 }  // namespace visitor
 }  // namespace nmodl

--- a/src/visitors/steadystate_visitor.cpp
+++ b/src/visitors/steadystate_visitor.cpp
@@ -10,7 +10,6 @@
 #include "ast/all.hpp"
 #include "codegen/codegen_naming.hpp"
 #include "utils/logger.hpp"
-#include "visitors/lookup_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
 
 namespace nmodl {
@@ -104,10 +103,10 @@ std::shared_ptr<ast::DerivativeBlock> SteadystateVisitor::create_steadystate_blo
 
 void SteadystateVisitor::visit_program(ast::Program& node) {
     // get DERIVATIVE blocks
-    const auto& deriv_blocks = AstLookupVisitor().lookup(node, ast::AstNodeType::DERIVATIVE_BLOCK);
+    const auto& deriv_blocks = collect_nodes(node, {ast::AstNodeType::DERIVATIVE_BLOCK});
 
     // get list of STEADYSTATE solve statements with names & methods
-    const auto& solve_block_nodes = AstLookupVisitor().lookup(node, ast::AstNodeType::SOLVE_BLOCK);
+    const auto& solve_block_nodes = collect_nodes(node, {ast::AstNodeType::SOLVE_BLOCK});
 
     // create new DERIVATIVE blocks for the STEADYSTATE solves
     for (const auto& solve_block_ptr: solve_block_nodes) {

--- a/src/visitors/sympy_conductance_visitor.hpp
+++ b/src/visitors/sympy_conductance_visitor.hpp
@@ -80,16 +80,16 @@ class SympyConductanceVisitor: public AstVisitor {
     std::map<std::string, std::size_t> binary_expr_index;
 
     /// use ion ast nodes
-    std::vector<std::shared_ptr<ast::Ast>> use_ion_nodes;
+    std::vector<std::shared_ptr<const ast::Ast>> use_ion_nodes;
 
     /// non specific currents
-    std::vector<std::shared_ptr<ast::Ast>> nonspecific_nodes;
+    std::vector<std::shared_ptr<const ast::Ast>> nonspecific_nodes;
 
     std::vector<std::string> generate_statement_strings(ast::BreakpointBlock& node);
     void lookup_useion_statements();
     void lookup_nonspecific_statements();
 
-    static std::string to_nmodl_for_sympy(ast::Ast& node);
+    static std::string to_nmodl_for_sympy(const ast::Ast& node);
 
   public:
     SympyConductanceVisitor() = default;

--- a/src/visitors/sympy_solver_visitor.hpp
+++ b/src/visitors/sympy_solver_visitor.hpp
@@ -21,7 +21,6 @@
 #include "ast/ast.hpp"
 #include "symtab/symbol.hpp"
 #include "visitors/ast_visitor.hpp"
-#include "visitors/lookup_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
 
 namespace nmodl {

--- a/src/visitors/units_visitor.cpp
+++ b/src/visitors/units_visitor.cpp
@@ -35,7 +35,7 @@ void UnitsVisitor::visit_program(ast::Program& node) {
  * On \c nrnunits.lib constant "1" is defined as "fuzz", so it must be converted.
  */
 void UnitsVisitor::visit_unit_def(ast::UnitDef& node) {
-    std::stringstream ss;
+    std::ostringstream ss;
     /*
      * In nrnunits.lib file "1" is defined as "fuzz", so there
      * must be a conversion to be able to parse "1" as unit
@@ -80,8 +80,8 @@ void UnitsVisitor::visit_unit_def(ast::UnitDef& node) {
  * care of all the units calculations.
  */
 void UnitsVisitor::visit_factor_def(ast::FactorDef& node) {
-    std::stringstream ss;
-    auto node_has_value_defined_in_modfile = node.get_value() != nullptr;
+    std::ostringstream ss;
+    const auto node_has_value_defined_in_modfile = node.get_value() != nullptr;
     if (node_has_value_defined_in_modfile) {
         /*
          * In nrnunits.lib file "1" is defined as "fuzz", so
@@ -97,7 +97,7 @@ void UnitsVisitor::visit_factor_def(ast::FactorDef& node) {
         // Parse the generated string for the defined unit using the units::UnitParser
         units_driver.parse_string(ss.str());
     } else {
-        std::stringstream ss_unit1, ss_unit2;
+        std::ostringstream ss_unit1, ss_unit2;
         std::string unit1_name, unit2_name;
         /*
          * In nrnunits.lib file "1" is defined as "fuzz", so

--- a/src/visitors/units_visitor.hpp
+++ b/src/visitors/units_visitor.hpp
@@ -24,8 +24,8 @@ namespace nmodl {
 namespace visitor {
 
 /**
- * @addtogroup visitor_classes
- * @{
+ * \addtogroup visitor_classes
+ * \{
  */
 
 /**
@@ -80,12 +80,12 @@ class UnitsVisitor: public AstVisitor {
 
     /// Get the parser::UnitDriver to be able to use it outside the visitor::UnitsVisitor
     /// scope keeping the same units::UnitTable
-    parser::UnitDriver get_unit_driver() const noexcept {
+    const parser::UnitDriver& get_unit_driver() const noexcept {
         return units_driver;
     }
 };
 
-/** @} */  // end of visitor_classes
+/** \} */  // end of visitor_classes
 
 }  // namespace visitor
 }  // namespace nmodl

--- a/src/visitors/var_usage_visitor.cpp
+++ b/src/visitors/var_usage_visitor.cpp
@@ -16,14 +16,14 @@ namespace nmodl {
 namespace visitor {
 
 /// rename matching variable
-void VarUsageVisitor::visit_name(ast::Name& node) {
+void VarUsageVisitor::visit_name(const ast::Name& node) {
     const auto& name = node.get_node_name();
     if (name == var_name) {
         used = true;
     }
 }
 
-bool VarUsageVisitor::variable_used(ast::Node& node, std::string name) {
+bool VarUsageVisitor::variable_used(const ast::Node& node, std::string name) {
     used = false;
     var_name = std::move(name);
     node.visit_children(*this);

--- a/src/visitors/var_usage_visitor.hpp
+++ b/src/visitors/var_usage_visitor.hpp
@@ -21,8 +21,8 @@ namespace nmodl {
 namespace visitor {
 
 /**
- * @addtogroup visitor_classes
- * @{
+ * \addtogroup visitor_classes
+ * \{
  */
 
 /**
@@ -32,21 +32,21 @@ namespace visitor {
  * \todo Check if macro is considered as variable
  */
 
-class VarUsageVisitor: protected AstVisitor {
+class VarUsageVisitor: protected ConstAstVisitor {
   private:
     /// variable to check usage
     std::string var_name;
     bool used = false;
 
-    void visit_name(ast::Name& node) override;
+    void visit_name(const ast::Name& node) override;
 
   public:
     VarUsageVisitor() = default;
 
-    bool variable_used(ast::Node& node, std::string name);
+    bool variable_used(const ast::Node& node, std::string name);
 };
 
-/** @} */  // end of visitor_classes
+/** \} */  // end of visitor_classes
 
 }  // namespace visitor
 }  // namespace nmodl

--- a/src/visitors/verbatim_var_rename_visitor.cpp
+++ b/src/visitors/verbatim_var_rename_visitor.cpp
@@ -76,17 +76,17 @@ std::string VerbatimVarRenameVisitor::rename_variable(const std::string& name) {
  */
 void VerbatimVarRenameVisitor::visit_verbatim(ast::Verbatim& node) {
     const auto& statement = node.get_statement();
-    auto text = statement->eval();
+    const auto& text = statement->eval();
     parser::CDriver driver;
 
     driver.scan_string(text);
-    auto tokens = driver.all_tokens();
+    const auto& tokens = driver.all_tokens();
 
-    std::string result;
+    std::ostringstream oss;
     for (const auto& token: tokens) {
-        result += rename_variable(token);
+        oss << rename_variable(token);
     }
-    statement->set(result);
+    statement->set(oss.str());
 }
 
 }  // namespace visitor

--- a/src/visitors/verbatim_visitor.cpp
+++ b/src/visitors/verbatim_visitor.cpp
@@ -15,7 +15,7 @@
 namespace nmodl {
 namespace visitor {
 
-void VerbatimVisitor::visit_verbatim(ast::Verbatim& node) {
+void VerbatimVisitor::visit_verbatim(const ast::Verbatim& node) {
     std::string block;
     const auto& statement = node.get_statement();
     if (statement) {

--- a/src/visitors/verbatim_visitor.hpp
+++ b/src/visitors/verbatim_visitor.hpp
@@ -35,7 +35,7 @@ namespace visitor {
  * generating report of all verbatim blocks from all mod files
  * in ModelDB.
  */
-class VerbatimVisitor: public AstVisitor {
+class VerbatimVisitor: public ConstAstVisitor {
   private:
     /// flag to enable/disable printing blocks as we visit them
     bool verbose = false;
@@ -46,11 +46,11 @@ class VerbatimVisitor: public AstVisitor {
   public:
     VerbatimVisitor() = default;
 
-    explicit VerbatimVisitor(bool flag) {
-        verbose = flag;
+    explicit VerbatimVisitor(bool verbose) {
+        this->verbose = verbose;
     }
 
-    void visit_verbatim(ast::Verbatim& node) override;
+    void visit_verbatim(const ast::Verbatim& node) override;
 
     const std::vector<std::string>& verbatim_blocks() const noexcept {
         return blocks;

--- a/src/visitors/visitor_utils.cpp
+++ b/src/visitors/visitor_utils.cpp
@@ -51,7 +51,7 @@ std::string suffix_random_string(const std::set<std::string>& vars,
 std::string get_new_name(const std::string& name,
                          const std::string& suffix,
                          std::map<std::string, int>& variables) {
-    auto it = variables.insert({name, 0});
+    auto it = variables.emplace(name, 0);
     auto counter = it.first->second;
     ++it.first->second;
 

--- a/src/visitors/visitor_utils.cpp
+++ b/src/visitors/visitor_utils.cpp
@@ -51,12 +51,13 @@ std::string suffix_random_string(const std::set<std::string>& vars,
 std::string get_new_name(const std::string& name,
                          const std::string& suffix,
                          std::map<std::string, int>& variables) {
-    int counter = 0;
-    if (variables.find(name) != variables.end()) {
-        counter = variables[name];
-    }
-    variables[name] = counter + 1;
-    return (name + "_" + suffix + "_" + std::to_string(counter));
+    auto it = variables.insert({name, 0});
+    auto counter = it.first->second;
+    ++it.first->second;
+
+    std::ostringstream oss;
+    oss << name << '_' << suffix << '_' << counter;
+    return oss.str();
 }
 
 std::shared_ptr<ast::LocalListStatement> get_local_list_statement(const StatementBlock& node) {
@@ -170,20 +171,32 @@ std::set<std::string> get_global_vars(const Program& node) {
 }
 
 
-bool calls_function(ast::Ast& node, const std::string& name) {
-    AstLookupVisitor lv(ast::AstNodeType::FUNCTION_CALL);
-    for (const auto& f: lv.lookup(node)) {
-        if (std::dynamic_pointer_cast<ast::FunctionCall>(f)->get_node_name() == name) {
-            return true;
-        }
-    }
-    return false;
+bool calls_function(const ast::Ast& node, const std::string& name) {
+    const auto& function_calls = collect_nodes(node, {ast::AstNodeType::FUNCTION_CALL});
+    return std::any_of(
+        function_calls.begin(),
+        function_calls.end(),
+        [&name](const std::shared_ptr<const ast::Ast>& f) {
+            return std::dynamic_pointer_cast<const ast::FunctionCall>(f)->get_node_name() == name;
+        });
 }
 
 }  // namespace visitor
 
+std::vector<std::shared_ptr<const ast::Ast>> collect_nodes(
+    const ast::Ast& node,
+    const std::vector<ast::AstNodeType>& types) {
+    visitor::ConstAstLookupVisitor visitor;
+    return visitor.lookup(node, types);
+}
 
-std::string to_nmodl(ast::Ast& node, const std::set<ast::AstNodeType>& exclude_types) {
+std::vector<std::shared_ptr<ast::Ast>> collect_nodes(ast::Ast& node,
+                                                     const std::vector<ast::AstNodeType>& types) {
+    visitor::AstLookupVisitor visitor;
+    return visitor.lookup(node, types);
+}
+
+std::string to_nmodl(const ast::Ast& node, const std::set<ast::AstNodeType>& exclude_types) {
     std::stringstream stream;
     visitor::NmodlPrintVisitor v(stream, exclude_types);
     node.accept(v);
@@ -191,7 +204,7 @@ std::string to_nmodl(ast::Ast& node, const std::set<ast::AstNodeType>& exclude_t
 }
 
 
-std::string to_json(ast::Ast& node, bool compact, bool expand, bool add_nmodl) {
+std::string to_json(const ast::Ast& node, bool compact, bool expand, bool add_nmodl) {
     std::stringstream stream;
     visitor::JSONVisitor v(stream);
     v.compact_json(compact);

--- a/src/visitors/visitor_utils.hpp
+++ b/src/visitors/visitor_utils.hpp
@@ -80,14 +80,23 @@ void remove_statements_from_block(ast::StatementBlock& block,
 std::set<std::string> get_global_vars(const ast::Program& node);
 
 
-/// Checks whether block contains a call to a perticular function
-bool calls_function(ast::Ast& node, const std::string& name);
+/// Checks whether block contains a call to a particular function
+bool calls_function(const ast::Ast& node, const std::string& name);
 
 }  // namespace visitor
 
+/// traverse \a node recursively and collect nodes of given \a types
+std::vector<std::shared_ptr<const ast::Ast>> collect_nodes(
+    const ast::Ast& node,
+    const std::vector<ast::AstNodeType>& types = {});
+
+/// traverse \a node recursively and collect nodes of given \a types
+std::vector<std::shared_ptr<ast::Ast>> collect_nodes(
+    ast::Ast& node,
+    const std::vector<ast::AstNodeType>& types = {});
 
 /// Given AST node, return the NMODL string representation
-std::string to_nmodl(ast::Ast& node, const std::set<ast::AstNodeType>& exclude_types = {});
+std::string to_nmodl(const ast::Ast& node, const std::set<ast::AstNodeType>& exclude_types = {});
 
 /// Given a shared pointer to an AST node, return the NMODL string representation
 template <typename T>
@@ -98,7 +107,7 @@ typename std::enable_if<std::is_base_of<ast::Ast, T>::value, std::string>::type 
 }
 
 /// Given AST node, return the JSON string representation
-std::string to_json(ast::Ast& node,
+std::string to_json(const ast::Ast& node,
                     bool compact = false,
                     bool expand = false,
                     bool add_nmodl = false);

--- a/test/unit/modtoken/modtoken.cpp
+++ b/test/unit/modtoken/modtoken.cpp
@@ -16,7 +16,6 @@
 #include "lexer/nmodl_lexer.hpp"
 #include "parser/nmodl_driver.hpp"
 #include "test/unit/utils/test_utils.hpp"
-#include "visitors/lookup_visitor.hpp"
 
 
 /** @file

--- a/test/unit/parser/parser.cpp
+++ b/test/unit/parser/parser.cpp
@@ -19,10 +19,10 @@
 #include "test/unit/utils/nmodl_constructs.hpp"
 #include "test/unit/utils/test_utils.hpp"
 #include "visitors/checkparent_visitor.hpp"
-#include "visitors/lookup_visitor.hpp"
+#include "visitors/visitor_utils.hpp"
+
 
 using namespace nmodl::test_utils;
-using nmodl::visitor::AstLookupVisitor;
 //=============================================================================
 // Parser tests
 //=============================================================================
@@ -170,7 +170,7 @@ SCENARIO("Check parents in valid NMODL constructs") {
         GIVEN(construct.second.name) {
             THEN("Check the parents in : " + construct.second.input) {
                 // check the parents
-                REQUIRE(!nmodl::visitor::test::CheckParentVisitor().check_ast(ast.get()));
+                REQUIRE(!nmodl::visitor::test::CheckParentVisitor().check_ast(*ast));
             }
         }
     }
@@ -213,9 +213,9 @@ void parse_neuron_block_string(const std::string& name, nmodl::ModToken& value) 
     driver.parse_string(name);
 
     const auto& ast_program = driver.get_ast();
-    const auto& neuron_blocks = AstLookupVisitor().lookup(*ast_program->get_shared_ptr(),
-                                                          nmodl::ast::AstNodeType::NEURON_BLOCK);
-    value = *(neuron_blocks[0]->get_token());
+    const auto& neuron_blocks = nmodl::collect_nodes(*ast_program->get_shared_ptr(),
+                                                     {nmodl::ast::AstNodeType::NEURON_BLOCK});
+    value = *(neuron_blocks.front()->get_token());
 }
 
 SCENARIO("Check if a NEURON block is parsed with correct location info in its token") {

--- a/test/unit/pybind/test_visitor.py
+++ b/test/unit/pybind/test_visitor.py
@@ -17,6 +17,18 @@ def test_lookup_visitor(ch_ast):
     assert eq_str == "m' = mInf-m"
 
 
+def test_lookup_visitor_any_node():
+    """Ensure the AstLookupVisitor.lookup methods accept any node"""
+    lookup_visitor = visitor.AstLookupVisitor(ast.AstNodeType.INTEGER)
+    int42 = ast.Integer(42, None)
+
+    eqs = lookup_visitor.lookup(int42)
+    assert len(eqs) == 1
+
+    eqs = lookup_visitor.lookup(int42, ast.AstNodeType.DOUBLE)
+    assert len(eqs) == 0
+
+
 def test_lookup_visitor_constructor(ch_ast):
     lookup_visitor = visitor.AstLookupVisitor(ast.AstNodeType.DIFF_EQ_EXPRESSION)
     eqs = lookup_visitor.lookup(ch_ast)

--- a/test/unit/pybind/test_visitor.py
+++ b/test/unit/pybind/test_visitor.py
@@ -19,15 +19,13 @@ def test_lookup_visitor(ch_ast):
 
 def test_lookup_visitor_constructor(ch_ast):
     lookup_visitor = visitor.AstLookupVisitor(ast.AstNodeType.DIFF_EQ_EXPRESSION)
-    ch_ast.accept(lookup_visitor)
-    eqs = lookup_visitor.get_nodes()
+    eqs = lookup_visitor.lookup(ch_ast)
     eq_str = nmodl.dsl.to_nmodl(eqs[0])
 
 
 def test_json_visitor(ch_ast):
     lookup_visitor = visitor.AstLookupVisitor(ast.AstNodeType.PRIME_NAME)
-    ch_ast.accept(lookup_visitor)
-    primes = lookup_visitor.get_nodes()
+    primes = lookup_visitor.lookup(ch_ast)
 
     # test compact json
     prime_str = nmodl.dsl.to_nmodl(primes[0])

--- a/test/unit/visitor/constant_folder.cpp
+++ b/test/unit/visitor/constant_folder.cpp
@@ -37,7 +37,7 @@ std::string run_constant_folding_visitor(const std::string& text) {
     NmodlPrintVisitor(stream).visit_program(*ast);
 
     // check that, after visitor rearrangement, parents are still up-to-date
-    CheckParentVisitor().visit_program(*ast);
+    CheckParentVisitor().check_ast(*ast);
 
     return stream.str();
 }

--- a/test/unit/visitor/defuse_analyze.cpp
+++ b/test/unit/visitor/defuse_analyze.cpp
@@ -13,7 +13,6 @@
 #include "visitors/checkparent_visitor.hpp"
 #include "visitors/defuse_analyze_visitor.hpp"
 #include "visitors/inline_visitor.hpp"
-#include "visitors/lookup_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"
 
 using namespace nmodl;
@@ -36,17 +35,17 @@ std::vector<DUChain> run_defuse_visitor(const std::string& text, const std::stri
     InlineVisitor().visit_program(*ast);
 
     std::vector<DUChain> chains;
-    DefUseAnalyzeVisitor v(ast->get_symbol_table());
+    DefUseAnalyzeVisitor v(*ast->get_symbol_table());
 
     /// analyse only derivative blocks in this test
-    auto blocks = AstLookupVisitor().lookup(*ast, AstNodeType::DERIVATIVE_BLOCK);
+    const auto& blocks = nmodl::collect_nodes(*ast, {AstNodeType::DERIVATIVE_BLOCK});
     chains.reserve(blocks.size());
-    for (auto& block: blocks) {
+    for (const auto& block: blocks) {
         chains.push_back(v.analyze(*block, variable));
     }
 
     // check that, after visitor rearrangement, parents are still up-to-date
-    CheckParentVisitor().visit_program(*ast);
+    CheckParentVisitor().check_ast(*ast);
 
     return chains;
 }

--- a/test/unit/visitor/global_to_range.cpp
+++ b/test/unit/visitor/global_to_range.cpp
@@ -11,7 +11,6 @@
 #include "parser/nmodl_driver.hpp"
 #include "test/unit/utils/nmodl_constructs.hpp"
 #include "visitors/global_var_visitor.hpp"
-#include "visitors/lookup_visitor.hpp"
 #include "visitors/nmodl_visitor.hpp"
 #include "visitors/perf_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"

--- a/test/unit/visitor/inline.cpp
+++ b/test/unit/visitor/inline.cpp
@@ -38,7 +38,7 @@ std::string run_inline_visitor(const std::string& text) {
 
 
     // check that, after visitor rearrangement, parents are still up-to-date
-    CheckParentVisitor().visit_program(*ast);
+    CheckParentVisitor().check_ast(*ast);
 
     return stream.str();
 }

--- a/test/unit/visitor/kinetic_block.cpp
+++ b/test/unit/visitor/kinetic_block.cpp
@@ -13,7 +13,6 @@
 #include "visitors/checkparent_visitor.hpp"
 #include "visitors/constant_folder_visitor.hpp"
 #include "visitors/kinetic_block_visitor.hpp"
-#include "visitors/lookup_visitor.hpp"
 #include "visitors/loop_unroll_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
@@ -50,16 +49,15 @@ std::vector<std::string> run_kinetic_block_visitor(const std::string& text) {
     KineticBlockVisitor().visit_program(*ast);
 
     // run lookup visitor to extract DERIVATIVE block(s) from AST
-    AstLookupVisitor v_lookup;
-    auto res = v_lookup.lookup(*ast, AstNodeType::DERIVATIVE_BLOCK);
-    results.reserve(res.size());
-    for (const auto& r: res) {
-        results.push_back(to_nmodl(r));
+    const auto& blocks = collect_nodes(*ast, {AstNodeType::DERIVATIVE_BLOCK});
+    results.reserve(blocks.size());
+    for (const auto& block: blocks) {
+        results.push_back(to_nmodl(block));
     }
 
 
     // check that, after visitor rearrangement, parents are still up-to-date
-    CheckParentVisitor().visit_program(*ast);
+    CheckParentVisitor().check_ast(*ast);
 
     return results;
 }

--- a/test/unit/visitor/local_to_assigned.cpp
+++ b/test/unit/visitor/local_to_assigned.cpp
@@ -11,7 +11,6 @@
 #include "parser/nmodl_driver.hpp"
 #include "test/unit/utils/nmodl_constructs.hpp"
 #include "visitors/local_to_assigned_visitor.hpp"
-#include "visitors/lookup_visitor.hpp"
 #include "visitors/nmodl_visitor.hpp"
 #include "visitors/perf_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"

--- a/test/unit/visitor/localize.cpp
+++ b/test/unit/visitor/localize.cpp
@@ -38,7 +38,7 @@ std::string run_localize_visitor(const std::string& text) {
     NmodlPrintVisitor(stream).visit_program(*ast);
 
     // check that, after visitor rearrangement, parents are still up-to-date
-    CheckParentVisitor().visit_program(*ast);
+    CheckParentVisitor().check_ast(*ast);
 
     return stream.str();
 }

--- a/test/unit/visitor/loop_unroll.cpp
+++ b/test/unit/visitor/loop_unroll.cpp
@@ -39,7 +39,7 @@ std::string run_loop_unroll_visitor(const std::string& text) {
     ConstantFolderVisitor().visit_program(*ast);
 
     // check that, after visitor rearrangement, parents are still up-to-date
-    CheckParentVisitor().visit_program(*ast);
+    CheckParentVisitor().check_ast(*ast);
 
     return to_nmodl(ast, {AstNodeType::DEFINE});
 }

--- a/test/unit/visitor/misc.cpp
+++ b/test/unit/visitor/misc.cpp
@@ -39,15 +39,15 @@ void run_visitor_passes(const std::string& text) {
         v1.visit_program(*ast);
         v2.visit_program(*ast);
         v3.visit_program(*ast);
-        v4.visit_program(*ast);
-        v4.visit_program(*ast);
+        v4.check_ast(*ast);
+        v4.check_ast(*ast);
         v1.visit_program(*ast);
         v1.visit_program(*ast);
-        v4.visit_program(*ast);
+        v4.check_ast(*ast);
         v2.visit_program(*ast);
         v3.visit_program(*ast);
         v2.visit_program(*ast);
-        v4.visit_program(*ast);
+        v4.check_ast(*ast);
     }
 }
 

--- a/test/unit/visitor/neuron_solve.cpp
+++ b/test/unit/visitor/neuron_solve.cpp
@@ -38,7 +38,7 @@ std::string run_cnexp_solve_visitor(const std::string& text) {
     NmodlPrintVisitor(stream).visit_program(*ast);
 
     // check that, after visitor rearrangement, parents are still up-to-date
-    CheckParentVisitor().visit_program(*ast);
+    CheckParentVisitor().check_ast(*ast);
 
     return stream.str();
 }

--- a/test/unit/visitor/nmodl.cpp
+++ b/test/unit/visitor/nmodl.cpp
@@ -34,7 +34,7 @@ std::string run_nmodl_visitor(const std::string& text) {
     NmodlPrintVisitor(stream).visit_program(*ast);
 
     // check that, after visitor rearrangement, parents are still up-to-date
-    CheckParentVisitor().visit_program(*ast);
+    CheckParentVisitor().check_ast(*ast);
 
     return stream.str();
 }
@@ -42,8 +42,8 @@ std::string run_nmodl_visitor(const std::string& text) {
 SCENARIO("Convert AST back to NMODL form", "[visitor][nmodl]") {
     for (const auto& construct: nmodl_valid_constructs) {
         auto test_case = construct.second;
-        std::string input_nmodl_text = reindent_text(test_case.input);
-        std::string output_nmodl_text = reindent_text(test_case.output);
+        const std::string& input_nmodl_text = reindent_text(test_case.input);
+        const std::string& output_nmodl_text = reindent_text(test_case.output);
         GIVEN(test_case.name) {
             THEN("Visitor successfully returns : " + input_nmodl_text) {
                 auto result = run_nmodl_visitor(input_nmodl_text);

--- a/test/unit/visitor/rename.cpp
+++ b/test/unit/visitor/rename.cpp
@@ -41,7 +41,7 @@ static std::string run_var_rename_visitor(
     NmodlPrintVisitor(stream).visit_program(*ast);
 
     // check that, after visitor rearrangement, parents are still up-to-date
-    CheckParentVisitor().visit_program(*ast);
+    CheckParentVisitor().check_ast(*ast);
 
     return stream.str();
 }

--- a/test/unit/visitor/solve_block.cpp
+++ b/test/unit/visitor/solve_block.cpp
@@ -38,7 +38,7 @@ std::string run_solve_block_visitor(const std::string& text) {
     NmodlPrintVisitor(stream).visit_program(*ast);
 
     // check that, after visitor rearrangement, parents are still up-to-date
-    CheckParentVisitor().visit_program(*ast);
+    CheckParentVisitor().check_ast(*ast);
 
     return stream.str();
 }

--- a/test/unit/visitor/steadystate.cpp
+++ b/test/unit/visitor/steadystate.cpp
@@ -13,7 +13,6 @@
 #include "visitors/checkparent_visitor.hpp"
 #include "visitors/constant_folder_visitor.hpp"
 #include "visitors/kinetic_block_visitor.hpp"
-#include "visitors/lookup_visitor.hpp"
 #include "visitors/loop_unroll_visitor.hpp"
 #include "visitors/steadystate_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"
@@ -59,14 +58,14 @@ std::vector<std::string> run_steadystate_visitor(
     SteadystateVisitor().visit_program(*ast);
 
     // run lookup visitor to extract results from AST
-    auto res = AstLookupVisitor().lookup(*ast, ret_nodetypes);
+    const auto& res = collect_nodes(*ast, ret_nodetypes);
     results.reserve(res.size());
     for (const auto& r: res) {
         results.push_back(to_nmodl(r));
     }
 
     // check that, after visitor rearrangement, parents are still up-to-date
-    CheckParentVisitor().visit_program(*ast);
+    CheckParentVisitor().check_ast(*ast);
 
     return results;
 }

--- a/test/unit/visitor/sympy_conductance.cpp
+++ b/test/unit/visitor/sympy_conductance.cpp
@@ -14,7 +14,6 @@
 #include "visitors/constant_folder_visitor.hpp"
 #include "visitors/inline_visitor.hpp"
 #include "visitors/local_var_rename_visitor.hpp"
-#include "visitors/lookup_visitor.hpp"
 #include "visitors/sympy_conductance_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
@@ -50,12 +49,11 @@ std::string run_sympy_conductance_visitor(const std::string& text) {
     SympyConductanceVisitor().visit_program(*ast);
 
     // check that, after visitor rearrangement, parents are still up-to-date
-    CheckParentVisitor().visit_program(*ast);
+    CheckParentVisitor().check_ast(*ast);
 
     // run lookup visitor to extract results from AST
-    AstLookupVisitor v_lookup;
     // return BREAKPOINT block as JSON string
-    return reindent_text(to_nmodl(v_lookup.lookup(*ast, AstNodeType::BREAKPOINT_BLOCK)[0]));
+    return reindent_text(to_nmodl(collect_nodes(*ast, {AstNodeType::BREAKPOINT_BLOCK}).front()));
 }
 
 std::string breakpoint_to_nmodl(const std::string& text) {
@@ -67,9 +65,8 @@ std::string breakpoint_to_nmodl(const std::string& text) {
     SymtabVisitor().visit_program(*ast);
 
     // run lookup visitor to extract results from AST
-    AstLookupVisitor v_lookup;
     // return BREAKPOINT block as JSON string
-    return reindent_text(to_nmodl(v_lookup.lookup(*ast, AstNodeType::BREAKPOINT_BLOCK)[0]));
+    return reindent_text(to_nmodl(collect_nodes(*ast, {AstNodeType::BREAKPOINT_BLOCK}).front()));
 }
 
 void run_sympy_conductance_passes(ast::Program& node) {

--- a/test/unit/visitor/sympy_solver.cpp
+++ b/test/unit/visitor/sympy_solver.cpp
@@ -12,7 +12,6 @@
 #include "test/unit/utils/test_utils.hpp"
 #include "visitors/checkparent_visitor.hpp"
 #include "visitors/constant_folder_visitor.hpp"
-#include "visitors/lookup_visitor.hpp"
 #include "visitors/loop_unroll_visitor.hpp"
 #include "visitors/nmodl_visitor.hpp"
 #include "visitors/sympy_solver_visitor.hpp"
@@ -55,13 +54,11 @@ std::vector<std::string> run_sympy_solver_visitor(
     SympySolverVisitor(pade, cse).visit_program(*ast);
 
     // check that, after visitor rearrangement, parents are still up-to-date
-    CheckParentVisitor().visit_program(*ast);
+    CheckParentVisitor().check_ast(*ast);
 
     // run lookup visitor to extract results from AST
-    AstLookupVisitor v_lookup;
-    auto res = v_lookup.lookup(*ast, ret_nodetype);
-    for (const auto& r: res) {
-        results.push_back(to_nmodl(r));
+    for (const auto& eq: collect_nodes(*ast, {ret_nodetype})) {
+        results.push_back(to_nmodl(eq));
     }
 
     return results;

--- a/test/unit/visitor/verbatim.cpp
+++ b/test/unit/visitor/verbatim.cpp
@@ -30,14 +30,14 @@ std::vector<std::string> run_verbatim_visitor(const std::string& text) {
     v.visit_program(*ast);
 
     // check that, after visitor rearrangement, parents are still up-to-date
-    CheckParentVisitor().visit_program(*ast);
+    CheckParentVisitor().check_ast(*ast);
 
     return v.verbatim_blocks();
 }
 
 TEST_CASE("Parse VERBATIM block using Verbatim Visitor") {
     SECTION("Single Block") {
-        std::string text = "VERBATIM int a; ENDVERBATIM";
+        const std::string text = "VERBATIM int a; ENDVERBATIM";
         auto blocks = run_verbatim_visitor(text);
 
         REQUIRE(blocks.size() == 1);


### PR DESCRIPTION
This pull-request mainly introduces a new `ConstVisitor` that allows one to write a visitor that is not able to modify the AST it manipulates. Here are the details:

* New `nmodl::visitor::ConstVisitor` class that provide a way to create visitors to traverse an AST without modifying it.
* Provide Python bindings for such visitor
* new helper function `collect_nodes` to replace direct usage of `AstLookupVisitor`
API of AstLookupVisitor is error prone as the user can easily manipulate a reference to a destructed object:
    ```
    const auto& verbatim_nodes = AstLookupVisitor().lookup(ast, {VERBATIM})
    ```
* Prefer \ to @ for doxygen comment to be compliant with coding conventions
* `CheckParentVisitor`:
  * API now uses const references to Ast node, not pointers.
  * Fix regression where the parent pointer was not checked anymore
* `JSONVisitor`: new `write` member function helper.
* `RenameVisitor`: prefer ostringstream to string for string concatenation
* constant visitors:
  * CheckParentVisitor
  * ConstAstLookupVisitor (new class)
  * DefUseAnalyzeVisitor
  * JSONVisitor
  * LocalizeVisitor
  * NmodlPrintVisitor
  * PerfVisitor
  * RenameVisitor
  * VarUsageVisitor
  * VerbatimVisitor
* `get_new_name` helper function: only look once in the map instead of at least 2, 3 at worse.
* CDriver: more const, more const reference, less IO flush, use unique_ptr instead of raw pointers



Besides, I would like to remove the `VerbatimVisitor` class because it is unused and can be replaced by this simple helper function:

```c++
std::vector<std::string> verbatim_blocks(const ast::Ast& node) {
    std::vector<std::string> blocks;
    for (const auto& verbatim: collect_nodes(node, {ast::AstNodeType::VERBATIM})) {
        const auto& statement = std::dynamic_pointer_cast<const ast::Verbatim>(verbatim)->get_statement();
        if (statement) {
            blocks.push_back(statement->eval());
        }
    }
    return blocks;
}
```
