### PR TITLE
All LALR1 parsers share the same location class

### DIFF
--- a/src/lexer/CMakeLists.txt
+++ b/src/lexer/CMakeLists.txt
@@ -2,8 +2,10 @@
 # Various project components and their source files
 # =============================================================================
 set(BISON_GENERATED_SOURCE_FILES
+    ${PROJECT_BINARY_DIR}/src/parser/nmodl/location.hh
     ${PROJECT_BINARY_DIR}/src/parser/nmodl/nmodl_parser.cpp
     ${PROJECT_BINARY_DIR}/src/parser/nmodl/nmodl_parser.hpp
+    ${PROJECT_BINARY_DIR}/src/parser/nmodl/position.hh
     ${PROJECT_BINARY_DIR}/src/parser/verbatim_parser.cpp
     ${PROJECT_BINARY_DIR}/src/parser/verbatim_parser.hpp
     ${PROJECT_BINARY_DIR}/src/parser/diffeq/diffeq_parser.cpp

--- a/src/parser/c11.yy
+++ b/src/parser/c11.yy
@@ -15,6 +15,7 @@
     #include <sstream>
 
     #include "parser/c11_driver.hpp"
+    #include "parser/nmodl/location.hh"
 }
 
 /** use C++ parser interface of bison */
@@ -52,6 +53,9 @@
 
 /** keep track of the current position within the input */
 %locations
+
+/** specify own location class */
+%define api.location.type {nmodl::parser::location}
 
 %token    <std::string>    IDENTIFIER
 %token    <std::string>    I_CONSTANT

--- a/src/parser/diffeq.yy
+++ b/src/parser/diffeq.yy
@@ -21,6 +21,7 @@
     #include "parser/diffeq_context.hpp"
     #include "parser/diffeq_driver.hpp"
     #include "parser/diffeq_helper.hpp"
+    #include "parser/nmodl/location.hh"
 }
 
 /** use C++ parser interface of bison */
@@ -34,9 +35,6 @@
 
 /** enable tracing parser for debugging */
 %define parse.trace
-
-/** enable location tracking */
-%locations
 
 /** add extra arguments to yyparse() and yylexe() methods */
 %parse-param {class DiffeqLexer& scanner}
@@ -61,6 +59,8 @@
 /** keep track of the current position within the input */
 %locations
 
+/** specify own location class */
+%define api.location.type {nmodl::parser::location}
 
 %token  <std::string>   ATOM
 %token  <std::string>   NEWLINE

--- a/src/parser/unit.yy
+++ b/src/parser/unit.yy
@@ -10,9 +10,7 @@
 
 %code requires
 {
-    #include <string>
-    #include <sstream>
-
+    #include "parser/nmodl/location.hh"
     #include "parser/unit_driver.hpp"
     #include "units/units.hpp"
 }
@@ -52,6 +50,9 @@
 
 /** keep track of the current position within the input */
 %locations
+
+/** specify own location class */
+%define api.location.type {nmodl::parser::location}
 
 %token                  END    0     "end of file"
 %token                  INVALID_TOKEN


### PR DESCRIPTION
`%define api.location.type {}` bison directive allows one to provide a custom location class.
See https://www.gnu.org/software/bison/manual/html_node/User-Defined-Location-Type.html

In this PR, all LALR1 parsers share the same `nmodl::parser::location` class, the one generated by `src/parser/nmodl.yy`.

`src/parser/verbatim.yy` remains unchanged because it is a reentrant parser whose _location_  is hidden in the compilation unit:
```c++
struct YYLTYPE
{
  int first_line;
  int first_column;
  int last_line;
  int last_column;
};
```

Fixes #380