### PR TITLE
Various fixes with OpenACC backend for watch and derivimplicit

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,7 @@
 #=============================================================================
 jobs:
 - job: 'ubuntu1604'
+  condition: false
   pool:
     vmImage: 'ubuntu-16.04'
   displayName: 'Ubuntu (16.04), GCC 8.3'
@@ -106,6 +107,9 @@ jobs:
   steps:
   - checkout: self
     submodules: true
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.7'
   - script: |
       brew install flex bison cmake python@3
       python3 -m pip install -U pip setuptools
@@ -122,6 +126,7 @@ jobs:
         make VERBOSE=1
       fi
       env CTEST_OUTPUT_ON_FAILURE=1 make test
+    condition: false
     displayName: 'Build and Run Tests'
   - script: |
       export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,16 +130,23 @@ jobs:
     displayName: 'Build and Run Tests'
   - script: |
       export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
-      python3 -m pip install -U pip setuptools scikit-build auditwheel
+      python3 -m pip install -U pip setuptools scikit-build delocate
       python3 setup.py sdist bdist_wheel -j 2
-      auditwheel repair dist/*.whl
+      delocate-wheel -w wheelhouse -v dist/*.whl
       rm -rf venv _skbuild
+    displayName: 'Build wheel'
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: '$(Build.SourcesDirectory)/wheelhouse'
+    displayName: 'Publish wheel as build artifact'
+  - script: |
       python3 -m venv venv
       source ./venv/bin/activate
       pip install --upgrade pip
-      pip install dist/*.whl
       # TODO : change this when we fix the issue with nmodl module
       export PYTHONPATH=$(pwd)/venv/lib/python3.8/site-packages:$PYTHONPATH
-      nmodl $(Build.Repository.LocalPath)/test/integration/mod/cabpump.mod sympy --analytic
+      pip install wheelhouse/*.whl
+      cd $(Build.Repository.LocalPath)/test/integration/mod
+      nmodl cabpump.mod sympy --analytic
       rm cabpump.cpp
-    displayName: 'Build and test pywheels'
+    displayName: 'Test wheel'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,7 +140,8 @@ jobs:
       pip install --upgrade pip
       # TODO : change this when we fix the issue with nmodl module
       export PYTHONPATH=$(pwd)/venv/lib/python3.8/site-packages:$PYTHONPATH
-      pip install wheelhouse/*.whl
+      # TODO : install from dist as wheelhouse one not working properly
+      pip install dist/*.whl
       cd $(Build.Repository.LocalPath)/test/integration/mod
       nmodl cabpump.mod sympy --analytic
       rm cabpump.cpp

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,9 +106,6 @@ jobs:
   steps:
   - checkout: self
     submodules: true
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.7'
   - script: |
       brew install flex bison cmake python@3
       python3 -m pip install -U pip setuptools

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -143,5 +143,6 @@ jobs:
       export PYTHONPATH=$(pwd)/venv/lib/python3.8/site-packages:$PYTHONPATH
       cd $(Build.Repository.LocalPath)/test/integration/mod
       nmodl cabpump.mod sympy --analytic
+      nmodl watch_test.mod sympy --analytic
       rm cabpump.cpp
     displayName: 'Test wheel'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,6 @@
 #=============================================================================
 jobs:
 - job: 'ubuntu1604'
-  condition: false
   pool:
     vmImage: 'ubuntu-16.04'
   displayName: 'Ubuntu (16.04), GCC 8.3'
@@ -126,7 +125,6 @@ jobs:
         make VERBOSE=1
       fi
       env CTEST_OUTPUT_ON_FAILURE=1 make test
-    condition: false
     displayName: 'Build and Run Tests'
   - script: |
       export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,8 +138,7 @@ jobs:
       python3 -m venv venv
       source ./venv/bin/activate
       pip install --upgrade pip
-      # TODO : install from dist as wheelhouse one not working properly
-      pip install dist/*.whl
+      pip install wheelhouse/*.whl
       # TODO : change this when we fix the issue with nmodl module
       export PYTHONPATH=$(pwd)/venv/lib/python3.8/site-packages:$PYTHONPATH
       cd $(Build.Repository.LocalPath)/test/integration/mod

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,10 +138,10 @@ jobs:
       python3 -m venv venv
       source ./venv/bin/activate
       pip install --upgrade pip
-      # TODO : change this when we fix the issue with nmodl module
-      export PYTHONPATH=$(pwd)/venv/lib/python3.8/site-packages:$PYTHONPATH
       # TODO : install from dist as wheelhouse one not working properly
       pip install dist/*.whl
+      # TODO : change this when we fix the issue with nmodl module
+      export PYTHONPATH=$(pwd)/venv/lib/python3.8/site-packages:$PYTHONPATH
       cd $(Build.Repository.LocalPath)/test/integration/mod
       nmodl cabpump.mod sympy --analytic
       rm cabpump.cpp

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -217,9 +217,9 @@ std::string CodegenAccVisitor::get_variable_device_pointer(const std::string& va
 void CodegenAccVisitor::print_newtonspace_transfer_to_device() const {
     int list_num = info.derivimplicit_list_num;
     printer->add_line("if (nt->compute_gpu) {");
-    printer->add_line("    auto device_vec = (double*) acc_copyin(vec, vec_size);");
-    printer->add_line("    auto device_ns = (NewtonSpace*) acc_deviceptr(ns);");
-    printer->add_line("    auto device_thread = (ThreadDatum*) acc_deviceptr(thread);");
+    printer->add_line("    auto device_vec = static_cast<double*> acc_copyin(vec, vec_size);");
+    printer->add_line("    auto device_ns = static_cast<NewtonSpace*> acc_deviceptr(ns);");
+    printer->add_line("    auto device_thread = static_cast<ThreadDatum*> acc_deviceptr(thread);");
     printer->add_line(
         "    acc_memcpy_to_device(&(device_thread[{}]._pvoid), &device_ns, sizeof(void*));"_format(
             info.thread_data_index - 1));

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -217,9 +217,9 @@ std::string CodegenAccVisitor::get_variable_device_pointer(const std::string& va
 void CodegenAccVisitor::print_newtonspace_transfer_to_device() const {
     int list_num = info.derivimplicit_list_num;
     printer->add_line("if (nt->compute_gpu) {");
-    printer->add_line("    auto device_vec = static_cast<double*> acc_copyin(vec, vec_size);");
-    printer->add_line("    auto device_ns = static_cast<NewtonSpace*> acc_deviceptr(ns);");
-    printer->add_line("    auto device_thread = static_cast<ThreadDatum*> acc_deviceptr(thread);");
+    printer->add_line("    auto device_vec = static_cast<double*>(acc_copyin(vec, vec_size));");
+    printer->add_line("    auto device_ns = static_cast<NewtonSpace*>(acc_deviceptr(ns));");
+    printer->add_line("    auto device_thread = static_cast<ThreadDatum*>(acc_deviceptr(thread));");
     printer->add_line(
         "    acc_memcpy_to_device(&(device_thread[{}]._pvoid), &device_ns, sizeof(void*));"_format(
             info.thread_data_index - 1));

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -219,8 +219,12 @@ void CodegenAccVisitor::print_newtonspace_transfer_to_device() const {
     printer->add_line("    auto device_vec = (double*) acc_copyin(vec, vec_size);");
     printer->add_line("    auto device_ns = (NewtonSpace*) acc_deviceptr(ns);");
     printer->add_line("    auto device_thread = (ThreadDatum*) acc_deviceptr(thread);");
-    printer->add_line("    acc_memcpy_to_device(&(device_thread[{}]._pvoid), &device_ns, sizeof(void*));"_format(info.thread_data_index-1));
-    printer->add_line("    acc_memcpy_to_device(&(device_thread[dith{}()].pval), &device_vec, sizeof(double*));"_format(list_num));
+    printer->add_line(
+        "    acc_memcpy_to_device(&(device_thread[{}]._pvoid), &device_ns, sizeof(void*));"_format(
+            info.thread_data_index - 1));
+    printer->add_line(
+        "    acc_memcpy_to_device(&(device_thread[dith{}()].pval), &device_vec, sizeof(double*));"_format(
+            list_num));
     printer->add_line("}");
 }
 

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -79,6 +79,11 @@ std::string CodegenAccVisitor::backend_name() const {
 
 
 void CodegenAccVisitor::print_memory_allocation_routine() const {
+    // memory for artificial cells should be allocated on CPU
+    if (info.artificial_cell) {
+        CodegenCVisitor::print_memory_allocation_routine();
+        return;
+    }
     printer->add_newline(2);
     auto args = "size_t num, size_t size, size_t alignment = 16";
     printer->add_line("static inline void* mem_alloc({}) {}"_format(args, "{"));

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -58,9 +58,18 @@ void CodegenAccVisitor::print_atomic_reduction_pragma() {
 
 
 void CodegenAccVisitor::print_backend_includes() {
-    printer->add_line("#include <cuda.h>");
-    printer->add_line("#include <cuda_runtime_api.h>");
-    printer->add_line("#include <openacc.h>");
+    /**
+     * Artificial cells are executed on CPU. As Random123 is allocated on GPU by default,
+     * we have to disable GPU allocations using `DISABLE_OPENACC` macro.
+     */
+    if (info.artificial_cell) {
+        printer->add_line("#undef DISABLE_OPENACC");
+        printer->add_line("#define DISABLE_OPENACC");
+    } else {
+        printer->add_line("#include <cuda.h>");
+        printer->add_line("#include <cuda_runtime_api.h>");
+        printer->add_line("#include <openacc.h>");
+    }
 }
 
 
