### PR TITLE
Fix FindPythonModule for cmake >= 3.19

### DIFF
--- a/cmake/FindPythonModule.cmake
+++ b/cmake/FindPythonModule.cmake
@@ -59,11 +59,12 @@ macro(find_python_module module)
       endif()
     endif()
 
-    find_package_handle_standard_args(
-      ${module} REQUIRED_VARS ${module_upper}_LOCATION _${module_upper}_VERSION_MATCH VERSION_VAR
-      ${module_upper}_VERSION_STRING)
-    if(NOT ${module}_FIND_OPTIONAL AND NOT _${module_upper}_VERSION_MATCH)
-      message(FATAL_ERROR "Missing python module ${module}")
+    if(NOT ${module}_FIND_OPTIONAL)
+      if(NOT ${module_upper}_LOCATION)
+        message(FATAL_ERROR "Missing python module \"${module}\"")
+      elseif (NOT _${module_upper}_VERSION_MATCH)
+        message(FATAL_ERROR "Found module \"${module}\", but version mismatch. Asked for \"${${module}_FIND_VERSION}\" but found \"${${module_upper}_VERSION_STRING}\"")
+      endif()
     endif()
     mark_as_advanced(${module_upper}_LOCATION)
   endif(NOT ${module_upper}_FOUND)

--- a/cmake/FindPythonModule.cmake
+++ b/cmake/FindPythonModule.cmake
@@ -62,8 +62,11 @@ macro(find_python_module module)
     if(NOT ${module}_FIND_OPTIONAL)
       if(NOT ${module_upper}_LOCATION)
         message(FATAL_ERROR "Missing python module \"${module}\"")
-      elseif (NOT _${module_upper}_VERSION_MATCH)
-        message(FATAL_ERROR "Found module \"${module}\", but version mismatch. Asked for \"${${module}_FIND_VERSION}\" but found \"${${module_upper}_VERSION_STRING}\"")
+      elseif(NOT _${module_upper}_VERSION_MATCH)
+        message(
+          FATAL_ERROR
+            "Found module \"${module}\", but version mismatch. Asked for \"${${module}_FIND_VERSION}\" but found \"${${module_upper}_VERSION_STRING}\""
+        )
       endif()
     endif()
     mark_as_advanced(${module_upper}_LOCATION)


### PR DESCRIPTION
find_package_handle_standard_args is no more usable outside a find_package function
Mimick it with basic if tests