### PR TITLE
Function call support

### DIFF
--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -80,8 +80,7 @@ void CodegenLLVMVisitor::create_function_call(llvm::Function* func,
     }
 
     // Process each argument and add it to a vector to pass to the function call instruction. Note
-    // that type checks are not needed here as NMODL operates on doubles by default. If that was not
-    // the case, cast instructions had to be created.
+    // that type checks are not needed here as NMODL operates on doubles by default.
     std::vector<llvm::Value*> argument_values;
     for (const auto& arg: arguments) {
         arg->accept(*this);

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -67,6 +67,8 @@ void CodegenLLVMVisitor::create_external_method_call(const std::string& name,
     DISPATCH("exp", llvm::Intrinsic::exp);
     DISPATCH("pow", llvm::Intrinsic::pow);
 #undef DISPATCH
+
+    throw std::runtime_error("Error: External method" + name + " is not currently supported");
 }
 
 void CodegenLLVMVisitor::create_function_call(llvm::Function* func,
@@ -240,7 +242,7 @@ void CodegenLLVMVisitor::visit_function_call(const ast::FunctionCall& node) {
             create_external_method_call(name, node.get_arguments());
         } else {
             throw std::runtime_error("Error: Unknown function name: " + name +
-                                     ". (External functions references are not supported)\n");
+                                     ". (External functions references are not supported)");
         }
     }
 }

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -113,6 +113,7 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     void visit_boolean(const ast::Boolean& node) override;
     void visit_double(const ast::Double& node) override;
     void visit_function_block(const ast::FunctionBlock& node) override;
+    void visit_function_call(const ast::FunctionCall& node) override;
     void visit_integer(const ast::Integer& node) override;
     void visit_local_list_statement(const ast::LocalListStatement& node) override;
     void visit_procedure_block(const ast::ProcedureBlock& node) override;

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -97,6 +97,12 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
         , fpm(module.get()) {}
 
     /**
+     * Emit function or procedure declaration in LLVM given the node
+     * \param node the AST node representing the function or procedure in NMODL
+     */
+    void emit_procedure_or_function_declaration(const ast::Block& node);
+
+    /**
      * Visit nmodl function or procedure
      * \param node the AST node representing the function or procedure in NMODL
      */

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -18,8 +18,8 @@
 #include <ostream>
 #include <string>
 
-#include "utils/logger.hpp"
 #include "symtab/symbol_table.hpp"
+#include "utils/logger.hpp"
 #include "visitors/ast_visitor.hpp"
 
 #include "llvm/IR/IRBuilder.h"
@@ -105,7 +105,8 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
      * \param name external method name
      * \param arguments expressions passed as arguments to the given external method
      */
-    void create_external_method_call(const std::string& name, const ast::ExpressionVector& arguments);
+    void create_external_method_call(const std::string& name,
+                                     const ast::ExpressionVector& arguments);
 
     /**
      * Create a function call to NMODL function or procedure in the same mod file
@@ -113,10 +114,13 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
      * \param name function name
      * \param arguments expressions passed as arguments to the function call
      */
-    void create_function_call(llvm::Function* func, const std::string& name, const ast::ExpressionVector& arguments);
+    void create_function_call(llvm::Function* func,
+                              const std::string& name,
+                              const ast::ExpressionVector& arguments);
 
     /**
      * Emit function or procedure declaration in LLVM given the node
+     *
      * \param node the AST node representing the function or procedure in NMODL
      */
     void emit_procedure_or_function_declaration(const ast::Block& node);

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "utils/logger.hpp"
+#include "symtab/symbol_table.hpp"
 #include "visitors/ast_visitor.hpp"
 
 #include "llvm/IR/IRBuilder.h"
@@ -69,7 +70,10 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     // Pointer to the local symbol table.
     llvm::ValueSymbolTable* local_named_values = nullptr;
 
-    // Run optimisation passes if true
+    // Pointer to AST symbol table.
+    symtab::SymbolTable* sym_tab;
+
+    // Run optimisation passes if true.
     bool opt_passes;
 
     /**
@@ -95,6 +99,21 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
         , opt_passes(opt_passes)
         , builder(*context)
         , fpm(module.get()) {}
+
+    /**
+     * Create a function call to an external method
+     * \param name external method name
+     * \param arguments expressions passed as arguments to the given external method
+     */
+    void create_external_method_call(const std::string& name, const ast::ExpressionVector& arguments);
+
+    /**
+     * Create a function call to NMODL function or procedure in the same mod file
+     * \param func LLVM function corresponding ti this call
+     * \param name function name
+     * \param arguments expressions passed as arguments to the function call
+     */
+    void create_function_call(llvm::Function* func, const std::string& name, const ast::ExpressionVector& arguments);
 
     /**
      * Emit function or procedure declaration in LLVM given the node

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -98,6 +98,7 @@ if(NMODL_ENABLE_LLVM)
   add_executable(testllvm visitor/main.cpp codegen/llvm.cpp)
   target_link_libraries(
     testllvm
+    codegen
     visitor
     symtab
     lexer

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -98,6 +98,7 @@ if(NMODL_ENABLE_LLVM)
   add_executable(testllvm visitor/main.cpp codegen/llvm.cpp)
   target_link_libraries(
     testllvm
+    llvm_codegen
     codegen
     visitor
     symtab
@@ -105,7 +106,6 @@ if(NMODL_ENABLE_LLVM)
     util
     test_util
     printer
-    llvm_codegen
     ${NMODL_WRAPPER_LIBS}
     ${LLVM_LIBS_TO_LINK})
   set(CODEGEN_TEST testllvm)


### PR DESCRIPTION
This patch introduces support for function call code generation, particularly:
- User-defined procedures and functions are supported
- Framework for external method has been created, currently support for `exp` and `pow` has been added

Added corresponding tests.

fixes #472