### PR TITLE
Grow NetSendBuffer_t dynamically when necessary

### DIFF
--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -117,6 +117,13 @@ void CodegenAccVisitor::print_abort_routine() const {
     printer->add_line("}");
 }
 
+void CodegenAccVisitor::print_net_send_buffering_grow() {
+    auto error = add_escape_quote("Error : netsend buffer size (%d) exceeded\\n");
+
+    printer->add_line("printf({}, nsb->_cnt);"_format(error));
+    printer->add_line("coreneuron_abort();");
+}
+
 /**
  * Each kernel like nrn_init, nrn_state and nrn_cur could be offloaded
  * to accelerator. In this case, at very top level, we print pragma

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -92,6 +92,9 @@ class CodegenAccVisitor: public CodegenCVisitor {
                                             const std::string& type) const override;
 
 
+    void print_net_send_buffering_grow() override;
+
+
   public:
     CodegenAccVisitor(const std::string& mod_file,
                       const std::string& output_dir,

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3700,13 +3700,15 @@ void CodegenCVisitor::print_net_receive_buffering(bool need_mech_inst) {
     printer->end_block(1);
 }
 
+void CodegenCVisitor::print_net_send_buffering_grow() {
+    printer->add_line("nsb->grow();");
+}
 
 void CodegenCVisitor::print_net_send_buffering() {
     if (!net_send_buffer_required()) {
         return;
     }
 
-    auto error = add_escape_quote("Error : netsend buffer size (%d) exceeded\\n");
     printer->add_newline(2);
     print_device_method_annotation();
     auto args =
@@ -3716,8 +3718,9 @@ void CodegenCVisitor::print_net_send_buffering() {
     printer->add_line("int i = nsb->_cnt;");
     printer->add_line("nsb->_cnt++;");
     printer->add_line("if(nsb->_cnt >= nsb->_size) {");
-    printer->add_line("    printf({}, nsb->_cnt);"_format(error));
-    printer->add_line("    coreneuron_abort();");
+    printer->increase_indent();
+    print_net_send_buffering_grow();
+    printer->decrease_indent();
     printer->add_line("}");
     printer->add_line("nsb->_sendtype[i] = type;");
     printer->add_line("nsb->_vdata_index[i] = vdata_index;");

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1373,6 +1373,13 @@ class CodegenCVisitor: public visitor::AstVisitor {
 
 
     /**
+     * Print statement that grows NetSendBuffering_t structure if needed.
+     * This function should be overridden for backends that cannot dynamically reallocate the buffer
+     */
+    virtual void print_net_send_buffering_grow();
+
+
+    /**
      * Print kernel for buffering net_send events
      *
      * This kernel is only needed for accelerator backends where \c net\_send needs to be executed


### PR DESCRIPTION
unless we're on OpenACC, then we throw an error. This uses https://github.com/BlueBrain/CoreNeuron/pull/395#