### PR TITLE
Georgemitenkov/llvm indexed names

### DIFF
--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -56,10 +56,11 @@ unsigned CodegenLLVMVisitor::get_array_index_or_length(const ast::IndexedName& i
     if (!integer)
         throw std::runtime_error("Error: expecting integer index or length");
 
-    // Check if integer should be looked up in the macros map.
+    // Check if integer value is taken from a macro.
     if (!integer->get_macro())
         return integer->get_value();
-    return macros[integer->get_macro()->get_node_name()];
+    const auto& macro = sym_tab->lookup(integer->get_macro()->get_node_name());
+    return static_cast<unsigned>(*macro->get_value());
 }
 
 void CodegenLLVMVisitor::run_llvm_opt_passes() {
@@ -263,10 +264,6 @@ void CodegenLLVMVisitor::visit_boolean(const ast::Boolean& node) {
     const auto& constant = llvm::ConstantInt::get(llvm::Type::getInt1Ty(*context),
                                                   node.get_value());
     values.push_back(constant);
-}
-
-void CodegenLLVMVisitor::visit_define(const ast::Define& node) {
-    macros[node.get_node_name()] = node.get_value()->get_value();
 }
 
 void CodegenLLVMVisitor::visit_double(const ast::Double& node) {

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -275,9 +275,12 @@ void CodegenLLVMVisitor::visit_local_list_statement(const ast::LocalListStatemen
                 throw std::runtime_error("Error: expecting integer length");
 
             // Check if integer should be looked up in the macros map.
-            if (integer->get_macro())
-            var_type = llvm::ArrayType::get(llvm::Type::getDoubleTy(*context),
-                                            integer->get_value());
+            unsigned length;
+            if (!integer->get_macro())
+                length = integer->get_value();
+            else
+                length = macros[integer->get_macro()->get_node_name()];
+            var_type = llvm::ArrayType::get(llvm::Type::getDoubleTy(*context), length);
         } else if (identifier->is_name()) {
             // This case corresponds to a scalar local variable. Its type is double by default.
             var_type = llvm::Type::getDoubleTy(*context);

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -25,6 +25,33 @@ namespace codegen {
 /*                            Helper routines                                           */
 /****************************************************************************************/
 
+bool CodegenLLVMVisitor::check_array_bounds(const ast::IndexedName& node, unsigned index) {
+    llvm::Type* array_type =
+        local_named_values->lookup(node.get_node_name())->getType()->getPointerElementType();
+    unsigned length = array_type->getArrayNumElements();
+    return 0 <= index && index < length;
+}
+
+unsigned CodegenLLVMVisitor::get_array_index_or_length(const ast::IndexedName& indexed_name) {
+    auto integer = dynamic_cast<ast::Integer*>(indexed_name.get_length().get());
+    if (!integer)
+        throw std::runtime_error("Error: expecting integer index or length");
+
+    // Check if integer should be looked up in the macros map.
+    if (!integer->get_macro())
+        return integer->get_value();
+    return macros[integer->get_macro()->get_node_name()];
+}
+
+llvm::Value* CodegenLLVMVisitor::create_GEP(const std::string& name, unsigned index) {
+    llvm::Type* index_type = llvm::Type::getInt32Ty(*context);
+    std::vector<llvm::Value*> indices;
+    indices.push_back(llvm::ConstantInt::get(index_type, 0));
+    indices.push_back(llvm::ConstantInt::get(index_type, index));
+
+    return builder.CreateInBoundsGEP(local_named_values->lookup(name), indices);
+}
+
 void CodegenLLVMVisitor::run_llvm_opt_passes() {
     /// run some common optimisation passes that are commonly suggested
     fpm.add(llvm::createInstructionCombiningPass());
@@ -43,6 +70,15 @@ void CodegenLLVMVisitor::run_llvm_opt_passes() {
     }
 }
 
+llvm::Value* CodegenLLVMVisitor::codegen_indexed_name(const ast::IndexedName& node) {
+    unsigned index = get_array_index_or_length(node);
+
+    // Check if index is within array bounds.
+    if (!check_array_bounds(node, index))
+        throw std::runtime_error("Error: Index is out of bounds");
+
+    return create_GEP(node.get_node_name(), index);
+}
 
 void CodegenLLVMVisitor::create_external_method_call(const std::string& name,
                                                      const ast::ExpressionVector& arguments) {
@@ -183,13 +219,21 @@ void CodegenLLVMVisitor::visit_binary_expression(const ast::BinaryExpression& no
     llvm::Value* rhs = values.back();
     values.pop_back();
     if (op == ast::BinaryOp::BOP_ASSIGN) {
-        // \todo: handle indexed name.
         auto var = dynamic_cast<ast::VarName*>(node.get_lhs().get());
         if (!var) {
             throw std::runtime_error("Error: only VarName assignment is currently supported.\n");
         }
-        llvm::Value* alloca = local_named_values->lookup(var->get_node_name());
-        builder.CreateStore(rhs, alloca);
+
+        const auto& identifier = var->get_name();
+        if (identifier->is_name()) {
+            llvm::Value* alloca = local_named_values->lookup(var->get_node_name());
+            builder.CreateStore(rhs, alloca);
+        } else if (identifier->is_indexed_name()) {
+            auto indexed_name = dynamic_cast<ast::IndexedName*>(identifier.get());
+            builder.CreateStore(rhs, codegen_indexed_name(*indexed_name));
+        } else {
+            throw std::runtime_error("Error: Unsupported variable type");
+        }
         return;
     }
 
@@ -251,10 +295,6 @@ void CodegenLLVMVisitor::visit_function_call(const ast::FunctionCall& node) {
     }
 }
 
-void CodegenLLVMVisitor::visit_indexed_name(const ast::IndexedName& node) {
-    // \todo: implement array element extraction.
-}
-
 void CodegenLLVMVisitor::visit_integer(const ast::Integer& node) {
     const auto& constant = llvm::ConstantInt::get(llvm::Type::getInt32Ty(*context),
                                                   node.get_value());
@@ -270,16 +310,7 @@ void CodegenLLVMVisitor::visit_local_list_statement(const ast::LocalListStatemen
         llvm::Type* var_type;
         if (identifier->is_indexed_name()) {
             auto indexed_name = dynamic_cast<ast::IndexedName*>(identifier.get());
-            auto integer = dynamic_cast<ast::Integer*>(indexed_name->get_length().get());
-            if (!integer)
-                throw std::runtime_error("Error: expecting integer length");
-
-            // Check if integer should be looked up in the macros map.
-            unsigned length;
-            if (!integer->get_macro())
-                length = integer->get_value();
-            else
-                length = macros[integer->get_macro()->get_node_name()];
+            unsigned length = get_array_index_or_length(*indexed_name);
             var_type = llvm::ArrayType::get(llvm::Type::getDoubleTy(*context), length);
         } else if (identifier->is_name()) {
             // This case corresponds to a scalar local variable. Its type is double by default.
@@ -340,9 +371,21 @@ void CodegenLLVMVisitor::visit_unary_expression(const ast::UnaryExpression& node
 }
 
 void CodegenLLVMVisitor::visit_var_name(const ast::VarName& node) {
-    // \todo: handle if var name is an indexed name (go one level deeper and move this code to
-    // visit_name?)
-    llvm::Value* var = builder.CreateLoad(local_named_values->lookup(node.get_node_name()));
+    const auto& identifier = node.get_name();
+    if (!identifier->is_name() && !identifier->is_indexed_name())
+        throw std::runtime_error("Error: Unsupported variable type");
+
+    llvm::Value* ptr;
+    if (identifier->is_name())
+        ptr = local_named_values->lookup(node.get_node_name());
+
+    if (identifier->is_indexed_name()) {
+        auto indexed_name = dynamic_cast<ast::IndexedName*>(identifier.get());
+        ptr = codegen_indexed_name(*indexed_name);
+    }
+
+    // Finally, load the variable from the pointer value.
+    llvm::Value* var = builder.CreateLoad(ptr);
     values.push_back(var);
 }
 

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -125,7 +125,7 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
      * \param index element index
      * \return GEP instruction value
      */
-    llvm::Value* create_GEP(const std::string& name, unsigned index);
+    llvm::Value* create_gep(const std::string& name, unsigned index);
 
     /**
      * Returns array index or length from given IndexedName

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -105,6 +105,15 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
         , builder(*context)
         , fpm(module.get()) {}
 
+
+    bool check_array_bounds(const ast::IndexedName& node, unsigned index);
+
+    unsigned get_array_index_or_length(const ast::IndexedName& node);
+
+    llvm::Value* create_GEP(const std::string& name, unsigned index);
+
+    llvm::Value* codegen_indexed_name(const ast::IndexedName& node);
+
     /**
      * Create a function call to an external method
      * \param name external method name
@@ -144,7 +153,6 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     void visit_function_block(const ast::FunctionBlock& node) override;
     void visit_function_call(const ast::FunctionCall& node) override;
     void visit_integer(const ast::Integer& node) override;
-    void visit_indexed_name(const ast::IndexedName& node) override;
     void visit_local_list_statement(const ast::LocalListStatement& node) override;
     void visit_procedure_block(const ast::ProcedureBlock& node) override;
     void visit_program(const ast::Program& node) override;

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -74,11 +74,6 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     symtab::SymbolTable* sym_tab;
 
     // Run optimisation passes if true.
-
-    // Map to store DEFINE values.
-    std::map<std::string, int> macros;
-
-    // Run optimisation passes if true
     bool opt_passes;
 
     /**
@@ -168,7 +163,6 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     // Visitors
     void visit_binary_expression(const ast::BinaryExpression& node) override;
     void visit_boolean(const ast::Boolean& node) override;
-    void visit_define(const ast::Define& node) override;
     void visit_double(const ast::Double& node) override;
     void visit_function_block(const ast::FunctionBlock& node) override;
     void visit_function_call(const ast::FunctionCall& node) override;

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -105,14 +105,34 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
         , builder(*context)
         , fpm(module.get()) {}
 
-
+    /**
+     * Checks if array index specified by the given IndexedName is within bounds
+     * \param node IndexedName representing array
+     * \return     \c true if the index is within bounds
+     */
     bool check_array_bounds(const ast::IndexedName& node, unsigned index);
 
-    unsigned get_array_index_or_length(const ast::IndexedName& node);
+    /**
+     * Generates LLVM code for the given IndexedName
+     * \param node IndexedName NMODL AST node
+     * \return LLVM code generated for this AST node
+     */
+    llvm::Value* codegen_indexed_name(const ast::IndexedName& node);
 
+    /**
+     * Returns GEP instruction to 1D array
+     * \param name 1D array name
+     * \param index element index
+     * \return GEP instruction value
+     */
     llvm::Value* create_GEP(const std::string& name, unsigned index);
 
-    llvm::Value* codegen_indexed_name(const ast::IndexedName& node);
+    /**
+     * Returns array index or length from given IndexedName
+     * \param node IndexedName representing array
+     * \return array index or length
+     */
+    unsigned get_array_index_or_length(const ast::IndexedName& node);
 
     /**
      * Create a function call to an external method

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -74,6 +74,11 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     symtab::SymbolTable* sym_tab;
 
     // Run optimisation passes if true.
+
+    // Map to store DEFINE values.
+    std::map<std::string, int> macros;
+
+    // Run optimisation passes if true
     bool opt_passes;
 
     /**
@@ -134,10 +139,12 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     // Visitors
     void visit_binary_expression(const ast::BinaryExpression& node) override;
     void visit_boolean(const ast::Boolean& node) override;
+    void visit_define(const ast::Define& node) override;
     void visit_double(const ast::Double& node) override;
     void visit_function_block(const ast::FunctionBlock& node) override;
     void visit_function_call(const ast::FunctionCall& node) override;
     void visit_integer(const ast::Integer& node) override;
+    void visit_indexed_name(const ast::IndexedName& node) override;
     void visit_local_list_statement(const ast::LocalListStatement& node) override;
     void visit_procedure_block(const ast::ProcedureBlock& node) override;
     void visit_program(const ast::Program& node) override;

--- a/test/unit/codegen/llvm.cpp
+++ b/test/unit/codegen/llvm.cpp
@@ -117,6 +117,31 @@ SCENARIO("Binary expression", "[visitor][llvm]") {
 }
 
 //=============================================================================
+// Define
+//=============================================================================
+
+SCENARIO("Define", "[visitor][llvm]") {
+    GIVEN("Procedure with array variable of length specified by DEFINE") {
+        std::string nmodl_text = R"(
+            DEFINE N 100
+
+            PROCEDURE foo() {
+                LOCAL x[N]
+            }
+        )";
+
+        THEN("macro is expanded and array is allocated") {
+            std::string module_string = run_llvm_visitor(nmodl_text);
+            std::smatch m;
+
+            // Check stack allocations for i and j
+            std::regex array(R"(%x = alloca \[100 x double\])");
+            REQUIRE(std::regex_search(module_string, m, array));
+        }
+    }
+}
+
+//=============================================================================
 // FunctionBlock
 //=============================================================================
 
@@ -251,6 +276,92 @@ SCENARIO("Function call", "[visitor][llvm]") {
         )";
 
         THEN("a runtime error is thrown") {
+            REQUIRE_THROWS_AS(run_llvm_visitor(nmodl_text), std::runtime_error);
+        }
+    }
+}
+
+//=============================================================================
+// IndexedName
+//=============================================================================
+
+SCENARIO("Indexed name", "[visitor][llvm]") {
+    GIVEN("Procedure with a local array variable") {
+        std::string nmodl_text = R"(
+            PROCEDURE foo() {
+                LOCAL x[2]
+            }
+        )";
+
+        THEN("array is allocated") {
+            std::string module_string = run_llvm_visitor(nmodl_text);
+            std::smatch m;
+
+            std::regex array(R"(%x = alloca \[2 x double\])");
+            REQUIRE(std::regex_search(module_string, m, array));
+        }
+    }
+
+    GIVEN("Procedure with a local array assignment") {
+        std::string nmodl_text = R"(
+            PROCEDURE foo() {
+                LOCAL x[2]
+                x[1] = 3
+            }
+        )";
+
+        THEN("element is stored to the array") {
+            std::string module_string = run_llvm_visitor(nmodl_text);
+            std::smatch m;
+
+            // Check GEP is created correctly to pint at array element.
+            std::regex GEP(
+                R"(%1 = getelementptr inbounds \[2 x double\], \[2 x double\]\* %x, i32 0, i32 1)");
+            REQUIRE(std::regex_search(module_string, m, GEP));
+
+            // Check the value is stored to the pointer.
+            std::regex store(R"(store double 3.000000e\+00, double\* %1)");
+            REQUIRE(std::regex_search(module_string, m, store));
+        }
+    }
+
+    GIVEN("Procedure with a assignment of array element") {
+        std::string nmodl_text = R"(
+            PROCEDURE foo() {
+                LOCAL x[2], y
+                x[1] = 3
+                y = x[1]
+            }
+        )";
+
+        THEN("array element is stored to the variable") {
+            std::string module_string = run_llvm_visitor(nmodl_text);
+            std::smatch m;
+
+            // Check GEP is created correctly to pint at array element.
+            std::regex GEP(
+                R"(%2 = getelementptr inbounds \[2 x double\], \[2 x double\]\* %x, i32 0, i32 1)");
+            REQUIRE(std::regex_search(module_string, m, GEP));
+
+            // Check the value is loaded from the pointer.
+            std::regex load(R"(%3 = load double, double\* %2)");
+            REQUIRE(std::regex_search(module_string, m, load));
+
+            // Check the value is stored to the the variable.
+            std::regex store(R"(store double %3, double\* %y)");
+            REQUIRE(std::regex_search(module_string, m, store));
+        }
+    }
+
+    GIVEN("Array with out of bounds access") {
+        std::string nmodl_text = R"(
+            PROCEDURE foo() {
+                LOCAL x[2]
+                x[5] = 3
+            }
+        )";
+
+        THEN("error is thrown") {
             REQUIRE_THROWS_AS(run_llvm_visitor(nmodl_text), std::runtime_error);
         }
     }


### PR DESCRIPTION
This PR addresses `IndexedName`s, adding the following:
- Initialising arrays in LOCAL blocks is now supported.
- Assigning to array elements is supported.
- Using array elements in expressions is possible now.

Note that this handles 1D arrays (same as NMODL)

Also, codegen for `DEFINE` node has been implemented: macros are currently stored in a dedicated map.

fixes #467