### PR TITLE
Fix range/state/ion/assigned variable ordering

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,7 +109,8 @@ jobs:
   - checkout: self
     submodules: true
   - script: |
-      brew install flex bison cmake python@3
+      brew install flex cmake python@3
+      brew install bison
       python3 -m pip install -U pip setuptools
       python3 -m pip install --user 'Jinja2>=2.9.3' 'PyYAML>=3.13' pytest 'sympy>=1.3,<1.6'
     displayName: 'Install Depdendencies'

--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -276,17 +276,87 @@ void CodegenHelperVisitor::find_non_range_variables() {
 /**
  * Find range variables i.e. ones that are belong to per instance allocation
  *
- * In order to be compatible with NEURON, we need to print range variables in
- * certain order. For example, range variables which are parameters comes first.
- * Also, there is difference between declaration order vs. definition order. For
- * example, POINTER variable in NEURON block is just declaration and doesn't
- * determine the order in which they will get printed. Below we query symbol table
- * and order all instance variables into certain order.
+ * In order to be compatible with NEURON, we need to print all variables in
+ * exact order as NEURON/MOD2C implementation. This is important because memory
+ * for all vatiables is allocated in single 1-D array with certain offset
+ * for each variable. The order of variables determine the offset and hence
+ * they must be in same order as NEURON.
+ *
+ * Here is how order is determined into NEURON/MOD2C implementation:
+ *
+ * First, following three lists are created
+ * - variables with parameter and range property (List 1)
+ * - variables with state and range property (List 2)
+ * - variables with assigned and range property (List 3)
+ *
+ * Once above three lists are created, we remove following variable from above
+ * three lists:
+ * - In NEURON/MOD2C implementation, we remove variables with NRNPRANGEIN
+ *   or NRNPRANGEOUT type
+ * - So who has NRNPRANGEIN and NRNPRANGEOUT type? these are such USEION read
+ *   or write variables that are not ionic currents.
+ * - This is the reason for mod files CaDynamics_E2.mod or cal_mig.mod, ica variable
+ *   is printed earlier in the list but other variables like cai, cao don't appear
+ *   in same order.
+ *
+ * Finally we create 4th list:
+ *  - variables with assigned property and not in the previous 3 lists
+ *
+ * We now print the variables in following order:
+ *
+ * - List 1 i.e. range + parameter variables are printed first
+ * - List 3 i.e. range + assigned variables are printed next
+ * - List 2 i.e. range + state variables are printed next
+ * - List 4 i.e. assigned variables not present in previous 3 lists
+ *
+ * NOTE:
+ * - State variables are also has property `assigned_definition` but these variables
+ *   are not from ASSIGNED block.
+ * - Variable can not be range as well as state, it's redeclaration error
+ * - Variable can be parameter as well as range. Without range, parameter
+ *   is considered as global variable i.e. one value for all instances.
+ * - If a variable is only defined as RANGE and not in assgined or parameter
+ *   or state block then it's not printed.
+ * - Note that if variable property is different than the variable type. For example,
+ *   if variable has range property, it doesn't mean the variable is declared as RANGE.
+ *   Other variables like STATE and ASSIGNED block variables also get range property.
+ * - Also, there is difference between declaration order vs. definition order. For
+ *   example, POINTER variable in NEURON block is just declaration and doesn't
+ *   determine the order in which they will get printed. Below we query symbol table
+ *   and order all instance variables into certain order.
  */
 void CodegenHelperVisitor::find_range_variables() {
     /// comparator to decide the order based on definition
     auto comparator = [](const SymbolType& first, const SymbolType& second) -> bool {
         return first->get_definition_order() < second->get_definition_order();
+    };
+
+    /// from symbols vector `vars`, remove all ion variables which are not ionic currents
+    auto remove_non_ioncur_vars = [](SymbolVectorType& vars, CodegenInfo& info) -> void {
+        vars.erase(std::remove_if(vars.begin(),
+                                  vars.end(),
+                                  [&](SymbolType& s) {
+                                      return info.is_ion_variable(s->get_name()) &&
+                                             !info.is_ionic_current(s->get_name());
+                                  }),
+                   vars.end());
+    };
+
+    /// if `seconday` vector contains any symbol that exist in the `primary` then remove ut
+    auto remove_var_exist = [](SymbolVectorType& primary, SymbolVectorType& secondary) -> void {
+        secondary.erase(std::remove_if(secondary.begin(),
+                                       secondary.end(),
+                                       [&primary](const SymbolType& tosearch) {
+                                           return std::find_if(primary.begin(),
+                                                               primary.end(),
+                                                               // compare by symbol name
+                                                               [&tosearch](
+                                                                   const SymbolType& symbol) {
+                                                                   return tosearch->get_name() ==
+                                                                          symbol->get_name();
+                                                               }) != primary.end();
+                                       }),
+                        secondary.end());
     };
 
     /**
@@ -299,8 +369,10 @@ void CodegenHelperVisitor::find_range_variables() {
                    | NmodlType::pointer_var
                    | NmodlType::bbcore_pointer_var
                    | NmodlType::state_var;
+
     // clang-format on
     info.range_parameter_vars = psymtab->get_variables(with, without);
+    remove_non_ioncur_vars(info.range_parameter_vars, info);
     std::sort(info.range_parameter_vars.begin(), info.range_parameter_vars.end(), comparator);
 
     /**
@@ -314,92 +386,50 @@ void CodegenHelperVisitor::find_range_variables() {
               | NmodlType::bbcore_pointer_var
               | NmodlType::state_var
               | NmodlType::param_assign;
+
     // clang-format on
     info.range_assigned_vars = psymtab->get_variables(with, without);
+    remove_non_ioncur_vars(info.range_assigned_vars, info);
     std::sort(info.range_assigned_vars.begin(), info.range_assigned_vars.end(), comparator);
+
 
     /**
      * Third come state variables. All state variables are kind of range by default.
-     * Note that some mod files like CaDynamics_E2.mod use cai as state variable
-     * and those are not considered as range+state variables while printing instance
-     * variables. Such read/write ion variables are assigned variables and hence they
-     * will be printed at laster stage.
-     * \todo Need to validate with more models and mod2c details.
+     * Note that some mod files like CaDynamics_E2.mod use cai as state variable which
+     * appear in USEION read/write list. These variables are not considered in this
+     * variables because non ionic-current variables are removed and printed later.
      */
     // clang-format off
     with = NmodlType::state_var;
     without = NmodlType::global_var
               | NmodlType::pointer_var
-              | NmodlType::bbcore_pointer_var
-              | NmodlType::read_ion_var
-              | NmodlType::write_ion_var;
+              | NmodlType::bbcore_pointer_var;
+
     // clang-format on
     info.state_vars = psymtab->get_variables(with, without);
     std::sort(info.state_vars.begin(), info.state_vars.end(), comparator);
 
-    /**
-     * Remaining variables are:
-     *  - all assigned variables without range
-     *  - read ion variables which appear in parameter or assigned block
-     *  - state variables which are not range but with ion variable of read/write type
-     */
+    /// range_state_vars is copy of state variables but without non ionic current variables
+    info.range_state_vars = info.state_vars;
+    remove_non_ioncur_vars(info.range_state_vars, info);
 
-    /**
-     * first get assigned definition without read ion variables
-     */
+    /// Remaining variables are assigned variables which are not in previous 3 lists
+
     // clang-format off
     with = NmodlType::assigned_definition;
     without = NmodlType::global_var
               | NmodlType::pointer_var
               | NmodlType::bbcore_pointer_var
-              | NmodlType::state_var
-              | NmodlType::range_var
-              | NmodlType::extern_neuron_variable
-              | NmodlType::read_ion_var;
+              | NmodlType::extern_neuron_variable;
+
     // clang-format on
     info.assigned_vars = psymtab->get_variables(with, without);
 
-    /**
-     * Now just use read-ion variables because every read-ion variable
-     * must be part of either assigned or parameter block. Otherwise code is not
-     * compiled anyway.
-     */
-    // clang-format off
-    with = NmodlType::read_ion_var;
-    without = NmodlType::global_var
-              | NmodlType::pointer_var
-              | NmodlType::bbcore_pointer_var
-              | NmodlType::state_var
-              | NmodlType::range_var
-              | NmodlType::extern_neuron_variable;
-    // clang-format on
-    auto variables = psymtab->get_variables(with, without);
-    info.assigned_vars.insert(info.assigned_vars.end(), variables.begin(), variables.end());
-
-    /*
-     * We want to have state variables which are read or write ion variables.
-     * This needs to be separated from other state variables because mod2c
-     * treat them separately for ordering.
-     */
-    // clang-format off
-    with = NmodlType::state_var;
-    without = NmodlType::global_var
-              | NmodlType::pointer_var
-              | NmodlType::bbcore_pointer_var
-              | NmodlType::range_var
-              | NmodlType::extern_neuron_variable;
-    // clang-format on
-    variables = psymtab->get_variables(with, without);
-    for (auto& variable: variables) {
-        // clang-format off
-        auto properties = NmodlType::read_ion_var
-                          | NmodlType::write_ion_var;
-        // clang-format on
-        if (variable->has_any_property(properties)) {
-            info.ion_state_vars.push_back(variable);
-            info.assigned_vars.push_back(variable);
-        }
-    }
+    /// make sure that variables already present in previous lists
+    /// are removed to avoid any duplication
+    remove_var_exist(info.range_parameter_vars, info.assigned_vars);
+    remove_var_exist(info.range_assigned_vars, info.assigned_vars);
+    remove_var_exist(info.range_state_vars, info.assigned_vars);
 }
 
 
@@ -615,14 +645,14 @@ void CodegenHelperVisitor::visit_program(const ast::Program& node) {
         }
     }
     node.visit_children(*this);
