### PR TITLE
Add support for for_netcon

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -2713,6 +2713,7 @@ void CodegenCVisitor::print_mechanism_register() {
         printer->add_line(pnt_recline);
     }
     if (info.for_netcon_used) {
+        // index where information about FOR_NETCON is stored in the integer array
         const auto index =
             std::find_if(info.semantics.begin(), info.semantics.end(), [](const IndexSemantics& a) {
                 return a.name == naming::FOR_NETCON_SEMANTIC;

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3777,15 +3777,17 @@ void CodegenCVisitor::visit_for_netcon(ast::ForNetcon& node) {
                                                      : "{} + id*{}"_format(index, num_int);
     printer->add_line("const size_t offset = {};"_format(offset));
     printer->add_line(
-        "for (auto i = nt->_fornetcon_perm_indices[indexes[offset]]; "
-        "i < nt->_fornetcon_perm_indices[indexes[offset]+1]; ++i) {");
+        "const size_t for_netcon_start = nt->_fornetcon_perm_indices[indexes[offset]]; ");
+    printer->add_line(
+        "const size_t for_netcon_end = nt->_fornetcon_perm_indices[indexes[offset] + 1]; ");
+
+    printer->add_line("for (auto i = for_netcon_start; i < for_netcon_end; ++i) {");
     printer->increase_indent();
     print_statement_block(*statement_block, false, false);
     printer->decrease_indent();
 
     printer->add_line("}");
 }
-
 
 void CodegenCVisitor::print_net_receive_kernel() {
     if (!net_receive_required()) {

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3772,9 +3772,6 @@ void CodegenCVisitor::visit_for_netcon(ast::ForNetcon& node) {
 
 
     printer->add_line("");  // the first line gets indented in a strange way.
-    if (layout == LayoutType::soa)
-        printer->add_line("//I think it is soa");
-
 
     std::string offset = (layout == LayoutType::soa) ? "{}*pnodecount + id"_format(index)
                                                      : "{} + id*{}"_format(index, num_int);

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cmath>
 #include <ctime>
+#include <regex>
 
 #include "ast/all.hpp"
 #include "codegen/codegen_helper_visitor.hpp"
@@ -42,6 +43,7 @@ using nmodl::utils::UseNumbersInString;
 /*                            Overloaded visitor routines                               */
 /****************************************************************************************/
 
+const std::regex regex_special_chars{R"([-[\]{}()*+?.,\^$|#\s])"};
 
 void CodegenCVisitor::visit_string(String& node) {
     if (!codegen) {
@@ -2710,6 +2712,14 @@ void CodegenCVisitor::print_mechanism_register() {
             method_name("net_receive"), net_recv_init_arg);
         printer->add_line(pnt_recline);
     }
+    if (info.for_netcon_used) {
+        const auto index =
+            std::find_if(info.semantics.begin(), info.semantics.end(), [](const IndexSemantics& a) {
+                return a.name == naming::FOR_NETCON_SEMANTIC;
+            })->index;
+        printer->add_line("add_nrn_fornetcons(mech_type, {});"_format(index));
+    }
+
     if (info.net_event_used || info.net_send_used) {
         printer->add_line("hoc_register_net_send_buffering(mech_type);");
     }
@@ -3733,6 +3743,46 @@ void CodegenCVisitor::print_net_send_buffering() {
     printer->add_line("nsb->_nsb_t[i] = t;");
     printer->add_line("nsb->_nsb_flag[i] = flag;");
     printer->end_block(1);
+}
+
+
+void CodegenCVisitor::visit_for_netcon(ast::ForNetcon& node) {
+    // For_netcon should take the same arguments as net_receive and apply the operations
+    // in the block to the weights of the netcons. Since all the weights are on the same vector,
+    // weights, we have a mask of operations that we apply iteratively, advancing the offset
+    // to the next netcon.
+    const auto& args = node.get_parameters();
+    RenameVisitor v;
+    auto& statement_block = node.get_statement_block();
+    for (size_t i_arg = 0; i_arg < args.size(); ++i_arg) {
+        // sanitize node_name since we want to substitute names like (*w) as they are
+        auto old_name =
+            std::regex_replace(args[i_arg]->get_node_name(), regex_special_chars, R"(\$&)");
+        auto new_name = "weights[{} + nt->_fornetcon_weight_perm[i]]"_format(i_arg);
+        v.set(old_name, new_name);
+        statement_block->accept(v);
+    }
+
+    const auto index =
+        std::find_if(info.semantics.begin(), info.semantics.end(), [](const IndexSemantics& a) {
+            return a.name == naming::FOR_NETCON_SEMANTIC;
+        })->index;
+    const auto num_int = int_variables_size();
+
+
+    printer->add_line("");  // the first line gets indented in a strange way.
+    std::string offset = (layout == LayoutType::soa)
+                             ? "{}*pnodecount + id"_format(index)
+                             : "{}*pnodecount + id + id*{}"_format(index, num_int);
+    printer->add_line("const size_t offset = {};"_format(offset));
+    printer->add_line(
+        "for (auto i = nt->_fornetcon_perm_indices[indexes[offset]]; "
+        "i < nt->_fornetcon_perm_indices[indexes[offset]+1]; ++i) {");
+    printer->increase_indent();
+    print_statement_block(*statement_block, false, false);
+    printer->decrease_indent();
+
+    printer->add_line("}");
 }
 
 

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3771,9 +3771,12 @@ void CodegenCVisitor::visit_for_netcon(ast::ForNetcon& node) {
 
 
     printer->add_line("");  // the first line gets indented in a strange way.
-    std::string offset = (layout == LayoutType::soa)
-                             ? "{}*pnodecount + id"_format(index)
-                             : "{}*pnodecount + id + id*{}"_format(index, num_int);
+    if (layout == LayoutType::soa)
+        printer->add_line("//I think it is soa");
+
+
+    std::string offset = (layout == LayoutType::soa) ? "{}*pnodecount + id"_format(index)
+                                                     : "{} + id*{}"_format(index, num_int);
     printer->add_line("const size_t offset = {};"_format(offset));
     printer->add_line(
         "for (auto i = nt->_fornetcon_perm_indices[indexes[offset]]; "

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -484,7 +484,8 @@ bool CodegenCVisitor::need_semicolon(Statement* node) const {
         if (expression->is_statement_block()
             || expression->is_eigen_newton_solver_block()
             || expression->is_eigen_linear_solver_block()
-            || expression->is_solution_expression()) {
+            || expression->is_solution_expression()
+            || expression->is_for_netcon()) {
             return false;
         }
     }
@@ -3770,16 +3771,14 @@ void CodegenCVisitor::visit_for_netcon(ast::ForNetcon& node) {
         })->index;
     const auto num_int = int_variables_size();
 
-
-    printer->add_line("");  // the first line gets indented in a strange way.
-
     std::string offset = (layout == LayoutType::soa) ? "{}*pnodecount + id"_format(index)
                                                      : "{} + id*{}"_format(index, num_int);
-    printer->add_line("const size_t offset = {};"_format(offset));
+    printer->add_text("const size_t offset = {};"_format(offset));
+    printer->add_newline();
     printer->add_line(
-        "const size_t for_netcon_start = nt->_fornetcon_perm_indices[indexes[offset]]; ");
+        "const size_t for_netcon_start = nt->_fornetcon_perm_indices[indexes[offset]];");
     printer->add_line(
-        "const size_t for_netcon_end = nt->_fornetcon_perm_indices[indexes[offset] + 1]; ");
+        "const size_t for_netcon_end = nt->_fornetcon_perm_indices[indexes[offset] + 1];");
 
     printer->add_line("for (auto i = for_netcon_start; i < for_netcon_end; ++i) {");
     printer->increase_indent();

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1855,6 +1855,7 @@ class CodegenCVisitor: public visitor::AstVisitor {
     void visit_watch_statement(ast::WatchStatement& node) override;
     void visit_while_statement(ast::WhileStatement& node) override;
     void visit_derivimplicit_callback(ast::DerivimplicitCallback& node) override;
+    void visit_for_netcon(ast::ForNetcon& node) override;
 };
 
 

--- a/src/visitors/rename_visitor.hpp
+++ b/src/visitors/rename_visitor.hpp
@@ -55,7 +55,7 @@ class RenameVisitor: public ConstAstVisitor {
     std::string new_var_name_prefix;
 
     /// Map that keeps the renamed variables to keep the same random suffix when a variable is
-    /// renamed accross the whole file
+    /// renamed across the whole file
     std::unordered_map<std::string, std::string> renamed_variables;
 
     /// add prefix to variable name


### PR DESCRIPTION
Tackles issue #390

For_netcon applies the operations of the block to the weights of
all the netcons. Since all the weights are on the same vector,
weights, this means appling the same operations to a mask of values
with the appropriate offset. The mask is the arguments of the
for_netcon block.

Note: the local variables are renamed to the correct position
in the corenrn vectors (no new variables added). Some of these
local variables may have been already substituted with special
characters that break rename_visitor (i.e. (*w) ). Thus, we need
to sanitize first the regex names that we are going to substitute.
