### PR TITLE
Build our own cmake 3.3.2 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ addons:
     packages:
       - flex
       - bison
-      - cmake
       - dvipng
       - doxygen
       - libboost-all-dev
@@ -61,7 +60,6 @@ addons:
   homebrew:
     packages:
       - boost
-      - cmake
       - flex
       - bison
       - openmpi
@@ -83,6 +81,12 @@ before_install:
     else
         pyenv global $PYTHON_VERSION;
     fi
+  -	curl -L -o cmake-3.3.2.tar.gz https://github.com/Kitware/CMake/releases/download/v3.3.2/cmake-3.3.2.tar.gz
+	tar -xvzf cmake-3.3.2.tar.gz
+	cd cmake-3.3.2
+	./bootstrap -- -DCMAKE_INSTALL_PREFIX=$HOME/cmake
+	make -j 3 install
+	export PATH=$HOME/cmake/bin:$PATH
   - eval "${MATRIX_EVAL}"
 
 #=============================================================================

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,15 +78,14 @@ before_install:
         brew unlink python@2;
         brew link --overwrite python@3.8;
         export SDKROOT="$(xcrun --show-sdk-path)";
+        curl -L -o cmake-3.3.2.tar.gz https://github.com/Kitware/CMake/releases/download/v3.3.2/cmake-3.3.2-Darwin-x86_64.tar.gz
+        mkdir cmake && tar -xzf cmake-3.3.2.tar.gz -C cmake --strip-components=3
     else
         pyenv global $PYTHON_VERSION;
+        curl -L -o cmake-3.3.2.tar.gz https://github.com/Kitware/CMake/releases/download/v3.3.2/cmake-3.3.2-Linux-x86_64.tar.gz
+        mkdir cmake && tar -xzf cmake-3.3.2.tar.gz -C cmake --strip-components=1
     fi
-  -	curl -L -o cmake-3.3.2.tar.gz https://github.com/Kitware/CMake/releases/download/v3.3.2/cmake-3.3.2.tar.gz
-	tar -xvzf cmake-3.3.2.tar.gz
-	cd cmake-3.3.2
-	./bootstrap -- -DCMAKE_INSTALL_PREFIX=$HOME/cmake
-	make -j 3 install
-	export PATH=$HOME/cmake/bin:$PATH
+  -	export PATH=$(pwd)/cmake/bin:$PATH
   - eval "${MATRIX_EVAL}"
 
 #=============================================================================

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,12 +78,12 @@ before_install:
         brew unlink python@2;
         brew link --overwrite python@3.8;
         export SDKROOT="$(xcrun --show-sdk-path)";
-        curl -L -o cmake-3.3.2.tar.gz https://github.com/Kitware/CMake/releases/download/v3.3.2/cmake-3.3.2-Darwin-x86_64.tar.gz
-        mkdir cmake && tar -xzf cmake-3.3.2.tar.gz -C cmake --strip-components=3
+        curl -L -o cmake-3.3.2.tar.gz https://github.com/Kitware/CMake/releases/download/v3.3.2/cmake-3.3.2-Darwin-x86_64.tar.gz;
+        mkdir cmake && tar -xzf cmake-3.3.2.tar.gz -C cmake --strip-components=3;
     else
         pyenv global $PYTHON_VERSION;
-        curl -L -o cmake-3.3.2.tar.gz https://github.com/Kitware/CMake/releases/download/v3.3.2/cmake-3.3.2-Linux-x86_64.tar.gz
-        mkdir cmake && tar -xzf cmake-3.3.2.tar.gz -C cmake --strip-components=1
+        curl -L -o cmake-3.3.2.tar.gz https://github.com/Kitware/CMake/releases/download/v3.3.2/cmake-3.3.2-Linux-x86_64.tar.gz;
+        mkdir cmake && tar -xzf cmake-3.3.2.tar.gz -C cmake --strip-components=1;
     fi
   -	export PATH=$(pwd)/cmake/bin:$PATH
   - eval "${MATRIX_EVAL}"


### PR DESCRIPTION
especially with homebrew one has to go with whatever version they
choose, which is not testing our minimum version and can cause unrelated
failures.