+    find_ion_variables();
     find_range_variables();
     find_non_range_variables();
-    find_ion_variables();
     find_table_variables();
 }
 
 
-codegen::CodegenInfo CodegenHelperVisitor::analyze(const ast::Program& node) {
+CodegenInfo CodegenHelperVisitor::analyze(const ast::Program& node) {
     node.accept(*this);
     return info;
 }

--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -654,7 +654,7 @@ void CodegenHelperVisitor::visit_program(const ast::Program& node) {
         }
     }
     node.visit_children(*this);
-    find_ion_variables(); // Keep this before find_*_range_variables()
+    find_ion_variables();  // Keep this before find_*_range_variables()
     find_range_variables();
     find_non_range_variables();
     find_table_variables();

--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -278,7 +278,7 @@ void CodegenHelperVisitor::find_non_range_variables() {
  *
  * In order to be compatible with NEURON, we need to print all variables in
  * exact order as NEURON/MOD2C implementation. This is important because memory
- * for all vatiables is allocated in single 1-D array with certain offset
+ * for all variables is allocated in single 1-D array with certain offset
  * for each variable. The order of variables determine the offset and hence
  * they must be in same order as NEURON.
  *
@@ -310,7 +310,7 @@ void CodegenHelperVisitor::find_non_range_variables() {
  * - List 4 i.e. assigned variables not present in previous 3 lists
  *
  * NOTE:
- * - State variables are also has property `assigned_definition` but these variables
+ * - State variables also have the property `assigned_definition` but these variables
  *   are not from ASSIGNED block.
  * - Variable can not be range as well as state, it's redeclaration error
  * - Variable can be parameter as well as range. Without range, parameter

--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -342,7 +342,7 @@ void CodegenHelperVisitor::find_range_variables() {
                    vars.end());
     };
 
-    /// if `seconday` vector contains any symbol that exist in the `primary` then remove ut
+    /// if `seconday` vector contains any symbol that exist in the `primary` then remove it
     auto remove_var_exist = [](SymbolVectorType& primary, SymbolVectorType& secondary) -> void {
         secondary.erase(std::remove_if(secondary.begin(),
                                        secondary.end(),

--- a/src/codegen/codegen_helper_visitor.hpp
+++ b/src/codegen/codegen_helper_visitor.hpp
@@ -46,6 +46,7 @@ namespace codegen {
  */
 class CodegenHelperVisitor: public visitor::ConstAstVisitor {
     using SymbolType = std::shared_ptr<symtab::Symbol>;
+    using SymbolVectorType = std::vector<std::shared_ptr<symtab::Symbol>>;
 
     /// holds all codegen related information
     codegen::CodegenInfo info;

--- a/src/codegen/codegen_info.cpp
+++ b/src/codegen/codegen_info.cpp
@@ -60,7 +60,7 @@ bool CodegenInfo::is_ion_variable(const std::string& name) const {
 }
 
 
-/// if a current
+/// if a current (ionic or non-specific)
 bool CodegenInfo::is_current(const std::string& name) const {
     for (auto& var: currents) {
         if (var == name) {
@@ -70,6 +70,26 @@ bool CodegenInfo::is_current(const std::string& name) const {
     return false;
 }
 
+/// true is a given variable name if a ionic current
+/// (i.e. currents excluding non-specific current)
+bool CodegenInfo::is_ionic_current(const std::string& name) const {
+    for (const auto& ion: ions) {
+        if (ion.is_ionic_current(name) == true) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/// true if given variable name is a ionic concentration
+bool CodegenInfo::is_ionic_conc(const std::string& name) const {
+    for (const auto& ion: ions) {
+        if (ion.is_ionic_conc(name) == true) {
+            return true;
+        }
+    }
+    return false;
+}
 
 bool CodegenInfo::function_uses_table(std::string& name) const {
     for (auto& function: functions_with_table) {

--- a/src/codegen/codegen_info.hpp
+++ b/src/codegen/codegen_info.hpp
@@ -284,11 +284,13 @@ struct CodegenInfo {
     /// reamining assigned variables
     std::vector<SymbolType> assigned_vars;
 
-    /// state variables
+    /// all state variables
     std::vector<SymbolType> state_vars;
 
-    /// ion variables which are also state variables
-    std::vector<SymbolType> ion_state_vars;
+    /// state variables excluding such useion read/write variables
+    /// that are not ionic currents. In neuron/mod2c these are stored
+    /// in the list "rangestate".
+    std::vector<SymbolType> range_state_vars;
 
     /// local variables in the global scope
     std::vector<SymbolType> top_local_variables;
@@ -364,6 +366,12 @@ struct CodegenInfo {
 
     /// if given variable is a current
     bool is_current(const std::string& name) const;
+
+    /// if given variable is a ionic current
+    bool is_ionic_current(const std::string& name) const;
+
+    /// if given variable is a ionic concentration
+    bool is_ionic_conc(const std::string& name) const;
 
     /// if watch statements are used
     bool is_watch_used() const noexcept {

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(testsymtab symtab/symbol_table.cpp)
 add_executable(testnewton newton/newton.cpp ${SOLVER_SOURCE_FILES})
 add_executable(testunitlexer units/lexer.cpp)
 add_executable(testunitparser units/parser.cpp)
+add_executable(testcodegen codegen/codegen_helper.cpp)
 
 target_link_libraries(testmodtoken lexer util)
 target_link_libraries(testlexer lexer util)
@@ -67,6 +68,16 @@ target_link_libraries(
   ${NMODL_WRAPPER_LIBS})
 target_link_libraries(
   testvisitor
+  visitor
+  symtab
+  lexer
+  util
+  test_util
+  printer
+  ${NMODL_WRAPPER_LIBS})
+target_link_libraries(
+  testcodegen
+  codegen
   visitor
   symtab
   lexer
@@ -99,6 +110,7 @@ foreach(
   testlexer
   testparser
   testvisitor
+  testcodegen
   testprinter
   testsymtab
   testnewton

--- a/test/unit/codegen/codegen_helper.cpp
+++ b/test/unit/codegen/codegen_helper.cpp
@@ -1,0 +1,130 @@
+/*************************************************************************
+ * Copyright (C) 2019-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#define CATCH_CONFIG_MAIN
+
+#include <catch/catch.hpp>
+
+#include "ast/program.hpp"
+#include "codegen/codegen_helper_visitor.hpp"
+#include "parser/nmodl_driver.hpp"
+#include "visitors/symtab_visitor.hpp"
+
+using namespace nmodl;
+using namespace visitor;
+using namespace codegen;
+
+using nmodl::parser::NmodlDriver;
+
+//=============================================================================
+// Helper for codege related visitor
+//=============================================================================
+std::string run_inline_visitor(const std::string& text) {
+    NmodlDriver driver;
+    const auto& ast = driver.parse_string(text);
+
+    /// construct symbol table and run codegen helper visitor
+    SymtabVisitor().visit_program(*ast);
+    CodegenHelperVisitor v;
+
+    /// symbols/variables are collected in info object
+    const auto& info = v.analyze(*ast);
+
+    /// semicolon separated list of variables
+    std::string variables;
+
+    /// range variables in order of code generation
+    for (const auto& var: info.range_parameter_vars) {
+        variables += var->get_name() + ";";
+    }
+    for (const auto& var: info.range_assigned_vars) {
+        variables += var->get_name() + ";";
+    }
+    for (const auto& var: info.range_state_vars) {
+        variables += var->get_name() + ";";
+    }
+    for (const auto& var: info.assigned_vars) {
+        variables += var->get_name() + ";";
+    }
+
+    return variables;
+}
+
+SCENARIO("unusual / failing mod files", "[codegen][var_order]") {
+    GIVEN("cal_mig.mod : USEION variables declared as RANGE") {
+        std::string nmodl_text = R"(
+            PARAMETER {
+              gcalbar=.003 (mho/cm2)
+              ki=.001 (mM)
+              cai = 50.e-6 (mM)
+              cao = 2 (mM)
+              q10 = 5
+              USEGHK=1
+            }
+            NEURON {
+              SUFFIX cal
+              USEION ca READ cai,cao WRITE ica
+              RANGE gcalbar, cai, ica, gcal, ggk
+              RANGE minf, tau
+              GLOBAL USEGHK
+            }
+            STATE {
+              m
+            }
+            ASSIGNED {
+              ica (mA/cm2)
+              gcal (mho/cm2)
+              minf
+              tau   (ms)
+              ggk
+            }
+            DERIVATIVE state {
+              rate(v)
+              m' = (minf - m)/tau
+            }
+        )";
+
+        THEN("ionic current variable declared as RANGE appears first") {
+            std::string expected = "gcalbar;ica;gcal;minf;tau;ggk;m;cai;cao;";
+            auto result = run_inline_visitor(nmodl_text);
+            REQUIRE(result == expected);
+        }
+    }
+
+    GIVEN("CaDynamics_E2.mod : USEION variables declared as STATE variable") {
+        std::string nmodl_text = R"(
+            NEURON  {
+              SUFFIX CaDynamics_E2
+              USEION ca READ ica WRITE cai
+              RANGE decay, gamma, minCai, depth
+            }
+
+            PARAMETER   {
+              gamma = 0.05 : percent of free calcium (not buffered)
+              decay = 80 (ms) : rate of removal of calcium
+              depth = 0.1 (um) : depth of shell
+              minCai = 1e-4 (mM)
+            }
+
+            ASSIGNED {ica (mA/cm2)}
+
+            STATE {
+              cai (mM)
+            }
+
+            DERIVATIVE states   {
+              cai' = -(10000)*(ica*gamma/(2*FARADAY*depth)) - (cai - minCai)/decay
+            }
+        )";
+
+        THEN("ion state variable is ordered after parameter and assigned ionic current") {
+            std::string expected = "gamma;decay;depth;minCai;ica;cai;";
+            auto result = run_inline_visitor(nmodl_text);
+            REQUIRE(result == expected);
+        }
+    }
+}


### PR DESCRIPTION
 - range variabes needs to be printed in the order as it's
   done in neuron/mod2c implementation
 - existing implementation had bugs when ion variables are
   state variables. (CaDynamics_E2.mod cal_mig.mod)
 - this PR reviews implementation in mod2c and documents are
   variable order is calculated in original implementation
   and fixes variable ordering issue.

TODO 

- [x] simplify implementation / code
- [x] document some of the implementation details
- [x] add unit tests for variable ordering

fixes #436