### PR TITLE
Partial fix #401 deprecated directive: parser_class_name

### DIFF
--- a/src/parser/c11.yy
+++ b/src/parser/c11.yy
@@ -49,7 +49,7 @@
 %define api.namespace {nmodl::parser}
 
 /** set the parser's class identifier */
-%define parser_class_name {CParser}
+%define api.parser.class {CParser}
 
 /** keep track of the current position within the input */
 %locations

--- a/src/parser/diffeq.yy
+++ b/src/parser/diffeq.yy
@@ -54,7 +54,7 @@
 %define api.namespace {nmodl::parser}
 
 /** set the parser's class identifier */
-%define parser_class_name {DiffeqParser}
+%define api.parser.class {DiffeqParser}
 
 /** keep track of the current position within the input */
 %locations

--- a/src/parser/nmodl.yy
+++ b/src/parser/nmodl.yy
@@ -62,7 +62,7 @@
 %define api.namespace {nmodl::parser}
 
 /** set the parser's class identifier */
-%define parser_class_name {NmodlParser}
+%define api.parser.class {NmodlParser}
 
 /** keep track of the current position within the input */
 %locations

--- a/src/parser/unit.yy
+++ b/src/parser/unit.yy
@@ -46,7 +46,7 @@
 %define api.namespace {nmodl::parser}
 
 /** set the parser's class identifier */
-%define parser_class_name {UnitParser}
+%define api.parser.class {UnitParser}
 
 /** keep track of the current position within the input */
 %locations


### PR DESCRIPTION
I am not sure how to solve the second part of #401 . The compiler does not really pin-point the position of the problem. I need to read more about shift/reduce errors 