### PR TITLE
Add NMODL_ENABLE_PYTHON_BINDINGS option to disable python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 
+# =============================================================================
+# Build options for NMODL
+# =============================================================================
+option(NMODL_ENABLE_PYTHON_BINDINGS "Enable pybin11 based python bindings" ON)
 option(NMODL_ENABLE_LEGACY_UNITS "Use original faraday, R, etc. instead of 2019 nist constants" OFF)
 if(NMODL_ENABLE_LEGACY_UNITS)
   add_definitions(-DUSE_LEGACY_UNITS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 # =============================================================================
 # Build options for NMODL
 # =============================================================================
-option(NMODL_ENABLE_PYTHON_BINDINGS "Enable pybin11 based python bindings" ON)
+option(NMODL_ENABLE_PYTHON_BINDINGS "Enable pybind11 based python bindings" ON)
 option(NMODL_ENABLE_LEGACY_UNITS "Use original faraday, R, etc. instead of 2019 nist constants" OFF)
 if(NMODL_ENABLE_LEGACY_UNITS)
   add_definitions(-DUSE_LEGACY_UNITS)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,7 @@ jobs:
       export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
       mkdir -p $(Build.Repository.LocalPath)/build
       cd $(Build.Repository.LocalPath)/build
-      cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DNMODL_ENABLE_PYTHON_BINDINGS=OFF
       make -j 2
       if [ $? -ne 0 ]
       then

--- a/nmodl/__init__.py
+++ b/nmodl/__init__.py
@@ -1,4 +1,10 @@
-from ._nmodl import NmodlDriver, to_json, to_nmodl  # noqa
-from ._nmodl import __version__
+import imp
+try:
+    # check if nmodl binds are built before importing
+    imp.find_module('_nmodl')
+    from ._nmodl import NmodlDriver, to_json, to_nmodl  # noqa
+    from ._nmodl import __version__
+    __all__ = ["NmodlDriver", "to_json", "to_nmodl"]
+except ImportError:
+    print("[NMODL] [warning] :: Python bindings are not available")
 
-__all__ = ["NmodlDriver", "to_json", "to_nmodl"]

--- a/src/nmodl/CMakeLists.txt
+++ b/src/nmodl/CMakeLists.txt
@@ -21,7 +21,11 @@ target_link_libraries(
 # =============================================================================
 # Add dependency with nmodl pytnon module (for consumer projects)
 # =============================================================================
-add_dependencies(nmodl _nmodl pywrapper)
+add_dependencies(nmodl pywrapper)
+
+if(NMODL_ENABLE_PYTHON_BINDINGS)
+  add_dependencies(nmodl _nmodl)
+endif()
 
 # =============================================================================
 # Install executable

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -43,30 +43,41 @@ else()
   target_link_libraries(pywrapper PRIVATE pybind11::embed)
 endif()
 
-# Note that LTO causes link time errors with GCC 8. To avoid this, we disable LTO for pybind using
-# NO_EXTRAS. See #266.
-pybind11_add_module(
-  _nmodl
-  NO_EXTRAS
-  ${NMODL_PROJECT_SOURCE_DIR}/src/ast/ast_common.hpp
-  ${NMODL_PROJECT_SOURCE_DIR}/src/pybind/pybind_utils.hpp
-  ${NMODL_PROJECT_SOURCE_DIR}/src/pybind/pynmodl.cpp
-  ${PYBIND_GENERATED_SOURCES}
-  $<TARGET_OBJECTS:symtab_obj>
-  $<TARGET_OBJECTS:visitor_obj>
-  $<TARGET_OBJECTS:lexer_obj>
-  $<TARGET_OBJECTS:util_obj>
-  $<TARGET_OBJECTS:printer_obj>)
+# avoid _nmodl target if python bindings are disabled
+if(NMODL_ENABLE_PYTHON_BINDINGS)
+  # ~~~
+  # Note that LTO causes link time errors with GCC 8. To avoid this, we disable LTO
+  # for pybind using NO_EXTRAS. See #266.
+  # ~~~
+  pybind11_add_module(
+    _nmodl
+    NO_EXTRAS
+    ${NMODL_PROJECT_SOURCE_DIR}/src/ast/ast_common.hpp
+    ${NMODL_PROJECT_SOURCE_DIR}/src/pybind/pybind_utils.hpp
+    ${NMODL_PROJECT_SOURCE_DIR}/src/pybind/pynmodl.cpp
+    ${PYBIND_GENERATED_SOURCES}
+    $<TARGET_OBJECTS:symtab_obj>
+    $<TARGET_OBJECTS:visitor_obj>
+    $<TARGET_OBJECTS:lexer_obj>
+    $<TARGET_OBJECTS:util_obj>
+    $<TARGET_OBJECTS:printer_obj>)
 
-add_dependencies(_nmodl pyastgen)
-add_dependencies(_nmodl lexer_obj)
-add_dependencies(_nmodl util_obj)
+  add_dependencies(_nmodl pyastgen)
+  add_dependencies(_nmodl lexer_obj)
+  add_dependencies(_nmodl util_obj)
 
-target_link_libraries(_nmodl PRIVATE fmt::fmt pyembed)
+  target_link_libraries(_nmodl PRIVATE fmt::fmt pyembed)
 
-# in case of wheel, python module shouldn't link to wrapper library
-if(LINK_AGAINST_PYTHON)
-  target_link_libraries(_nmodl PRIVATE pywrapper)
+  # in case of wheel, python module shouldn't link to wrapper library
+  if(LINK_AGAINST_PYTHON)
+    target_link_libraries(_nmodl PRIVATE pywrapper)
+  endif()
+
+  add_custom_command(
+    OUTPUT $<TARGET_FILE:_nmodl>
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:_nmodl> ${PROJECT_BINARY_DIR}/nmodl
+    DEPENDS ${NMODL_PYTHON_FILES_IN} $<TARGET_FILE:_nmodl>
+    COMMENT "-- COPYING NMODL PYTHON MODULE --")
 endif()
 
 add_custom_target(copy_python_files ALL DEPENDS ${NMODL_PYTHON_FILES_OUT})
@@ -74,8 +85,7 @@ add_custom_command(
   OUTPUT ${NMODL_PYTHON_FILES_OUT}
   COMMAND ${CMAKE_COMMAND} -E copy_directory ${NMODL_PROJECT_SOURCE_DIR}/nmodl
           ${PROJECT_BINARY_DIR}/lib/nmodl
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:_nmodl> ${PROJECT_BINARY_DIR}/nmodl
-  DEPENDS ${NMODL_PYTHON_FILES_IN} $<TARGET_FILE:_nmodl>
+  DEPENDS ${NMODL_PYTHON_FILES_IN}
   COMMENT "-- COPYING NMODL PYTHON FILES --")
 
 # =============================================================================
@@ -88,12 +98,18 @@ file(COPY ${NMODL_PROJECT_SOURCE_DIR}/nmodl/ext DESTINATION ${CMAKE_BINARY_DIR}/
 # =============================================================================
 # Install python binding components
 # =============================================================================
-# scikit already installs the package in /nmodl. If we add it another time things are installed
-# twice with the wheel and in weird places. Let's just move the .so libs
+# ~~~
+# scikit already installs the package in /nmodl. If we add it another time
+# things are installed twice with the wheel and in weird places. Let's just
+# move the .so libs
+# ~~~
 if(NOT LINK_AGAINST_PYTHON)
-  install(TARGETS _nmodl DESTINATION nmodl/)
   install(TARGETS pywrapper DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}lib)
-elseif(SKBUILD) # skbuild needs the installation dir to be in nmodl to do the correct inplace
+  if(NMODL_ENABLE_PYTHON_BINDINGS)
+    install(TARGETS _nmodl DESTINATION nmodl/)
+  endif()
+elseif(SKBUILD)
+  # skbuild needs the installation dir to be in nmodl to do the correct inplace
   install(DIRECTORY ${CMAKE_BINARY_DIR}/lib/nmodl DESTINATION .)
 else()
   install(DIRECTORY ${CMAKE_BINARY_DIR}/lib/ DESTINATION lib)

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -62,10 +62,7 @@ if(NMODL_ENABLE_PYTHON_BINDINGS)
     $<TARGET_OBJECTS:util_obj>
     $<TARGET_OBJECTS:printer_obj>)
 
-  add_dependencies(_nmodl pyastgen)
-  add_dependencies(_nmodl lexer_obj)
-  add_dependencies(_nmodl util_obj)
-
+  add_dependencies(_nmodl pyastgen lexer_obj util_obj)
   target_link_libraries(_nmodl PRIVATE fmt::fmt pyembed)
 
   # in case of wheel, python module shouldn't link to wrapper library
@@ -74,9 +71,9 @@ if(NMODL_ENABLE_PYTHON_BINDINGS)
   endif()
 
   add_custom_command(
-    OUTPUT $<TARGET_FILE:_nmodl>
+    OUTPUT ${PROJECT_BINARY_DIR}/lib/nmodl
     COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:_nmodl> ${PROJECT_BINARY_DIR}/nmodl
-    DEPENDS ${NMODL_PYTHON_FILES_IN} $<TARGET_FILE:_nmodl>
+    DEPENDS ${NMODL_PYTHON_FILES_IN} _nmodl
     COMMENT "-- COPYING NMODL PYTHON MODULE --")
 endif()
 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -124,9 +124,12 @@ endforeach()
 # pybind11 tests
 # =============================================================================
 add_test(NAME Ode COMMAND ${PYTHON_EXECUTABLE} -m pytest ${NMODL_PROJECT_SOURCE_DIR}/test/unit/ode)
-add_test(NAME Pybind COMMAND ${PYTHON_EXECUTABLE} -m pytest
-                             ${NMODL_PROJECT_SOURCE_DIR}/test/unit/pybind)
-foreach(test_name Ode Pybind)
-  set_tests_properties(${test_name}
-                       PROPERTIES ENVIRONMENT PYTHONPATH=${PROJECT_BINARY_DIR}/lib:$ENV{PYTHONPATH})
-endforeach()
+set_tests_properties(Ode PROPERTIES ENVIRONMENT
+                                    PYTHONPATH=${PROJECT_BINARY_DIR}/lib:$ENV{PYTHONPATH})
+
+if(NMODL_ENABLE_PYTHON_BINDINGS)
+  add_test(NAME Pybind COMMAND ${PYTHON_EXECUTABLE} -m pytest
+                               ${NMODL_PROJECT_SOURCE_DIR}/test/unit/pybind)
+  set_tests_properties(Pybind PROPERTIES ENVIRONMENT
+                                         PYTHONPATH=${PROJECT_BINARY_DIR}/lib:$ENV{PYTHONPATH})
+endif()


### PR DESCRIPTION
  - NMODL_ENABLE_PYTHON_BINDINGS=ON by default
  - if python bindings are not enabled, show warning at the import
  - do not add dependency with _nmodl target
  - use imp module to test existence of package

fixes #391 (not really but I think this is sufficient for now)