### PR TITLE
Fixes issue with net_send_buffering declared and defined after net_init

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -4243,8 +4243,8 @@ void CodegenCVisitor::print_compute_functions() {
         auto block = callback->get_node_to_solve().get();
         print_derivimplicit_kernel(block);
     }
-    print_net_init();
     print_net_send_buffering();
+    print_net_init();
     print_watch_activate();
     print_watch_check();
     print_net_receive_kernel();

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -852,8 +852,8 @@ void CodegenIspcVisitor::print_codegen_wrapper_routines() {
 
     print_check_table_thread_function();
 
-    print_net_init();
     print_net_send_buffering();
+    print_net_init();
     print_watch_activate();
     fallback_codegen.print_watch_check();  // requires C style variable declarations and loops
 


### PR DESCRIPTION
With the recent changes in the mod files for the `delayed connection` there are issues in the source files generated by `NMODL` because `net_send_buffering()` is called by `net_init()` but defined after it.
This PR prints the `net_send_buffering()` function before `net_init()` to solve this issue.
I have an additional question, whether `net_receive_buffering()` should also be printed before `net_init()` to avoid issues in the future.
cc: @pramodk @ohm314 @cattabiani 