### PR TITLE
Add option to run LLVM optimisation passes

### DIFF
--- a/cmake/LLVMHelper.cmake
+++ b/cmake/LLVMHelper.cmake
@@ -5,7 +5,7 @@
 find_package(LLVM REQUIRED CONFIG)
 
 # include LLVM header and core library
-llvm_map_components_to_libnames(LLVM_LIBS_TO_LINK core)
+llvm_map_components_to_libnames(LLVM_LIBS_TO_LINK core native)
 set(CMAKE_REQUIRED_INCLUDES ${LLVM_INCLUDE_DIRS})
 set(CMAKE_REQUIRED_LIBRARIES ${LLVM_LIBS_TO_LINK})
 

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -164,14 +164,18 @@ int main(int argc, const char* argv[]) {
     /// floating point data type
     std::string data_type("double");
 
+#ifdef NMODL_LLVM_BACKEND
+    /// generate llvm IR
+    bool llvm_ir(false);
+
+    /// run llvm optimisation passes
+    bool llvm_opt_passes(false);
+#endif
+
     app.get_formatter()->column_width(40);
     app.set_help_all_flag("-H,--help-all", "Print this help message including all sub-commands");
 
     app.add_flag("-v,--verbose", verbose, "Verbose logger output")->ignore_case();
-
-#ifdef NMODL_LLVM_BACKEND
-    app.add_flag("--llvm", llvm_backend, "Enable LLVM based code generation")->ignore_case();
-#endif
 
     app.add_option("file", mod_files, "One or more MOD files to process")
         ->ignore_case()
@@ -273,6 +277,15 @@ int main(int argc, const char* argv[]) {
         optimize_ionvar_copies_codegen,
         "Optimize copies of ion variables ({})"_format(optimize_ionvar_copies_codegen))->ignore_case();
 
+#ifdef NMODL_LLVM_BACKEND
+    auto llvm_opt = app.add_subcommand("llvm", "LLVM code generation option")->ignore_case();
+    llvm_opt->add_flag("--ir",
+        llvm_ir,
+        "Generate LLVM IR ({})"_format(llvm_ir))->ignore_case();
+    llvm_opt->add_flag("--opt",
+        llvm_opt_passes,
+        "Run LLVM optimisation passes ({})"_format(llvm_opt_passes))->ignore_case();
+#endif
     // clang-format on
 
     CLI11_PARSE(app, argc, argv);
@@ -556,9 +569,9 @@ int main(int argc, const char* argv[]) {
             }
 
 #ifdef NMODL_LLVM_BACKEND
-            if (llvm_backend) {
+            if (llvm_ir) {
                 logger->info("Running LLVM backend code generator");
-                CodegenLLVMVisitor visitor(modfile, output_dir);
+                CodegenLLVMVisitor visitor(modfile, output_dir, llvm_opt_passes);
                 visitor.visit_program(*ast);
             }
 #endif

--- a/test/integration/mod/procedure.mod
+++ b/test/integration/mod/procedure.mod
@@ -21,11 +21,17 @@ PROCEDURE complex_sum(v) {
     }
 }
 
-PROCEDURE loop_function(v) {
+PROCEDURE loop_proc(v) {
     LOCAL i
     i = 0
     WHILE(i < 10) {
         printf("Hello World")
         i = i + 1
     }
+}
+
+FUNCTION square(x) {
+    LOCAL res
+    res = x * x
+    square = res
 }

--- a/test/unit/codegen/llvm.cpp
+++ b/test/unit/codegen/llvm.cpp
@@ -23,14 +23,14 @@ using nmodl::parser::NmodlDriver;
 // Utility to get LLVM module as a string
 //=============================================================================
 
-std::string run_llvm_visitor(const std::string& text) {
+std::string run_llvm_visitor(const std::string& text, bool opt = false) {
     NmodlDriver driver;
     const auto& ast = driver.parse_string(text);
 
     SymtabVisitor().visit_program(*ast);
     InlineVisitor().visit_program(*ast);
 
-    codegen::CodegenLLVMVisitor llvm_visitor("unknown", ".");
+    codegen::CodegenLLVMVisitor llvm_visitor("unknown", ".", opt);
     llvm_visitor.visit_program(*ast);
     return llvm_visitor.print_module();
 }
@@ -52,13 +52,24 @@ SCENARIO("Binary expression", "[visitor][llvm]") {
             std::string module_string = run_llvm_visitor(nmodl_text);
             std::smatch m;
 
-            // Check the values are loaded correctly and added
             std::regex rhs(R"(%1 = load double, double\* %b)");
             std::regex lhs(R"(%2 = load double, double\* %a)");
             std::regex res(R"(%3 = fadd double %2, %1)");
+
+            // Check the values are loaded correctly and added
             REQUIRE(std::regex_search(module_string, m, rhs));
             REQUIRE(std::regex_search(module_string, m, lhs));
             REQUIRE(std::regex_search(module_string, m, res));
+        }
+
+        THEN("with optimisation enabled, all ops are eliminated") {
+            std::string module_string = run_llvm_visitor(nmodl_text, true);
+            std::smatch m;
+
+            // Check if the values are optimised out
+            std::regex empty_proc(
+                R"(define void @add\(double %a1, double %b2\) \{\n(\s)*ret void\n\})");
+            REQUIRE(std::regex_search(module_string, m, empty_proc));
         }
     }
 


### PR DESCRIPTION
  - update CLI argument from --llvm to llvm --ir --opt
  - --ir runs CodegenLLVMVicitor and emits LLVM IR
  - --opt runs basic LLVM optimisation passes
  - update simple test to check optimisation passes

@georgemitenkov : I was playing with LLVM passes to see if/how they work. I have opened this PR to your  #470 just for simplicity (to easily see the diff). This is just a draft PR anyway! If you think it's useful then we can use it after #470 is finalised or keep it for `later`. 

What this does is: current output **without** optimisations enabled:

```
$ ./bin/nmodl ../test/integration/mod/procedure.mod llvm --ir
[NMODL] [info] :: Processing ../test/integration/mod/procedure.mod
[NMODL] [info] :: Running symtab visitor
[NMODL] [info] :: Running CVode to cnexp visitor
[NMODL] [info] :: Running LOCAL to ASSIGNED visitor
[NMODL] [info] :: Running code compatibility checker
[NMODL] [info] :: Running verbatim rename visitor
[NMODL] [info] :: Running KINETIC block visitor
[NMODL] [info] :: Running STEADYSTATE visitor
[NMODL] [info] :: Parsing Units
[NMODL] [info] :: Running cnexp visitor
[NMODL] [info] :: Running C backend code generator
[NMODL] [warning] :: RenameVisitor :: Renaming variable v at 15.23 to arg_v
[NMODL] [warning] :: RenameVisitor :: Renaming variable v at 18.28 to arg_v
[NMODL] [warning] :: RenameVisitor :: Renaming variable v at 19.27 to arg_v
[NMODL] [warning] :: RenameVisitor :: Renaming variable v at 24.25 to arg_v
[NMODL] [info] :: Running LLVM backend code generator
; ModuleID = 'procedure'
source_filename = "procedure"

define void @hello_world() {
  ret void
}

define void @simple_sum(double %x1, double %y2) {
  %x = alloca double
  store double %x1, double* %x
  %y = alloca double
  store double %y2, double* %y
  %z = alloca double
  %1 = load double, double* %y
  %2 = load double, double* %x
  %3 = fadd double %2, %1
  store double %3, double* %z
  ret void
}

define void @complex_sum(double %arg_v1) {
  %arg_v = alloca double
  store double %arg_v1, double* %arg_v
  %alpha = alloca double
  %beta = alloca double
  %sum = alloca double
  %1 = load double, double* %arg_v
  %2 = fadd double %1, 4.000000e+01
  %3 = fsub double -0.000000e+00, %2
  %4 = fmul double 1.000000e-01, %3
  store double %4, double* %alpha
  %5 = load double, double* %arg_v
  %6 = fadd double %5, 6.500000e+01
  %7 = fsub double -0.000000e+00, %6
  %8 = fdiv double %7, 1.800000e+01
  %9 = fmul double 4.000000e+00, %8
  store double %9, double* %beta
  %10 = load double, double* %beta
  %11 = load double, double* %alpha
  %12 = fadd double %11, %10
  store double %12, double* %sum
  ret void
}

define void @loop_function(double %arg_v1) {
  %arg_v = alloca double
  store double %arg_v1, double* %arg_v
  %i = alloca double
  store double 0.000000e+00, double* %i
  ret void
}
```

And with optimisations enabled:

```
$ ./bin/nmodl ../test/integration/mod/procedure.mod llvm --ir --opt
[NMODL] [info] :: Processing ../test/integration/mod/procedure.mod
[NMODL] [info] :: Running symtab visitor
[NMODL] [info] :: Running CVode to cnexp visitor
[NMODL] [info] :: Running LOCAL to ASSIGNED visitor
[NMODL] [info] :: Running code compatibility checker
[NMODL] [info] :: Running verbatim rename visitor
[NMODL] [info] :: Running KINETIC block visitor
[NMODL] [info] :: Running STEADYSTATE visitor
[NMODL] [info] :: Parsing Units
[NMODL] [info] :: Running cnexp visitor
[NMODL] [info] :: Running C backend code generator
[NMODL] [warning] :: RenameVisitor :: Renaming variable v at 15.23 to arg_v
[NMODL] [warning] :: RenameVisitor :: Renaming variable v at 18.28 to arg_v
[NMODL] [warning] :: RenameVisitor :: Renaming variable v at 19.27 to arg_v
[NMODL] [warning] :: RenameVisitor :: Renaming variable v at 24.25 to arg_v
[NMODL] [info] :: Running LLVM backend code generator
[NMODL] [info] :: Running LLVM optimisation passes
; ModuleID = 'procedure'
source_filename = "procedure"

define void @hello_world() {
  ret void
}

define void @simple_sum(double %x1, double %y2) {
  ret void
}

define void @complex_sum(double %arg_v1) {
  ret void
}

define void @loop_function(double %arg_v1) {
  ret void
}
```