### PR TITLE
Fix issue with const-ness of ion variables

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -731,7 +731,10 @@ bool CodegenCVisitor::is_constant_variable(const std::string& name) const {
     auto symbol = program_symtab->lookup_in_scope(name);
     bool is_constant = false;
     if (symbol != nullptr) {
-        if (symbol->has_any_property(NmodlType::param_assign) && symbol->get_write_count() == 0) {
+        // per mechanism ion variables needs to be updated from neuron/coreneuron values
+        if (info.is_ion_variable(name)) {
+            is_constant = false;
+        } else if (symbol->has_any_property(NmodlType::param_assign) && symbol->get_write_count() == 0) {
             is_constant = true;
         }
     }

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -734,7 +734,8 @@ bool CodegenCVisitor::is_constant_variable(const std::string& name) const {
         // per mechanism ion variables needs to be updated from neuron/coreneuron values
         if (info.is_ion_variable(name)) {
             is_constant = false;
-        } else if (symbol->has_any_property(NmodlType::param_assign) && symbol->get_write_count() == 0) {
+        } else if (symbol->has_any_property(NmodlType::param_assign) &&
+                   symbol->get_write_count() == 0) {
             is_constant = true;
         }
     }


### PR DESCRIPTION
  - per mechanism ion variables needs to be updated from
    values calculated by neuron/coreneuron (in eion.cpp)
  - with the changes in #389 and #393, read variables can
    not be declared as constant
  - in this PR we avoid const declaration for ION variables

fixes #394