### PR TITLE
fixup! ispc nmodl constants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ before_install:
         curl -L -o cmake-3.3.2.tar.gz https://github.com/Kitware/CMake/releases/download/v3.3.2/cmake-3.3.2-Linux-x86_64.tar.gz;
         mkdir -p $HOME/cmake && tar -xzf cmake-3.3.2.tar.gz -C $HOME/cmake --strip-components=1;
     fi
-  -	export PATH=$HOME/cmake/bin:$PATH
+  - export PATH=$HOME/cmake/bin:$PATH
   - eval "${MATRIX_EVAL}"
 
 #=============================================================================

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,13 +79,13 @@ before_install:
         brew link --overwrite python@3.8;
         export SDKROOT="$(xcrun --show-sdk-path)";
         curl -L -o cmake-3.3.2.tar.gz https://github.com/Kitware/CMake/releases/download/v3.3.2/cmake-3.3.2-Darwin-x86_64.tar.gz;
-        mkdir cmake && tar -xzf cmake-3.3.2.tar.gz -C cmake --strip-components=3;
+        mkdir -p $HOME/cmake && tar -xzf cmake-3.3.2.tar.gz -C $HOME/cmake --strip-components=3;
     else
         pyenv global $PYTHON_VERSION;
         curl -L -o cmake-3.3.2.tar.gz https://github.com/Kitware/CMake/releases/download/v3.3.2/cmake-3.3.2-Linux-x86_64.tar.gz;
-        mkdir cmake && tar -xzf cmake-3.3.2.tar.gz -C cmake --strip-components=1;
+        mkdir -p $HOME/cmake && tar -xzf cmake-3.3.2.tar.gz -C $HOME/cmake --strip-components=1;
     fi
-  -	export PATH=$(pwd)/cmake/bin:$PATH
+  -	export PATH=$HOME/cmake/bin:$PATH
   - eval "${MATRIX_EVAL}"
 
 #=============================================================================

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -477,12 +477,17 @@ void CodegenIspcVisitor::print_headers_include() {
 }
 
 void CodegenIspcVisitor::print_nmodl_constants() {
-    printer->add_newline(2);
-    printer->add_line("/** constants used in nmodl. */");
-    // we use here macros to work around ispc's PI being declared in global namespace
-    printer->add_line("static const uniform double FARADAY = 96485.3d;");
-    printer->add_line("static const uniform double ISPC_PI = 3.14159d;");
-    printer->add_line("static const uniform double R = 8.3145d;");
+    if (!info.factor_definitions.empty()) {
+        printer->add_newline(2);
+        printer->add_line("/** constants used in nmodl */");
+        for (auto& it: info.factor_definitions) {
+            const std::string name = it->get_node_name() == "PI" ? "ISPC_PI" : it->get_node_name();
+            std::string format_string = "static const uniform double {} = {};";
+            printer->add_line(fmt::format(format_string.c_str(),
+                                          name,
+                                          double_to_string(it->get_value()->get_value())));
+        }
+    }
 }
 
 void CodegenIspcVisitor::print_wrapper_headers_include() {


### PR DESCRIPTION
Fix  issue #433

- Constants were hard-coded so no custom constants, no
 unit changes, no double_to_string handling

I leave to double_to_string to handle how to chop doubles