### PR TITLE
Disable extra nmodl targets if used as sub-module

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
   displayName: 'Ubuntu (16.04), GCC 8.3'
   steps:
   - checkout: self
-    submodules: True
+    submodules: False
   - script: |
       sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
       sudo apt-add-repository -y ppa:deadsnakes/ppa

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,11 @@ schedules:
     - master
   always: True
 
+# Trigger build for certain branches only
+trigger:
+- master
+- llvm
+- releases/*
 
 jobs:
 - job: 'ubuntu1604'

--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -10,10 +10,10 @@ function(initialize_submodule path)
     message(
       FATAL_ERROR "git not found and ${path} sub-module not cloned (use git clone --recursive)")
   endif()
-  message(STATUS "Sub-module : missing ${path}: running git submodule update --init --recursive")
+  message(STATUS "Sub-module : missing ${path}: running git submodule update --init")
   execute_process(
     COMMAND
-      git submodule update --init --recursive -- ${path}
+      git submodule update --init -- ${path}
     WORKING_DIRECTORY ${NMODL_PROJECT_SOURCE_DIR})
 endfunction()
 

--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -11,10 +11,8 @@ function(initialize_submodule path)
       FATAL_ERROR "git not found and ${path} sub-module not cloned (use git clone --recursive)")
   endif()
   message(STATUS "Sub-module : missing ${path}: running git submodule update --init")
-  execute_process(
-    COMMAND
-      git submodule update --init -- ${path}
-    WORKING_DIRECTORY ${NMODL_PROJECT_SOURCE_DIR})
+  execute_process(COMMAND git submodule update --init -- ${path}
+                  WORKING_DIRECTORY ${NMODL_PROJECT_SOURCE_DIR})
 endfunction()
 
 # check for external project and initialize submodule if it is missing

--- a/src/lexer/CMakeLists.txt
+++ b/src/lexer/CMakeLists.txt
@@ -176,21 +176,25 @@ add_library(lexer_obj OBJECT ${LEXER_SOURCE_FILES} ${BISON_GENERATED_SOURCE_FILE
 set_property(TARGET lexer_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 add_library(lexer STATIC $<TARGET_OBJECTS:lexer_obj>)
-
-add_executable(nmodl_lexer main_nmodl.cpp)
-add_executable(c_lexer main_c.cpp)
-add_executable(units_lexer main_units.cpp)
-
 target_link_libraries(lexer fmt::fmt)
-target_link_libraries(nmodl_lexer lexer util)
-target_link_libraries(c_lexer lexer util)
-target_link_libraries(units_lexer lexer util)
+
+if(NOT NMODL_AS_SUBPROJECT)
+  add_executable(nmodl_lexer main_nmodl.cpp)
+  add_executable(c_lexer main_c.cpp)
+  add_executable(units_lexer main_units.cpp)
+
+  target_link_libraries(nmodl_lexer lexer util)
+  target_link_libraries(c_lexer lexer util)
+  target_link_libraries(units_lexer lexer util)
+endif()
 
 # =============================================================================
 # Install executable
 # =============================================================================
-install(TARGETS nmodl_lexer DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/lexer CONFIGURATIONS Debug)
-install(TARGETS c_lexer DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/lexer CONFIGURATIONS Debug)
-install(TARGETS units_lexer DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/lexer CONFIGURATIONS Debug)
+if(NOT NMODL_AS_SUBPROJECT)
+  install(TARGETS nmodl_lexer DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/lexer CONFIGURATIONS Debug)
+  install(TARGETS c_lexer DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/lexer CONFIGURATIONS Debug)
+  install(TARGETS units_lexer DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/lexer CONFIGURATIONS Debug)
+endif()
 
 add_custom_target(parser-gen DEPENDS ${BISON_GENERATED_SOURCE_FILES})

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -4,17 +4,23 @@
 
 # lexer library links with all parser related files so no need to have parser as a separate library
 
-add_executable(nmodl_parser main_nmodl.cpp)
-add_executable(c_parser main_c.cpp)
-add_executable(units_parser main_units.cpp)
+if(NOT NMODL_AS_SUBPROJECT)
+  add_executable(nmodl_parser main_nmodl.cpp)
+  add_executable(c_parser main_c.cpp)
+  add_executable(units_parser main_units.cpp)
 
-target_link_libraries(nmodl_parser lexer util)
-target_link_libraries(c_parser lexer util)
-target_link_libraries(units_parser util visitor lexer)
+  target_link_libraries(nmodl_parser lexer util)
+  target_link_libraries(c_parser lexer util)
+  target_link_libraries(units_parser util visitor lexer)
+endif()
 
 # =============================================================================
 # Install executable
 # =============================================================================
-install(TARGETS nmodl_parser DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/parser CONFIGURATIONS Debug)
-install(TARGETS c_parser DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/parser CONFIGURATIONS Debug)
-install(TARGETS units_parser DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/parser CONFIGURATIONS Debug)
+if(NOT NMODL_AS_SUBPROJECT)
+  install(TARGETS nmodl_parser DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/parser CONFIGURATIONS
+                  Debug)
+  install(TARGETS c_parser DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/parser CONFIGURATIONS Debug)
+  install(TARGETS units_parser DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/parser CONFIGURATIONS
+                  Debug)
+endif()

--- a/src/visitors/CMakeLists.txt
+++ b/src/visitors/CMakeLists.txt
@@ -63,8 +63,6 @@ add_library(visitor STATIC $<TARGET_OBJECTS:visitor_obj>)
 
 add_dependencies(visitor lexer util pywrapper)
 
-add_executable(nmodl_visitor main.cpp)
-
 # ~~~
 # pybind11::embed adds PYTHON_LIBRARIES to target_link_libraries. To avoid link to
 # libpython, we can use `pybind11::module` interface library from pybind11.
@@ -74,17 +72,24 @@ if(NOT LINK_AGAINST_PYTHON)
 else()
   target_link_libraries(visitor PRIVATE pybind11::embed)
 endif()
-target_link_libraries(
-  nmodl_visitor
-  printer
-  visitor
-  symtab
-  util
-  lexer
-  ${NMODL_WRAPPER_LIBS})
+
+if(NOT NMODL_AS_SUBPROJECT)
+  add_executable(nmodl_visitor main.cpp)
+
+  target_link_libraries(
+    nmodl_visitor
+    printer
+    visitor
+    symtab
+    util
+    lexer
+    ${NMODL_WRAPPER_LIBS})
+endif()
 
 # =============================================================================
 # Install executable
 # =============================================================================
-install(TARGETS nmodl_visitor DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/visitor CONFIGURATIONS
-                Debug)
+if(NOT NMODL_AS_SUBPROJECT)
+  install(TARGETS nmodl_visitor DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/visitor CONFIGURATIONS
+                  Debug)
+endif()


### PR DESCRIPTION
  - nmodl has multiple utility lexer/parsers
  - when nmodl is used as submodule in neuron or
    coreneuron then disable these targets