### PR TITLE
Code generator visitors are now ConstAstVisitors ... and more!

### DIFF
--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -100,14 +100,14 @@ class CodegenAccVisitor: public CodegenCVisitor {
                       const std::string& output_dir,
                       LayoutType layout,
                       const std::string& float_type,
-                      const bool optimize_ionvar_copies)
+                      bool optimize_ionvar_copies)
         : CodegenCVisitor(mod_file, output_dir, layout, float_type, optimize_ionvar_copies) {}
 
     CodegenAccVisitor(const std::string& mod_file,
                       std::ostream& stream,
                       LayoutType layout,
                       const std::string& float_type,
-                      const bool optimize_ionvar_copies)
+                      bool optimize_ionvar_copies)
         : CodegenCVisitor(mod_file, stream, layout, float_type, optimize_ionvar_copies) {}
 };
 

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -45,7 +45,7 @@ using nmodl::utils::UseNumbersInString;
 
 const std::regex regex_special_chars{R"([-[\]{}()*+?.,\^$|#\s])"};
 
-void CodegenCVisitor::visit_string(String& node) {
+void CodegenCVisitor::visit_string(const String& node) {
     if (!codegen) {
         return;
     }
@@ -57,12 +57,12 @@ void CodegenCVisitor::visit_string(String& node) {
 }
 
 
-void CodegenCVisitor::visit_integer(Integer& node) {
+void CodegenCVisitor::visit_integer(const Integer& node) {
     if (!codegen) {
         return;
     }
     const auto& macro = node.get_macro();
-    auto value = node.get_value();
+    const auto& value = node.get_value();
     if (macro) {
         macro->accept(*this);
     } else {
@@ -71,7 +71,7 @@ void CodegenCVisitor::visit_integer(Integer& node) {
 }
 
 
-void CodegenCVisitor::visit_float(Float& node) {
+void CodegenCVisitor::visit_float(const Float& node) {
     if (!codegen) {
         return;
     }
@@ -79,7 +79,7 @@ void CodegenCVisitor::visit_float(Float& node) {
 }
 
 
-void CodegenCVisitor::visit_double(Double& node) {
+void CodegenCVisitor::visit_double(const Double& node) {
     if (!codegen) {
         return;
     }
@@ -87,7 +87,7 @@ void CodegenCVisitor::visit_double(Double& node) {
 }
 
 
-void CodegenCVisitor::visit_boolean(Boolean& node) {
+void CodegenCVisitor::visit_boolean(const Boolean& node) {
     if (!codegen) {
         return;
     }
@@ -95,7 +95,7 @@ void CodegenCVisitor::visit_boolean(Boolean& node) {
 }
 
 
-void CodegenCVisitor::visit_name(Name& node) {
+void CodegenCVisitor::visit_name(const Name& node) {
     if (!codegen) {
         return;
     }
@@ -103,12 +103,12 @@ void CodegenCVisitor::visit_name(Name& node) {
 }
 
 
-void CodegenCVisitor::visit_unit(ast::Unit& node) {
+void CodegenCVisitor::visit_unit(const ast::Unit& node) {
     // do not print units
 }
 
 
-void CodegenCVisitor::visit_prime_name(PrimeName& node) {
+void CodegenCVisitor::visit_prime_name(const PrimeName& node) {
     throw std::runtime_error("PRIME encountered during code generation, ODEs not solved?");
 }
 
@@ -116,7 +116,7 @@ void CodegenCVisitor::visit_prime_name(PrimeName& node) {
 /**
  * \todo : Validate how @ is being handled in neuron implementation
  */
-void CodegenCVisitor::visit_var_name(VarName& node) {
+void CodegenCVisitor::visit_var_name(const VarName& node) {
     if (!codegen) {
         return;
     }
@@ -136,7 +136,7 @@ void CodegenCVisitor::visit_var_name(VarName& node) {
 }
 
 
-void CodegenCVisitor::visit_indexed_name(IndexedName& node) {
+void CodegenCVisitor::visit_indexed_name(const IndexedName& node) {
     if (!codegen) {
         return;
     }
@@ -147,7 +147,7 @@ void CodegenCVisitor::visit_indexed_name(IndexedName& node) {
 }
 
 
-void CodegenCVisitor::visit_local_list_statement(LocalListStatement& node) {
+void CodegenCVisitor::visit_local_list_statement(const LocalListStatement& node) {
     if (!codegen) {
         return;
     }
@@ -157,7 +157,7 @@ void CodegenCVisitor::visit_local_list_statement(LocalListStatement& node) {
 }
 
 
-void CodegenCVisitor::visit_if_statement(IfStatement& node) {
+void CodegenCVisitor::visit_if_statement(const IfStatement& node) {
     if (!codegen) {
         return;
     }
@@ -173,7 +173,7 @@ void CodegenCVisitor::visit_if_statement(IfStatement& node) {
 }
 
 
-void CodegenCVisitor::visit_else_if_statement(ElseIfStatement& node) {
+void CodegenCVisitor::visit_else_if_statement(const ElseIfStatement& node) {
     if (!codegen) {
         return;
     }
@@ -184,7 +184,7 @@ void CodegenCVisitor::visit_else_if_statement(ElseIfStatement& node) {
 }
 
 
-void CodegenCVisitor::visit_else_statement(ElseStatement& node) {
+void CodegenCVisitor::visit_else_statement(const ElseStatement& node) {
     if (!codegen) {
         return;
     }
@@ -193,7 +193,7 @@ void CodegenCVisitor::visit_else_statement(ElseStatement& node) {
 }
 
 
-void CodegenCVisitor::visit_while_statement(WhileStatement& node) {
+void CodegenCVisitor::visit_while_statement(const WhileStatement& node) {
     printer->add_text("while (");
     node.get_condition()->accept(*this);
     printer->add_text(") ");
@@ -201,7 +201,7 @@ void CodegenCVisitor::visit_while_statement(WhileStatement& node) {
 }
 
 
-void CodegenCVisitor::visit_from_statement(ast::FromStatement& node) {
+void CodegenCVisitor::visit_from_statement(const ast::FromStatement& node) {
     if (!codegen) {
         return;
     }
@@ -225,7 +225,7 @@ void CodegenCVisitor::visit_from_statement(ast::FromStatement& node) {
 }
 
 
-void CodegenCVisitor::visit_paren_expression(ParenExpression& node) {
+void CodegenCVisitor::visit_paren_expression(const ParenExpression& node) {
     if (!codegen) {
         return;
     }
@@ -235,13 +235,13 @@ void CodegenCVisitor::visit_paren_expression(ParenExpression& node) {
 }
 
 
-void CodegenCVisitor::visit_binary_expression(BinaryExpression& node) {
+void CodegenCVisitor::visit_binary_expression(const BinaryExpression& node) {
     if (!codegen) {
         return;
     }
     auto op = node.get_op().eval();
-    auto lhs = node.get_lhs();
-    auto rhs = node.get_rhs();
+    const auto& lhs = node.get_lhs();
+    const auto& rhs = node.get_rhs();
     if (op == "^") {
         printer->add_text("pow(");
         lhs->accept(*this);
@@ -256,7 +256,7 @@ void CodegenCVisitor::visit_binary_expression(BinaryExpression& node) {
 }
 
 
-void CodegenCVisitor::visit_binary_operator(BinaryOperator& node) {
+void CodegenCVisitor::visit_binary_operator(const BinaryOperator& node) {
     if (!codegen) {
         return;
     }
@@ -264,7 +264,7 @@ void CodegenCVisitor::visit_binary_operator(BinaryOperator& node) {
 }
 
 
-void CodegenCVisitor::visit_unary_operator(UnaryOperator& node) {
+void CodegenCVisitor::visit_unary_operator(const UnaryOperator& node) {
     if (!codegen) {
         return;
     }
@@ -277,7 +277,7 @@ void CodegenCVisitor::visit_unary_operator(UnaryOperator& node) {
  * Sometime we want to analyse ast nodes even if code generation is
  * false. Hence we visit children even if code generation is false.
  */
-void CodegenCVisitor::visit_statement_block(StatementBlock& node) {
+void CodegenCVisitor::visit_statement_block(const StatementBlock& node) {
     if (!codegen) {
         node.visit_children(*this);
         return;
@@ -286,7 +286,7 @@ void CodegenCVisitor::visit_statement_block(StatementBlock& node) {
 }
 
 
-void CodegenCVisitor::visit_function_call(FunctionCall& node) {
+void CodegenCVisitor::visit_function_call(const FunctionCall& node) {
     if (!codegen) {
         return;
     }
@@ -294,7 +294,7 @@ void CodegenCVisitor::visit_function_call(FunctionCall& node) {
 }
 
 
-void CodegenCVisitor::visit_verbatim(Verbatim& node) {
+void CodegenCVisitor::visit_verbatim(const Verbatim& node) {
     if (!codegen) {
         return;
     }
@@ -1279,13 +1279,13 @@ std::string CodegenCVisitor::k_const() {
 /****************************************************************************************/
 
 
-void CodegenCVisitor::visit_watch_statement(ast::WatchStatement& node) {
+void CodegenCVisitor::visit_watch_statement(const ast::WatchStatement& node) {
     printer->add_text("nrn_watch_activate(inst, id, pnodecount, {}, v, watch_remove)"_format(
         current_watch_statement++));
 }
 
 
-void CodegenCVisitor::print_statement_block(ast::StatementBlock& node,
+void CodegenCVisitor::print_statement_block(const ast::StatementBlock& node,
                                             bool open_brace,
                                             bool close_brace) {
     if (open_brace) {
@@ -1314,7 +1314,7 @@ void CodegenCVisitor::print_statement_block(ast::StatementBlock& node,
 }
 
 
-void CodegenCVisitor::print_function_call(FunctionCall& node) {
+void CodegenCVisitor::print_function_call(const FunctionCall& node) {
     auto name = node.get_node_name();
     auto function_name = name;
     if (defined_method(name)) {
@@ -1424,7 +1424,7 @@ void CodegenCVisitor::print_function_prototypes() {
 }
 
 
-static TableStatement* get_table_statement(ast::Block& node) {
+static const TableStatement* get_table_statement(const ast::Block& node) {
     // TableStatementVisitor v;
 
     const auto& table_statements = collect_nodes(node, {AstNodeType::TABLE_STATEMENT});
@@ -1435,11 +1435,11 @@ static TableStatement* get_table_statement(ast::Block& node) {
                                                                  table_statements.size());
         throw std::runtime_error(message);
     }
-    return dynamic_cast<TableStatement*>(table_statements.front().get());
+    return dynamic_cast<const TableStatement*>(table_statements.front().get());
 }
 
 
-void CodegenCVisitor::print_table_check_function(Block& node) {
+void CodegenCVisitor::print_table_check_function(const Block& node) {
     auto statement = get_table_statement(node);
     auto table_variables = statement->get_table_vars();
     auto depend_variables = statement->get_depend_vars();
@@ -1521,7 +1521,7 @@ void CodegenCVisitor::print_table_check_function(Block& node) {
 }
 
 
-void CodegenCVisitor::print_table_replacement_function(ast::Block& node) {
+void CodegenCVisitor::print_table_replacement_function(const ast::Block& node) {
     auto name = node.get_node_name();
     auto statement = get_table_statement(node);
     auto table_variables = statement->get_table_vars();
@@ -1607,7 +1607,7 @@ void CodegenCVisitor::print_check_table_thread_function() {
 }
 
 
-void CodegenCVisitor::print_function_or_procedure(ast::Block& node, const std::string& name) {
+void CodegenCVisitor::print_function_or_procedure(const ast::Block& node, const std::string& name) {
     printer->add_newline(2);
     print_function_declaration(node, name);
     printer->add_text(" ");
@@ -1627,7 +1627,7 @@ void CodegenCVisitor::print_function_or_procedure(ast::Block& node, const std::s
 }
 
 
-void CodegenCVisitor::print_function_procedure_helper(ast::Block& node) {
+void CodegenCVisitor::print_function_procedure_helper(const ast::Block& node) {
     codegen = true;
     auto name = node.get_node_name();
 
@@ -1644,12 +1644,12 @@ void CodegenCVisitor::print_function_procedure_helper(ast::Block& node) {
 }
 
 
-void CodegenCVisitor::print_procedure(ast::ProcedureBlock& node) {
+void CodegenCVisitor::print_procedure(const ast::ProcedureBlock& node) {
     print_function_procedure_helper(node);
 }
 
 
-void CodegenCVisitor::print_function(ast::FunctionBlock& node) {
+void CodegenCVisitor::print_function(const ast::FunctionBlock& node) {
     auto name = node.get_node_name();
 
     // name of return variable
@@ -1679,7 +1679,7 @@ std::string CodegenCVisitor::find_var_unique_name(const std::string& original_na
     return unique_name;
 }
 
-void CodegenCVisitor::visit_eigen_newton_solver_block(ast::EigenNewtonSolverBlock& node) {
+void CodegenCVisitor::visit_eigen_newton_solver_block(const ast::EigenNewtonSolverBlock& node) {
     // solution vector to store copy of state vars for Newton solver
     printer->add_newline();
 
@@ -1751,7 +1751,7 @@ void CodegenCVisitor::visit_eigen_newton_solver_block(ast::EigenNewtonSolverBloc
     printer->add_line("newton_functor.finalize();");
 }
 
-void CodegenCVisitor::visit_eigen_linear_solver_block(ast::EigenLinearSolverBlock& node) {
+void CodegenCVisitor::visit_eigen_linear_solver_block(const ast::EigenLinearSolverBlock& node) {
     printer->add_newline();
 
     // Check if there is a variable defined in the mod file as X, J, Jm or F and if yes
@@ -3187,7 +3187,7 @@ void CodegenCVisitor::print_instance_variable_setup() {
 }
 
 
-void CodegenCVisitor::print_initial_block(InitialBlock* node) {
+void CodegenCVisitor::print_initial_block(const InitialBlock* node) {
     if (info.artificial_cell) {
         printer->add_line("double v = 0.0;");
     } else {
@@ -3457,7 +3457,7 @@ void CodegenCVisitor::print_watch_check() {
 }
 
 
-void CodegenCVisitor::print_net_receive_common_code(Block& node, bool need_mech_inst) {
+void CodegenCVisitor::print_net_receive_common_code(const Block& node, bool need_mech_inst) {
     printer->add_line("int tid = pnt->_tid;");
     printer->add_line("int id = pnt->_i_instance;");
     printer->add_line("double v = 0;");
@@ -3495,7 +3495,7 @@ void CodegenCVisitor::print_net_receive_common_code(Block& node, bool need_mech_
 }
 
 
-void CodegenCVisitor::print_net_send_call(FunctionCall& node) {
+void CodegenCVisitor::print_net_send_call(const FunctionCall& node) {
     auto arguments = node.get_arguments();
     auto tqitem = get_variable_name("tqitem");
     std::string weight_index = "weight_index";
@@ -3527,7 +3527,7 @@ void CodegenCVisitor::print_net_send_call(FunctionCall& node) {
 }
 
 
-void CodegenCVisitor::print_net_move_call(FunctionCall& node) {
+void CodegenCVisitor::print_net_move_call(const FunctionCall& node) {
     if (!printing_net_receive) {
         std::cout << "Error : net_move only allowed in NET_RECEIVE block" << std::endl;
         abort();
@@ -3555,8 +3555,8 @@ void CodegenCVisitor::print_net_move_call(FunctionCall& node) {
 }
 
 
-void CodegenCVisitor::print_net_event_call(FunctionCall& node) {
-    auto arguments = node.get_arguments();
+void CodegenCVisitor::print_net_event_call(const FunctionCall& node) {
+    const auto& arguments = node.get_arguments();
     if (info.artificial_cell) {
         printer->add_text("net_event(pnt, ");
         print_vector_elements(arguments, ", ");
@@ -3594,7 +3594,7 @@ void CodegenCVisitor::print_net_event_call(FunctionCall& node) {
  *
  * So, the `R` in AST needs to be renamed with `(*R)`.
  */
-static void rename_net_receive_arguments(ast::NetReceiveBlock& net_receive_node, ast::Node& node) {
+static void rename_net_receive_arguments(const ast::NetReceiveBlock& net_receive_node, const ast::Node& node) {
     auto parameters = net_receive_node.get_parameters();
     for (auto& parameter: parameters) {
         auto name = parameter->get_node_name();
@@ -3757,7 +3757,7 @@ void CodegenCVisitor::print_net_send_buffering() {
 }
 
 
-void CodegenCVisitor::visit_for_netcon(ast::ForNetcon& node) {
+void CodegenCVisitor::visit_for_netcon(const ast::ForNetcon& node) {
     // For_netcon should take the same arguments as net_receive and apply the operations
     // in the block to the weights of the netcons. Since all the weights are on the same vector,
     // weights, we have a mask of operations that we apply iteratively, advancing the offset
@@ -3973,7 +3973,7 @@ void CodegenCVisitor::print_newtonspace_transfer_to_device() const {
 }
 
 
-void CodegenCVisitor::visit_derivimplicit_callback(ast::DerivimplicitCallback& node) {
+void CodegenCVisitor::visit_derivimplicit_callback(const ast::DerivimplicitCallback& node) {
     if (!codegen) {
         return;
     }
@@ -3992,7 +3992,7 @@ void CodegenCVisitor::visit_derivimplicit_callback(ast::DerivimplicitCallback& n
     printer->add_line(statement);
 }
 
-void CodegenCVisitor::visit_solution_expression(SolutionExpression& node) {
+void CodegenCVisitor::visit_solution_expression(const SolutionExpression& node) {
     auto block = node.get_node_to_solve().get();
     if (block->is_statement_block()) {
         auto statement_block = dynamic_cast<ast::StatementBlock*>(block);
@@ -4070,7 +4070,7 @@ void CodegenCVisitor::print_nrn_state() {
 /****************************************************************************************/
 
 
-void CodegenCVisitor::print_nrn_current(BreakpointBlock& node) {
+void CodegenCVisitor::print_nrn_current(const BreakpointBlock& node) {
     auto args = internal_method_parameters();
     const auto& block = node.get_statement_block();
     printer->add_newline(2);
@@ -4087,7 +4087,7 @@ void CodegenCVisitor::print_nrn_current(BreakpointBlock& node) {
 }
 
 
-void CodegenCVisitor::print_nrn_cur_conductance_kernel(BreakpointBlock& node) {
+void CodegenCVisitor::print_nrn_cur_conductance_kernel(const BreakpointBlock& node) {
     const auto& block = node.get_statement_block();
     print_statement_block(*block, false, false);
     if (!info.currents.empty()) {
@@ -4154,7 +4154,7 @@ void CodegenCVisitor::print_nrn_cur_non_conductance_kernel() {
 }
 
 
-void CodegenCVisitor::print_nrn_cur_kernel(BreakpointBlock& node) {
+void CodegenCVisitor::print_nrn_cur_kernel(const BreakpointBlock& node) {
     printer->add_line("int node_id = node_index[id];");
     printer->add_line("double v = voltage[node_id];");
     if (ion_variable_struct_required()) {
@@ -4358,7 +4358,7 @@ void CodegenCVisitor::set_codegen_global_variables(std::vector<SymbolType>& glob
 }
 
 
-void CodegenCVisitor::setup(Program& node) {
+void CodegenCVisitor::setup(const Program& node) {
     program_symtab = node.get_symbol_table();
 
     CodegenHelperVisitor v;
@@ -4378,7 +4378,7 @@ void CodegenCVisitor::setup(Program& node) {
 }
 
 
-void CodegenCVisitor::visit_program(Program& node) {
+void CodegenCVisitor::visit_program(const Program& node) {
     setup(node);
     print_codegen_routines();
     print_wrapper_routines();

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -104,7 +104,7 @@ enum class MemberType {
  */
 struct IndexVariableInfo {
     /// symbol for the variable
-    std::shared_ptr<symtab::Symbol> symbol;
+    const std::shared_ptr<symtab::Symbol> symbol;
 
     /// if variable reside in vdata field of NrnThread
     /// typically true for bbcore pointer
@@ -121,11 +121,11 @@ struct IndexVariableInfo {
     /// if the variable is qualified as constant (this is property of IndexVariable)
     bool is_constant = false;
 
-    IndexVariableInfo(const std::shared_ptr<symtab::Symbol>& symbol,
+    IndexVariableInfo(std::shared_ptr<symtab::Symbol> symbol,
                       bool is_vdata = false,
                       bool is_index = false,
                       bool is_integer = false)
-        : symbol(symbol)
+        : symbol(std::move(symbol))
         , is_vdata(is_vdata)
         , is_index(is_index)
         , is_integer(is_integer) {}
@@ -185,7 +185,7 @@ using printer::CodePrinter;
  *    error checking. For example, see netstim.mod where we
  *    have removed return from verbatim block.
  */
-class CodegenCVisitor: public visitor::AstVisitor {
+class CodegenCVisitor: public visitor::ConstAstVisitor {
   protected:
     using SymbolType = std::shared_ptr<symtab::Symbol>;
 
@@ -723,7 +723,7 @@ class CodegenCVisitor: public visitor::AstVisitor {
      * \param open_brace  Print an opening brace if \c false
      * \param close_brace Print a closing brace if \c true
      */
-    void print_statement_block(ast::StatementBlock& node,
+    void print_statement_block(const ast::StatementBlock& node,
                                bool open_brace = true,
                                bool close_brace = true);
 
@@ -1220,28 +1220,28 @@ class CodegenCVisitor: public visitor::AstVisitor {
      * Print call to internal or external function
      * \param node The AST node representing a function call
      */
-    void print_function_call(ast::FunctionCall& node);
+    void print_function_call(const ast::FunctionCall& node);
 
 
     /**
      * Print call to \c net\_send
      * \param node The AST node representing the function call
      */
-    void print_net_send_call(ast::FunctionCall& node);
+    void print_net_send_call(const ast::FunctionCall& node);
 
 
     /**
      * Print call to net\_move
      * \param node The AST node representing the function call
      */
-    void print_net_move_call(ast::FunctionCall& node);
+    void print_net_move_call(const ast::FunctionCall& node);
 
 
     /**
      * Print call to net\_event
      * \param node The AST node representing the function call
      */
-    void print_net_event_call(ast::FunctionCall& node);
+    void print_net_event_call(const ast::FunctionCall& node);
 
 
     /**
@@ -1337,14 +1337,14 @@ class CodegenCVisitor: public visitor::AstVisitor {
      * \param node the AST node representing the function or procedure in NMODL
      * \param name the name of the function or procedure
      */
-    void print_function_or_procedure(ast::Block& node, const std::string& name);
+    void print_function_or_procedure(const ast::Block& node, const std::string& name);
 
 
     /**
      * Common helper function to help printing function or procedure blocks
      * \param node the AST node representing the function or procedure in NMODL
      */
-    void print_function_procedure_helper(ast::Block& node);
+    void print_function_procedure_helper(const ast::Block& node);
 
     /**
      * Print thread related memory allocation and deallocation callbacks
@@ -1375,7 +1375,7 @@ class CodegenCVisitor: public visitor::AstVisitor {
      *
      * \param node The AST Node representing a NMODL initial block
      */
-    void print_initial_block(ast::InitialBlock* node);
+    void print_initial_block(const ast::InitialBlock* node);
 
 
     /**
@@ -1391,7 +1391,7 @@ class CodegenCVisitor: public visitor::AstVisitor {
      * \param need_mech_inst \c true if a local \c inst variable needs to be defined in generated
      * code
      */
-    void print_net_receive_common_code(ast::Block& node, bool need_mech_inst = true);
+    void print_net_receive_common_code(const ast::Block& node, bool need_mech_inst = true);
 
 
     /**
@@ -1506,7 +1506,7 @@ class CodegenCVisitor: public visitor::AstVisitor {
      * Print main body of nrn_cur function
      * \param node the AST node representing the NMODL breakpoint block
      */
-    void print_nrn_cur_kernel(ast::BreakpointBlock& node);
+    void print_nrn_cur_kernel(const ast::BreakpointBlock& node);
 
 
     /**
@@ -1517,7 +1517,7 @@ class CodegenCVisitor: public visitor::AstVisitor {
      *
      * \param node the AST node representing the NMODL breakpoint block
      */
-    void print_nrn_cur_conductance_kernel(ast::BreakpointBlock& node);
+    void print_nrn_cur_conductance_kernel(const ast::BreakpointBlock& node);
 
 
     /**
@@ -1535,7 +1535,7 @@ class CodegenCVisitor: public visitor::AstVisitor {
      * \note nrn_cur_kernel will have two calls to nrn_current if no conductance keywords specified
      * \param node the AST node representing the NMODL breakpoint block
      */
-    void print_nrn_current(ast::BreakpointBlock& node);
+    void print_nrn_current(const ast::BreakpointBlock& node);
 
 
     /**
@@ -1677,17 +1677,17 @@ class CodegenCVisitor: public visitor::AstVisitor {
      *                     as-is in the target code. This defaults to \c double.
      * \param extension    The file extension to use. This defaults to \c .cpp .
      */
-    CodegenCVisitor(const std::string& mod_filename,
+    CodegenCVisitor(std::string mod_filename,
                     const std::string& output_dir,
                     LayoutType layout,
-                    const std::string& float_type,
+                    std::string float_type,
                     const bool optimize_ionvar_copies,
                     const std::string& extension = ".cpp")
         : target_printer(new CodePrinter(output_dir + "/" + mod_filename + extension))
         , printer(target_printer)
-        , mod_filename(mod_filename)
+        , mod_filename(std::move(mod_filename))
         , layout(layout)
-        , float_type(float_type)
+        , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
 
     /**
@@ -1802,28 +1802,28 @@ class CodegenCVisitor: public visitor::AstVisitor {
      * Print \c check\_function() for functions or procedure using table
      * \param node The AST node representing a function or procedure block
      */
-    void print_table_check_function(ast::Block& node);
+    void print_table_check_function(const ast::Block& node);
 
 
     /**
      * Print replacement function for function or procedure using table
      * \param node The AST node representing a function or procedure block
      */
-    void print_table_replacement_function(ast::Block& node);
+    void print_table_replacement_function(const ast::Block& node);
 
 
     /**
      * Print NMODL function in target backend code
      * \param node
      */
-    void print_function(ast::FunctionBlock& node);
+    void print_function(const ast::FunctionBlock& node);
 
 
     /**
      * Print NMODL procedure in target backend code
      * \param node
      */
-    virtual void print_procedure(ast::ProcedureBlock& node);
+    virtual void print_procedure(const ast::ProcedureBlock& node);
 
 
     /** Setup the target backend code generator
@@ -1831,7 +1831,7 @@ class CodegenCVisitor: public visitor::AstVisitor {
      * Typically called from within \c visit\_program but may be called from
      * specialized targets to setup this Code generator as fallback.
      */
-    void setup(ast::Program& node);
+    void setup(const ast::Program& node);
 
 
     /**
@@ -1848,36 +1848,36 @@ class CodegenCVisitor: public visitor::AstVisitor {
      */
     std::string find_var_unique_name(const std::string& original_name) const;
 
-    void visit_binary_expression(ast::BinaryExpression& node) override;
-    void visit_binary_operator(ast::BinaryOperator& node) override;
-    void visit_boolean(ast::Boolean& node) override;
-    void visit_double(ast::Double& node) override;
-    void visit_else_if_statement(ast::ElseIfStatement& node) override;
-    void visit_else_statement(ast::ElseStatement& node) override;
-    void visit_float(ast::Float& node) override;
-    void visit_from_statement(ast::FromStatement& node) override;
-    void visit_function_call(ast::FunctionCall& node) override;
-    void visit_eigen_newton_solver_block(ast::EigenNewtonSolverBlock& node) override;
-    void visit_eigen_linear_solver_block(ast::EigenLinearSolverBlock& node) override;
-    void visit_if_statement(ast::IfStatement& node) override;
-    void visit_indexed_name(ast::IndexedName& node) override;
-    void visit_integer(ast::Integer& node) override;
-    void visit_local_list_statement(ast::LocalListStatement& node) override;
-    void visit_name(ast::Name& node) override;
-    void visit_paren_expression(ast::ParenExpression& node) override;
-    void visit_prime_name(ast::PrimeName& node) override;
-    void visit_program(ast::Program& node) override;
-    void visit_statement_block(ast::StatementBlock& node) override;
-    void visit_string(ast::String& node) override;
-    void visit_solution_expression(ast::SolutionExpression& node) override;
-    void visit_unary_operator(ast::UnaryOperator& node) override;
-    void visit_unit(ast::Unit& node) override;
-    void visit_var_name(ast::VarName& node) override;
-    void visit_verbatim(ast::Verbatim& node) override;
-    void visit_watch_statement(ast::WatchStatement& node) override;
-    void visit_while_statement(ast::WhileStatement& node) override;
-    void visit_derivimplicit_callback(ast::DerivimplicitCallback& node) override;
-    void visit_for_netcon(ast::ForNetcon& node) override;
+    void visit_binary_expression(const ast::BinaryExpression& node) override;
+    void visit_binary_operator(const ast::BinaryOperator& node) override;
+    void visit_boolean(const ast::Boolean& node) override;
+    void visit_double(const ast::Double& node) override;
+    void visit_else_if_statement(const ast::ElseIfStatement& node) override;
+    void visit_else_statement(const ast::ElseStatement& node) override;
+    void visit_float(const ast::Float& node) override;
+    void visit_from_statement(const ast::FromStatement& node) override;
+    void visit_function_call(const ast::FunctionCall& node) override;
+    void visit_eigen_newton_solver_block(const ast::EigenNewtonSolverBlock& node) override;
+    void visit_eigen_linear_solver_block(const ast::EigenLinearSolverBlock& node) override;
+    void visit_if_statement(const ast::IfStatement& node) override;
+    void visit_indexed_name(const ast::IndexedName& node) override;
+    void visit_integer(const ast::Integer& node) override;
+    void visit_local_list_statement(const ast::LocalListStatement& node) override;
+    void visit_name(const ast::Name& node) override;
+    void visit_paren_expression(const ast::ParenExpression& node) override;
+    void visit_prime_name(const ast::PrimeName& node) override;
+    void visit_program(const ast::Program& node) override;
+    void visit_statement_block(const ast::StatementBlock& node) override;
+    void visit_string(const ast::String& node) override;
+    void visit_solution_expression(const ast::SolutionExpression& node) override;
+    void visit_unary_operator(const ast::UnaryOperator& node) override;
+    void visit_unit(const ast::Unit& node) override;
+    void visit_var_name(const ast::VarName& node) override;
+    void visit_verbatim(const ast::Verbatim& node) override;
+    void visit_watch_statement(const ast::WatchStatement& node) override;
+    void visit_while_statement(const ast::WhileStatement& node) override;
+    void visit_derivimplicit_callback(const ast::DerivimplicitCallback& node) override;
+    void visit_for_netcon(const ast::ForNetcon& node) override;
 };
 
 

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1677,7 +1677,7 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      *                     as-is in the target code. This defaults to \c double.
      * \param extension    The file extension to use. This defaults to \c .cpp .
      */
-    CodegenCVisitor(std::string mod_filename,
+    CodegenCVisitor(const std::string& mod_filename,
                     const std::string& output_dir,
                     LayoutType layout,
                     std::string float_type,
@@ -1685,7 +1685,7 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
                     const std::string& extension = ".cpp")
         : target_printer(new CodePrinter(output_dir + "/" + mod_filename + extension))
         , printer(target_printer)
-        , mod_filename(std::move(mod_filename))
+        , mod_filename(mod_filename)
         , layout(layout)
         , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}

--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -411,7 +411,7 @@ void CodegenHelperVisitor::find_table_variables() {
 }
 
 
-void CodegenHelperVisitor::visit_suffix(Suffix& node) {
+void CodegenHelperVisitor::visit_suffix(const Suffix& node) {
     const auto& type = node.get_type()->get_node_name();
     if (type == naming::POINT_PROCESS) {
         info.point_process = true;
@@ -424,12 +424,12 @@ void CodegenHelperVisitor::visit_suffix(Suffix& node) {
 }
 
 
-void CodegenHelperVisitor::visit_electrode_current(ElectrodeCurrent& node) {
+void CodegenHelperVisitor::visit_electrode_current(const ElectrodeCurrent& node) {
     info.electrode_current = true;
 }
 
 
-void CodegenHelperVisitor::visit_initial_block(InitialBlock& node) {
+void CodegenHelperVisitor::visit_initial_block(const InitialBlock& node) {
     if (under_net_receive_block) {
         info.net_receive_initial_node = &node;
     } else {
@@ -439,7 +439,7 @@ void CodegenHelperVisitor::visit_initial_block(InitialBlock& node) {
 }
 
 
-void CodegenHelperVisitor::visit_net_receive_block(NetReceiveBlock& node) {
+void CodegenHelperVisitor::visit_net_receive_block(const NetReceiveBlock& node) {
     under_net_receive_block = true;
     info.net_receive_node = &node;
     info.num_net_receive_parameters = node.get_parameters().size();
@@ -448,18 +448,18 @@ void CodegenHelperVisitor::visit_net_receive_block(NetReceiveBlock& node) {
 }
 
 
-void CodegenHelperVisitor::visit_derivative_block(DerivativeBlock& node) {
+void CodegenHelperVisitor::visit_derivative_block(const DerivativeBlock& node) {
     under_derivative_block = true;
     node.visit_children(*this);
     under_derivative_block = false;
 }
 
-void CodegenHelperVisitor::visit_derivimplicit_callback(ast::DerivimplicitCallback& node) {
+void CodegenHelperVisitor::visit_derivimplicit_callback(const ast::DerivimplicitCallback& node) {
     info.derivimplicit_callbacks.push_back(&node);
 }
 
 
-void CodegenHelperVisitor::visit_breakpoint_block(BreakpointBlock& node) {
+void CodegenHelperVisitor::visit_breakpoint_block(const BreakpointBlock& node) {
     under_breakpoint_block = true;
     info.breakpoint_node = &node;
     node.visit_children(*this);
@@ -467,13 +467,13 @@ void CodegenHelperVisitor::visit_breakpoint_block(BreakpointBlock& node) {
 }
 
 
-void CodegenHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
+void CodegenHelperVisitor::visit_nrn_state_block(const ast::NrnStateBlock& node) {
     info.nrn_state_block = &node;
     node.visit_children(*this);
 }
 
 
-void CodegenHelperVisitor::visit_procedure_block(ast::ProcedureBlock& node) {
+void CodegenHelperVisitor::visit_procedure_block(const ast::ProcedureBlock& node) {
     info.procedures.push_back(&node);
     node.visit_children(*this);
     if (table_statement_used) {
@@ -483,7 +483,7 @@ void CodegenHelperVisitor::visit_procedure_block(ast::ProcedureBlock& node) {
 }
 
 
-void CodegenHelperVisitor::visit_function_block(ast::FunctionBlock& node) {
+void CodegenHelperVisitor::visit_function_block(const ast::FunctionBlock& node) {
     info.functions.push_back(&node);
     node.visit_children(*this);
     if (table_statement_used) {
@@ -493,15 +493,17 @@ void CodegenHelperVisitor::visit_function_block(ast::FunctionBlock& node) {
 }
 
 
-void CodegenHelperVisitor::visit_eigen_newton_solver_block(ast::EigenNewtonSolverBlock& node) {
+void CodegenHelperVisitor::visit_eigen_newton_solver_block(
+    const ast::EigenNewtonSolverBlock& node) {
     info.eigen_newton_solver_exist = true;
 }
 
-void CodegenHelperVisitor::visit_eigen_linear_solver_block(ast::EigenLinearSolverBlock& node) {
+void CodegenHelperVisitor::visit_eigen_linear_solver_block(
+    const ast::EigenLinearSolverBlock& node) {
     info.eigen_linear_solver_exist = true;
 }
 
-void CodegenHelperVisitor::visit_function_call(FunctionCall& node) {
+void CodegenHelperVisitor::visit_function_call(const FunctionCall& node) {
     auto name = node.get_node_name();
     if (name == naming::NET_SEND_METHOD) {
         info.net_send_used = true;
@@ -512,7 +514,7 @@ void CodegenHelperVisitor::visit_function_call(FunctionCall& node) {
 }
 
 
-void CodegenHelperVisitor::visit_conductance_hint(ConductanceHint& node) {
+void CodegenHelperVisitor::visit_conductance_hint(const ConductanceHint& node) {
     const auto& ion = node.get_ion();
     const auto& variable = node.get_conductance();
     std::string ion_name;
@@ -538,7 +540,7 @@ void CodegenHelperVisitor::visit_conductance_hint(ConductanceHint& node) {
  * is because prime_variables_by_order should contain state variable name and
  * not the one replaced by solver pass.
  */
-void CodegenHelperVisitor::visit_statement_block(ast::StatementBlock& node) {
+void CodegenHelperVisitor::visit_statement_block(const ast::StatementBlock& node) {
     const auto& statements = node.get_statements();
     for (auto& statement: statements) {
         statement->accept(*this);
@@ -562,12 +564,12 @@ void CodegenHelperVisitor::visit_statement_block(ast::StatementBlock& node) {
     }
 }
 
-void CodegenHelperVisitor::visit_factor_def(ast::FactorDef& node) {
+void CodegenHelperVisitor::visit_factor_def(const ast::FactorDef& node) {
     info.factor_definitions.push_back(&node);
 }
 
 
-void CodegenHelperVisitor::visit_binary_expression(BinaryExpression& node) {
+void CodegenHelperVisitor::visit_binary_expression(const BinaryExpression& node) {
     if (node.get_op().eval() == "=") {
         assign_lhs = node.get_lhs();
     }
@@ -576,34 +578,34 @@ void CodegenHelperVisitor::visit_binary_expression(BinaryExpression& node) {
 }
 
 
-void CodegenHelperVisitor::visit_bbcore_pointer(BbcorePointer& node) {
+void CodegenHelperVisitor::visit_bbcore_pointer(const BbcorePointer& node) {
     info.bbcore_pointer_used = true;
 }
 
 
-void CodegenHelperVisitor::visit_watch(ast::Watch& node) {
+void CodegenHelperVisitor::visit_watch(const ast::Watch& node) {
     info.watch_count++;
 }
 
 
-void CodegenHelperVisitor::visit_watch_statement(ast::WatchStatement& node) {
+void CodegenHelperVisitor::visit_watch_statement(const ast::WatchStatement& node) {
     info.watch_statements.push_back(&node);
     node.visit_children(*this);
 }
 
 
-void CodegenHelperVisitor::visit_for_netcon(ast::ForNetcon& node) {
+void CodegenHelperVisitor::visit_for_netcon(const ast::ForNetcon& node) {
     info.for_netcon_used = true;
 }
 
 
-void CodegenHelperVisitor::visit_table_statement(ast::TableStatement& node) {
+void CodegenHelperVisitor::visit_table_statement(const ast::TableStatement& node) {
     info.table_count++;
     table_statement_used = true;
 }
 
 
-void CodegenHelperVisitor::visit_program(ast::Program& node) {
+void CodegenHelperVisitor::visit_program(const ast::Program& node) {
     psymtab = node.get_symbol_table();
     auto blocks = node.get_blocks();
     for (auto& block: blocks) {
@@ -620,24 +622,24 @@ void CodegenHelperVisitor::visit_program(ast::Program& node) {
 }
 
 
-codegen::CodegenInfo CodegenHelperVisitor::analyze(ast::Program& node) {
+codegen::CodegenInfo CodegenHelperVisitor::analyze(const ast::Program& node) {
     node.accept(*this);
     return info;
 }
 
-void CodegenHelperVisitor::visit_linear_block(ast::LinearBlock& node) {
+void CodegenHelperVisitor::visit_linear_block(const ast::LinearBlock& node) {
     info.vectorize = false;
 }
 
-void CodegenHelperVisitor::visit_non_linear_block(ast::NonLinearBlock& node) {
+void CodegenHelperVisitor::visit_non_linear_block(const ast::NonLinearBlock& node) {
     info.vectorize = false;
 }
 
-void CodegenHelperVisitor::visit_discrete_block(ast::DiscreteBlock& node) {
+void CodegenHelperVisitor::visit_discrete_block(const ast::DiscreteBlock& node) {
     info.vectorize = false;
 }
 
-void CodegenHelperVisitor::visit_partial_block(ast::PartialBlock& node) {
+void CodegenHelperVisitor::visit_partial_block(const ast::PartialBlock& node) {
     info.vectorize = false;
 }
 

--- a/src/codegen/codegen_helper_visitor.hpp
+++ b/src/codegen/codegen_helper_visitor.hpp
@@ -44,7 +44,7 @@ namespace codegen {
  *  - POINTER rng and if it's also assigned rng[4] then it is printed as one value.
  *    Need to check what is correct value.
  */
-class CodegenHelperVisitor: public visitor::AstVisitor {
+class CodegenHelperVisitor: public visitor::ConstAstVisitor {
     using SymbolType = std::shared_ptr<symtab::Symbol>;
 
     /// holds all codegen related information
@@ -78,35 +78,35 @@ class CodegenHelperVisitor: public visitor::AstVisitor {
     CodegenHelperVisitor() = default;
 
     /// run visitor and return information for code generation
-    codegen::CodegenInfo analyze(ast::Program& node);
+    codegen::CodegenInfo analyze(const ast::Program& node);
 
-    void visit_electrode_current(ast::ElectrodeCurrent& node) override;
-    void visit_suffix(ast::Suffix& node) override;
-    void visit_function_call(ast::FunctionCall& node) override;
-    void visit_binary_expression(ast::BinaryExpression& node) override;
-    void visit_conductance_hint(ast::ConductanceHint& node) override;
-    void visit_procedure_block(ast::ProcedureBlock& node) override;
-    void visit_function_block(ast::FunctionBlock& node) override;
-    void visit_eigen_newton_solver_block(ast::EigenNewtonSolverBlock& node) override;
-    void visit_eigen_linear_solver_block(ast::EigenLinearSolverBlock& node) override;
-    void visit_statement_block(ast::StatementBlock& node) override;
-    void visit_initial_block(ast::InitialBlock& node) override;
-    void visit_breakpoint_block(ast::BreakpointBlock& node) override;
-    void visit_derivative_block(ast::DerivativeBlock& node) override;
-    void visit_derivimplicit_callback(ast::DerivimplicitCallback& node) override;
-    void visit_net_receive_block(ast::NetReceiveBlock& node) override;
-    void visit_bbcore_pointer(ast::BbcorePointer& node) override;
-    void visit_watch(ast::Watch& node) override;
-    void visit_watch_statement(ast::WatchStatement& node) override;
-    void visit_for_netcon(ast::ForNetcon& node) override;
-    void visit_table_statement(ast::TableStatement& node) override;
-    void visit_program(ast::Program& node) override;
-    void visit_factor_def(ast::FactorDef& node) override;
-    void visit_nrn_state_block(ast::NrnStateBlock& node) override;
-    void visit_linear_block(ast::LinearBlock& node) override;
-    void visit_non_linear_block(ast::NonLinearBlock& node) override;
-    void visit_discrete_block(ast::DiscreteBlock& node) override;
-    void visit_partial_block(ast::PartialBlock& node) override;
+    void visit_electrode_current(const ast::ElectrodeCurrent& node) override;
+    void visit_suffix(const ast::Suffix& node) override;
+    void visit_function_call(const ast::FunctionCall& node) override;
+    void visit_binary_expression(const ast::BinaryExpression& node) override;
+    void visit_conductance_hint(const ast::ConductanceHint& node) override;
+    void visit_procedure_block(const ast::ProcedureBlock& node) override;
+    void visit_function_block(const ast::FunctionBlock& node) override;
+    void visit_eigen_newton_solver_block(const ast::EigenNewtonSolverBlock& node) override;
+    void visit_eigen_linear_solver_block(const ast::EigenLinearSolverBlock& node) override;
+    void visit_statement_block(const ast::StatementBlock& node) override;
+    void visit_initial_block(const ast::InitialBlock& node) override;
+    void visit_breakpoint_block(const ast::BreakpointBlock& node) override;
+    void visit_derivative_block(const ast::DerivativeBlock& node) override;
+    void visit_derivimplicit_callback(const ast::DerivimplicitCallback& node) override;
+    void visit_net_receive_block(const ast::NetReceiveBlock& node) override;
+    void visit_bbcore_pointer(const ast::BbcorePointer& node) override;
+    void visit_watch(const ast::Watch& node) override;
+    void visit_watch_statement(const ast::WatchStatement& node) override;
+    void visit_for_netcon(const ast::ForNetcon& node) override;
+    void visit_table_statement(const ast::TableStatement& node) override;
+    void visit_program(const ast::Program& node) override;
+    void visit_factor_def(const ast::FactorDef& node) override;
+    void visit_nrn_state_block(const ast::NrnStateBlock& node) override;
+    void visit_linear_block(const ast::LinearBlock& node) override;
+    void visit_non_linear_block(const ast::NonLinearBlock& node) override;
+    void visit_discrete_block(const ast::DiscreteBlock& node) override;
+    void visit_partial_block(const ast::PartialBlock& node) override;
 };
 
 /** @} */  // end of codegen_details

--- a/src/codegen/codegen_info.hpp
+++ b/src/codegen/codegen_info.hpp
@@ -58,7 +58,7 @@ struct Ion {
     Ion() = delete;
 
     Ion(std::string name)
-        : name(name) {}
+        : name(std::move(name)) {}
 
     /**
      * Check if variable name is a ionic current
@@ -67,7 +67,7 @@ struct Ion {
      * If it is read variable then also get NRNCURIN flag.
      * If it is write variables then also get NRNCUROUT flag.
      */
-    bool is_ionic_current(std::string text) const {
+    bool is_ionic_current(const std::string& text) const {
         return text == ("i" + name);
     }
 
@@ -76,7 +76,7 @@ struct Ion {
      *
      * This is equivalent of IONIN flag in mod2c.
      */
-    bool is_intra_cell_conc(std::string text) const {
+    bool is_intra_cell_conc(const std::string& text) const {
         return text == (name + "i");
     }
 
@@ -85,7 +85,7 @@ struct Ion {
      *
      * This is equivalent of IONOUT flag in mod2c.
      */
-    bool is_extra_cell_conc(std::string text) const {
+    bool is_extra_cell_conc(const std::string& text) const {
         return text == (name + "o");
     }
 
@@ -94,12 +94,12 @@ struct Ion {
      *
      * This is equivalent of IONEREV flag in mod2c.
      */
-    bool is_rev_potential(std::string text) const {
+    bool is_rev_potential(const std::string& text) const {
         return text == ("e" + name);
     }
 
     /// check if it is either internal or external concentration
-    bool is_ionic_conc(std::string text) const {
+    bool is_ionic_conc(const std::string& text) const {
         return is_intra_cell_conc(text) || is_extra_cell_conc(text);
     }
 };
@@ -241,34 +241,34 @@ struct CodegenInfo {
     int num_equations = 0;
 
     /// derivative block
-    ast::BreakpointBlock* breakpoint_node = nullptr;
+    const ast::BreakpointBlock* breakpoint_node = nullptr;
 
     /// nrn_state block
-    ast::NrnStateBlock* nrn_state_block = nullptr;
+    const ast::NrnStateBlock* nrn_state_block = nullptr;
 
     /// net receive block for point process
-    ast::NetReceiveBlock* net_receive_node = nullptr;
+    const ast::NetReceiveBlock* net_receive_node = nullptr;
 
     /// number of arguments to net_receive block
     int num_net_receive_parameters = 0;
 
     /// initial block within net receive block
-    ast::InitialBlock* net_receive_initial_node = nullptr;
+    const ast::InitialBlock* net_receive_initial_node = nullptr;
 
     /// initial block
-    ast::InitialBlock* initial_node = nullptr;
+    const ast::InitialBlock* initial_node = nullptr;
 
     /// all procedures defined in the mod file
-    std::vector<ast::ProcedureBlock*> procedures;
+    std::vector<const ast::ProcedureBlock*> procedures;
 
     /// derivimplicit callbacks need to be emited
-    std::vector<ast::DerivimplicitCallback*> derivimplicit_callbacks;
+    std::vector<const ast::DerivimplicitCallback*> derivimplicit_callbacks;
 
     /// all functions defined in the mod file
-    std::vector<ast::FunctionBlock*> functions;
+    std::vector<const ast::FunctionBlock*> functions;
 
     /// all factors defined in the mod file
-    std::vector<ast::FactorDef*> factor_definitions;
+    std::vector<const ast::FactorDef*> factor_definitions;
 
     /// ions used in the mod file
     std::vector<Ion> ions;
@@ -324,7 +324,7 @@ struct CodegenInfo {
     std::vector<SymbolType> table_assigned_variables;
 
     /// function or procedures with table statement
-    std::vector<ast::Block*> functions_with_table;
+    std::vector<const ast::Block*> functions_with_table;
 
     /// represent conductance statements used in mod file
     std::vector<Conductance> conductances;
@@ -342,7 +342,7 @@ struct CodegenInfo {
     std::vector<ast::Node*> top_verbatim_blocks;
 
     /// all watch statements
-    std::vector<ast::WatchStatement*> watch_statements;
+    std::vector<const ast::WatchStatement*> watch_statements;
 
     /// true if eigen newton solver is used
     bool eigen_newton_solver_exist = false;

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -45,7 +45,7 @@ const std::unordered_set<std::string> CodegenIspcVisitor::incompatible_var_names
 /*
  * Rename math functions for ISPC backend
  */
-void CodegenIspcVisitor::visit_function_call(ast::FunctionCall& node) {
+void CodegenIspcVisitor::visit_function_call(const ast::FunctionCall& node) {
     if (!codegen) {
         return;
     }
@@ -63,7 +63,7 @@ void CodegenIspcVisitor::visit_function_call(ast::FunctionCall& node) {
 /*
  * Rename special global variables
  */
-void CodegenIspcVisitor::visit_var_name(ast::VarName& node) {
+void CodegenIspcVisitor::visit_var_name(const ast::VarName& node) {
     if (!codegen) {
         return;
     }
@@ -74,7 +74,7 @@ void CodegenIspcVisitor::visit_var_name(ast::VarName& node) {
     CodegenCVisitor::visit_var_name(node);
 }
 
-void CodegenIspcVisitor::visit_local_list_statement(ast::LocalListStatement& node) {
+void CodegenIspcVisitor::visit_local_list_statement(const ast::LocalListStatement& node) {
     if (!codegen) {
         return;
     }
@@ -375,7 +375,7 @@ CodegenIspcVisitor::ParamVector CodegenIspcVisitor::get_global_function_parms(
 }
 
 
-void CodegenIspcVisitor::print_procedure(ast::ProcedureBlock& node) {
+void CodegenIspcVisitor::print_procedure(const ast::ProcedureBlock& node) {
     codegen = true;
     const auto& name = node.get_node_name();
     print_function_or_procedure(node, name);
@@ -655,7 +655,7 @@ bool CodegenIspcVisitor::check_incompatibilities() {
 void CodegenIspcVisitor::move_procs_to_wrapper() {
     auto nameset = std::set<std::string>();
 
-    auto populate_nameset = [&nameset](ast::Block* block) {
+    auto populate_nameset = [&nameset](const ast::Block* block) {
         if (block) {
             const auto& names = collect_nodes(*block, {ast::AstNodeType::NAME});
             for (const auto& name: names) {
@@ -671,7 +671,7 @@ void CodegenIspcVisitor::move_procs_to_wrapper() {
         return !collect_nodes(node, incompatible_node_types).empty();
     };
 
-    auto target_procedures = std::vector<ast::ProcedureBlock*>();
+    auto target_procedures = std::vector<const ast::ProcedureBlock*>();
     for (const auto& procedure: info.procedures) {
         const auto& name = procedure->get_name()->get_node_name();
         if (nameset.find(name) == nameset.end() || has_incompatible_nodes(*procedure)) {
@@ -681,7 +681,7 @@ void CodegenIspcVisitor::move_procs_to_wrapper() {
         }
     }
     info.procedures = target_procedures;
-    auto target_functions = std::vector<ast::FunctionBlock*>();
+    auto target_functions = std::vector<const ast::FunctionBlock*>();
     for (const auto& function: info.functions) {
         const auto& name = function->get_name()->get_node_name();
         if (nameset.find(name) == nameset.end() || has_incompatible_nodes(*function)) {
@@ -721,7 +721,7 @@ void CodegenIspcVisitor::print_block_wrappers_initial_equation_state() {
 }
 
 
-void CodegenIspcVisitor::visit_program(ast::Program& node) {
+void CodegenIspcVisitor::visit_program(const ast::Program& node) {
     setup(node);
 
     // we need setup to check incompatibilities

--- a/src/codegen/codegen_ispc_visitor.hpp
+++ b/src/codegen/codegen_ispc_visitor.hpp
@@ -56,8 +56,8 @@ class CodegenIspcVisitor: public CodegenCVisitor {
     std::vector<bool> emit_fallback =
         std::vector<bool>(static_cast<size_t>(BlockType::BlockTypeEnd), false);
 
-    std::vector<ast::ProcedureBlock*> wrapper_procedures;
-    std::vector<ast::FunctionBlock*> wrapper_functions;
+    std::vector<const ast::ProcedureBlock*> wrapper_procedures;
+    std::vector<const ast::FunctionBlock*> wrapper_functions;
 
   protected:
     /// doubles are differently represented in ispc than in C
@@ -159,7 +159,7 @@ class CodegenIspcVisitor: public CodegenCVisitor {
 
 
     /// nmodl procedure definition
-    void print_procedure(ast::ProcedureBlock& node) override;
+    void print_procedure(const ast::ProcedureBlock& node) override;
 
 
     void print_backend_compute_routine_decl();
@@ -239,10 +239,10 @@ class CodegenIspcVisitor: public CodegenCVisitor {
         : CodegenCVisitor(mod_file, stream, layout, float_type, optimize_ionvar_copies)
         , fallback_codegen(mod_file, layout, float_type, optimize_ionvar_copies, wrapper_printer) {}
 
-    void visit_function_call(ast::FunctionCall& node) override;
-    void visit_var_name(ast::VarName& node) override;
-    void visit_program(ast::Program& node) override;
-    void visit_local_list_statement(ast::LocalListStatement& node) override;
+    void visit_function_call(const ast::FunctionCall& node) override;
+    void visit_var_name(const ast::VarName& node) override;
+    void visit_program(const ast::Program& node) override;
+    void visit_local_list_statement(const ast::LocalListStatement& node) override;
 };
 
 /** @} */  // end of codegen_backends

--- a/src/lexer/main_c.cpp
+++ b/src/lexer/main_c.cpp
@@ -5,10 +5,9 @@
  * Lesser General Public License. See top-level LICENSE file for details.
  *************************************************************************/
 
-#include <fstream>
 #include <sstream>
 
-#include "CLI/CLI.hpp"
+#include <CLI/CLI.hpp>
 
 #include "config/config.h"
 #include "lexer/c11_lexer.hpp"

--- a/src/lexer/main_nmodl.cpp
+++ b/src/lexer/main_nmodl.cpp
@@ -8,7 +8,7 @@
 #include <fstream>
 #include <streambuf>
 
-#include "CLI/CLI.hpp"
+#include <CLI/CLI.hpp>
 
 #include "ast/ast.hpp"
 #include "config/config.h"

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -8,7 +8,7 @@
 #include <string>
 #include <vector>
 
-#include "CLI/CLI.hpp"
+#include <CLI/CLI.hpp>
 
 #include "ast/program.hpp"
 #include "codegen/codegen_acc_visitor.hpp"

--- a/src/parser/diffeq_context.cpp
+++ b/src/parser/diffeq_context.cpp
@@ -26,13 +26,13 @@ Term::Term(const std::string& expr, const std::string& state)
 }
 
 
-void Term::print() {
+void Term::print() const {
     std::cout << "Term [expr, deriv, a, b] : ";
     std::cout << expr << ", " << deriv << ", " << a << ", " << b << std::endl;
 }
 
 
-void DiffEqContext::print() {
+void DiffEqContext::print() const {
     std::cout << "-----------------DiffEq Context----------------" << std::endl;
     std::cout << "deriv_invalid = " << deriv_invalid << std::endl;
     std::cout << "eqn_invalid   = " << eqn_invalid << std::endl;
@@ -44,7 +44,7 @@ void DiffEqContext::print() {
 }
 
 
-std::string DiffEqContext::cvode_deriv() {
+std::string DiffEqContext::cvode_deriv() const {
     std::string result;
     if (!deriv_invalid) {
         result = solution.deriv;
@@ -53,7 +53,7 @@ std::string DiffEqContext::cvode_deriv() {
 }
 
 
-std::string DiffEqContext::cvode_eqnrhs() {
+std::string DiffEqContext::cvode_eqnrhs() const {
     std::string result;
     if (!eqn_invalid) {
         result = solution.b;
@@ -67,7 +67,7 @@ std::string DiffEqContext::cvode_eqnrhs() {
  * expression but with replacing every state variable with (state+0.001). In order
  * to do this we scan original expression and build new by replacing only state variable.
  */
-std::string DiffEqContext::get_expr_for_nonlinear() {
+std::string DiffEqContext::get_expr_for_nonlinear() const {
     std::string expression;
 
     /// build lexer instance
@@ -96,7 +96,7 @@ std::string DiffEqContext::get_expr_for_nonlinear() {
 /**
  * Return solution for non-cnexp method and when equation is linear
  */
-std::string DiffEqContext::get_cvode_linear_diffeq() {
+std::string DiffEqContext::get_cvode_linear_diffeq() const {
     auto result = "D" + state + " = " + "D" + state + "/(1.0-dt*(" + solution.deriv + "))";
     return result;
 }
@@ -105,7 +105,7 @@ std::string DiffEqContext::get_cvode_linear_diffeq() {
 /**
  * Return solution for non-cnexp method and when equation is non-linear.
  */
-std::string DiffEqContext::get_cvode_nonlinear_diffeq() {
+std::string DiffEqContext::get_cvode_nonlinear_diffeq() const {
     std::string expr = get_expr_for_nonlinear();
     std::string sol = "D" + state + " = " + "D" + state + "/(1.0-dt*(";
     sol += "((" + expr + ")-(" + solution.expr + "))/0.001))";
@@ -116,7 +116,7 @@ std::string DiffEqContext::get_cvode_nonlinear_diffeq() {
 /**
  * Return solution for cnexp method
  */
-std::string DiffEqContext::get_cnexp_solution() {
+std::string DiffEqContext::get_cnexp_solution() const {
     auto a = cvode_deriv();
     auto b = cvode_eqnrhs();
     /**
@@ -139,7 +139,7 @@ std::string DiffEqContext::get_cnexp_solution() {
 /**
  * Return solution for euler method
  */
-std::string DiffEqContext::get_euler_solution() {
+std::string DiffEqContext::get_euler_solution() const {
     return state + " = " + state + "+dt*(" + rhs + ")";
 }
 
@@ -147,7 +147,7 @@ std::string DiffEqContext::get_euler_solution() {
 /**
  * Return solution for non-cnexp method
  */
-std::string DiffEqContext::get_non_cnexp_solution() {
+std::string DiffEqContext::get_non_cnexp_solution() const {
     std::string result;
     if (!deriv_invalid) {
         result = get_cvode_linear_diffeq();

--- a/src/parser/diffeq_context.hpp
+++ b/src/parser/diffeq_context.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <string>
+#include <utility>
 
 namespace nmodl {
 namespace parser {
@@ -38,26 +39,26 @@ struct Term {
     Term(const std::string& expr, const std::string& state);
 
     Term(std::string expr, std::string deriv, std::string a, std::string b)
-        : expr(expr)
-        , deriv(deriv)
-        , a(a)
-        , b(b) {}
+        : expr(std::move(expr))
+        , deriv(std::move(deriv))
+        , a(std::move(a))
+        , b(std::move(b)) {}
 
     /// helper routines used in parser
 
-    bool deriv_nonzero() {
+    bool deriv_nonzero() const {
         return deriv != "0.0";
     }
 
-    bool a_nonzero() {
+    bool a_nonzero() const {
         return a != "0.0";
     }
 
-    bool b_nonzero() {
+    bool b_nonzero() const {
         return b != "0.0";
     }
 
-    void print();
+    void print() const;
 };
 
 
@@ -80,25 +81,22 @@ class DiffEqContext {
     /// order of the diff equation
     int order = 0;
 
-    /// if equation is non-linear then expression to use during code generation
-    std::string expr_for_nonlinear;
-
     /// return solution for cnexp method
-    std::string get_cnexp_solution();
+    std::string get_cnexp_solution() const;
 
     /// return solution for euler method
-    std::string get_euler_solution();
+    std::string get_euler_solution() const;
 
     /// return solution for non-cnexp method
-    std::string get_non_cnexp_solution();
+    std::string get_non_cnexp_solution() const;
 
     /// for non-cnexp methods : return the solution based on if equation is linear or not
-    std::string get_cvode_linear_diffeq();
-    std::string get_cvode_nonlinear_diffeq();
+    std::string get_cvode_linear_diffeq() const;
+    std::string get_cvode_nonlinear_diffeq() const;
 
     /// \todo Methods inherited neuron implementation
-    std::string cvode_deriv();
-    std::string cvode_eqnrhs();
+    std::string cvode_deriv() const;
+    std::string cvode_eqnrhs() const;
 
   public:
     /// "final" solution of the equation
@@ -113,13 +111,13 @@ class DiffEqContext {
     DiffEqContext() = default;
 
     DiffEqContext(std::string state, int order, std::string rhs, std::string method)
-        : state(state)
+        : state(std::move(state))
         , order(order)
-        , rhs(rhs)
-        , method(method) {}
+        , rhs(std::move(rhs))
+        , method(std::move(method)) {}
 
     /// return the state variable
-    std::string state_variable() const {
+    const std::string& state_variable() const {
         return state;
     }
 
@@ -127,10 +125,10 @@ class DiffEqContext {
     std::string get_solution(bool& cnexp_possible);
 
     /// return expression with Dstate added
-    std::string get_expr_for_nonlinear();
+    std::string get_expr_for_nonlinear() const;
 
     /// print the context (for debugging)
-    void print();
+    void print() const;
 };
 
 }  // namespace diffeq

--- a/src/parser/diffeq_helper.hpp
+++ b/src/parser/diffeq_helper.hpp
@@ -29,13 +29,16 @@ namespace diffeq {
 enum class MathOp { add = 1, sub, mul, div };
 
 template <MathOp Op>
-inline Term eval_derivative(Term& first, Term& second, bool& deriv_invalid, bool& eqn_invalid);
+inline Term eval_derivative(const Term& first,
+                            const Term& second,
+                            bool& deriv_invalid,
+                            bool& eqn_invalid);
 
 
 /// implement (f(x) + g(x))' = f'(x) + g'(x)
 template <>
-inline Term eval_derivative<MathOp::add>(Term& first,
-                                         Term& second,
+inline Term eval_derivative<MathOp::add>(const Term& first,
+                                         const Term& second,
                                          bool& deriv_invalid,
                                          bool& eqn_invalid) {
     Term solution;
@@ -71,8 +74,8 @@ inline Term eval_derivative<MathOp::add>(Term& first,
 
 /// implement (f(x) - g(x))' = f'(x) - g'(x)
 template <>
-inline Term eval_derivative<MathOp::sub>(Term& first,
-                                         Term& second,
+inline Term eval_derivative<MathOp::sub>(const Term& first,
+                                         const Term& second,
                                          bool& deriv_invalid,
                                          bool& eqn_invalid) {
     Term solution;
@@ -108,8 +111,8 @@ inline Term eval_derivative<MathOp::sub>(Term& first,
 
 /// implement (f(x) * g(x))' = f'(x)g(x) + f(x)g'(x)
 template <>
-inline Term eval_derivative<MathOp::mul>(Term& first,
-                                         Term& second,
+inline Term eval_derivative<MathOp::mul>(const Term& first,
+                                         const Term& second,
                                          bool& deriv_invalid,
                                          bool& eqn_invalid) {
     Term solution;
@@ -146,8 +149,8 @@ inline Term eval_derivative<MathOp::mul>(Term& first,
  * and this needs to be discussed with Michael.
  */
 template <>
-inline Term eval_derivative<MathOp::div>(Term& first,
-                                         Term& second,
+inline Term eval_derivative<MathOp::div>(const Term& first,
+                                         const Term& second,
                                          bool& deriv_invalid,
                                          bool& eqn_invalid) {
     Term solution;

--- a/src/parser/main_c.cpp
+++ b/src/parser/main_c.cpp
@@ -5,9 +5,7 @@
  * Lesser General Public License. See top-level LICENSE file for details.
  *************************************************************************/
 
-#include <fstream>
-
-#include "CLI/CLI.hpp"
+#include <CLI/CLI.hpp>
 
 #include "config/config.h"
 #include "parser/c11_driver.hpp"

--- a/src/parser/main_nmodl.cpp
+++ b/src/parser/main_nmodl.cpp
@@ -6,7 +6,7 @@
  *************************************************************************/
 
 
-#include "CLI/CLI.hpp"
+#include <CLI/CLI.hpp>
 
 #include "ast/program.hpp"
 #include "config/config.h"

--- a/src/parser/main_units.cpp
+++ b/src/parser/main_units.cpp
@@ -7,7 +7,7 @@
 
 #include <fstream>
 
-#include "CLI/CLI.hpp"
+#include <CLI/CLI.hpp>
 
 #include "config/config.h"
 #include "parser/unit_driver.hpp"

--- a/src/units/units.hpp
+++ b/src/units/units.hpp
@@ -1,5 +1,3 @@
-#include <utility>
-
 /*************************************************************************
  * Copyright (C) 2018-2019 Blue Brain Project
  *
@@ -152,7 +150,7 @@ class Unit {
     double parse_double(std::string double_string);
 
     /// Getter for the vector of nominators of the Unit
-    std::vector<std::string> get_nominator_unit() const {
+    const std::vector<std::string>& get_nominator_unit() const noexcept {
         return nominator;
     }
 

--- a/src/visitors/after_cvode_to_cnexp_visitor.cpp
+++ b/src/visitors/after_cvode_to_cnexp_visitor.cpp
@@ -12,7 +12,6 @@
 #include "ast/string.hpp"
 #include "codegen/codegen_naming.hpp"
 #include "utils/logger.hpp"
-#include "visitors/visitor_utils.hpp"
 
 namespace nmodl {
 namespace visitor {

--- a/src/visitors/constant_folder_visitor.cpp
+++ b/src/visitors/constant_folder_visitor.cpp
@@ -159,21 +159,21 @@ void ConstantFolderVisitor::visit_wrapped_expression(ast::WrappedExpression& nod
         return;
     }
 
-    std::string nmodl_before = to_nmodl(binary_expr);
+    const std::string nmodl_before = to_nmodl(binary_expr);
 
     /// compute the value of expression
     auto value = compute(get_value(lhs), op, get_value(rhs));
 
     /// if both operands are not integers or floats, result is double
     if (lhs->is_integer() && rhs->is_integer()) {
-        node.set_expression(std::make_shared<ast::Integer>(int(value), nullptr));
+        node.set_expression(std::make_shared<ast::Integer>(static_cast<int>(value), nullptr));
     } else if (lhs->is_double() || rhs->is_double()) {
         node.set_expression(std::make_shared<ast::Double>(stringutils::to_string(value)));
     } else {
         node.set_expression(std::make_shared<ast::Float>(stringutils::to_string(value)));
     }
 
-    std::string nmodl_after = to_nmodl(node.get_expression());
+    const std::string nmodl_after = to_nmodl(node.get_expression());
     logger->debug("ConstantFolderVisitor : expression {} folded to {}", nmodl_before, nmodl_after);
 }
 

--- a/src/visitors/main.cpp
+++ b/src/visitors/main.cpp
@@ -5,9 +5,7 @@
  * Lesser General Public License. See top-level LICENSE file for details.
  *************************************************************************/
 
-#include <sstream>
-
-#include "CLI/CLI.hpp"
+#include <CLI/CLI.hpp>
 
 #include "ast/program.hpp"
 #include "config/config.h"


### PR DESCRIPTION
* code generator visitors now extends `ConstAstVisitor` !
* bump hpc-coding-conventions submodule
* setup.py: fix typo in project description
* prefer ostringstream than string concatenation
* remove `const` specifier from lvalue parameter of function declarations
* add `static` specifier to some symbols not meant to be exported in compilation unit
* remove couple of copies
* prefer `std::move` in constructors
* include system headers with <>, not ""
* prevent unecessary IO flushes.
* fix indentation of .mod file