### PR TITLE
Fixes small imprecisions in the jupyter notebooks (issue #368)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ venv.bak/
 .clang-tidy
 .cmake-format.yaml
 .pre-commit-config.yaml
+.ipynb_checkpoints

--- a/docs/notebooks/nmodl-kinetic-schemes.ipynb
+++ b/docs/notebooks/nmodl-kinetic-schemes.ipynb
@@ -28,8 +28,13 @@
     "\n",
     "where\n",
     "- $k_i$ is the rate coefficient\n",
-    "- $\\nu_{ij}^L$, $\\nu_{ij}^R$ are stoichiometric coefficients - must be positive integers (including zero)\n",
-    "***\n",
+    "- $\\nu_{ij}^L$, $\\nu_{ij}^R$ are stoichiometric coefficients - must be positive integers (including zero)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Law of Mass Action\n",
     "\n",
     "- This allows us to convert these reaction equations to a set of ODEs\n",
@@ -37,9 +42,7 @@
     "$$\\frac{dY_j}{dt} = \\sum_i \\Delta \\nu_{ij} r_i$$\n",
     "\n",
     "where $\\Delta \\nu_{ij} = \\nu_{ij}^R - \\nu_{ij}^L$, and\n",
-    "$$r_i = k_i \\prod_j Y_j^{\\nu_{ij}^R}$$\n",
-    "\n",
-    "***"
+    "$$r_i = k_i \\prod_j Y_j^{\\nu_{ij}^R}$$"
    ]
   },
   {
@@ -454,7 +457,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/nmodl-sympy-solver-cnexp.ipynb
+++ b/docs/notebooks/nmodl-sympy-solver-cnexp.ipynb
@@ -241,7 +241,7 @@
    "metadata": {},
    "source": [
     "##### Ex. 5\n",
-    "Single nonlinear ODE: unsupported, so does not modify DERIVATIVE block, leaves it to a later visitor pass to deal with"
+    "Single nonlinear ODE with analytic solution"
    ]
   },
   {
@@ -272,11 +272,39 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "##### Ex. 6\n",
+    "Single nonlinear ODE (more complicated and not handled yet): unsupported, so does not modify DERIVATIVE block, leaves it to a later visitor pass to deal with"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "exact solution:\t     m' = exp(m)^2\n",
+      "pade approx:\t     m' = exp(m)^2\n"
+     ]
+    }
+   ],
+   "source": [
+    "ex6 = \"\"\"\n",
+    "BREAKPOINT {\n",
+    "    SOLVE states METHOD cnexp\n",
+    "}\n",
+    "DERIVATIVE states {\n",
+    "    m' = exp(m)^2\n",
+    "}\n",
+    "\"\"\"\n",
+    "print(\"exact solution:\\t\", run_sympy_solver(ex6, pade=False)[0])\n",
+    "print(\"pade approx:\\t\", run_sympy_solver(ex6, pade=True)[0])"
+   ]
   }
  ],
  "metadata": {
@@ -295,7 +323,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- .gitignore ignores jupyter folder .ipynb_checkpoints
- kinetic schemes now correctly displays the law of mass action
- m' = m^3 in cnexp now is correctly computed. Added an
  additional example to show what happens if the equation is not
  handled. This fixes issue #368