### PR TITLE
Reorder pywheels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,13 +75,6 @@ add_custom_target(
   "${CMAKE_SOURCE_DIR}/docs/notebooks/*.ipynb")
 
 # =============================================================================
-# Adjust install prefix for wheel
-# =============================================================================
-if(NOT LINK_AGAINST_PYTHON)
-  set(NMODL_INSTALL_DIR_SUFFIX "nmodl/.data/")
-endif()
-
-# =============================================================================
 # Include cmake modules
 # =============================================================================
 list(APPEND CMAKE_MODULE_PATH ${NMODL_PROJECT_SOURCE_DIR}/cmake)
@@ -94,6 +87,13 @@ include(FlexHelper)
 include(GitRevision)
 include(PythonLinkHelper)
 include(RpathHelper)
+
+# =============================================================================
+# Adjust install prefix for wheel
+# =============================================================================
+if(NOT LINK_AGAINST_PYTHON)
+  set(NMODL_INSTALL_DIR_SUFFIX "nmodl/.data/")
+endif()
 
 # =============================================================================
 # Find required python packages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,6 @@ add_subdirectory(src/solver)
 # =============================================================================
 if(NOT LINK_AGAINST_PYTHON)
   install(DIRECTORY share/ DESTINATION nmodl/.data/share)
-  install(DIRECTORY share/ DESTINATION share)
 else()
   install(DIRECTORY share/ DESTINATION share)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,13 @@ add_custom_target(
   "${CMAKE_SOURCE_DIR}/docs/notebooks/*.ipynb")
 
 # =============================================================================
+# Adjust install prefix for wheel
+# =============================================================================
+if(NOT LINK_AGAINST_PYTHON)
+  set(NMODL_INSTALL_DIR_SUFFIX "nmodl/.data/")
+endif()
+
+# =============================================================================
 # Include cmake modules
 # =============================================================================
 list(APPEND CMAKE_MODULE_PATH ${NMODL_PROJECT_SOURCE_DIR}/cmake)
@@ -194,8 +201,4 @@ add_subdirectory(src/solver)
 # =============================================================================
 # Install unit database, examples and utility scripts from share
 # =============================================================================
-if(NOT LINK_AGAINST_PYTHON)
-  install(DIRECTORY share/ DESTINATION nmodl/.data/share)
-else()
-  install(DIRECTORY share/ DESTINATION share)
-endif()
+install(DIRECTORY share/ DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}share)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,4 +194,9 @@ add_subdirectory(src/solver)
 # =============================================================================
 # Install unit database, examples and utility scripts from share
 # =============================================================================
