### PR TITLE
fix typos : ElctrodeCurrent to ElectrodeCurrent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ addons:
   # for Mac builds, we use Homebrew
   homebrew:
     packages:
+      - bison
       - boost
       - cmake
       - flex
@@ -75,7 +76,6 @@ before_install:
   # unlink python2 and use python3 as it's required for nmodl
   # install older bison because of #314
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/187c0d5/Formula/bison.rb;
         export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
         brew unlink python@2;
         brew link --overwrite python@3.8;

--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -424,7 +424,7 @@ void CodegenHelperVisitor::visit_suffix(Suffix& node) {
 }
 
 
-void CodegenHelperVisitor::visit_elctrode_current(ElctrodeCurrent& node) {
+void CodegenHelperVisitor::visit_electrode_current(ElectrodeCurrent& node) {
     info.electrode_current = true;
 }
 

--- a/src/codegen/codegen_helper_visitor.hpp
+++ b/src/codegen/codegen_helper_visitor.hpp
@@ -80,7 +80,7 @@ class CodegenHelperVisitor: public visitor::AstVisitor {
     /// run visitor and return information for code generation
     codegen::CodegenInfo analyze(ast::Program& node);
 
-    void visit_elctrode_current(ast::ElctrodeCurrent& node) override;
+    void visit_electrode_current(ast::ElectrodeCurrent& node) override;
     void visit_suffix(ast::Suffix& node) override;
     void visit_function_call(ast::FunctionCall& node) override;
     void visit_binary_expression(ast::BinaryExpression& node) override;

--- a/src/language/code_generator.cmake
+++ b/src/language/code_generator.cmake
@@ -82,8 +82,8 @@ set(AST_GENERATED_SOURCES
     ${PROJECT_BINARY_DIR}/src/ast/double_unit.hpp
     ${PROJECT_BINARY_DIR}/src/ast/eigen_linear_solver_block.hpp
     ${PROJECT_BINARY_DIR}/src/ast/eigen_newton_solver_block.hpp
-    ${PROJECT_BINARY_DIR}/src/ast/elctrode_current.hpp
     ${PROJECT_BINARY_DIR}/src/ast/electrode_cur_var.hpp
+    ${PROJECT_BINARY_DIR}/src/ast/electrode_current.hpp
     ${PROJECT_BINARY_DIR}/src/ast/else_if_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/else_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/expression.hpp

--- a/src/language/nmodl.yaml
+++ b/src/language/nmodl.yaml
@@ -1989,7 +1989,7 @@
                             separator: ", "
                       brief: "Represents NONSPECIFIC_CURRENT variables statement in NMODL"
 
-                  - ElctrodeCurrent:
+                  - ElectrodeCurrent:
                       nmodl: "ELECTRODE_CURRENT "
                       members:
                         - currents:

--- a/src/parser/nmodl.yy
+++ b/src/parser/nmodl.yy
@@ -2281,7 +2281,7 @@ neuron_statement :
                     }
                 |   neuron_statement ELECTRODE_CURRENT electrode_current_var_list
                     {
-                        $1.emplace_back(new ast::ElctrodeCurrent($3));
+                        $1.emplace_back(new ast::ElectrodeCurrent($3));
                         $$ = $1;
                     }
                 |   neuron_statement SECTION section_var_list


### PR DESCRIPTION
Useful since ast_decl enum is exposed to python API (for example)