### PR TITLE
Add symtab get_variables and get_variables_with_properties defaults. Fix #403

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ addons:
       - boost
       - cmake
       - flex
+      - bison
       - openmpi
       - python@3
     update: true
@@ -75,7 +76,6 @@ before_install:
   # unlink python2 and use python3 as it's required for nmodl
   # install older bison because of #314
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-        brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/187c0d5/Formula/bison.rb;
         export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
         brew unlink python@2;
         brew link --overwrite python@3.8;

--- a/src/language/templates/pybind/pysymtab.cpp
+++ b/src/language/templates/pybind/pysymtab.cpp
@@ -214,10 +214,13 @@ void init_symtab_module(py::module& m) {
     symbol_table.def("name", &SymbolTable::name)
         .def("title", &SymbolTable::title)
         .def("is_method_defined", &SymbolTable::is_method_defined)
-        .def("get_variables", &SymbolTable::get_variables)
+        .def("get_variables",
+             &SymbolTable::get_variables,
+             py::arg("with") = syminfo::NmodlType::empty,
+             py::arg("without") = syminfo::NmodlType::empty)
         .def("get_variables_with_properties",
              &SymbolTable::get_variables_with_properties,
-             py::arg("properties"),
+             py::arg("properties") = syminfo::NmodlType(-1),
              py::arg("all") = false)
         .def("get_variables_with_status",
              &SymbolTable::get_variables_with_status,

--- a/src/language/templates/pybind/pysymtab.cpp
+++ b/src/language/templates/pybind/pysymtab.cpp
@@ -220,7 +220,7 @@ void init_symtab_module(py::module& m) {
              py::arg("without") = syminfo::NmodlType::empty)
         .def("get_variables_with_properties",
              &SymbolTable::get_variables_with_properties,
-             py::arg("properties") = syminfo::NmodlType(-1),
+             py::arg("properties"),
              py::arg("all") = false)
         .def("get_variables_with_status",
              &SymbolTable::get_variables_with_status,

--- a/src/symtab/symbol_table.hpp
+++ b/src/symtab/symbol_table.hpp
@@ -152,7 +152,7 @@ class SymbolTable {
      * \param all all/any
      */
     std::vector<std::shared_ptr<Symbol>> get_variables_with_properties(
-        syminfo::NmodlType properties = syminfo::NmodlType(-1),
+        syminfo::NmodlType properties,
         bool all = false) const;
 
     std::vector<std::shared_ptr<Symbol>> get_variables_with_status(syminfo::Status status,

--- a/src/symtab/symbol_table.hpp
+++ b/src/symtab/symbol_table.hpp
@@ -131,11 +131,28 @@ class SymbolTable {
         return parent ? parent->name() : "None";
     }
 
-    std::vector<std::shared_ptr<Symbol>> get_variables(syminfo::NmodlType with,
-                                                       syminfo::NmodlType without);
+    /**
+     * get variables
+     *
+     * \param with variables with properties. 0 matches everything
+     * \param without variables without properties. 0 matches nothing
+     *
+     * The two different behaviors for 0 depend on the fact that we get
+     * get variables with ALL the with properties and without ANY of the
+     * without properties
+     */
+    std::vector<std::shared_ptr<Symbol>> get_variables(
+        syminfo::NmodlType with = syminfo::NmodlType::empty,
+        syminfo::NmodlType without = syminfo::NmodlType::empty);
 
+    /**
+     * get variables with properties
+     *
+     * \param properties variables with properties. -1 matches everything
+     * \param all all/any
+     */
     std::vector<std::shared_ptr<Symbol>> get_variables_with_properties(
-        syminfo::NmodlType properties,
+        syminfo::NmodlType properties = syminfo::NmodlType(-1),
         bool all = false) const;
 
     std::vector<std::shared_ptr<Symbol>> get_variables_with_status(syminfo::Status status,


### PR DESCRIPTION
Fix issue #399. Now these 2 functions can be called without
properties as inputs to collect all the symbols

Fix issue #403

Edit: due to the misleading -1 value and the fact that get_variables_with_properties does not make much sense with a default value, the default of this function has been dropped. Get_variables still returns all the variables in case no input is present