@@ -85,6 +94,22 @@ void CodegenAccVisitor::print_memory_allocation_routine() const {
     printer->add_line("}");
 }
 
+/**
+ * OpenACC kernels running on GPU doesn't support `abort()`. CUDA/OpenACC supports
+ * `assert()` in device kernel that can be used for similar purpose. Also, `printf`
+ * is supported on device.
+ *
+ * @todo : we need to implement proper error handling mechanism to propogate errors
+ *         from GPU to CPU. For example, error code can be returned like original
+ *         neuron implementation.
+ */
+void CodegenAccVisitor::print_abort_routine() const {
+    printer->add_newline(2);
+    printer->add_line("static inline void coreneuron_abort() {");
+    printer->add_line("    printf(\"Error : Issue while running OpenACC kernel \\n\");");
+    printer->add_line("    assert(0==1);");
+    printer->add_line("}");
+}
 
 /**
  * Each kernel like nrn_init, nrn_state and nrn_cur could be offloaded
@@ -166,11 +191,13 @@ void CodegenAccVisitor::print_global_variable_device_create_annotation() {
     }
 }
 
+
 void CodegenAccVisitor::print_global_variable_device_update_annotation() {
     if (!info.artificial_cell) {
         printer->add_line("#pragma acc update device ({}_global)"_format(info.mod_suffix));
     }
 }
+
 
 std::string CodegenAccVisitor::get_variable_device_pointer(const std::string& variable,
                                                            const std::string& type) const {
@@ -179,6 +206,19 @@ std::string CodegenAccVisitor::get_variable_device_pointer(const std::string& va
     }
     return "({}) acc_deviceptr({})"_format(type, variable);
 }
+
+
+void CodegenAccVisitor::print_newtonspace_transfer_to_device() const {
+    int list_num = info.derivimplicit_list_num;
+    printer->add_line("if (nt->compute_gpu) {");
+    printer->add_line("    auto device_vec = (double*) acc_copyin(vec, vec_size);");
+    printer->add_line("    auto device_ns = (NewtonSpace*) acc_deviceptr(ns);");
+    printer->add_line("    auto device_thread = (ThreadDatum*) acc_deviceptr(thread);");
+    printer->add_line("    acc_memcpy_to_device(&(device_thread[{}]._pvoid), &device_ns, sizeof(void*));"_format(info.thread_data_index-1));
+    printer->add_line("    acc_memcpy_to_device(&(device_thread[dith{}()].pval), &device_vec, sizeof(double*));"_format(list_num));
+    printer->add_line("}");
+}
+
 
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -106,7 +106,8 @@ void CodegenAccVisitor::print_memory_allocation_routine() const {
  *
  * @todo : we need to implement proper error handling mechanism to propogate errors
  *         from GPU to CPU. For example, error code can be returned like original
- *         neuron implementation.
+ *         neuron implementation. For now we use `assert(0==1)` pattern which is
+ *         used for OpenACC/CUDA.
  */
 void CodegenAccVisitor::print_abort_routine() const {
     printer->add_newline(2);

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -49,6 +49,10 @@ class CodegenAccVisitor: public CodegenCVisitor {
     void print_memory_allocation_routine() const override;
 
 
+    /// abort routine
+    void print_abort_routine() const override;
+
+
     /// annotations like "acc enter data present(...)" for main kernel
     void print_kernel_data_present_annotation_block_begin() override;
 
@@ -80,6 +84,9 @@ class CodegenAccVisitor: public CodegenCVisitor {
 
     /// update global variable from host to the device
     void print_global_variable_device_update_annotation() override;
+
+    /// transfer newtonspace structure to device
+    void print_newtonspace_transfer_to_device() const override;
 
     std::string get_variable_device_pointer(const std::string& variable,
                                             const std::string& type) const override;

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3253,7 +3253,7 @@ void CodegenCVisitor::print_nrn_init(bool skip_init_check) {
         printer->add_line("auto ns = newtonspace{}(thread);"_format(list_num));
         printer->add_line("auto& th = thread[dith{}()];"_format(list_num));
 
-        printer->add_line("if (*ns == NULL) {");
+        printer->add_line("if (*ns == nullptr) {");
         printer->add_line("    int vec_size = 2*{}*pnodecount*sizeof(double);"_format(nequation));
         printer->add_line("    double* vec = makevector(vec_size);"_format(nequation));
         printer->add_line("    th.pval = vec;"_format(list_num));

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3203,6 +3203,7 @@ void CodegenCVisitor::print_global_function_common_code(BlockType type) {
     std::string method = compute_method_name(type);
     auto args = "NrnThread* nt, Memb_list* ml, int type";
 
+    // watch statement function doesn't have type argument
     if (type == BlockType::Watch) {
         args = "NrnThread* nt, Memb_list* ml";
     }

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1264,8 +1264,8 @@ std::string CodegenCVisitor::k_const() {
 
 
 void CodegenCVisitor::visit_watch_statement(ast::WatchStatement& node) {
-    printer->add_text(
-        "nrn_watch_activate(inst, id, pnodecount, {}, v, watch_remove)"_format(current_watch_statement++));
+    printer->add_text("nrn_watch_activate(inst, id, pnodecount, {}, v, watch_remove)"_format(
+        current_watch_statement++));
 }
 
 
@@ -2674,7 +2674,7 @@ void CodegenCVisitor::print_mechanism_register() {
     }
 
     if (info.is_watch_used()) {
-        auto watch_fun =  compute_method_name(BlockType::Watch);
+        auto watch_fun = compute_method_name(BlockType::Watch);
         printer->add_line("hoc_register_watch_check({}, mech_type);"_format(watch_fun));
     }
 
@@ -3203,7 +3203,7 @@ void CodegenCVisitor::print_global_function_common_code(BlockType type) {
     std::string method = compute_method_name(type);
     auto args = "NrnThread* nt, Memb_list* ml, int type";
 
-    if ( type == BlockType::Watch) {
+    if (type == BlockType::Watch) {
         args = "NrnThread* nt, Memb_list* ml";
     }
 
@@ -3314,7 +3314,8 @@ void CodegenCVisitor::print_watch_activate() {
     auto inst = "{}* inst"_format(instance_struct());
 
     printer->start_block(
-        "static void nrn_watch_activate({}, int id, int pnodecount, int watch_id, double v, bool &watch_remove) "_format(inst));
+        "static void nrn_watch_activate({}, int id, int pnodecount, int watch_id, double v, bool &watch_remove) "_format(
+            inst));
 
     // initialize all variables only during first watch statement
     printer->add_line("if (watch_remove == false) {");

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1257,7 +1257,7 @@ std::string CodegenCVisitor::k_const() {
 
 void CodegenCVisitor::visit_watch_statement(ast::WatchStatement& node) {
     printer->add_text(
-        "nrn_watch_activate(inst, id, pnodecount, {})"_format(current_watch_statement++));
+        "nrn_watch_activate(inst, id, pnodecount, {}, v)"_format(current_watch_statement++));
 }
 
 
@@ -3281,7 +3281,7 @@ void CodegenCVisitor::print_watch_activate() {
     auto inst = "{}* inst"_format(instance_struct());
 
     printer->start_block(
-        "static void nrn_watch_activate({}, int id, int pnodecount, int watch_id) "_format(inst));
+        "static void nrn_watch_activate({}, int id, int pnodecount, int watch_id, double v) "_format(inst));
 
     // initialize all variables only during first watch statement
     printer->add_line("if (watch_id == 0) {");
@@ -3329,6 +3329,11 @@ void CodegenCVisitor::print_watch_check() {
     print_channel_iteration_tiling_block_begin(BlockType::Watch);
     print_channel_iteration_block_begin(BlockType::Watch);
     print_post_channel_iteration_common_code();
+
+    if (info.is_voltage_used_by_watch_statements()) {
+        printer->add_line("int node_id = node_index[id];");
+        printer->add_line("double v = voltage[node_id];");
+    }
 
     for (int i = 0; i < info.watch_statements.size(); i++) {
         auto statement = info.watch_statements[i];
@@ -3720,7 +3725,16 @@ void CodegenCVisitor::print_net_receive_kernel() {
     if (info.artificial_cell) {
         printer->add_line("double t = nt->_t;");
     }
+
+    // set voltage variable if it is used in the block (e.g. for WATCH statement)
+    auto v_used = VarUsageVisitor().variable_used(*node->get_statement_block(), "v");
+    if (v_used) {
+        printer->add_line("int node_id = ml->nodeindices[id];");
+        printer->add_line("v = nt->_actual_v[node_id];");
+    }
+
     printer->add_line("{} = t;"_format(get_variable_name("tsave")));
+
     printer->add_indent();
     node->get_statement_block()->accept(*this);
     printer->add_newline();

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -960,6 +960,12 @@ class CodegenCVisitor: public visitor::AstVisitor {
 
 
     /**
+     * Print backend specific abort routine
+     */
+    virtual void print_abort_routine() const;
+
+
+    /**
      * Print standard C/C++ includes
      */
     void print_standard_includes();
@@ -1313,6 +1319,12 @@ class CodegenCVisitor: public visitor::AstVisitor {
 
 
     /**
+     * Common helper function to help printing function or procedure blocks
+     * \param node the AST node representing the function or procedure in NMODL
+     */
+    void print_function_procedure_helper(ast::Block& node);
+
+    /**
      * Print thread related memory allocation and deallocation callbacks
      */
     void print_thread_memory_callbacks();
@@ -1412,6 +1424,12 @@ class CodegenCVisitor: public visitor::AstVisitor {
      * \param block The corresponding AST node represening an NMODL \c derivimplicit block
      */
     void print_derivimplicit_kernel(ast::Block* block);
+
+
+    /**
+     * Print code block to transfer newtonspace structure to device
+     */
+    virtual void print_newtonspace_transfer_to_device() const;
 
 
     /**

--- a/src/codegen/codegen_info.cpp
+++ b/src/codegen/codegen_info.cpp
@@ -8,11 +8,14 @@
 #include "codegen/codegen_info.hpp"
 
 #include "ast/all.hpp"
+#include "visitors/var_usage_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
 
 
 namespace nmodl {
 namespace codegen {
+
+using visitor::VarUsageVisitor;
 
 /// if any ion has write variable
 bool CodegenInfo::ion_has_write_variable() const {

--- a/src/codegen/codegen_info.cpp
+++ b/src/codegen/codegen_info.cpp
@@ -101,5 +101,24 @@ bool CodegenInfo::nrn_state_has_eigen_solver_block() const {
     return !collect_nodes(*nrn_state_block, {ast::AstNodeType::EIGEN_NEWTON_SOLVER_BLOCK}).empty();
 }
 
+/**
+ * Check if WatchStatement uses voltage variable v
+ *
+ * Watch statement has condition expression which could use voltage
+ * variable `v`. To avoid memory access into voltage array we check
+ * if `v` is used and then print necessary code.
+ *
+ * @return true if voltage variable b is used otherwise false
+ */
+bool CodegenInfo::is_voltage_used_by_watch_statements() const {
+    for (const auto& statement: watch_statements) {
+        auto v_used = VarUsageVisitor().variable_used(*statement, "v");
+        if (v_used) {
+            return true;
+        }
+    }
+    return false;
+}
+
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/codegen_info.hpp
+++ b/src/codegen/codegen_info.hpp
@@ -385,6 +385,9 @@ struct CodegenInfo {
     /// true if EigenNewtonSolver is used in nrn_state block
     bool nrn_state_has_eigen_solver_block() const;
 
+    /// true if WatchStatement uses voltage v variable
+    bool is_voltage_used_by_watch_statements() const;
+
     /// if we need a call back to wrote_conc in neuron/coreneuron
     bool require_wrote_conc = false;
 };

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -828,6 +828,7 @@ void CodegenIspcVisitor::print_codegen_wrapper_routines() {
 
     print_memory_allocation_routine();
     print_thread_memory_callbacks();
+    print_abort_routine();
     print_global_variable_setup();
     /* this is a godawful mess.. the global variables have to be copied over into the fallback
      * such that they are available to the fallback generator.

--- a/test/integration/mod/watch_test.mod
+++ b/test/integration/mod/watch_test.mod
@@ -1,0 +1,57 @@
+NEURON {
+  POINT_PROCESS watchtest
+  NONSPECIFIC_CURRENT i
+  GLOBAL ena, ek, erev, gna, gk, gpas
+  RANGE e, g
+}
+
+UNITS {
+  (mV) = (millivolt)
+  (nA) = (nanoamp)
+  (umho) = (micromho)
+}
+
+PARAMETER {
+  ena = 50 (mV)
+  ek = -80 (mV)
+  erev = -65 (mV)
+  gna = 0.1 (umho)
+  gk = 0.03 (umho)
+  gpas = 0.0001 (umho)
+}
+
+ASSIGNED {
+  v (mV)
+  i (nA)
+  e (mV)
+  g (umho)
+}
+
+DEFINE init 1
+DEFINE rise 2
+DEFINE fall 3
+DEFINE off 4
+
+INITIAL {
+  g = gpas
+  e = erev
+  net_send(0, init)
+}
+
+BREAKPOINT {
+  i = g*(v - e)
+}
+
+NET_RECEIVE(w) {
+  if (flag == init) {
+    WATCH (v > -55) rise
+  }else if (flag == rise) {
+    g = gna
+    e = ena
+    WATCH (v > 10) fall
+  }else if (flag == fall) {
+    g = gk
+    e = ek
+    WATCH (v < -70) off
+  }
+}


### PR DESCRIPTION
 * Various fixes with OpenACC backend for watch & derivimplicit
     - artificial cells shouldn't use cuda memory allocation routines (but on cpu)
     - artificial cells shouldn't be compiled for GPU
     - use backend specific abort routine as abort is not supported on gpus
     - transfer routine to copy newtonspace on gpu
 * Azure CI changes
  - use python 3.7
  - use delocate on OS X instead of auditwheel
* Add test for watch statement

    Fixes #379 #115 #375