### PR TITLE
NrnState block transformations in AST to help code generation

### DIFF
--- a/src/ast/ast_common.hpp
+++ b/src/ast/ast_common.hpp
@@ -43,6 +43,9 @@ namespace ast {
  *
  * NMODL support different binary operators and this
  * type is used to store their value in the AST.
+ *
+ * \note `+=` and `-=` are not supported by NMODL. They
+ * are added for code generation purpose.
  */
 typedef enum {
     BOP_ADDITION,        ///< \+
@@ -58,7 +61,9 @@ typedef enum {
     BOP_LESS_EQUAL,      ///< <=
     BOP_ASSIGN,          ///< =
     BOP_NOT_EQUAL,       ///< !=
-    BOP_EXACT_EQUAL      ///< ==
+    BOP_EXACT_EQUAL,     ///< ==
+    BOP_ADD_ASSIGN,      ///< \+=
+    BOP_SUB_ASSIGN       ///< \-=
 } BinaryOp;
 
 /**
@@ -68,7 +73,7 @@ typedef enum {
  * is used to lookup the corresponding symbol for the operator.
  */
 static const std::string BinaryOpNames[] =
-    {"+", "-", "*", "/", "^", "&&", "||", ">", "<", ">=", "<=", "=", "!=", "=="};
+    {"+", "-", "*", "/", "^", "&&", "||", ">", "<", ">=", "<=", "=", "!=", "==", "+=", "-="};
 
 /// enum type for unary operators
 typedef enum { UOP_NOT, UOP_NEGATION } UnaryOp;

--- a/src/ast/ast_common.hpp
+++ b/src/ast/ast_common.hpp
@@ -44,8 +44,8 @@ namespace ast {
  * NMODL support different binary operators and this
  * type is used to store their value in the AST.
  *
- * \note `+=` and `-=` are not supported by NMODL. They
- * are added for code generation purpose.
+ * \note `+=` and `-=` are not supported by NMODL but they
+ * are added for code generation nodes.
  */
 typedef enum {
     BOP_ADDITION = 0,    ///< \+
@@ -111,11 +111,16 @@ typedef enum { LTMINUSGT, LTLT, MINUSGT } ReactionOp;
 /// string representation of ast::ReactionOp
 static const std::string ReactionOpNames[] = {"<->", "<<", "->"};
 
-/// convert operator in std::string form to ast::BinaryOp
+/**
+ * Get corresponding ast::BinaryOp for given string
+ * @param op Binary operator in string format
+ * @return ast::BinaryOp for given string
+ */
 static inline BinaryOp string_to_binaryop(const std::string& op) {
+    /// check if binary operator supported otherwise error
     auto it = std::find(std::begin(BinaryOpNames), std::end(BinaryOpNames), op);
     if (it == std::end(BinaryOpNames)) {
-        throw std::runtime_error("Error in string_to_binaryop, can not find " + op);
+        throw std::runtime_error("Error in string_to_binaryop, can't find " + op);
     }
     int pos = std::distance(std::begin(BinaryOpNames), it);
     return static_cast<BinaryOp>(pos);

--- a/src/ast/ast_common.hpp
+++ b/src/ast/ast_common.hpp
@@ -48,7 +48,7 @@ namespace ast {
  * are added for code generation purpose.
  */
 typedef enum {
-    BOP_ADDITION,        ///< \+
+    BOP_ADDITION = 0,    ///< \+
     BOP_SUBTRACTION,     ///< --
     BOP_MULTIPLICATION,  ///< \c *
     BOP_DIVISION,        ///< \/
@@ -111,6 +111,15 @@ typedef enum { LTMINUSGT, LTLT, MINUSGT } ReactionOp;
 /// string representation of ast::ReactionOp
 static const std::string ReactionOpNames[] = {"<->", "<<", "->"};
 
+/// convert operator in std::string form to ast::BinaryOp
+static inline BinaryOp string_to_binaryop(const std::string& op) {
+    auto it = std::find(std::begin(BinaryOpNames), std::end(BinaryOpNames), op);
+    if (it == std::end(BinaryOpNames)) {
+        throw std::runtime_error("Error in string_to_binaryop, can not find " + op);
+    }
+    int pos = std::distance(std::begin(BinaryOpNames), it);
+    return static_cast<BinaryOp>(pos);
+}
 /** @} */  // end of ast_prop
 
 }  // namespace ast

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -46,36 +46,6 @@ namespace codegen {
  * @{
  */
 
-/**
- * \enum BlockType
- * \brief Helper to represent various block types
- *
- * Note: do not assign integers to these enums
- *
- */
-enum BlockType {
-    /// initial block
-    Initial,
-
-    /// breakpoint block
-    Equation,
-
-    /// ode_* routines block (not used)
-    Ode,
-
-    /// derivative block
-    State,
-
-    /// watch block
-    Watch,
-
-    /// net_receive block
-    NetReceive,
-
-    /// fake ending block type for loops on the enums. Keep it at the end
-    BlockTypeEnd
-};
-
 
 /**
  * \enum MemberType
@@ -155,7 +125,7 @@ enum class LayoutType {
  *
  * \todo If shadow_lhs is empty then we assume shadow statement not required
  */
-struct ShadowUseStatement {
+struct ShadowUseStatement_del {
     std::string lhs;
     std::string op;
     std::string rhs;

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -115,22 +115,6 @@ enum class LayoutType {
     soa
 };
 
-
-/**
- * \class ShadowUseStatement
- * \brief Represents ion write statement during code generation
- *
- * Ion update statement needs use of shadow vectors for certain backends
- * as atomics operations are not supported on cpu backend.
- *
- * \todo If shadow_lhs is empty then we assume shadow statement not required
- */
-struct ShadowUseStatement_del {
-    std::string lhs;
-    std::string op;
-    std::string rhs;
-};
-
 /** @} */  // end of codegen_details
 
 

--- a/src/codegen/codegen_info.cpp
+++ b/src/codegen/codegen_info.cpp
@@ -235,8 +235,9 @@ std::vector<ShadowUseStatement> CodegenInfo::ion_write_statements(BlockType type
                 if (type == BlockType::Equation) {
                     auto current = breakpoint_current(var);
                     auto lhs = variable_names.first;
-                    auto op = "+=";
-                    auto rhs = current;
+                    // \todo "+=" is not supported by NMODL
+                    auto op = "=";
+                    auto rhs = lhs + " + " + current;
                     if (point_process) {
                         auto area = codegen::naming::NODE_AREA_VARIABLE;
                         rhs += "*(1.e2/{})"_format(area);

--- a/src/codegen/codegen_info.cpp
+++ b/src/codegen/codegen_info.cpp
@@ -243,5 +243,26 @@ std::string CodegenInfo::breakpoint_current(std::string current) const {
     return current;
 }
 
+
+bool CodegenInfo::is_an_instance_variable(const std::string& varname) const {
+    /// check if symbol of given name exist
+    auto check_symbol = [](const std::string& name, const std::vector<SymbolType>& symbols) {
+        for (auto& symbol: symbols) {
+            if (symbol->get_name() == name) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    /// check if variable exist into all possible types
+    if (check_symbol(varname, assigned_vars) || check_symbol(varname, state_vars) ||
+        check_symbol(varname, range_parameter_vars) || check_symbol(varname, range_assigned_vars) ||
+        check_symbol(varname, range_state_vars)) {
+        return true;
+    }
+    return false;
+}
+
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/codegen_info.cpp
+++ b/src/codegen/codegen_info.cpp
@@ -157,46 +157,6 @@ std::pair<std::string, std::string> CodegenInfo::write_ion_variable_name(
     return {"ion_" + name, name};
 }
 
-/**
- * \details Depending upon the block type, we have to print read/write ion variables
- * during code generation. Depending on block/procedure being printed, this
- * method return statements as vector. As different code backends could have
- * different variable names, we rely on backend-specific read_ion_variable_name
- * and write_ion_variable_name method which will be overloaded.
- *
- * \todo After looking into mod2c and neuron implementation, it seems like
- * Ode block type is not used. Need to look into implementation details.
- * \todo Ion copy optimization is not implemented yet. This is currently
- * implemented in C backend using `ion_read_statements_optimized()`.
- */
-std::vector<std::string> CodegenInfo::ion_read_statements(BlockType type) {
-    std::vector<std::string> statements;
-    for (const auto& ion: ions) {
-        const std::string& name = ion.name;
-        for (const auto& var: ion.reads) {
-            if (type == BlockType::Ode && ion.is_ionic_conc(var) && state_variable(var)) {
-                continue;
-            }
-            auto variable_names = read_ion_variable_name(var);
-            std::string& first = variable_names.first;
-            std::string& second = variable_names.second;
-            statements.push_back("{} = {}"_format(first, second));
-        }
-        for (const auto& var: ion.writes) {
-            if (type == BlockType::Ode && ion.is_ionic_conc(var) && state_variable(var)) {
-                continue;
-            }
-            if (ion.is_ionic_conc(var)) {
-                auto variables = read_ion_variable_name(var);
-                std::string& first = variables.first;
-                std::string& second = variables.second;
-                statements.push_back("{} = {}"_format(first, second));
-            }
-        }
-    }
-    return statements;
-}
-
 
 /**
  * \todo If intra or extra cellular ionic concentration is written

--- a/src/codegen/codegen_info.cpp
+++ b/src/codegen/codegen_info.cpp
@@ -235,9 +235,8 @@ std::vector<ShadowUseStatement> CodegenInfo::ion_write_statements(BlockType type
                 if (type == BlockType::Equation) {
                     auto current = breakpoint_current(var);
                     auto lhs = variable_names.first;
-                    // \todo "+=" is not supported by NMODL
-                    auto op = "=";
-                    auto rhs = lhs + " + " + current;
+                    auto op = "+=";
+                    auto rhs = current;
                     if (point_process) {
                         auto area = codegen::naming::NODE_AREA_VARIABLE;
                         rhs += "*(1.e2/{})"_format(area);

--- a/src/codegen/codegen_info.cpp
+++ b/src/codegen/codegen_info.cpp
@@ -17,8 +17,8 @@ namespace nmodl {
 namespace codegen {
 
 using namespace fmt::literals;
-using visitor::VarUsageVisitor;
 using symtab::syminfo::NmodlType;
+using visitor::VarUsageVisitor;
 
 /// if any ion has write variable
 bool CodegenInfo::ion_has_write_variable() const {
@@ -172,7 +172,7 @@ std::pair<std::string, std::string> CodegenInfo::write_ion_variable_name(
 std::vector<std::string> CodegenInfo::ion_read_statements(BlockType type) {
     std::vector<std::string> statements;
     for (const auto& ion: ions) {
-        std::string& name = ion.name;
+        const std::string& name = ion.name;
         for (const auto& var: ion.reads) {
             if (type == BlockType::Ode && ion.is_ionic_conc(var) && state_variable(var)) {
                 continue;

--- a/src/codegen/codegen_info.hpp
+++ b/src/codegen/codegen_info.hpp
@@ -467,13 +467,6 @@ struct CodegenInfo {
      */
     std::pair<std::string, std::string> write_ion_variable_name(const std::string& name) const;
 
-    /**
-     * For a given output block type, return statements for all read ion variables
-     *
-     * \param type The type of code block being generated
-     * \return     A \c vector of strings representing the reading of ion variables
-     */
-    std::vector<std::string> ion_read_statements(BlockType type);
 
     /**
      * For a given output block type, return statements for writing back ion variables

--- a/src/codegen/codegen_info.hpp
+++ b/src/codegen/codegen_info.hpp
@@ -467,16 +467,6 @@ struct CodegenInfo {
      */
     std::pair<std::string, std::string> write_ion_variable_name(const std::string& name) const;
 
-
-    /**
-     * For a given output block type, return statements for writing back ion variables
-     *
-     * \param type The type of code block being generated
-     * \return     A \c vector of strings representing the write-back of ion variables
-     */
-    std::vector<ShadowUseStatement> ion_write_statements(BlockType type);
-
-
     /**
      * Determine the variable name for the "current" used in breakpoint block taking into account
      * intermediate code transformations.

--- a/src/codegen/codegen_info.hpp
+++ b/src/codegen/codegen_info.hpp
@@ -164,7 +164,13 @@ enum BlockType {
  * Ion update statement needs use of shadow vectors for certain backends
  * as atomics operations are not supported on cpu backend.
  *
- * \todo If shadow_lhs is empty then we assume shadow statement not required
+ * \todo Currently `nrn_wrote_conc` is also added to shadow update statements
+ * list as it's corresponding to ion update statement in INITIAL block. This
+ * needs to be factored out.
+ * \todo This can be represented as AST node (like ast::CodegenAtomicStatement)
+ * but currently C backend use this same implementation. So we are using this
+ * same structure and then converting to ast::CodegenAtomicStatement for LLVM
+ * visitor.
  */
 struct ShadowUseStatement {
     std::string lhs;

--- a/src/codegen/codegen_info.hpp
+++ b/src/codegen/codegen_info.hpp
@@ -485,6 +485,16 @@ struct CodegenInfo {
      */
     std::string breakpoint_current(std::string current) const;
 
+    /**
+     * Check if variable with given name is an instance variable
+     *
+     * Instance varaibles are local to each mechanism instance and
+     * needs to be accessed with an array index. Such variables are
+     * assigned, range, parameter+range etc.
+     * @param varname Name of the variable
+     * @return True if variable is per mechanism instance
+     */
+    bool is_an_instance_variable(const std::string& varname) const;
 
     /// if we need a call back to wrote_conc in neuron/coreneuron
     bool require_wrote_conc = false;

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -9,6 +9,7 @@
 #include "codegen_llvm_helper_visitor.hpp"
 
 #include "ast/all.hpp"
+#include "codegen/codegen_helper_visitor.hpp"
 #include "utils/logger.hpp"
 #include "visitors/visitor_utils.hpp"
 
@@ -17,11 +18,67 @@ namespace codegen {
 
 using namespace fmt::literals;
 
+/**
+ * \brief Create variable definition statement
+ * @param names Name of the variables to be defined
+ * @param type Type of the variables
+ * @return Statement defining variables
+ */
+static std::shared_ptr<ast::CodegenVarListStatement> create_variable_statement(
+    const std::vector<std::string>& names,
+    ast::AstNodeType type) {
+    /// create variables for the given name
+    ast::CodegenVarVector variables;
+    for (const auto& name: names) {
+        auto varname = new ast::Name(new ast::String(name));
+        variables.emplace_back(new ast::CodegenVar(0, varname));
+    }
+    auto var_type = new ast::CodegenVarType(type);
+    /// construct statement and return it
+    return std::make_shared<ast::CodegenVarListStatement>(var_type, variables);
+}
+
+/**
+ * \brief Create expression for a given NMODL code statement
+ * @param code NMODL code statement
+ * @return Expression representing given NMODL code
+ */
+static std::shared_ptr<ast::Expression> create_statement_as_expression(const std::string& code) {
+    const auto& statement = visitor::create_statement(code);
+    auto expr_statement = std::dynamic_pointer_cast<ast::ExpressionStatement>(statement);
+    auto expr = expr_statement->get_expression()->clone();
+    return std::make_shared<ast::WrappedExpression>(expr);
+}
+
+/**
+ * \brief Create expression for given NMODL code expression
+ * @param code NMODL code expression
+ * @return Expression representing NMODL code
+ */
+std::shared_ptr<ast::Expression> get_expression(const std::string& code) {
+    /// as provided code is only expression and not a full statement, create
+    /// a temporary assignment statement
+    const auto& wrapped_expr = create_statement_as_expression("some_var = " + code);
+    /// now extract RHS (representing original code) and return it as expression
+    auto expr = std::dynamic_pointer_cast<ast::WrappedExpression>(wrapped_expr)->get_expression();
+    auto rhs = std::dynamic_pointer_cast<ast::BinaryExpression>(expr)->get_rhs();
+    return std::make_shared<ast::WrappedExpression>(rhs->clone());
+}
+
+/**
+ * \brief Visit StatementBlock and convert Local statement for code generation
+ * @param node AST node representing Statement block
+ *
+ * Statement blocks can have LOCAL statement and if it exist it's typically
+ * first statement in the vector. We have to remove LOCAL statement and convert
+ * it to CodegenVarListStatement that will represent all variables as double.
+ */
 void CodegenLLVMHelperVisitor::visit_statement_block(ast::StatementBlock& node) {
+    /// first process all children blocks if any
     node.visit_children(*this);
 
-    /// if local list statement exist, we have to replace it
-    auto local_statement = visitor::get_local_list_statement(node);
+    /// check if block contains LOCAL statement
+    const auto& local_statement = visitor::get_local_list_statement(node);
     if (local_statement) {
         /// create codegen variables from local variables
         ast::CodegenVarVector variables;
@@ -33,34 +90,60 @@ void CodegenLLVMHelperVisitor::visit_statement_block(ast::StatementBlock& node) 
         const auto& statements = node.get_statements();
         node.erase_statement(statements.begin());
 
-        /// create new codegen variable statement
+        /// create new codegen variable statement and insert at the beginning of the block
         auto type = new ast::CodegenVarType(ast::AstNodeType::DOUBLE);
         auto statement = std::make_shared<ast::CodegenVarListStatement>(type, variables);
-
-        /// insert codegen variable statement
         node.insert_statement(statements.begin(), statement);
     }
 }
 
-void CodegenLLVMHelperVisitor::add_function_procedure_node(ast::Block& node) {
+/**
+ * \brief Add code generation function for FUNCTION or PROCEDURE block
+ * @param node AST node representing FUNCTION or PROCEDURE
+ *
+ * When we have a PROCEDURE or FUNCTION like
+ *
+ * \code{.mod}
+ *      FUNCTION sum(x,y) {
+ *          LOCAL res
+ *          res = x + y
+ *          sum = res
+ *      }
+ * \endcode
+ *
+ * this gets typically converted to C/C++ code as:
+ *
+ * \code{.cpp}
+ *      double sum(double x, double y) {
+ *          double res;
+ *          double ret_sum;
+ *          res = x + y;
+ *          ret_sum = res;
+ *          return ret_sum;
+ * \endcode
+ *
+ * We perform following transformations so that code generation backends
+ * will have minimum logic:
+ *  - Add return type
+ *  - Add type for the function arguments
+ *  - Define variables and return variable
+ *  - Add return type (int for PROCEDURE and double for FUNCTION)
+ */
+void CodegenLLVMHelperVisitor::create_function_for_node(ast::Block& node) {
+    /// name of the function from the node
     std::string function_name = node.get_node_name();
-
-    const auto& source_node_type = node.get_node_type();
     auto name = new ast::Name(new ast::String(function_name));
+
+    /// return variable name has "ret_" prefix
     auto return_var = new ast::Name(new ast::String("ret_" + function_name));
-    ast::CodegenVarType* var_type = nullptr;
-    ast::CodegenVarType* return_type = nullptr;
 
     /// return type based on node type
-    bool is_function = source_node_type == ast::AstNodeType::FUNCTION_BLOCK;
-    if (is_function) {
-        var_type = new ast::CodegenVarType(ast::AstNodeType::DOUBLE);
+    ast::CodegenVarType* ret_var_type = nullptr;
+    if (node.get_node_type() == ast::AstNodeType::FUNCTION_BLOCK) {
+        ret_var_type = new ast::CodegenVarType(ast::AstNodeType::DOUBLE);
     } else {
-        var_type = new ast::CodegenVarType(ast::AstNodeType::INTEGER);
+        ret_var_type = new ast::CodegenVarType(ast::AstNodeType::INTEGER);
     }
-
-    /// return type is same as variable type
-    return_type = var_type->clone();
 
     /// function body and it's statement
     auto block = node.get_statement_block()->clone();
@@ -69,39 +152,122 @@ void CodegenLLVMHelperVisitor::add_function_procedure_node(ast::Block& node) {
     /// insert return variable at the start of the block
     ast::CodegenVarVector codegen_vars;
     codegen_vars.emplace_back(new ast::CodegenVar(0, return_var->clone()));
-    auto statement = std::make_shared<ast::CodegenVarListStatement>(var_type, codegen_vars);
+    auto statement = std::make_shared<ast::CodegenVarListStatement>(ret_var_type, codegen_vars);
     block->insert_statement(statements.begin(), statement);
 
     /// add return statement
     auto return_statement = new ast::CodegenReturnStatement(return_var);
     block->emplace_back_statement(return_statement);
 
-    /// prepare arguments
-    ast::CodegenArgumentVector code_arguments;
+    /// prepare function arguments based original node arguments
+    ast::CodegenArgumentVector fun_arguments;
     const auto& arguments = node.get_parameters();
     for (const auto& arg: arguments) {
+        /// create new type and name for creating new ast node
         auto type = new ast::CodegenVarType(ast::AstNodeType::DOUBLE);
         auto var = arg->get_name()->clone();
-        code_arguments.emplace_back(new ast::CodegenArgument(type, var));
+        fun_arguments.emplace_back(new ast::CodegenArgument(type, var));
     }
 
-    /// add new node to AST
+    /// return type of the function is same as return variable type
+    ast::CodegenVarType* fun_ret_type = ret_var_type->clone();
+
+    /// we have all information for code generation function, create a new node
+    /// which will be inserted later into AST
     auto function =
-        std::make_shared<ast::CodegenFunction>(return_type, name, code_arguments, block);
+        std::make_shared<ast::CodegenFunction>(fun_ret_type, name, fun_arguments, block);
     codegen_functions.push_back(function);
 }
 
 void CodegenLLVMHelperVisitor::visit_procedure_block(ast::ProcedureBlock& node) {
     node.visit_children(*this);
-    add_function_procedure_node(node);
+    create_function_for_node(node);
 }
 
 void CodegenLLVMHelperVisitor::visit_function_block(ast::FunctionBlock& node) {
     node.visit_children(*this);
-    add_function_procedure_node(node);
+    create_function_for_node(node);
+}
+
+/**
+ * \brief Convert ast::NrnStateBlock to corresponding code generation function nrn_state
+ * @param node AST node representing ast::NrnStateBlock
+ *
+ * Solver passes converts DERIVATIVE block from MOD into ast::NrnStateBlock node
+ * that represent `nrn_state` function in the generated CPP code. To help this
+ * code generation, we perform various transformation on ast::NrnStateBlock and
+ * create new code generation function.
+ */
+void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
+    /// double and integer variables in the new function
+    std::vector<std::string> double_variables{"v"};
+    std::vector<std::string> int_variables{"id", "node_id"};
+
+    /// statements for new function to be generated
+    ast::StatementVector function_statements;
+
+    /// create variable definition statements and insert at the beginning
+    function_statements.push_back(
+        create_variable_statement(double_variables, ast::AstNodeType::DOUBLE));
+    function_statements.push_back(
+        create_variable_statement(int_variables, ast::AstNodeType::INTEGER));
+
+    /// create now main compute part : for loop over channels
+
+    /// for loop constructs : initialization, condition and increment
+    const auto& initialization = create_statement_as_expression("id=0");
+    const auto& condition = get_expression("id < node_count");
+    const auto& increment = create_statement_as_expression("id = id + 1");
+
+    /// loop body : initialization + solve blocks
+    ast::StatementVector loop_body;
+
+    /// access node index and corresponding voltage
+    loop_body.push_back(visitor::create_statement("node_id = node_index[id]"));
+    loop_body.push_back(visitor::create_statement("v = voltage[node_id]"));
+
+    /// extract solution expressions that are derivative blocks
+    const auto& solutions = collect_nodes(node, {ast::AstNodeType::SOLUTION_EXPRESSION});
+    for (const auto& statement: solutions) {
+        const auto& solution = std::dynamic_pointer_cast<ast::SolutionExpression>(statement);
+        auto solution_expr = solution->get_node_to_solve()->clone();
+        loop_body.emplace_back(std::make_shared<ast::ExpressionStatement>(solution_expr));
+    }
+
+    /// now construct a new code block which will become the bidy of the loop
+    auto block = std::make_shared<ast::StatementBlock>(loop_body);
+
+    /// create for loop node
+    auto for_loop_statement =
+        std::make_shared<ast::CodegenForStatement>(initialization, condition, increment, block);
+
+    /// loop itself becomes one of the statement in the function
+    function_statements.push_back(for_loop_statement);
+
+    /// new block for the function
+    auto function_block = new ast::StatementBlock(function_statements);
+
+    /// name of the function and it's return type
+    std::string function_name = "nrn_state_" + stringutils::tolower(info.mod_suffix);
+    auto name = new ast::Name(new ast::String(function_name));
+    auto return_type = new ast::CodegenVarType(ast::AstNodeType::VOID);
+
+    /// \todo : currently there are no arguments
+    ast::CodegenArgumentVector code_arguments;
+
+    /// finally, create new function
+    auto function =
+        std::make_shared<ast::CodegenFunction>(return_type, name, code_arguments, function_block);
+    codegen_functions.push_back(function);
+
+    std::cout << nmodl::to_nmodl(function);
 }
 
 void CodegenLLVMHelperVisitor::visit_program(ast::Program& node) {
+    /// run codegen helper visitor to collect information
+    CodegenHelperVisitor v;
+    info = v.analyze(node);
+
     logger->info("Running CodegenLLVMHelperVisitor");
     node.visit_children(*this);
     for (auto& fun: codegen_functions) {

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -226,6 +226,12 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     loop_body.push_back(visitor::create_statement("node_id = node_index[id]"));
     loop_body.push_back(visitor::create_statement("v = voltage[node_id]"));
 
+    /// read ion variables
+    const auto& read_statements = info.ion_read_statements(BlockType::State);
+    for (auto& statement: read_statements) {
+        loop_body.push_back(visitor::create_statement(statement));
+    }
+
     /// extract solution expressions that are derivative blocks
     const auto& solutions = collect_nodes(node, {ast::AstNodeType::SOLUTION_EXPRESSION});
     for (const auto& statement: solutions) {

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -412,7 +412,7 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     /// create now main compute part : for loop over channel instances
 
     /// loop constructs : initialization, condition and increment
-    const auto& initialization = create_statement_as_expression("id=0");
+    const auto& initialization = create_statement_as_expression("id = 0");
     const auto& condition = create_expression("id < node_count");
     const auto& increment = create_statement_as_expression("id = id + 1");
 
@@ -469,7 +469,7 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     loop_body.insert(loop_body.end(), loop_index_statements.begin(), loop_index_statements.end());
     loop_body.insert(loop_body.end(), loop_body_statements.begin(), loop_body_statements.end());
 
-    /// now construct a new code block which will become the bidy of the loop
+    /// now construct a new code block which will become the body of the loop
     auto loop_block = std::make_shared<ast::StatementBlock>(loop_body);
 
     /// convert all variables inside loop body to instance variables

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -186,19 +186,9 @@ static void append_statements_from_block(ast::StatementVector& statements, const
 
 static std::shared_ptr<ast::CodegenAtomicStatement> create_atomic_statement(ShadowUseStatement& statement) {
     auto lhs = std::make_shared<ast::Name>(new ast::String(statement.lhs));
-    ast::BinaryOp op;
-    if (statement.op.compare("-=")) {
-        op = ast::BinaryOp::BOP_SUB_ASSIGN;
-    } else if (statement.op.compare("+=")) {
-        op = ast::BinaryOp::BOP_ADD_ASSIGN;
-    } else if (statement.op.compare("=")) {
-        op = ast::BinaryOp::BOP_ASSIGN;
-    } else {
-        throw std::runtime_error("Unsupported operator in create_atomic_statement");
-    }
+    auto op = ast::BinaryOperator(ast::string_to_binaryop(statement.op));
     auto rhs = get_expression(statement.rhs);
-    auto atomic_op = ast::BinaryOperator(op);
-    return std::make_shared<ast::CodegenAtomicStatement>(lhs, atomic_op, rhs);
+    return std::make_shared<ast::CodegenAtomicStatement>(lhs, op, rhs);
 }
 
 

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -68,10 +68,12 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
                              ast::StatementVector& body_statements);
 
     void ion_write_statements(BlockType type,
-                             std::vector<std::string>& int_variables,
-                             std::vector<std::string>& double_variables,
-                             ast::StatementVector& index_statements,
-                             ast::StatementVector& body_statements);
+                              std::vector<std::string>& int_variables,
+                              std::vector<std::string>& double_variables,
+                              ast::StatementVector& index_statements,
+                              ast::StatementVector& body_statements);
+
+    void convert_to_instance_variable(ast::Node& node, std::string& index_var);
 
     void visit_statement_block(ast::StatementBlock& node) override;
     void visit_procedure_block(ast::ProcedureBlock& node) override;

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -28,12 +28,31 @@ namespace codegen {
 
 /**
  * \class CodegenLLVMHelperVisitor
- * \brief Helper visitor to gather AST information to help LLVM code generation
+ * \brief Helper visitor for AST information to help code generation backends
+ *
+ * Code generation backends convert NMODL AST to C++ code. But during this
+ * C++ code generation, various transformations happens and final code generated
+ * is quite different / large than actual kernel represented in MOD file ro
+ * NMODL AST.
+ *
+ * Currently, these transformations are embedded into code generation backends
+ * like ast::CodegenCVisitor. If we have to generate code for new simulator, there
+ * will be duplication of these transformations. Also, for completely new
+ * backends like NEURON simulator or SIMD library, we will have code duplication.
+ *
+ * In order to avoid this, we perform maximum transformations in this visitor.
+ * Currently we focus on transformations that will help LLVM backend but later
+ * these will be common across all backends.
  */
 class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
+    /// newly generated code generation specific functions
     std::vector<std::shared_ptr<ast::CodegenFunction>> codegen_functions;
 
-    void add_function_procedure_node(ast::Block& node);
+    /// ast information for code generation
+    codegen::CodegenInfo info;
+
+    /// create new function for FUNCTION or PROCEDURE block
+    void create_function_for_node(ast::Block& node);
 
   public:
     CodegenLLVMHelperVisitor() = default;
@@ -41,6 +60,7 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
     void visit_statement_block(ast::StatementBlock& node) override;
     void visit_procedure_block(ast::ProcedureBlock& node) override;
     void visit_function_block(ast::FunctionBlock& node) override;
+    void visit_nrn_state_block(ast::NrnStateBlock& node) override;
     void visit_program(ast::Program& node) override;
 };
 

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -61,6 +61,18 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
   public:
     CodegenLLVMHelperVisitor() = default;
 
+    void ion_read_statements(BlockType type,
+                             std::vector<std::string>& int_variables,
+                             std::vector<std::string>& double_variables,
+                             ast::StatementVector& index_statements,
+                             ast::StatementVector& body_statements);
+
+    void ion_write_statements(BlockType type,
+                             std::vector<std::string>& int_variables,
+                             std::vector<std::string>& double_variables,
+                             ast::StatementVector& index_statements,
+                             ast::StatementVector& body_statements);
+
     void visit_statement_block(ast::StatementBlock& node) override;
     void visit_procedure_block(ast::ProcedureBlock& node) override;
     void visit_function_block(ast::FunctionBlock& node) override;

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -51,6 +51,10 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
     /// ast information for code generation
     codegen::CodegenInfo info;
 
+    /// default integer and float node type
+    const ast::AstNodeType INTEGER_TYPE = ast::AstNodeType::INTEGER;
+    const ast::AstNodeType FLOAT_TYPE = ast::AstNodeType::DOUBLE;
+
     /// create new function for FUNCTION or PROCEDURE block
     void create_function_for_node(ast::Block& node);
 

--- a/src/language/code_generator.cmake
+++ b/src/language/code_generator.cmake
@@ -193,6 +193,7 @@ set(AST_GENERATED_SOURCES
     ${PROJECT_BINARY_DIR}/src/ast/valence.hpp
     ${PROJECT_BINARY_DIR}/src/ast/var_name.hpp
     ${PROJECT_BINARY_DIR}/src/ast/verbatim.hpp
+    ${PROJECT_BINARY_DIR}/src/ast/void.hpp
     ${PROJECT_BINARY_DIR}/src/ast/watch.hpp
     ${PROJECT_BINARY_DIR}/src/ast/watch_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/while_statement.hpp

--- a/src/language/code_generator.cmake
+++ b/src/language/code_generator.cmake
@@ -66,6 +66,7 @@ set(AST_GENERATED_SOURCES
     ${PROJECT_BINARY_DIR}/src/ast/boolean.hpp
     ${PROJECT_BINARY_DIR}/src/ast/breakpoint_block.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_argument.hpp
+    ${PROJECT_BINARY_DIR}/src/ast/codegen_atomic_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_for_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_function.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_return_statement.hpp

--- a/src/language/codegen.yaml
+++ b/src/language/codegen.yaml
@@ -220,3 +220,34 @@
                             vector: true
                             separator: ", "
                             add: true
+                  - CodegenAtomicStatement:
+                      brief: "Represent atomic operation"
+                      description: |
+                        During code generation certain operations like ion updaates, vec_rhs or
+                        vec_d updates (for synapse) needs to be atomic operations. For example,
+                        here are some examples:
+
+                        \code{.cpp}
+                            vec_d[node_id] += g
+                            vec_rhs[node_id] -= rhs
+                            ion_ina[indexes[some_index] += ina[id]
+                            ion_cai[indexes[some_index] = cai[id]  // cai here is state variable
+                        \endcode
+
+                        These operations will be represented by atomic statement node type:
+                        * `vec_d[node_id]` will be lhs
+                        * `+=` will be atomic_op
+                        * `g` will be rhs
+
+                      members:
+                        - lhs:
+                            brief: "Variable to be updated atomically"
+                            type: Identifier
+                        - atomic_op:
+                            brief: "Operator"
+                            type: BinaryOperator
+                            prefix: {value: " "}
+                            suffix: {value: " "}
+                        - rhs:
+                            brief: "Expression for atomic operation"
+                            type: Expression

--- a/src/language/codegen.yaml
+++ b/src/language/codegen.yaml
@@ -231,8 +231,8 @@
                         \code{.cpp}
                             vec_d[node_id] += g
                             vec_rhs[node_id] -= rhs
-                            ion_ina[indexes[some_index] += ina[id]
-                            ion_cai[indexes[some_index] = cai[id]  // cai here is state variable
+                            ion_ina[indexes[some_index]] += ina[id]
+                            ion_cai[indexes[some_index]] = cai[id]  // cai here is state variable
                         \endcode
 
                         These operations will be represented by atomic statement node type:

--- a/src/language/codegen.yaml
+++ b/src/language/codegen.yaml
@@ -28,6 +28,9 @@
             - Expression:
                 children:
                   - Number:
+                  - Void:
+                      nmodl: "VOID"
+                      brief: "Represent void type in code generation"
                   - Identifier:
                       children:
                         - CodegenVarType:
@@ -185,7 +188,7 @@
                             brief: "condition expression for the loop"
                             type: Expression
                             optional: true
-                            prefix: {value: ";"}
+                            prefix: {value: "; "}
                             suffix: {value: "; "}
                         - increment:
                             brief: "increment or decrement expression for the loop"

--- a/src/language/codegen.yaml
+++ b/src/language/codegen.yaml
@@ -224,8 +224,9 @@
                       brief: "Represent atomic operation"
                       description: |
                         During code generation certain operations like ion updaates, vec_rhs or
-                        vec_d updates (for synapse) needs to be atomic operations. For example,
-                        here are some examples:
+                        vec_d updates (for synapse) needs to be atomic operations if executed by
+                        multiple threads. In case of SIMD, there are conflicts for `vec_d` and
+                        `vec_rhs` for synapse types. Here are some statements from C++ backend:
 
                         \code{.cpp}
                             vec_d[node_id] += g
@@ -235,9 +236,9 @@
                         \endcode
 
                         These operations will be represented by atomic statement node type:
-                        * `vec_d[node_id]` will be lhs
-                        * `+=` will be atomic_op
-                        * `g` will be rhs
+                        * `vec_d[node_id]` : lhs
+                        * `+=` : atomic_op
+                        * `g` : rhs
 
                       members:
                         - lhs:

--- a/src/language/codegen.yaml
+++ b/src/language/codegen.yaml
@@ -223,7 +223,7 @@
                   - CodegenAtomicStatement:
                       brief: "Represent atomic operation"
                       description: |
-                        During code generation certain operations like ion updaates, vec_rhs or
+                        During code generation certain operations like ion updates, vec_rhs or
                         vec_d updates (for synapse) needs to be atomic operations if executed by
                         multiple threads. In case of SIMD, there are conflicts for `vec_d` and
                         `vec_rhs` for synapse types. Here are some statements from C++ backend:

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -98,13 +98,14 @@ if(NMODL_ENABLE_LLVM)
   add_executable(testllvm visitor/main.cpp codegen/llvm.cpp)
   target_link_libraries(
     testllvm
+    llvm_codegen
+    codegen
     visitor
     symtab
     lexer
     util
     test_util
     printer
-    llvm_codegen
     ${NMODL_WRAPPER_LIBS}
     ${LLVM_LIBS_TO_LINK})
   set(CODEGEN_TEST testllvm)


### PR DESCRIPTION
  - added Void node type to represent void return type
  - llvm helper started handling visit_nrn_state_block
    - NrnStateBlock is being converted into CodegenFunction
    - for loop body with solution blocks created
    - voltage and node index initialization code added

Todo

- [x] Handle ION updates statements
- [x] Handle breakpoint block in case of empty currents
- [x] Replace all range variable types with indexed variable

We have MOD file as:

```
 PROCEDURE rates(v(mV)) {
     LOCAL alpha, beta, sum, q10
     UNITSOFF
     q10 = 3^((celsius-6.3)/10)
     alpha = .1*vtrap(-(v+40), 10)
     beta = 4*exp(-(v+65)/18)
     sum = alpha+beta
     mtau = 1/(q10*sum)
     minf = alpha/sum
     alpha = .07*exp(-(v+65)/20)
     beta = 1/(exp(-(v+35)/10)+1)
     sum = alpha+beta
     htau = 1/(q10*sum)
     hinf = alpha/sum
     alpha = .01*vtrap(-(v+55), 10)
     beta = .125*exp(-(v+65)/80)
     sum = alpha+beta
     ntau = 1/(q10*sum)
     ninf = alpha/sum
 }

DERIVATIVE states {
         rates(v)
         m' =  (minf-m)/mtau
         h' = (hinf-h)/htau
         n' = (ninf-n)/ntau
 }
```

After various passes of NMODL, before code generation, MOD file AST is:

```
 PROCEDURE rates(v(mV)) {
     LOCAL alpha, beta, sum, q10
     UNITSOFF
     q10 = 3^((celsius-6.3)/10)
     alpha = .1*vtrap(-(v+40), 10)
     beta = 4*exp(-(v+65)/18)
     sum = alpha+beta
     mtau = 1/(q10*sum)
     minf = alpha/sum
     alpha = .07*exp(-(v+65)/20)
     beta = 1/(exp(-(v+35)/10)+1)
     sum = alpha+beta
     htau = 1/(q10*sum)
     hinf = alpha/sum
     alpha = .01*vtrap(-(v+55), 10)
     beta = .125*exp(-(v+65)/80)
     sum = alpha+beta
     ntau = 1/(q10*sum)
     ninf = alpha/sum
 }

 NRN_STATE SOLVE states METHOD cnexp{
     rates(v)
     m = m+(1.0-exp(dt*((((-1.0)))/mtau)))*(-(((minf))/mtau)/((((-1.0)))/mtau)-m)
     h = h+(1.0-exp(dt*((((-1.0)))/htau)))*(-(((hinf))/htau)/((((-1.0)))/htau)-h)
     n = n+(1.0-exp(dt*((((-1.0)))/ntau)))*(-(((ninf))/ntau)/((((-1.0)))/ntau)-n)
 }
```
Generated C++ code is:

```cpp
     void nrn_state_hh(NrnThread* nt, Memb_list* ml, int type) {
         int nodecount = ml->nodecount;
         int pnodecount = ml->_nodecount_padded;
         const int* __restrict__ node_index = ml->nodeindices;
         double* __restrict__ data = ml->data;
         const double* __restrict__ voltage = nt->_actual_v;
         Datum* __restrict__ indexes = ml->pdata;
         ThreadDatum* __restrict__ thread = ml->_thread;
         hh_Instance* __restrict__ inst = (hh_Instance*) ml->instance;

         int start = 0;
         int end = nodecount;
         #pragma ivdep
         for (int id = start; id < end; id++) {
             int node_id = node_index[id];
             double v = voltage[node_id];
             inst->ena[id] = inst->ion_ena[indexes[0*pnodecount+id]];
             inst->ek[id] = inst->ion_ek[indexes[3*pnodecount+id]];
             rates_hh(id, pnodecount, inst, data, indexes, thread, nt, v, v);
             inst->m[id] = inst->m[id] + (1.0 - exp(nt->_dt * (((( -1.0))) / inst->mtau[id]))) * ( -(((inst->minf[id])) / inst->mtau[id]) / (((( -1.0))) / inst->mtau[id]) - inst-  >m[id]);
             inst->h[id] = inst->h[id] + (1.0 - exp(nt->_dt * (((( -1.0))) / inst->htau[id]))) * ( -(((inst->hinf[id])) / inst->htau[id]) / (((( -1.0))) / inst->htau[id]) - inst-  >h[id]);
             inst->n[id] = inst->n[id] + (1.0 - exp(nt->_dt * (((( -1.0))) / inst->ntau[id]))) * ( -(((inst->ninf[id])) / inst->ntau[id]) / (((( -1.0))) / inst->ntau[id]) - inst-  >n[id]);
         }
     }
```

With this PR, transformed NMODL AST is:

```
 INTEGER rates(DOUBLE arg_v){
     INTEGER ret_rates                                     // note : this should be initialised to zero by default
     DOUBLE alpha, beta, sum, q10
     UNITSOFF
     q10 = 3^((celsius-6.3)/10)
     alpha = .1*vtrap(-(arg_v+40), 10)
     beta = 4*exp(-(arg_v+65)/18)
     sum = alpha+beta
     mtau[id] = 1/(q10*sum)
     minf[id] = alpha/sum
     alpha = .07*exp(-(arg_v+65)/20)
     beta = 1/(exp(-(arg_v+35)/10)+1)
     sum = alpha+beta
     htau[id] = 1/(q10*sum)
     hinf[id] = alpha/sum
     alpha = .01*vtrap(-(arg_v+55), 10)
     beta = .125*exp(-(arg_v+65)/80)
     sum = alpha+beta
     ntau[id] = 1/(q10*sum)
     ninf[id] = alpha/sum
     return ret_rates
 }

VOID nrn_state_hh(){
    INTEGER id
    for(id = 0; id<node_count; id = id+1) {
        INTEGER node_id, ena_id, ek_id
        DOUBLE v
        node_id = node_index[id]
        ena_id = ion_ena_index[id]
        ek_id = ion_ek_index[id]
        v = voltage[node_id]
        ena[id] = ion_ena[ena_id]
        ek[id] = ion_ek[ek_id]
        rates(v)
        m[id] = m[id]+(1.0-exp(dt*((((-1.0)))/mtau[id])))*(-(((minf[id]))/mtau[id])/((((-1.0)))/mtau[id])-m[id])
        h[id] = h[id]+(1.0-exp(dt*((((-1.0)))/htau[id])))*(-(((hinf[id]))/htau[id])/((((-1.0)))/htau[id])-h[id])
        n[id] = n[id]+(1.0-exp(dt*((((-1.0)))/ntau[id])))*(-(((ninf[id]))/ntau[id])/((((-1.0)))/ntau[id])-n[id])
    }
}
```

See #474