### PR TITLE
FunctionBlock code generation and terminator checks

### DIFF
--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -50,9 +50,9 @@ void CodegenLLVMVisitor::visit_procedure_or_function(const ast::Block& node) {
     builder.SetInsertPoint(body);
     local_named_values = func->getValueSymbolTable();
 
-    // When processing a function, it returns a value named ret_<function_name>. Note that the
-    // renaming has been done by RenameVisitor pass and is a necessary precondition. Otherwise, the
-    // behaviour is undefined.
+    // When processing a function, it returns a value named ret_<function_name>. Therefore, we
+    // allocate it on stack. Note that the renaming has been done by RenameVisitor pass and is a
+    // necessary precondition. Otherwise, the behaviour is undefined.
     std::string return_var_name = "ret_" + name;
     if (node.is_function_block()) {
         builder.CreateAlloca(llvm::Type::getDoubleTy(*context),
@@ -77,8 +77,8 @@ void CodegenLLVMVisitor::visit_procedure_or_function(const ast::Block& node) {
             statement->accept(*this);
     }
 
-    // Add the terminator. If visiting function, the convention is that it returns a dummy 0.0
-    // value.
+    // Add the terminator. If visiting function, we need to return the value specified by
+    // ret_<function_name>.
     if (node.is_function_block()) {
         llvm::Value* return_var = builder.CreateLoad(local_named_values->lookup(return_var_name));
         builder.CreateRet(return_var);

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -32,7 +32,7 @@ void CodegenLLVMVisitor::visit_procedure_or_function(const ast::Block& node) {
 
     // Procedure or function parameters are doubles by default.
     std::vector<llvm::Type*> arg_types;
-    for (size_t i = 0, e = parameters.size(); i < e; ++i)
+    for (size_t i = 0; i < parameters.size(); ++i)
         arg_types.push_back(llvm::Type::getDoubleTy(*context));
 
     // If visiting a function, the return type is a double by default.

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -74,10 +74,17 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
         , output_dir(output_dir)
         , builder(*context) {}
 
+    /**
+     * Visit nmodl function or procedure
+     * \param node the AST node representing the function or procedure in NMODL
+     */
+    void visit_procedure_or_function(const ast::Block& node);
+
     // Visitors
     void visit_binary_expression(const ast::BinaryExpression& node) override;
     void visit_boolean(const ast::Boolean& node) override;
     void visit_double(const ast::Double& node) override;
+    void visit_function_block(const ast::FunctionBlock& node) override;
     void visit_integer(const ast::Integer& node) override;
     void visit_local_list_statement(const ast::LocalListStatement& node) override;
     void visit_procedure_block(const ast::ProcedureBlock& node) override;

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -59,8 +59,8 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     // Stack to hold visited values
     std::vector<llvm::Value*> values;
 
-    // Mappings for named values for lookups
-    std::map<std::string, llvm::Value*> named_values;
+    // Pointer to the local symbol table.
+    llvm::ValueSymbolTable* local_named_values = nullptr;
 
   public:
     /**

--- a/test/unit/codegen/llvm.cpp
+++ b/test/unit/codegen/llvm.cpp
@@ -156,8 +156,8 @@ SCENARIO("Procedure", "[visitor][llvm]") {
             std::string module_string = run_llvm_visitor(nmodl_text);
             std::smatch m;
 
-            // Check procedure has empty body
-            std::regex procedure(R"(define void @empty\(\) \{\n\})");
+            // Check procedure has empty body with a void return.
+            std::regex procedure(R"(define void @empty\(\) \{\n(\s)*ret void\n\})");
             REQUIRE(std::regex_search(module_string, m, procedure));
         }
     }
@@ -171,15 +171,19 @@ SCENARIO("Procedure", "[visitor][llvm]") {
             std::string module_string = run_llvm_visitor(nmodl_text);
             std::smatch m;
 
-            // Check procedure signature
+            // Check procedure signature.
             std::regex function_signature(R"(define void @with_argument\(double %x1\) \{)");
             REQUIRE(std::regex_search(module_string, m, function_signature));
 
-            // Check that procedure arguments are allocated on the local stack
+            // Check that procedure arguments are allocated on the local stack.
             std::regex alloca_instr(R"(%x = alloca double)");
             std::regex store_instr(R"(store double %x1, double\* %x)");
             REQUIRE(std::regex_search(module_string, m, alloca_instr));
             REQUIRE(std::regex_search(module_string, m, store_instr));
+
+            // Check terminator.
+            std::regex terminator(R"(ret void)");
+            REQUIRE(std::regex_search(module_string, m, terminator));
         }
     }
 }


### PR DESCRIPTION
This PR adds support for LLVM code generation for `FunctionBlock`. Since the code is almost identical to `ProcedureBlock`'s codegen, it was refactored into a helper function `visit_procedure_or_function()`. The differences are:
- Procedure returns void, Function returns a dummy double 0.0 (similarly to C visitor).
- Procedure has a void return type in its signature, and function has a double return type.

Also, tests were altered to enforce the existence of the block terminator (`ret` instruction) in both procedure and function.