-install(DIRECTORY share/ DESTINATION share)
+if(NOT LINK_AGAINST_PYTHON)
+  install(DIRECTORY share/ DESTINATION nmodl/.data/share)
+  install(DIRECTORY share/ DESTINATION share)
+else()
+  install(DIRECTORY share/ DESTINATION share)
+endif()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -133,6 +133,8 @@ jobs:
       source ./venv/bin/activate
       pip install --upgrade pip
       pip install dist/*.whl
+      # TODO : change this when we fix the issue with nmodl module
+      export PYTHONPATH=$(pwd)/venv/lib/python3.8/site-packages:$PYTHONPATH
       nmodl $(Build.Repository.LocalPath)/test/integration/mod/cabpump.mod sympy --analytic
       rm cabpump.cpp
     displayName: 'Build and test pywheels'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -133,6 +133,7 @@ jobs:
       source ./venv/bin/activate
       pip install --upgrade pip
       pip install dist/*.whl
+      # TODO : change this when we fix the issue with nmodl module
       export PYTHONPATH=$(pwd)/venv/lib/python3.8/site-packages:$PYTHONPATH
       nmodl $(Build.Repository.LocalPath)/test/integration/mod/cabpump.mod sympy --analytic
       rm cabpump.cpp

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -133,8 +133,6 @@ jobs:
       source ./venv/bin/activate
       pip install --upgrade pip
       pip install dist/*.whl
-      # TODO : change this when we fix the issue with nmodl module
-      export PYTHONPATH=$(pwd)/venv/lib/python3.8/site-packages:$PYTHONPATH
       nmodl $(Build.Repository.LocalPath)/test/integration/mod/cabpump.mod sympy --analytic
       rm cabpump.cpp
     displayName: 'Build and test pywheels'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -133,6 +133,7 @@ jobs:
       source ./venv/bin/activate
       pip install --upgrade pip
       pip install dist/*.whl
+      export PYTHONPATH=$(pwd)/venv/lib/python3.8/site-packages:$PYTHONPATH
       nmodl $(Build.Repository.LocalPath)/test/integration/mod/cabpump.mod sympy --analytic
       rm cabpump.cpp
     displayName: 'Build and test pywheels'

--- a/pywheel/shim/_binwrapper.py
+++ b/pywheel/shim/_binwrapper.py
@@ -10,23 +10,26 @@ import stat
 from pkg_resources import working_set
 from find_libpython import find_libpython
 
+
 def _config_exe(exe_name):
     """Sets the environment to run the real executable (returned)"""
 
-    package_name = 'nmodl'
+    package_name = "nmodl"
 
-    assert package_name in working_set.by_key, "NMODL package not found! Verify PYTHONPATH"
+    assert (
+        package_name in working_set.by_key
+    ), "NMODL package not found! Verify PYTHONPATH"
 
-    NMODL_PREFIX = os.path.join(working_set.by_key[package_name].location, 'nmodl')
-    NMODL_HOME = os.path.join(NMODL_PREFIX, '.data')
-    NMODL_BIN = os.path.join(NMODL_HOME, 'bin')
-    NMODL_LIB = os.path.join(NMODL_HOME, 'lib')
+    NMODL_PREFIX = os.path.join(working_set.by_key[package_name].location, "nmodl")
+    NMODL_HOME = os.path.join(NMODL_PREFIX, ".data")
+    NMODL_BIN = os.path.join(NMODL_HOME, "bin")
+    NMODL_LIB = os.path.join(NMODL_HOME, "lib")
 
     # add pywrapper path to environment
     if sys.platform == "darwin":
-        os.environ["NMODL_WRAPLIB"] = os.path.join(NMODL_LIB, 'libpywrapper.dylib')
+        os.environ["NMODL_WRAPLIB"] = os.path.join(NMODL_LIB, "libpywrapper.dylib")
     else:
-        os.environ["NMODL_WRAPLIB"] = os.path.join(NMODL_LIB, 'libpywrapper.so')
+        os.environ["NMODL_WRAPLIB"] = os.path.join(NMODL_LIB, "libpywrapper.so")
 
     # add libpython*.so path to environment
     os.environ["NMODL_PYLIB"] = find_libpython()
@@ -34,10 +37,10 @@ def _config_exe(exe_name):
     # add nmodl home to environment (i.e. necessary for nrnunits.lib)
     os.environ["NMODLHOME"] = NMODL_HOME
 
-
     return os.path.join(NMODL_BIN, exe_name)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     """Set the pointed file as executable"""
     exe = _config_exe(os.path.basename(sys.argv[0]))
     st = os.stat(exe)

--- a/pywheel/shim/_binwrapper.py
+++ b/pywheel/shim/_binwrapper.py
@@ -17,16 +17,17 @@ def _config_exe(exe_name):
 
     assert package_name in working_set.by_key, "NMODL package not found! Verify PYTHONPATH"
     NMODL_PREFIX = os.path.join(working_set.by_key[package_name].location, 'nmodl')
-    NMODL_PREFIX_DATA = os.path.join(NMODL_PREFIX, '.data')
-    if sys.platform == "darwin" :
-        os.environ["NMODL_WRAPLIB"] = os.path.join(NMODL_PREFIX_DATA, 'libpywrapper.dylib')
+    NMODL_BIN = os.path.join(NMODL_PREFIX, '.data/bin')
+    NMODL_LIB = os.path.join(NMODL_PREFIX, '.data/lib')
+    if sys.platform == "darwin":
+        os.environ["NMODL_WRAPLIB"] = os.path.join(NMODL_LIB, 'libpywrapper.dylib')
     else:
-        os.environ["NMODL_WRAPLIB"] = os.path.join(NMODL_PREFIX_DATA, 'libpywrapper.so')
+        os.environ["NMODL_WRAPLIB"] = os.path.join(NMODL_LIB, 'libpywrapper.so')
 
     # find libpython*.so in the system
     os.environ["NMODL_PYLIB"] = find_libpython()
 
-    return os.path.join(NMODL_PREFIX_DATA, exe_name)
+    return os.path.join(NMODL_BIN, exe_name)
 
 if __name__ == '__main__':
     """Set the pointed file as executable"""

--- a/pywheel/shim/_binwrapper.py
+++ b/pywheel/shim/_binwrapper.py
@@ -16,16 +16,24 @@ def _config_exe(exe_name):
     package_name = 'nmodl'
 
     assert package_name in working_set.by_key, "NMODL package not found! Verify PYTHONPATH"
+
     NMODL_PREFIX = os.path.join(working_set.by_key[package_name].location, 'nmodl')
-    NMODL_BIN = os.path.join(NMODL_PREFIX, '.data/bin')
-    NMODL_LIB = os.path.join(NMODL_PREFIX, '.data/lib')
+    NMODL_HOME = os.path.join(NMODL_PREFIX, '.data')
+    NMODL_BIN = os.path.join(NMODL_HOME, 'bin')
+    NMODL_LIB = os.path.join(NMODL_HOME, 'lib')
+
+    # add pywrapper path to environment
     if sys.platform == "darwin":
         os.environ["NMODL_WRAPLIB"] = os.path.join(NMODL_LIB, 'libpywrapper.dylib')
     else:
         os.environ["NMODL_WRAPLIB"] = os.path.join(NMODL_LIB, 'libpywrapper.so')
 
-    # find libpython*.so in the system
+    # add libpython*.so path to environment
     os.environ["NMODL_PYLIB"] = find_libpython()
+
+    # add nmodl home to environment (i.e. necessary for nrnunits.lib)
+    os.environ["NMODLHOME"] = NMODL_HOME
+
 
     return os.path.join(NMODL_BIN, exe_name)
 

--- a/pywheel/shim/find_libpython.py
+++ b/pywheel/shim/find_libpython.py
@@ -84,7 +84,8 @@ def _linked_libpython_unix():
     dlinfo = Dl_info()
     retcode = libdl.dladdr(
         ctypes.cast(ctypes.pythonapi.Py_GetVersion, ctypes.c_void_p),
-        ctypes.pointer(dlinfo))
+        ctypes.pointer(dlinfo),
+    )
     if retcode == 0:  # means error
         return None
     path = os.path.realpath(dlinfo.dli_fname.decode())
@@ -106,9 +107,9 @@ def library_name(name, suffix=SHLIB_SUFFIX, is_windows=is_windows):
     'python37'
     """
     if not is_windows and name.startswith("lib"):
-        name = name[len("lib"):]
+        name = name[len("lib") :]
     if suffix and name.endswith(suffix):
-        name = name[:-len(suffix)]
+        name = name[: -len(suffix)]
     return name
 
 
@@ -132,9 +133,11 @@ def uniquifying(items):
 
 def uniquified(func):
     """ Wrap iterator returned from `func` by `uniquifying`. """
+
     @functools.wraps(func)
     def wrapper(*args, **kwds):
         return uniquifying(func(*args, **kwds))
+
     return wrapper
 
 
@@ -159,10 +162,15 @@ def candidate_names(suffix=SHLIB_SUFFIX):
     sysdata = dict(
         v=sys.version_info,
         # VERSION is X.Y in Linux/macOS and XY in Windows:
-        VERSION=(sysconfig.get_config_var("VERSION") or
-                 "{v.major}.{v.minor}".format(v=sys.version_info)),
-        ABIFLAGS=(sysconfig.get_config_var("ABIFLAGS") or
-                  sysconfig.get_config_var("abiflags") or ""),
+        VERSION=(
+            sysconfig.get_config_var("VERSION")
+            or "{v.major}.{v.minor}".format(v=sys.version_info)
+        ),
+        ABIFLAGS=(
+            sysconfig.get_config_var("ABIFLAGS")
+            or sysconfig.get_config_var("abiflags")
+            or ""
+        ),
     )
 
     for stem in [
@@ -172,7 +180,6 @@ def candidate_names(suffix=SHLIB_SUFFIX):
         "python",
     ]:
         yield dlprefix + stem + suffix
-
 
 
 @uniquified
@@ -190,8 +197,8 @@ def candidate_paths(suffix=SHLIB_SUFFIX):
 
     # List candidates for directories in which libpython may exist
     lib_dirs = []
-    append_truthy(lib_dirs, sysconfig.get_config_var('LIBPL'))
-    append_truthy(lib_dirs, sysconfig.get_config_var('srcdir'))
+    append_truthy(lib_dirs, sysconfig.get_config_var("LIBPL"))
+    append_truthy(lib_dirs, sysconfig.get_config_var("srcdir"))
     append_truthy(lib_dirs, sysconfig.get_config_var("LIBDIR"))
 
     # LIBPL seems to be the right config_var to use.  It is the one
@@ -203,9 +210,9 @@ def candidate_paths(suffix=SHLIB_SUFFIX):
     if is_windows:
         lib_dirs.append(os.path.join(os.path.dirname(sys.executable)))
     else:
-        lib_dirs.append(os.path.join(
-            os.path.dirname(os.path.dirname(sys.executable)),
-            "lib"))
+        lib_dirs.append(
+            os.path.join(os.path.dirname(os.path.dirname(sys.executable)), "lib")
+        )
 
     # For macOS:
     append_truthy(lib_dirs, sysconfig.get_config_var("PYTHONFRAMEWORKPREFIX"))
@@ -222,6 +229,7 @@ def candidate_paths(suffix=SHLIB_SUFFIX):
     # In macOS and Windows, ctypes.util.find_library returns a full path:
     for basename in lib_basenames:
         yield ctypes.util.find_library(library_name(basename))
+
 
 # Possibly useful links:
 # * https://packages.ubuntu.com/bionic/amd64/libpython3.6/filelist
@@ -249,8 +257,7 @@ def normalize_path(path, suffix=SHLIB_SUFFIX, is_apple=is_apple):
     if os.path.exists(path + suffix):
         return os.path.realpath(path + suffix)
     if is_apple:
-        return normalize_path(_remove_suffix_apple(path),
-                              suffix=".so", is_apple=False)
+        return normalize_path(_remove_suffix_apple(path), suffix=".so", is_apple=False)
     return None
 
 
@@ -265,9 +272,9 @@ def _remove_suffix_apple(path):
     'libpython3.7'
     """
     if path.endswith(".dylib"):
-        return path[:-len(".dylib")]
+        return path[: -len(".dylib")]
     if path.endswith(".so"):
-        return path[:-len(".so")]
+        return path[: -len(".so")]
     return path
 
 
@@ -312,14 +319,13 @@ def print_all(items):
 
 def cli_find_libpython(cli_op, verbose):
     import logging
+
     # Importing `logging` module here so that using `logging.debug`
     # instead of `logger.debug` outside of this function becomes an
     # error.
 
     if verbose:
-        logging.basicConfig(
-            format="%(levelname)s %(message)s",
-            level=logging.DEBUG)
+        logging.basicConfig(format="%(levelname)s %(message)s", level=logging.DEBUG)
 
     if cli_op == "list-all":
         print_all(finding_libpython())
@@ -336,25 +342,34 @@ def cli_find_libpython(cli_op, verbose):
 
 def main(args=None):
     import argparse
-    parser = argparse.ArgumentParser(
-        description=__doc__)
+
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--verbose", "-v", action="store_true",
-        help="Print debugging information.")
+        "--verbose", "-v", action="store_true", help="Print debugging information."
+    )
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
         "--list-all",
-        action="store_const", dest="cli_op", const="list-all",
-        help="Print list of all paths found.")
+        action="store_const",
+        dest="cli_op",
+        const="list-all",
+        help="Print list of all paths found.",
+    )
     group.add_argument(
         "--candidate-names",
-        action="store_const", dest="cli_op", const="candidate-names",
-        help="Print list of candidate names of libpython.")
+        action="store_const",
+        dest="cli_op",
+        const="candidate-names",
+        help="Print list of candidate names of libpython.",
+    )
     group.add_argument(
         "--candidate-paths",
-        action="store_const", dest="cli_op", const="candidate-paths",
-        help="Print list of candidate paths of libpython.")
+        action="store_const",
+        dest="cli_op",
+        const="candidate-paths",
+        help="Print list of candidate paths of libpython.",
+    )
 
     ns = parser.parse_args(args)
     parser.exit(cli_find_libpython(**vars(ns)))

--- a/setup.py
+++ b/setup.py
@@ -99,9 +99,11 @@ if "bdist_wheel" in sys.argv:
     cmake_args.append("-DLINK_AGAINST_PYTHON=FALSE")
 
 
-def exclude_nmodl(cmake_manifest):
-    return list(filter(lambda name: not name.endswith('bin/nmodl'), cmake_manifest))
-
+# def exclude_nmodl(cmake_manifest):
+#     # print("HERE!")
+#     # print(list(filter(lambda name: name.endswith('bin/nmodl'), cmake_manifest)))
+#     # return list(filter(lambda name: not name.endswith('bin/nmodl'), cmake_manifest))
+#     return cmake_manifest
 
 # For CI, we want to build separate wheel
 package_name = 'NMODL'
@@ -118,7 +120,7 @@ setup(
     long_description="",
     packages=["nmodl"],
     scripts=["pywheel/shim/nmodl", "pywheel/shim/find_libpython.py"],
-    cmake_process_manifest_hook=exclude_nmodl,
+    # cmake_process_manifest_hook=exclude_nmodl,
     include_package_data=True,
     cmake_minimum_required_version="3.3.0",
     cmake_args=cmake_args,

--- a/setup.py
+++ b/setup.py
@@ -98,18 +98,10 @@ cmake_args = ["-DPYTHON_EXECUTABLE=" + sys.executable]
 if "bdist_wheel" in sys.argv:
     cmake_args.append("-DLINK_AGAINST_PYTHON=FALSE")
 
-
-# def exclude_nmodl(cmake_manifest):
-#     # print("HERE!")
-#     # print(list(filter(lambda name: name.endswith('bin/nmodl'), cmake_manifest)))
-#     # return list(filter(lambda name: not name.endswith('bin/nmodl'), cmake_manifest))
-#     return cmake_manifest
-
 # For CI, we want to build separate wheel
 package_name = 'NMODL'
 if "NMODL_NIGHTLY_TAG" in os.environ:
     package_name += os.environ['NMODL_NIGHTLY_TAG']
-
 
 setup(
     name=package_name,
@@ -120,7 +112,6 @@ setup(
     long_description="",
     packages=["nmodl"],
     scripts=["pywheel/shim/nmodl", "pywheel/shim/find_libpython.py"],
-    # cmake_process_manifest_hook=exclude_nmodl,
     include_package_data=True,
     cmake_minimum_required_version="3.3.0",
     cmake_args=cmake_args,

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -34,9 +34,5 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fast_math.ispc
 # =============================================================================
 # Install include files
 # =============================================================================
-
-if(NOT LINK_AGAINST_PYTHON)
-  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/fast_math.ispc DESTINATION nmodl/.data/include/nmodl)
-else()
-  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/fast_math.ispc DESTINATION include/nmodl)
-endif()
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/fast_math.ispc
+        DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}include/nmodl)

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -34,4 +34,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fast_math.ispc
 # =============================================================================
 # Install include files
 # =============================================================================
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/fast_math.ispc DESTINATION include/nmodl)
+
+if(NOT LINK_AGAINST_PYTHON)
+  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/fast_math.ispc DESTINATION nmodl/.data/include/nmodl)
+else()
+  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/fast_math.ispc DESTINATION include/nmodl)
+endif()

--- a/src/lexer/CMakeLists.txt
+++ b/src/lexer/CMakeLists.txt
@@ -192,7 +192,15 @@ target_link_libraries(units_lexer lexer util)
 # =============================================================================
 # Install executable
 # =============================================================================
-install(TARGETS nmodl_lexer DESTINATION bin/lexer)
-install(TARGETS c_lexer DESTINATION bin/lexer)
-install(TARGETS units_lexer DESTINATION bin/lexer)
+
+if(LINK_AGAINST_PYTHON)
+  install(TARGETS nmodl_lexer DESTINATION bin/lexer)
+  install(TARGETS c_lexer DESTINATION bin/lexer)
+  install(TARGETS units_lexer DESTINATION bin/lexer)
+else()
+  install(TARGETS nmodl_lexer DESTINATION nmodl/.data/bin/lexer)
+  install(TARGETS c_lexer DESTINATION nmodl/.data/bin/lexer)
+  install(TARGETS units_lexer DESTINATION nmodl/.data/bin/lexer)
+endif()
+
 add_custom_target(parser-gen DEPENDS ${BISON_GENERATED_SOURCE_FILES})

--- a/src/lexer/CMakeLists.txt
+++ b/src/lexer/CMakeLists.txt
@@ -189,18 +189,12 @@ target_link_libraries(lexer fmt::fmt)
 target_link_libraries(nmodl_lexer lexer util)
 target_link_libraries(c_lexer lexer util)
 target_link_libraries(units_lexer lexer util)
+
 # =============================================================================
 # Install executable
 # =============================================================================
-
-if(LINK_AGAINST_PYTHON)
-  install(TARGETS nmodl_lexer DESTINATION bin/lexer)
-  install(TARGETS c_lexer DESTINATION bin/lexer)
-  install(TARGETS units_lexer DESTINATION bin/lexer)
-else()
-  install(TARGETS nmodl_lexer DESTINATION nmodl/.data/bin/lexer)
-  install(TARGETS c_lexer DESTINATION nmodl/.data/bin/lexer)
-  install(TARGETS units_lexer DESTINATION nmodl/.data/bin/lexer)
-endif()
+install(TARGETS nmodl_lexer DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/lexer)
+install(TARGETS c_lexer DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/lexer)
+install(TARGETS units_lexer DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/lexer)
 
 add_custom_target(parser-gen DEPENDS ${BISON_GENERATED_SOURCE_FILES})

--- a/src/nmodl/CMakeLists.txt
+++ b/src/nmodl/CMakeLists.txt
@@ -26,10 +26,5 @@ add_dependencies(nmodl _nmodl pywrapper)
 # =============================================================================
 # Install executable
 # =============================================================================
-if(LINK_AGAINST_PYTHON)
-  install(TARGETS nmodl DESTINATION bin)
-  install(FILES nmodl.hpp DESTINATION include)
-else()
-  install(TARGETS nmodl DESTINATION nmodl/.data/bin)
-  install(FILES nmodl.hpp DESTINATION nmodl/.data/include)
-endif()
+install(TARGETS nmodl DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin)
+install(FILES nmodl.hpp DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}include)

--- a/src/nmodl/CMakeLists.txt
+++ b/src/nmodl/CMakeLists.txt
@@ -26,5 +26,10 @@ add_dependencies(nmodl _nmodl pywrapper)
 # =============================================================================
 # Install executable
 # =============================================================================
-install(TARGETS nmodl DESTINATION bin)
-install(FILES nmodl.hpp DESTINATION include)
+if(LINK_AGAINST_PYTHON)
+  install(TARGETS nmodl DESTINATION bin)
+  install(FILES nmodl.hpp DESTINATION include)
+else()
+  install(TARGETS nmodl DESTINATION nmodl/.data/bin)
+  install(FILES nmodl.hpp DESTINATION nmodl/.data/include)
+endif()

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -15,13 +15,6 @@ target_link_libraries(units_parser util visitor lexer)
 # =============================================================================
 # Install executable
 # =============================================================================
-
-if(LINK_AGAINST_PYTHON)
-  install(TARGETS nmodl_parser DESTINATION bin/parser)
-  install(TARGETS c_parser DESTINATION bin/parser)
-  install(TARGETS units_parser DESTINATION bin/parser)
-else()
-  install(TARGETS nmodl_parser DESTINATION nmodl/.data/bin/parser)
-  install(TARGETS c_parser DESTINATION nmodl/.data/bin/parser)
-  install(TARGETS units_parser DESTINATION nmodl/.data/bin/parser)
-endif()
+install(TARGETS nmodl_parser DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/parser)
+install(TARGETS c_parser DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/parser)
+install(TARGETS units_parser DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/parser)

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -15,6 +15,13 @@ target_link_libraries(units_parser util visitor lexer)
 # =============================================================================
 # Install executable
 # =============================================================================
-install(TARGETS nmodl_parser DESTINATION bin/parser)
-install(TARGETS c_parser DESTINATION bin/parser)
-install(TARGETS units_parser DESTINATION bin/parser)
+
+if(LINK_AGAINST_PYTHON)
+  install(TARGETS nmodl_parser DESTINATION bin/parser)
+  install(TARGETS c_parser DESTINATION bin/parser)
+  install(TARGETS units_parser DESTINATION bin/parser)
+else()
+  install(TARGETS nmodl_parser DESTINATION nmodl/.data/bin/parser)
+  install(TARGETS c_parser DESTINATION nmodl/.data/bin/parser)
+  install(TARGETS units_parser DESTINATION nmodl/.data/bin/parser)
+endif()

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -92,7 +92,7 @@ file(COPY ${NMODL_PROJECT_SOURCE_DIR}/nmodl/ext DESTINATION ${CMAKE_BINARY_DIR}/
 # twice with the wheel and in weird places. Let's just move the .so libs
 if(NOT LINK_AGAINST_PYTHON)
   install(TARGETS _nmodl DESTINATION nmodl)
-  install(TARGETS pywrapper DESTINATION nmodl/.data/lib)
+  install(TARGETS pywrapper DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}lib)
 elseif(SKBUILD) # skbuild needs the installation dir to be in nmodl to do the correct inplace
   install(DIRECTORY ${CMAKE_BINARY_DIR}/lib/nmodl DESTINATION .)
 else()

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -91,9 +91,9 @@ file(COPY ${NMODL_PROJECT_SOURCE_DIR}/nmodl/ext DESTINATION ${CMAKE_BINARY_DIR}/
 # scikit already installs the package in /nmodl. If we add it another time things are installed
 # twice with the wheel and in weird places. Let's just move the .so libs
 if(NOT LINK_AGAINST_PYTHON)
-  install(TARGETS _nmodl DESTINATION nmodl/)
-  install(TARGETS pywrapper DESTINATION nmodl/.data/)
-  install(FILES ${CMAKE_BINARY_DIR}/bin/nmodl DESTINATION nmodl/.data/)
+  install(TARGETS _nmodl DESTINATION nmodl)
+  install(TARGETS pywrapper DESTINATION nmodl/.data/lib)
+  # install(FILES ${CMAKE_BINARY_DIR}/bin/nmodl DESTINATION nmodl/.data/)
 elseif(SKBUILD) # skbuild needs the installation dir to be in nmodl to do the correct inplace
   install(DIRECTORY ${CMAKE_BINARY_DIR}/lib/nmodl DESTINATION .)
 else()

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -93,7 +93,6 @@ file(COPY ${NMODL_PROJECT_SOURCE_DIR}/nmodl/ext DESTINATION ${CMAKE_BINARY_DIR}/
 if(NOT LINK_AGAINST_PYTHON)
   install(TARGETS _nmodl DESTINATION nmodl)
   install(TARGETS pywrapper DESTINATION nmodl/.data/lib)
-  # install(FILES ${CMAKE_BINARY_DIR}/bin/nmodl DESTINATION nmodl/.data/)
 elseif(SKBUILD) # skbuild needs the installation dir to be in nmodl to do the correct inplace
   install(DIRECTORY ${CMAKE_BINARY_DIR}/lib/nmodl DESTINATION .)
 else()

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -91,7 +91,7 @@ file(COPY ${NMODL_PROJECT_SOURCE_DIR}/nmodl/ext DESTINATION ${CMAKE_BINARY_DIR}/
 # scikit already installs the package in /nmodl. If we add it another time things are installed
 # twice with the wheel and in weird places. Let's just move the .so libs
 if(NOT LINK_AGAINST_PYTHON)
-  install(TARGETS _nmodl DESTINATION nmodl)
+  install(TARGETS _nmodl DESTINATION nmodl/)
   install(TARGETS pywrapper DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}lib)
 elseif(SKBUILD) # skbuild needs the installation dir to be in nmodl to do the correct inplace
   install(DIRECTORY ${CMAKE_BINARY_DIR}/lib/nmodl DESTINATION .)

--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -13,8 +13,4 @@ file(COPY ${NMODL_PROJECT_SOURCE_DIR}/ext/eigen/Eigen DESTINATION ${CMAKE_BINARY
 # =============================================================================
 # Install solver headers and eigen from include
 # =============================================================================
-if(LINK_AGAINST_PYTHON)
-  install(DIRECTORY ${CMAKE_BINARY_DIR}/include/ DESTINATION include)
-else()
-  install(DIRECTORY ${CMAKE_BINARY_DIR}/include/ DESTINATION nmodl/.data/include)
-endif()
+install(DIRECTORY ${CMAKE_BINARY_DIR}/include/ DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}include)

--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -13,4 +13,8 @@ file(COPY ${NMODL_PROJECT_SOURCE_DIR}/ext/eigen/Eigen DESTINATION ${CMAKE_BINARY
 # =============================================================================
 # Install solver headers and eigen from include
 # =============================================================================
-install(DIRECTORY ${CMAKE_BINARY_DIR}/include/ DESTINATION include)
+if(LINK_AGAINST_PYTHON)
+  install(DIRECTORY ${CMAKE_BINARY_DIR}/include/ DESTINATION include)
+else()
+  install(DIRECTORY ${CMAKE_BINARY_DIR}/include/ DESTINATION nmodl/.data/include)
+endif()

--- a/src/visitors/CMakeLists.txt
+++ b/src/visitors/CMakeLists.txt
@@ -84,9 +84,4 @@ target_link_libraries(
 # =============================================================================
 # Install executable
 # =============================================================================
-
-if(LINK_AGAINST_PYTHON)
-  install(TARGETS nmodl_visitor DESTINATION bin/visitor)
-else()
-  install(TARGETS nmodl_visitor DESTINATION nmodl/.data/bin/visitor)
-endif()
+install(TARGETS nmodl_visitor DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/visitor)

--- a/src/visitors/CMakeLists.txt
+++ b/src/visitors/CMakeLists.txt
@@ -84,4 +84,9 @@ target_link_libraries(
 # =============================================================================
 # Install executable
 # =============================================================================
-install(TARGETS nmodl_visitor DESTINATION bin/visitor)
+
+if(LINK_AGAINST_PYTHON)
+  install(TARGETS nmodl_visitor DESTINATION bin/visitor)
+else()
+  install(TARGETS nmodl_visitor DESTINATION nmodl/.data/bin/visitor)
+endif()


### PR DESCRIPTION
During a NOT LINK_AGAINST_PYTHON build (for pywheels) the stuff
inside lib/nmodl becomes root (in the build and then, through
skbuild, in site-packages after the wheel is installed) and
everything else (that was outside) goes inside site-packages/.data.

Notes:

- `libpywrapper` goes inside `site-packages/nmodl/.data/lib`
- `nmodl/nmodl/ext` is copied with the `nmodl/nmodl` folder by skbuild.
  No easy way to not have it also in `site-packages/nmodl/ext` without
  removing it from its current location (`nmodl/nmodl/ext`) in the
  source files
- the shim now also correctly sets `NMODLHOME` to point to `site-packages/nmodl/.data`
- Removed workaround for when the nmodl binary was overwriting the shim. Now that we mimic the full install folder in `.data` no more binary is copied (not sure why, probably skbuild magic)

TODO:

- remove Ioannis workaround for mac pywheels
- ~~remove double copy of share folder for pywheels. Workaround linked to
  issue #377 in place to check if the folder reordering works in the CIs~~
- ~~solve issue #377~~