### PR TITLE
Set CodegenCVisitor::optimize_ion_variable_copies by a CLI flag

### DIFF
--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -89,14 +89,16 @@ class CodegenAccVisitor: public CodegenCVisitor {
     CodegenAccVisitor(const std::string& mod_file,
                       const std::string& output_dir,
                       LayoutType layout,
-                      const std::string& float_type)
-        : CodegenCVisitor(mod_file, output_dir, layout, float_type) {}
+                      const std::string& float_type,
+                      const bool optimize_ionvar_copies)
+        : CodegenCVisitor(mod_file, output_dir, layout, float_type, optimize_ionvar_copies) {}
 
     CodegenAccVisitor(const std::string& mod_file,
                       std::ostream& stream,
                       LayoutType layout,
-                      const std::string& float_type)
-        : CodegenCVisitor(mod_file, stream, layout, float_type) {}
+                      const std::string& float_type,
+                      const bool optimize_ionvar_copies)
+        : CodegenCVisitor(mod_file, stream, layout, float_type, optimize_ionvar_copies) {}
 };
 
 /** @} */  // end of codegen_backends

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1201,7 +1201,7 @@ bool CodegenCVisitor::channel_task_dependency_enabled() {
 
 
 bool CodegenCVisitor::optimize_ion_variable_copies() const {
-    return true;
+    return optimize_ionvar_copies;
 }
 
 

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -205,6 +205,11 @@ class CodegenCVisitor: public visitor::AstVisitor {
     bool codegen = false;
 
     /**
+     * Flag to indicate if visitor should avoid ion variable copies
+     */
+    bool optimize_ionvar_copies = true;
+
+    /**
      * Variable name should be converted to instance name (but not for function arguments)
      */
     bool enable_variable_name_lookup = true;
@@ -996,7 +1001,7 @@ class CodegenCVisitor: public visitor::AstVisitor {
 
 
     /**
-     * Check if ion variable are copies avoided
+     * Check if ion variable copies should be avoided
      */
     bool optimize_ion_variable_copies() const;
 
@@ -1594,6 +1599,7 @@ class CodegenCVisitor: public visitor::AstVisitor {
                     const std::string& output_dir,
                     LayoutType layout,
                     const std::string& float_type,
+                    const bool optimize_ionvar_copies,
                     const std::string& extension,
                     const std::string& wrapper_ext)
         : target_printer(new CodePrinter(output_dir + "/" + mod_filename + extension))
@@ -1601,7 +1607,8 @@ class CodegenCVisitor: public visitor::AstVisitor {
         , printer(target_printer)
         , mod_filename(mod_filename)
         , layout(layout)
-        , float_type(float_type) {}
+        , float_type(float_type)
+        , optimize_ionvar_copies(optimize_ionvar_copies) {}
 
 
   public:
@@ -1627,12 +1634,14 @@ class CodegenCVisitor: public visitor::AstVisitor {
                     const std::string& output_dir,
                     LayoutType layout,
                     const std::string& float_type,
+                    const bool optimize_ionvar_copies,
                     const std::string& extension = ".cpp")
         : target_printer(new CodePrinter(output_dir + "/" + mod_filename + extension))
         , printer(target_printer)
         , mod_filename(mod_filename)
         , layout(layout)
-        , float_type(float_type) {}
+        , float_type(float_type)
+        , optimize_ionvar_copies(optimize_ionvar_copies) {}
 
     /**
      * \copybrief nmodl::codegen::CodegenCVisitor
@@ -1654,12 +1663,14 @@ class CodegenCVisitor: public visitor::AstVisitor {
     CodegenCVisitor(const std::string& mod_filename,
                     std::ostream& stream,
                     LayoutType layout,
-                    const std::string& float_type)
+                    const std::string& float_type,
+                    const bool optimize_ionvar_copies)
         : target_printer(new CodePrinter(stream))
         , printer(target_printer)
         , mod_filename(mod_filename)
         , layout(layout)
-        , float_type(float_type) {}
+        , float_type(float_type)
+        , optimize_ionvar_copies(optimize_ionvar_copies) {}
 
 
     /**
@@ -1683,12 +1694,14 @@ class CodegenCVisitor: public visitor::AstVisitor {
     CodegenCVisitor(std::string mod_filename,
                     LayoutType layout,
                     std::string float_type,
+                    const bool optimize_ionvar_copies,
                     std::shared_ptr<CodePrinter>& target_printer)
         : target_printer(target_printer)
         , printer(target_printer)
         , mod_filename(mod_filename)
         , layout(layout)
-        , float_type(float_type) {}
+        , float_type(float_type)
+        , optimize_ionvar_copies(optimize_ionvar_copies) {}
 
 
     /**

--- a/src/codegen/codegen_cuda_visitor.hpp
+++ b/src/codegen/codegen_cuda_visitor.hpp
@@ -107,14 +107,17 @@ class CodegenCudaVisitor: public CodegenCVisitor {
     CodegenCudaVisitor(const std::string& mod_file,
                        const std::string& output_dir,
                        LayoutType layout,
-                       const std::string& float_type)
-        : CodegenCVisitor(mod_file, output_dir, layout, float_type, ".cu") {}
+                       const std::string& float_type,
+                       const bool optimize_ionvar_copies)
+        : CodegenCVisitor(mod_file, output_dir, layout, float_type, optimize_ionvar_copies, ".cu") {
+    }
 
     CodegenCudaVisitor(const std::string& mod_file,
                        std::ostream& stream,
                        LayoutType layout,
-                       const std::string& float_type)
-        : CodegenCVisitor(mod_file, stream, layout, float_type) {}
+                       const std::string& float_type,
+                       const bool optimize_ionvar_copies)
+        : CodegenCVisitor(mod_file, stream, layout, float_type, optimize_ionvar_copies) {}
 };
 
 /** @} */  // end of codegen_backends

--- a/src/codegen/codegen_ispc_visitor.hpp
+++ b/src/codegen/codegen_ispc_visitor.hpp
@@ -218,17 +218,25 @@ class CodegenIspcVisitor: public CodegenCVisitor {
     CodegenIspcVisitor(const std::string& mod_file,
                        const std::string& output_dir,
                        LayoutType layout,
-                       const std::string& float_type)
-        : CodegenCVisitor(mod_file, output_dir, layout, float_type, ".ispc", ".cpp")
-        , fallback_codegen(mod_file, layout, float_type, wrapper_printer) {}
+                       const std::string& float_type,
+                       const bool optimize_ionvar_copies)
+        : CodegenCVisitor(mod_file,
+                          output_dir,
+                          layout,
+                          float_type,
+                          optimize_ionvar_copies,
+                          ".ispc",
+                          ".cpp")
+        , fallback_codegen(mod_file, layout, float_type, optimize_ionvar_copies, wrapper_printer) {}
 
 
     CodegenIspcVisitor(const std::string& mod_file,
                        std::ostream& stream,
                        LayoutType layout,
-                       const std::string& float_type)
-        : CodegenCVisitor(mod_file, stream, layout, float_type)
-        , fallback_codegen(mod_file, layout, float_type, wrapper_printer) {}
+                       const std::string& float_type,
+                       const bool optimize_ionvar_copies)
+        : CodegenCVisitor(mod_file, stream, layout, float_type, optimize_ionvar_copies)
+        , fallback_codegen(mod_file, layout, float_type, optimize_ionvar_copies, wrapper_printer) {}
 
     void visit_function_call(ast::FunctionCall& node) override;
     void visit_var_name(ast::VarName& node) override;

--- a/src/codegen/codegen_omp_visitor.hpp
+++ b/src/codegen/codegen_omp_visitor.hpp
@@ -73,14 +73,16 @@ class CodegenOmpVisitor: public CodegenCVisitor {
     CodegenOmpVisitor(std::string mod_file,
                       std::string output_dir,
                       LayoutType layout,
-                      std::string float_type)
-        : CodegenCVisitor(mod_file, output_dir, layout, float_type) {}
+                      std::string float_type,
+                      const bool optimize_ionvar_copies)
+        : CodegenCVisitor(mod_file, output_dir, layout, float_type, optimize_ionvar_copies) {}
 
     CodegenOmpVisitor(std::string mod_file,
                       std::stringstream& stream,
                       LayoutType layout,
-                      std::string float_type)
-        : CodegenCVisitor(mod_file, stream, layout, float_type) {}
+                      std::string float_type,
+                      const bool optimize_ionvar_copies)
+        : CodegenCVisitor(mod_file, stream, layout, float_type, optimize_ionvar_copies) {}
 };
 
 /** @} */  // end of codegen_backends

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -254,7 +254,7 @@ int main(int argc, const char* argv[]) {
     codegen_opt->add_flag("--force",
         force_codegen,
         "Force code generation even if there is any incompatibility");
-    codegen_opt->add_flag("--opt-ionvar-cp",
+    codegen_opt->add_flag("--opt-ionvar-copy",
         optimize_ionvar_copies_codegen,
         "Optimize copies of ion variables ({})"_format(optimize_ionvar_copies_codegen))->ignore_case();
 

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -122,9 +122,12 @@ int main(int argc, const char* argv[]) {
     /// true if verbatim blocks
     bool verbatim_rename(true);
 
-    /// true if code generation is forced to happed even if there
+    /// true if code generation is forced to happen even if there
     /// is any incompatibility
     bool force_codegen(false);
+
+    /// true if ion variable copies should be avoided
+    bool optimize_ionvar_copies_codegen(true);
 
     /// directory where code will be generated
     std::string output_dir(".");
@@ -251,6 +254,9 @@ int main(int argc, const char* argv[]) {
     codegen_opt->add_flag("--force",
         force_codegen,
         "Force code generation even if there is any incompatibility");
+    codegen_opt->add_flag("--opt-ionvar-cp",
+        optimize_ionvar_copies_codegen,
+        "Optimize copies of ion variables ({})"_format(optimize_ionvar_copies_codegen))->ignore_case();
 
     // clang-format on
 
@@ -488,31 +494,36 @@ int main(int argc, const char* argv[]) {
 
             if (ispc_backend) {
                 logger->info("Running ISPC backend code generator");
-                CodegenIspcVisitor visitor(modfile, output_dir, mem_layout, data_type);
+                CodegenIspcVisitor visitor(
+                    modfile, output_dir, mem_layout, data_type, optimize_ionvar_copies_codegen);
                 visitor.visit_program(*ast);
             }
 
             else if (oacc_backend) {
                 logger->info("Running OpenACC backend code generator");
-                CodegenAccVisitor visitor(modfile, output_dir, mem_layout, data_type);
+                CodegenAccVisitor visitor(
+                    modfile, output_dir, mem_layout, data_type, optimize_ionvar_copies_codegen);
                 visitor.visit_program(*ast);
             }
 
             else if (omp_backend) {
                 logger->info("Running OpenMP backend code generator");
-                CodegenOmpVisitor visitor(modfile, output_dir, mem_layout, data_type);
+                CodegenOmpVisitor visitor(
+                    modfile, output_dir, mem_layout, data_type, optimize_ionvar_copies_codegen);
                 visitor.visit_program(*ast);
             }
 
             else if (c_backend) {
                 logger->info("Running C backend code generator");
-                CodegenCVisitor visitor(modfile, output_dir, mem_layout, data_type);
+                CodegenCVisitor visitor(
+                    modfile, output_dir, mem_layout, data_type, optimize_ionvar_copies_codegen);
                 visitor.visit_program(*ast);
             }
 
             if (cuda_backend) {
                 logger->info("Running CUDA backend code generator");
-                CodegenCudaVisitor visitor(modfile, output_dir, mem_layout, data_type);
+                CodegenCudaVisitor visitor(
+                    modfile, output_dir, mem_layout, data_type, optimize_ionvar_copies_codegen);
                 visitor.visit_program(*ast);
             }
         }


### PR DESCRIPTION
`CodegenCVisitor::optimize_ion_variable_copies` was hard-coded as true. Now it can be set by a CLI flag

- Fix issue #388