### PR TITLE
Fix printing token in ISPC rename when there is none

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -37,6 +37,8 @@ using visitor::VarUsageVisitor;
 using symtab::syminfo::NmodlType;
 using SymbolType = std::shared_ptr<symtab::Symbol>;
 
+using nmodl::utils::UseRandomNumbers;
+
 /****************************************************************************************/
 /*                            Overloaded visitor routines                               */
 /****************************************************************************************/
@@ -1636,7 +1638,7 @@ void CodegenCVisitor::print_function(ast::FunctionBlock& node) {
 }
 
 std::string CodegenCVisitor::find_var_unique_name(const std::string& original_name) const {
-    auto singleton_random_string_class = nmodl::utils::SingletonRandomString<4>::instance();
+    auto singleton_random_string_class = nmodl::utils::SingletonRandomString<4>::instance(UseRandomNumbers::WithNumbers);
     std::string unique_name = original_name;
     if (singleton_random_string_class->random_string_exists(original_name)) {
         unique_name = original_name;

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -37,7 +37,7 @@ using visitor::VarUsageVisitor;
 using symtab::syminfo::NmodlType;
 using SymbolType = std::shared_ptr<symtab::Symbol>;
 
-using nmodl::utils::UseRandomNumbers;
+using nmodl::utils::UseNumbersInString;
 
 /****************************************************************************************/
 /*                            Overloaded visitor routines                               */
@@ -1639,7 +1639,7 @@ void CodegenCVisitor::print_function(ast::FunctionBlock& node) {
 
 std::string CodegenCVisitor::find_var_unique_name(const std::string& original_name) const {
     auto singleton_random_string_class = nmodl::utils::SingletonRandomString<4>::instance(
-        UseRandomNumbers::WithNumbers);
+        UseNumbersInString::WithNumbers);
     std::string unique_name = original_name;
     if (singleton_random_string_class->random_string_exists(original_name)) {
         unique_name = original_name;

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1638,7 +1638,8 @@ void CodegenCVisitor::print_function(ast::FunctionBlock& node) {
 }
 
 std::string CodegenCVisitor::find_var_unique_name(const std::string& original_name) const {
-    auto singleton_random_string_class = nmodl::utils::SingletonRandomString<4>::instance(UseRandomNumbers::WithNumbers);
+    auto singleton_random_string_class = nmodl::utils::SingletonRandomString<4>::instance(
+        UseRandomNumbers::WithNumbers);
     std::string unique_name = original_name;
     if (singleton_random_string_class->random_string_exists(original_name)) {
         unique_name = original_name;

--- a/src/utils/common_utils.cpp
+++ b/src/utils/common_utils.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <sys/stat.h>
 
+#include "common_utils.hpp"
 
 namespace nmodl {
 namespace utils {
@@ -56,7 +57,7 @@ bool make_path(const std::string& path) {
     }
 }
 
-std::string generate_random_string(const int len) {
+std::string generate_random_string(const int len, UseRandomNumbers use_numbers) {
     std::string s(len, 0);
     static const char alphanum[] =
         "0123456789"
@@ -64,7 +65,12 @@ std::string generate_random_string(const int len) {
         "abcdefghijklmnopqrstuvwxyz";
     std::random_device dev;
     std::mt19937 rng(dev());
-    std::uniform_int_distribution<std::mt19937::result_type> dist(0, (sizeof(alphanum) - 1));
+    std::uniform_int_distribution <std::mt19937::result_type> dist;
+    if (use_numbers) {
+        dist = std::uniform_int_distribution<std::mt19937::result_type>(0, (sizeof(alphanum) - 1));
+    } else {
+        dist = std::uniform_int_distribution<std::mt19937::result_type>(10, (sizeof(alphanum) - 1));
+    }
     for (int i = 0; i < len; ++i) {
         s[i] = alphanum[dist(rng)];
     }

--- a/src/utils/common_utils.cpp
+++ b/src/utils/common_utils.cpp
@@ -65,7 +65,7 @@ std::string generate_random_string(const int len, UseRandomNumbers use_numbers) 
         "abcdefghijklmnopqrstuvwxyz";
     std::random_device dev;
     std::mt19937 rng(dev());
-    std::uniform_int_distribution <std::mt19937::result_type> dist;
+    std::uniform_int_distribution<std::mt19937::result_type> dist;
     if (use_numbers) {
         dist = std::uniform_int_distribution<std::mt19937::result_type>(0, (sizeof(alphanum) - 1));
     } else {

--- a/src/utils/common_utils.cpp
+++ b/src/utils/common_utils.cpp
@@ -57,7 +57,7 @@ bool make_path(const std::string& path) {
     }
 }
 
-std::string generate_random_string(const int len, UseRandomNumbers use_numbers) {
+std::string generate_random_string(const int len, UseNumbersInString use_numbers) {
     std::string s(len, 0);
     static const char alphanum[] =
         "0123456789"

--- a/src/utils/common_utils.hpp
+++ b/src/utils/common_utils.hpp
@@ -81,9 +81,17 @@ bool make_path(const std::string& path);
 /// Check if directory with given path exist
 bool is_dir_exist(const std::string& path);
 
+/// Enum to wrap bool variable to select if random string
+/// should have numbers or not
+enum UseRandomNumbers : bool
+{
+    WithNumbers = true,
+    WithoutNumbers = false
+};
+
 /// Generate random std::string of length len based on a
 /// uniform distribution
-std::string generate_random_string(int len);
+std::string generate_random_string(int len, UseRandomNumbers use_numbers);
 
 /**
  * \class SingletonRandomString
@@ -103,8 +111,9 @@ class SingletonRandomString {
     SingletonRandomString& operator=(SingletonRandomString const&) = delete;
 
     /// Function to instantiate the SingletonRandomString class
-    static std::shared_ptr<SingletonRandomString> instance() {
+    static std::shared_ptr<SingletonRandomString> instance(const UseRandomNumbers use_numbers_) {
         static std::shared_ptr<SingletonRandomString> s{new SingletonRandomString};
+        s->use_numbers = use_numbers_;
         return s;
     }
 
@@ -135,9 +144,9 @@ class SingletonRandomString {
     std::string reset_random_string(const std::string& var_name) {
         if (random_string_exists(var_name)) {
             random_strings.erase(var_name);
-            random_strings.insert({var_name, generate_random_string(SIZE)});
+            random_strings.insert({var_name, generate_random_string(SIZE, use_numbers)});
         } else {
-            random_strings.insert({var_name, generate_random_string(SIZE)});
+            random_strings.insert({var_name, generate_random_string(SIZE, use_numbers)});
         }
         return random_strings[var_name];
     }
@@ -153,6 +162,9 @@ class SingletonRandomString {
 
     /// std::map that keeps the random strings assigned to variables as suffix
     std::map<std::string, std::string> random_strings;
+
+    /// bool to control if random string will include numbers or not
+    UseRandomNumbers use_numbers = WithNumbers;
 };
 
 /** @} */  // end of utils

--- a/src/utils/common_utils.hpp
+++ b/src/utils/common_utils.hpp
@@ -83,11 +83,7 @@ bool is_dir_exist(const std::string& path);
 
 /// Enum to wrap bool variable to select if random string
 /// should have numbers or not
-enum UseRandomNumbers : bool
-{
-    WithNumbers = true,
-    WithoutNumbers = false
-};
+enum UseRandomNumbers : bool { WithNumbers = true, WithoutNumbers = false };
 
 /// Generate random std::string of length len based on a
 /// uniform distribution

--- a/src/utils/common_utils.hpp
+++ b/src/utils/common_utils.hpp
@@ -83,11 +83,11 @@ bool is_dir_exist(const std::string& path);
 
 /// Enum to wrap bool variable to select if random string
 /// should have numbers or not
-enum UseRandomNumbers : bool { WithNumbers = true, WithoutNumbers = false };
+enum UseNumbersInString : bool { WithNumbers = true, WithoutNumbers = false };
 
 /// Generate random std::string of length len based on a
 /// uniform distribution
-std::string generate_random_string(int len, UseRandomNumbers use_numbers);
+std::string generate_random_string(int len, UseNumbersInString use_numbers);
 
 /**
  * \class SingletonRandomString
@@ -107,7 +107,7 @@ class SingletonRandomString {
     SingletonRandomString& operator=(SingletonRandomString const&) = delete;
 
     /// Function to instantiate the SingletonRandomString class
-    static std::shared_ptr<SingletonRandomString> instance(const UseRandomNumbers use_numbers_) {
+    static std::shared_ptr<SingletonRandomString> instance(const UseNumbersInString use_numbers_) {
         static std::shared_ptr<SingletonRandomString> s{new SingletonRandomString};
         s->use_numbers = use_numbers_;
         return s;
@@ -160,7 +160,7 @@ class SingletonRandomString {
     std::map<std::string, std::string> random_strings;
 
     /// bool to control if random string will include numbers or not
-    UseRandomNumbers use_numbers = WithNumbers;
+    UseNumbersInString use_numbers = WithNumbers;
 };
 
 /** @} */  // end of utils

--- a/src/visitors/rename_visitor.cpp
+++ b/src/visitors/rename_visitor.cpp
@@ -26,9 +26,12 @@ std::string RenameVisitor::new_name_generator(const std::string old_name) {
         } else {
             const auto& vars = get_global_vars(*ast);
             if (add_prefix) {
-                new_name = suffix_random_string(vars, new_var_name_prefix + old_name, UseRandomNumbers::WithoutNumbers);
+                new_name = suffix_random_string(vars,
+                                                new_var_name_prefix + old_name,
+                                                UseRandomNumbers::WithoutNumbers);
             } else {
-                new_name = suffix_random_string(vars, new_var_name, UseRandomNumbers::WithoutNumbers);
+                new_name =
+                    suffix_random_string(vars, new_var_name, UseRandomNumbers::WithoutNumbers);
             }
             renamed_variables[old_name] = new_name;
         }
@@ -48,11 +51,10 @@ void RenameVisitor::visit_name(ast::Name& node) {
     if (std::regex_match(name, var_name_regex)) {
         std::string new_name = new_name_generator(name);
         node.get_value()->set(new_name);
-        std::string token_string = node.get_token() != nullptr ? " at " + node.get_token()->position() : "";
-        logger->warn("RenameVisitor :: Renaming variable {}{} to {}",
-                     name,
-                     token_string,
-                     new_name);
+        std::string token_string = node.get_token() != nullptr
+                                       ? " at " + node.get_token()->position()
+                                       : "";
+        logger->warn("RenameVisitor :: Renaming variable {}{} to {}", name, token_string, new_name);
     }
 }
 

--- a/src/visitors/rename_visitor.cpp
+++ b/src/visitors/rename_visitor.cpp
@@ -16,6 +16,8 @@
 namespace nmodl {
 namespace visitor {
 
+using nmodl::utils::UseRandomNumbers;
+
 std::string RenameVisitor::new_name_generator(const std::string old_name) {
     std::string new_name;
     if (add_random_suffix) {
@@ -24,9 +26,9 @@ std::string RenameVisitor::new_name_generator(const std::string old_name) {
         } else {
             const auto& vars = get_global_vars(*ast);
             if (add_prefix) {
-                new_name = suffix_random_string(vars, new_var_name_prefix + old_name);
+                new_name = suffix_random_string(vars, new_var_name_prefix + old_name, UseRandomNumbers::WithoutNumbers);
             } else {
-                new_name = suffix_random_string(vars, new_var_name);
+                new_name = suffix_random_string(vars, new_var_name, UseRandomNumbers::WithoutNumbers);
             }
             renamed_variables[old_name] = new_name;
         }
@@ -46,9 +48,10 @@ void RenameVisitor::visit_name(ast::Name& node) {
     if (std::regex_match(name, var_name_regex)) {
         std::string new_name = new_name_generator(name);
         node.get_value()->set(new_name);
+        std::string token_string = node.get_token() != nullptr ? " at " + node.get_token()->position() : "";
         logger->warn("RenameVisitor :: Renaming variable {}{} to {}",
                      name,
-                     node.get_token() != nullptr ? " at " + node.get_token()->position() : "",
+                     token_string,
                      new_name);
     }
 }

--- a/src/visitors/rename_visitor.cpp
+++ b/src/visitors/rename_visitor.cpp
@@ -16,7 +16,7 @@
 namespace nmodl {
 namespace visitor {
 
-using nmodl::utils::UseRandomNumbers;
+using nmodl::utils::UseNumbersInString;
 
 std::string RenameVisitor::new_name_generator(const std::string old_name) {
     std::string new_name;
@@ -28,10 +28,10 @@ std::string RenameVisitor::new_name_generator(const std::string old_name) {
             if (add_prefix) {
                 new_name = suffix_random_string(vars,
                                                 new_var_name_prefix + old_name,
-                                                UseRandomNumbers::WithoutNumbers);
+                                                UseNumbersInString::WithoutNumbers);
             } else {
                 new_name =
-                    suffix_random_string(vars, new_var_name, UseRandomNumbers::WithoutNumbers);
+                    suffix_random_string(vars, new_var_name, UseNumbersInString::WithoutNumbers);
             }
             renamed_variables[old_name] = new_name;
         }

--- a/src/visitors/rename_visitor.cpp
+++ b/src/visitors/rename_visitor.cpp
@@ -46,9 +46,9 @@ void RenameVisitor::visit_name(ast::Name& node) {
     if (std::regex_match(name, var_name_regex)) {
         std::string new_name = new_name_generator(name);
         node.get_value()->set(new_name);
-        logger->warn("RenameVisitor :: Renaming variable {} in {} to {}",
+        logger->warn("RenameVisitor :: Renaming variable {}{} to {}",
                      name,
-                     node.get_token()->position(),
+                     node.get_token() != nullptr ? " at " + node.get_token()->position() : "",
                      new_name);
     }
 }

--- a/src/visitors/sympy_solver_visitor.cpp
+++ b/src/visitors/sympy_solver_visitor.cpp
@@ -24,6 +24,8 @@ namespace visitor {
 
 using symtab::syminfo::NmodlType;
 
+using nmodl::utils::UseRandomNumbers;
+
 void SympySolverVisitor::init_block_data(ast::Node* node) {
     // clear any previous data
     expression_statements.clear();
@@ -160,10 +162,10 @@ void SympySolverVisitor::construct_eigen_solver_block(
     bool linear) {
     // Provide random string to append to X, J, Jm and F matrices that
     // are produced by sympy
-    std::string unique_X = suffix_random_string(vars, "X");
-    std::string unique_J = suffix_random_string(vars, "J");
-    std::string unique_Jm = suffix_random_string(vars, "Jm");
-    std::string unique_F = suffix_random_string(vars, "F");
+    std::string unique_X = suffix_random_string(vars, "X", UseRandomNumbers::WithNumbers);
+    std::string unique_J = suffix_random_string(vars, "J", UseRandomNumbers::WithNumbers);
+    std::string unique_Jm = suffix_random_string(vars, "Jm", UseRandomNumbers::WithNumbers);
+    std::string unique_F = suffix_random_string(vars, "F", UseRandomNumbers::WithNumbers);
 
     // filter solutions for matrices named "X", "J", "Jm" and "F" and change them to
     // unique_X, unique_J, unique_Jm and unique_F respectively

--- a/src/visitors/sympy_solver_visitor.cpp
+++ b/src/visitors/sympy_solver_visitor.cpp
@@ -24,7 +24,7 @@ namespace visitor {
 
 using symtab::syminfo::NmodlType;
 
-using nmodl::utils::UseRandomNumbers;
+using nmodl::utils::UseNumbersInString;
 
 void SympySolverVisitor::init_block_data(ast::Node* node) {
     // clear any previous data
@@ -162,10 +162,10 @@ void SympySolverVisitor::construct_eigen_solver_block(
     bool linear) {
     // Provide random string to append to X, J, Jm and F matrices that
     // are produced by sympy
-    std::string unique_X = suffix_random_string(vars, "X", UseRandomNumbers::WithNumbers);
-    std::string unique_J = suffix_random_string(vars, "J", UseRandomNumbers::WithNumbers);
-    std::string unique_Jm = suffix_random_string(vars, "Jm", UseRandomNumbers::WithNumbers);
-    std::string unique_F = suffix_random_string(vars, "F", UseRandomNumbers::WithNumbers);
+    std::string unique_X = suffix_random_string(vars, "X", UseNumbersInString::WithNumbers);
+    std::string unique_J = suffix_random_string(vars, "J", UseNumbersInString::WithNumbers);
+    std::string unique_Jm = suffix_random_string(vars, "Jm", UseNumbersInString::WithNumbers);
+    std::string unique_F = suffix_random_string(vars, "F", UseNumbersInString::WithNumbers);
 
     // filter solutions for matrices named "X", "J", "Jm" and "F" and change them to
     // unique_X, unique_J, unique_Jm and unique_F respectively

--- a/src/visitors/sympy_solver_visitor.cpp
+++ b/src/visitors/sympy_solver_visitor.cpp
@@ -162,10 +162,10 @@ void SympySolverVisitor::construct_eigen_solver_block(
     bool linear) {
     // Provide random string to append to X, J, Jm and F matrices that
     // are produced by sympy
-    std::string unique_X = suffix_random_string(vars, "X", UseNumbersInString::WithNumbers);
-    std::string unique_J = suffix_random_string(vars, "J", UseNumbersInString::WithNumbers);
-    std::string unique_Jm = suffix_random_string(vars, "Jm", UseNumbersInString::WithNumbers);
-    std::string unique_F = suffix_random_string(vars, "F", UseNumbersInString::WithNumbers);
+    std::string unique_X = suffix_random_string(vars, "X");
+    std::string unique_J = suffix_random_string(vars, "J");
+    std::string unique_Jm = suffix_random_string(vars, "Jm");
+    std::string unique_F = suffix_random_string(vars, "F");
 
     // filter solutions for matrices named "X", "J", "Jm" and "F" and change them to
     // unique_X, unique_J, unique_Jm and unique_F respectively

--- a/src/visitors/visitor_utils.cpp
+++ b/src/visitors/visitor_utils.cpp
@@ -43,6 +43,11 @@ std::string suffix_random_string(const std::set<std::string>& vars,
     return new_string;
 }
 
+std::string suffix_random_string(const std::set<std::string>& vars,
+                                 const std::string& original_string) {
+    return suffix_random_string(vars, original_string, UseNumbersInString::WithNumbers);
+}
+
 std::string get_new_name(const std::string& name,
                          const std::string& suffix,
                          std::map<std::string, int>& variables) {

--- a/src/visitors/visitor_utils.cpp
+++ b/src/visitors/visitor_utils.cpp
@@ -25,11 +25,14 @@ namespace visitor {
 using namespace ast;
 using symtab::syminfo::NmodlType;
 
+using nmodl::utils::UseRandomNumbers;
+
 std::string suffix_random_string(const std::set<std::string>& vars,
-                                 const std::string& original_string) {
+                                 const std::string& original_string,
+                                 const UseRandomNumbers use_num) {
     std::string new_string = original_string;
     std::string random_string;
-    auto singleton_random_string_class = nmodl::utils::SingletonRandomString<4>::instance();
+    auto singleton_random_string_class = nmodl::utils::SingletonRandomString<4>::instance(use_num);
     // Check if there is a variable defined in the mod file as original_string and if yes
     // try to use a different string in the form "original_string"_"random_string"
     while (vars.find(new_string) != vars.end()) {

--- a/src/visitors/visitor_utils.cpp
+++ b/src/visitors/visitor_utils.cpp
@@ -25,11 +25,11 @@ namespace visitor {
 using namespace ast;
 using symtab::syminfo::NmodlType;
 
-using nmodl::utils::UseRandomNumbers;
+using nmodl::utils::UseNumbersInString;
 
 std::string suffix_random_string(const std::set<std::string>& vars,
                                  const std::string& original_string,
-                                 const UseRandomNumbers use_num) {
+                                 const UseNumbersInString use_num) {
     std::string new_string = original_string;
     std::string random_string;
     auto singleton_random_string_class = nmodl::utils::SingletonRandomString<4>::instance(use_num);

--- a/src/visitors/visitor_utils.hpp
+++ b/src/visitors/visitor_utils.hpp
@@ -27,10 +27,19 @@ using nmodl::utils::UseNumbersInString;
 /// Return a std::string in the form "original_string"_"random_string", where
 /// random_string is a string defined in the nmodl::utils::SingletonRandomString
 /// for the original_string. Vars is a const ref to std::set<std::string> which
-/// holds the names that need to be checked for uniqueness
+/// holds the names that need to be checked for uniqueness. Choose if the
+/// "random_string" will include numbers using "use_num"
 std::string suffix_random_string(const std::set<std::string>& vars,
                                  const std::string& original_string,
                                  const UseNumbersInString use_num);
+
+/// Return a std::string in the form "original_string"_"random_string", where
+/// random_string is a string defined in the nmodl::utils::SingletonRandomString
+/// for the original_string. Vars is a const ref to std::set<std::string> which
+/// holds the names that need to be checked for uniqueness. Adds numbers in the
+/// "random_string"
+std::string suffix_random_string(const std::set<std::string>& vars,
+                                 const std::string& original_string);
 
 /// Return new name variable by appending `_suffix_COUNT` where `COUNT` is
 /// number of times the given variable is already used.

--- a/src/visitors/visitor_utils.hpp
+++ b/src/visitors/visitor_utils.hpp
@@ -17,16 +17,20 @@
 #include <string>
 
 #include <ast/ast_decl.hpp>
+#include <utils/common_utils.hpp>
 
 namespace nmodl {
 namespace visitor {
+
+using nmodl::utils::UseRandomNumbers;
 
 /// Return a std::string in the form "original_string"_"random_string", where
 /// random_string is a string defined in the nmodl::utils::SingletonRandomString
 /// for the original_string. Vars is a const ref to std::set<std::string> which
 /// holds the names that need to be checked for uniqueness
 std::string suffix_random_string(const std::set<std::string>& vars,
-                                 const std::string& original_string);
+                                 const std::string& original_string,
+                                 const UseRandomNumbers use_num);
 
 /// Return new name variable by appending `_suffix_COUNT` where `COUNT` is
 /// number of times the given variable is already used.

--- a/src/visitors/visitor_utils.hpp
+++ b/src/visitors/visitor_utils.hpp
@@ -22,7 +22,7 @@
 namespace nmodl {
 namespace visitor {
 
-using nmodl::utils::UseRandomNumbers;
+using nmodl::utils::UseNumbersInString;
 
 /// Return a std::string in the form "original_string"_"random_string", where
 /// random_string is a string defined in the nmodl::utils::SingletonRandomString
@@ -30,7 +30,7 @@ using nmodl::utils::UseRandomNumbers;
 /// holds the names that need to be checked for uniqueness
 std::string suffix_random_string(const std::set<std::string>& vars,
                                  const std::string& original_string,
-                                 const UseRandomNumbers use_num);
+                                 const UseNumbersInString use_num);
 
 /// Return new name variable by appending `_suffix_COUNT` where `COUNT` is
 /// number of times the given variable is already used.


### PR DESCRIPTION
- If there is no token in variable which is being renamed then there is a segmentation fault
- For example when running localize pass with ISPC rename visitor