### PR TITLE
Implement exprelr and vexpm1

### DIFF
--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -32,6 +32,8 @@ add_dependencies(codegen lexer util visitor)
 # copy to build directory to make usable from build directory
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fast_math.ispc
                ${CMAKE_BINARY_DIR}/include/nmodl/fast_math.ispc COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fast_math.hpp
+               ${CMAKE_BINARY_DIR}/include/nmodl/fast_math.hpp COPYONLY)
 
 # =============================================================================
 # Install include files

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -2337,6 +2337,7 @@ void CodegenCVisitor::print_backend_info() {
 void CodegenCVisitor::print_standard_includes() {
     printer->add_newline();
     printer->add_line("#include <math.h>");
+    printer->add_line("#include \"nmodl/fast_math.hpp\" // extend math with some useful functions");
     printer->add_line("#include <stdio.h>");
     printer->add_line("#include <stdlib.h>");
     printer->add_line("#include <string.h>");

--- a/src/codegen/fast_math.hpp
+++ b/src/codegen/fast_math.hpp
@@ -28,7 +28,7 @@ static inline uint64_t dp2uint64(double x) {
     return *((uint64_t*) (&x));
 }
 
-static inline float uint322sp(int32_t x) {
+static inline float int322sp(int32_t x) {
     return *((float*) (&x));
 }
 
@@ -182,7 +182,7 @@ static inline float vexp(float initial_x) {
 
     z = 1.0f + egm1(x);
 
-    z *= uint322sp((n + 0x7f) << 23);
+    z *= int322sp((n + 0x7f) << 23);
 
     if (initial_x > MAXLOGF)
         z = f_inf();
@@ -202,7 +202,7 @@ static inline float vexpm1(float initial_x) {
     const int32_t n = z;
 
     const int32_t twopnm1 = ((n - 1) + 0x7f) << 23;
-    x = 2 * (uint322sp(twopnm1) * egm1(x) + uint322sp(twopnm1)) - 1;
+    x = 2 * (int322sp(twopnm1) * egm1(x) + int322sp(twopnm1)) - 1;
 
     if (initial_x > MAXLOGF)
         x = f_inf();

--- a/src/codegen/fast_math.hpp
+++ b/src/codegen/fast_math.hpp
@@ -7,30 +7,33 @@
  * Note that the fast ISPC exponentials Based on VDT implementation of
  * D. Piparo et al. See https://github.com/dpiparo/vdt for additional
  * license information.
- * exprelr and expm1 are based on https://arbor.readthedocs.io/en/latest/internals/simd_api.html?highlight=exprelr#operatorname-expm1-x
+ * exprelr and expm1 are based on
+ *https://arbor.readthedocs.io/en/latest/internals/simd_api.html?highlight=exprelr#operatorname-expm1-x
  *************************************************************************/
 
 #pragma once
+
+#include <stdint.h>
 
 /**
  * \file
  * \brief Implementation of different math functions with ISPC
  */
 
-static inline double uint642dp(u_int64_t ll) {
-    return *(( double*) (&ll));
+static inline double uint642dp(uint64_t ll) {
+    return *((double*) (&ll));
 }
 
-static inline u_int64_t dp2uint64(double x) {
-    return *(( u_int64_t*) (&x));
+static inline uint64_t dp2uint64(double x) {
+    return *((uint64_t*) (&x));
 }
 
 static inline float uint322sp(int32_t x) {
-    return *(( float*) (&x));
+    return *((float*) (&x));
 }
 
 static inline unsigned int sp2uint32(float x) {
-    return *(( u_int32_t*) (&x));
+    return *((uint32_t*) (&x));
 }
 
 static inline double dpfloor(const double x) {
@@ -46,27 +49,27 @@ static inline float spfloor(const float x) {
 }
 
 static inline float f_inf() {
-    u_int32_t v = 0x7F800000;
+    uint32_t v = 0x7F800000;
     return *((float*) (&v));
 }
 
 static inline double inf() {
-    u_int64_t v = 0x7FF0000000000000;
+    uint64_t v = 0x7FF0000000000000;
     return *((double*) (&v));
 }
 
 
 static const double EXP_LIMIT = 708.0;
 
-static const double PX1exp = 1.26177193074810590878-4;
-static const double PX2exp = 3.02994407707441961300-2;
-static const double PX3exp = 9.99999999999999999910-1;
-static const double QX1exp = 3.00198505138664455042-6;
-static const double QX2exp = 2.52448340349684104192-3;
-static const double QX3exp = 2.27265548208155028766-1;
+static const double PX1exp = 1.26177193074810590878E-4;
+static const double PX2exp = 3.02994407707441961300E-2;
+static const double PX3exp = 9.99999999999999999910E-1;
+static const double QX1exp = 3.00198505138664455042E-6;
+static const double QX2exp = 2.52448340349684104192E-3;
+static const double QX3exp = 2.27265548208155028766E-1;
 static const double QX4exp = 2.00000000000000000009;
 
-static const double LOG2E = 1.4426950408889634073599; // 1/ln(2)
+static const double LOG2E = 1.4426950408889634073599;  // 1/ln(2)
 
 static const float MAXLOGF = 88.72283905206835f;
 static const float MINLOGF = -88.f;
@@ -81,12 +84,11 @@ static const float PX4expf = 4.1665795894E-2f;
 static const float PX5expf = 1.6666665459E-1f;
 static const float PX6expf = 5.0000001201E-1f;
 
-static const float LOG2EF = 1.44269504088896341f; // 1/ln(2)
+static const float LOG2EF = 1.44269504088896341f;  // 1/ln(2)
 
 static inline double egm1(double x, double px) {
-
-    x -= px * 6.93145751953125d-1;
-    x -= px * 1.42860682030941723212d-6;
+    x -= px * 6.93145751953125E-1;
+    x -= px * 1.42860682030941723212E-6;
 
     const double xx = x * x;
 
@@ -105,7 +107,7 @@ static inline double egm1(double x, double px) {
     qx *= xx;
     qx += QX4exp;
 
-    return 2.0d*px / (qx - px);
+    return 2.0 * px / (qx - px);
 }
 
 /// double precision exp function
@@ -115,7 +117,7 @@ static inline double vexp(double initial_x) {
     const int32_t n = px;
 
     x = 1.0 + egm1(x, px);
-    x *= uint642dp((((u_int64_t) n) + 1023) << 52);
+    x *= uint642dp((((uint64_t) n) + 1023) << 52);
 
     if (initial_x > EXP_LIMIT)
         x = inf();
@@ -125,18 +127,14 @@ static inline double vexp(double initial_x) {
     return x;
 }
 
-/// double precision expm1 function
+/// double precision exp function
 static inline double vexpm1(double initial_x) {
     double x = initial_x;
     double px = dpfloor(LOG2E * x + 0.5);
+    const int32_t n = px;
 
-    const int32_t n = ((px > 0.5) || (px >= -0.5)) ? px : 0;
-
-    x = egm1(x, px);
-    const double pow2nm1 = uint642dp((((u_int64_t) n-1) + 1023) << 52);
-    x *= pow2nm1;
-    x += pow2nm1-1;
-    x *= 2;
+    const uint64_t twopnm1 = (((uint64_t)(n - 1)) + 1023) << 52;
+    x = 2 * (uint642dp(twopnm1) * egm1(x, px) + uint642dp(twopnm1)) - 1;
 
     if (initial_x > EXP_LIMIT)
         x = inf();
@@ -146,17 +144,17 @@ static inline double vexpm1(double initial_x) {
     return x;
 }
 
+
 /// double precision exprelr function ()
 static inline double exprelr(double initial_x) {
-    if (1.0+initial_x == 1.0) {
+    if (1.0 + initial_x == 1.0) {
         return 1.0;
     }
 
-    return initial_x/vexpm1(initial_x);
+    return initial_x / vexpm1(initial_x);
 }
 
 static inline float egm1(float x) {
-
     float z = x * PX1expf;
     z += PX2expf;
     z *= x;
@@ -167,7 +165,7 @@ static inline float egm1(float x) {
     z += PX5expf;
     z *= x;
     z += PX6expf;
-    z *= x*x;
+    z *= x * x;
     z += x;
 
     return z;
@@ -194,7 +192,7 @@ static inline float vexp(float initial_x) {
     return z;
 }
 
-/// single precision expm1 function
+/// single precision exp function
 static inline float vexpm1(float initial_x) {
     float x = initial_x;
     float z = spfloor(LOG2EF * x + 0.5f);
@@ -203,25 +201,22 @@ static inline float vexpm1(float initial_x) {
     x -= z * C2F;
     const int32_t n = z;
 
-    z = egm1(x);
-    const double pow2nm1 = uint322sp((n-1 + 0x7f) << 23);
-    z *= pow2nm1;
-    z += pow2nm1-1;
-    z *= 2;
+    const int32_t twopnm1 = ((n - 1) + 0x7f) << 23;
+    x = 2 * (uint322sp(twopnm1) * egm1(x) + uint322sp(twopnm1)) - 1;
 
     if (initial_x > MAXLOGF)
-        z = f_inf();
+        x = f_inf();
     if (initial_x < MINLOGF)
-        z = -1.f;
+        x = -1.0f;
 
-    return z;
+    return x;
 }
 
 /// single precision exprelr function
 static inline float exprelr(float initial_x) {
-    if (1.0+initial_x == 1.0) {
+    if (1.0 + initial_x == 1.0) {
         return 1.0;
     }
 
-    return initial_x/vexpm1(initial_x);
+    return initial_x / vexpm1(initial_x);
 }

--- a/src/codegen/fast_math.hpp
+++ b/src/codegen/fast_math.hpp
@@ -10,76 +10,78 @@
  * exprelr and expm1 are based on https://arbor.readthedocs.io/en/latest/internals/simd_api.html?highlight=exprelr#operatorname-expm1-x
  *************************************************************************/
 
+#pragma once
+
 /**
  * \file
  * \brief Implementation of different math functions with ISPC
  */
 
-static inline double uint642dp(unsigned int64 ll) {
-    return *((varying double*) (&ll));
+static inline double uint642dp(u_int64_t ll) {
+    return *(( double*) (&ll));
 }
 
-static inline unsigned int64 dp2uint64(double x) {
-    return *((varying unsigned int64*) (&x));
+static inline u_int64_t dp2uint64(double x) {
+    return *(( u_int64_t*) (&x));
 }
 
-static inline float uint322sp(int32 x) {
-    return *((varying float*) (&x));
+static inline float uint322sp(int32_t x) {
+    return *(( float*) (&x));
 }
 
 static inline unsigned int sp2uint32(float x) {
-    return *((varying unsigned int32*) (&x));
+    return *(( u_int32_t*) (&x));
 }
 
 static inline double dpfloor(const double x) {
-    int32 ret = x;
+    int32_t ret = x;
     ret -= (sp2uint32(x) >> 31);
     return ret;
 }
 
 static inline float spfloor(const float x) {
-    int32 ret = x;
+    int32_t ret = x;
     ret -= (sp2uint32(x) >> 31);
     return ret;
 }
 
-static inline uniform float f_inf() {
-    uniform unsigned int32 v = 0x7F800000;
+static inline float f_inf() {
+    u_int32_t v = 0x7F800000;
     return *((float*) (&v));
 }
 
-static inline uniform double inf() {
-    uniform unsigned int64 v = 0x7FF0000000000000;
+static inline double inf() {
+    u_int64_t v = 0x7FF0000000000000;
     return *((double*) (&v));
 }
 
 
-static const uniform double EXP_LIMIT = 708.d;
+static const double EXP_LIMIT = 708.0;
 
-static const uniform double PX1exp = 1.26177193074810590878d-4;
-static const uniform double PX2exp = 3.02994407707441961300d-2;
-static const uniform double PX3exp = 9.99999999999999999910d-1;
-static const uniform double QX1exp = 3.00198505138664455042d-6;
-static const uniform double QX2exp = 2.52448340349684104192d-3;
-static const uniform double QX3exp = 2.27265548208155028766d-1;
-static const uniform double QX4exp = 2.00000000000000000009d;
+static const double PX1exp = 1.26177193074810590878-4;
+static const double PX2exp = 3.02994407707441961300-2;
+static const double PX3exp = 9.99999999999999999910-1;
+static const double QX1exp = 3.00198505138664455042-6;
+static const double QX2exp = 2.52448340349684104192-3;
+static const double QX3exp = 2.27265548208155028766-1;
+static const double QX4exp = 2.00000000000000000009;
 
-static const uniform double LOG2E = 1.4426950408889634073599d; // 1/ln(2)
+static const double LOG2E = 1.4426950408889634073599; // 1/ln(2)
 
-static const uniform float MAXLOGF = 88.72283905206835f;
-static const uniform float MINLOGF = -88.f;
+static const float MAXLOGF = 88.72283905206835f;
+static const float MINLOGF = -88.f;
 
-static const uniform float C1F = 0.693359375f;
-static const uniform float C2F = -2.12194440e-4f;
+static const float C1F = 0.693359375f;
+static const float C2F = -2.12194440e-4f;
 
-static const uniform float PX1expf = 1.9875691500E-4f;
-static const uniform float PX2expf = 1.3981999507E-3f;
-static const uniform float PX3expf = 8.3334519073E-3f;
-static const uniform float PX4expf = 4.1665795894E-2f;
-static const uniform float PX5expf = 1.6666665459E-1f;
-static const uniform float PX6expf = 5.0000001201E-1f;
+static const float PX1expf = 1.9875691500E-4f;
+static const float PX2expf = 1.3981999507E-3f;
+static const float PX3expf = 8.3334519073E-3f;
+static const float PX4expf = 4.1665795894E-2f;
+static const float PX5expf = 1.6666665459E-1f;
+static const float PX6expf = 5.0000001201E-1f;
 
-static const uniform float LOG2EF = 1.44269504088896341f; // 1/ln(2)
+static const float LOG2EF = 1.44269504088896341f; // 1/ln(2)
 
 static inline double egm1(double x, double px) {
 
@@ -109,16 +111,16 @@ static inline double egm1(double x, double px) {
 /// double precision exp function
 static inline double vexp(double initial_x) {
     double x = initial_x;
-    double px = dpfloor(LOG2E * x + 0.5d);
-    const int32 n = px;
+    double px = dpfloor(LOG2E * x + 0.5);
+    const int32_t n = px;
 
-    x = 1.0d + egm1(x, px);
-    x *= uint642dp((((unsigned int64) n) + 1023) << 52);
+    x = 1.0 + egm1(x, px);
+    x *= uint642dp((((u_int64_t) n) + 1023) << 52);
 
     if (initial_x > EXP_LIMIT)
         x = inf();
     if (initial_x < -EXP_LIMIT)
-        x = 0.d;
+        x = 0.0;
 
     return x;
 }
@@ -126,12 +128,12 @@ static inline double vexp(double initial_x) {
 /// double precision expm1 function
 static inline double vexpm1(double initial_x) {
     double x = initial_x;
-    double px = dpfloor(LOG2E * x + 0.5d);
+    double px = dpfloor(LOG2E * x + 0.5);
 
-    const int32 n = ((px > 0.5) || (px >= -0.5)) ? px : 0;
+    const int32_t n = ((px > 0.5) || (px >= -0.5)) ? px : 0;
 
     x = egm1(x, px);
-    const double pow2nm1 = uint642dp((((unsigned int64) n-1) + 1023) << 52);
+    const double pow2nm1 = uint642dp((((u_int64_t) n-1) + 1023) << 52);
     x *= pow2nm1;
     x += pow2nm1-1;
     x *= 2;
@@ -139,7 +141,7 @@ static inline double vexpm1(double initial_x) {
     if (initial_x > EXP_LIMIT)
         x = inf();
     if (initial_x < -EXP_LIMIT)
-        x = -1.d;
+        x = -1.0;
 
     return x;
 }
@@ -178,7 +180,7 @@ static inline float vexp(float initial_x) {
 
     x -= z * C1F;
     x -= z * C2F;
-    const int32 n = z;
+    const int32_t n = z;
 
     z = 1.0f + egm1(x);
 
@@ -199,7 +201,7 @@ static inline float vexpm1(float initial_x) {
 
     x -= z * C1F;
     x -= z * C2F;
-    const int32 n = z;
+    const int32_t n = z;
 
     z = egm1(x);
     const double pow2nm1 = uint322sp((n-1 + 0x7f) << 23);
@@ -223,6 +225,3 @@ static inline float exprelr(float initial_x) {
 
     return initial_x/vexpm1(initial_x);
 }
-
-
-

--- a/src/codegen/fast_math.hpp
+++ b/src/codegen/fast_math.hpp
@@ -4,11 +4,8 @@
  * This file is part of NMODL distributed under the terms of the GNU
  * Lesser General Public License. See top-level LICENSE file for details.
  *
- * Note that the fast ISPC exponentials Based on VDT implementation of
- * D. Piparo et al. See https://github.com/dpiparo/vdt for additional
- * license information.
- * exprelr and expm1 are based on
- * https://arbor.readthedocs.io/en/latest/internals/simd_api.html#implementation-of-vector-transcendental-functions
+ * Note: fast_math.ispc translated into .hpp syntax. More information in
+ * fast_math.ispc
  *************************************************************************/
 
 #pragma once
@@ -17,7 +14,7 @@
 
 /**
  * \file
- * \brief Implementation of different math functions with ISPC
+ * \brief Implementation of different math functions
  */
 
 static inline double uint642dp(uint64_t ll) {
@@ -61,6 +58,9 @@ static inline double inf() {
 
 static const double EXP_LIMIT = 708.0;
 
+static const double C1 = 6.93145751953125E-1;
+static const double C2 = 1.42860682030941723212E-6;
+
 static const double PX1exp = 1.26177193074810590878E-4;
 static const double PX2exp = 3.02994407707441961300E-2;
 static const double PX3exp = 9.99999999999999999910E-1;
@@ -87,8 +87,8 @@ static const float PX6expf = 5.0000001201E-1f;
 static const float LOG2EF = 1.44269504088896341f;  // 1/ln(2)
 
 static inline double egm1(double x, double px) {
-    x -= px * 6.93145751953125E-1;
-    x -= px * 1.42860682030941723212E-6;
+    x -= px * C1;
+    x -= px * C2;
 
     const double xx = x * x;
 

--- a/src/codegen/fast_math.hpp
+++ b/src/codegen/fast_math.hpp
@@ -8,7 +8,7 @@
  * D. Piparo et al. See https://github.com/dpiparo/vdt for additional
  * license information.
  * exprelr and expm1 are based on
- *https://arbor.readthedocs.io/en/latest/internals/simd_api.html?highlight=exprelr#operatorname-expm1-x
+ * https://arbor.readthedocs.io/en/latest/internals/simd_api.html#implementation-of-vector-transcendental-functions
  *************************************************************************/
 
 #pragma once

--- a/src/codegen/fast_math.hpp
+++ b/src/codegen/fast_math.hpp
@@ -127,7 +127,7 @@ static inline double vexp(double initial_x) {
     return x;
 }
 
-/// double precision exp function
+/// double precision exp(x) - 1 function, used for small x.
 static inline double vexpm1(double initial_x) {
     double x = initial_x;
     double px = dpfloor(LOG2E * x + 0.5);

--- a/src/codegen/fast_math.ispc
+++ b/src/codegen/fast_math.ispc
@@ -23,7 +23,7 @@ static inline unsigned int64 dp2uint64(double x) {
     return *((varying unsigned int64*) (&x));
 }
 
-static inline float uint322sp(int32 x) {
+static inline float int322sp(int32 x) {
     return *((varying float*) (&x));
 }
 
@@ -181,7 +181,7 @@ static inline float vexp(float initial_x) {
 
     z = 1.0f + egm1(x);
 
-    z *= uint322sp((n + 0x7f) << 23);
+    z *= int322sp((n + 0x7f) << 23);
 
     if (initial_x > MAXLOGF)
         z = f_inf();
@@ -201,7 +201,7 @@ static inline float vexpm1(float initial_x) {
     const int32 n = z;
 
     const int32 twopnm1 = ((n-1) + 0x7f) << 23;
-    x = 2*(uint322sp(twopnm1)*egm1(x) + uint322sp(twopnm1)) - 1.0f;
+    x = 2*(int322sp(twopnm1)*egm1(x) + int322sp(twopnm1)) - 1.0f;
 
     if (initial_x > MAXLOGF)
         x = f_inf();

--- a/src/codegen/fast_math.ispc
+++ b/src/codegen/fast_math.ispc
@@ -123,35 +123,34 @@ static inline double vexp(double initial_x) {
     return x;
 }
 
-/// double precision expm1 function
+
+/// double precision exp function
 static inline double vexpm1(double initial_x) {
     double x = initial_x;
     double px = dpfloor(LOG2E * x + 0.5d);
+    const int32 n = px;
 
-    const int32 n = ((px > 0.5) || (px >= -0.5)) ? px : 0;
-
-    x = egm1(x, px);
-    const double pow2nm1 = uint642dp((((unsigned int64) n-1) + 1023) << 52);
-    x *= pow2nm1;
-    x += pow2nm1-1;
-    x *= 2;
+    const unsigned int64 twopnm1 = (((unsigned int64) (n-1) ) + 1023) << 52;
+    x = 2*(uint642dp(twopnm1)*egm1(x, px) + uint642dp(twopnm1)) - 1.0d;
 
     if (initial_x > EXP_LIMIT)
         x = inf();
     if (initial_x < -EXP_LIMIT)
-        x = -1.d;
+        x = -1.0d;
 
     return x;
 }
 
+
 /// double precision exprelr function ()
 static inline double exprelr(double initial_x) {
-    if (1.0+initial_x == 1.0) {
-        return 1.0;
+    if (1.0d+initial_x == 1.0d) {
+        return 1.0d;
     }
 
     return initial_x/vexpm1(initial_x);
 }
+
 
 static inline float egm1(float x) {
 
@@ -192,7 +191,7 @@ static inline float vexp(float initial_x) {
     return z;
 }
 
-/// single precision expm1 function
+/// single precision exp function
 static inline float vexpm1(float initial_x) {
     float x = initial_x;
     float z = spfloor(LOG2EF * x + 0.5f);
@@ -201,24 +200,21 @@ static inline float vexpm1(float initial_x) {
     x -= z * C2F;
     const int32 n = z;
 
-    z = egm1(x);
-    const double pow2nm1 = uint322sp((n-1 + 0x7f) << 23);
-    z *= pow2nm1;
-    z += pow2nm1-1;
-    z *= 2;
+    const int32 twopnm1 = ((n-1) + 0x7f) << 23;
+    x = 2*(uint322sp(twopnm1)*egm1(x) + uint322sp(twopnm1)) - 1.0f;
 
     if (initial_x > MAXLOGF)
-        z = f_inf();
+        x = f_inf();
     if (initial_x < MINLOGF)
-        z = -1.f;
+        x = -1.0f;
 
-    return z;
+    return x;
 }
 
 /// single precision exprelr function
 static inline float exprelr(float initial_x) {
-    if (1.0+initial_x == 1.0) {
-        return 1.0;
+    if (1.0f+initial_x == 1.0f) {
+        return 1.0f;
     }
 
     return initial_x/vexpm1(initial_x);

--- a/src/codegen/fast_math.ispc
+++ b/src/codegen/fast_math.ispc
@@ -7,6 +7,7 @@
  * Note that the fast ISPC exponentials Based on VDT implementation of
  * D. Piparo et al. See https://github.com/dpiparo/vdt for additional
  * license information.
+ * exprelr and expm1 are based on https://arbor.readthedocs.io/en/latest/internals/simd_api.html?highlight=exprelr#operatorname-expm1-x
  *************************************************************************/
 
 /**
@@ -143,6 +144,15 @@ static inline double vexpm1(double initial_x) {
     return x;
 }
 
+/// double precision exprelr function ()
+static inline double vexprelr(double initial_x) {
+    if (1.0+initial_x == 1.0) {
+        return 1.0;
+    }
+
+    return initial_x/expm1(initial_x);
+}
+
 static inline float expgm1(float x) {
 
     float z = x * PX1expf;
@@ -204,5 +214,15 @@ static inline float vexpm1(float initial_x) {
 
     return z;
 }
+
+/// single precision exprelr function
+static inline float vexprelr(float initial_x) {
+    if (1.0+initial_x == 1.0) {
+        return 1.0;
+    }
+
+    return initial_x/expm1(initial_x);
+}
+
 
 

--- a/src/codegen/fast_math.ispc
+++ b/src/codegen/fast_math.ispc
@@ -63,7 +63,7 @@ static const uniform double QX2exp = 2.52448340349684104192d-3;
 static const uniform double QX3exp = 2.27265548208155028766d-1;
 static const uniform double QX4exp = 2.00000000000000000009d;
 
-static const uniform double LOG2E = 1.4426950408889634073599d;
+static const uniform double LOG2E = 1.4426950408889634073599d; // 1/ln(2)
 
 static const uniform float MAXLOGF = 88.72283905206835f;
 static const uniform float MINLOGF = -88.f;
@@ -78,13 +78,9 @@ static const uniform float PX4expf = 4.1665795894E-2f;
 static const uniform float PX5expf = 1.6666665459E-1f;
 static const uniform float PX6expf = 5.0000001201E-1f;
 
-static const uniform float LOG2EF = 1.44269504088896341f;
+static const uniform float LOG2EF = 1.44269504088896341f; // 1/ln(2)
 
-/// double precision exp function
-static inline double vexp(double initial_x) {
-    double x = initial_x;
-    double px = dpfloor(LOG2E * x + 0.5d);
-    const int32 n = px;
+static inline double expgm1(double x, double px) {
 
     x -= px * 6.93145751953125d-1;
     x -= px * 1.42860682030941723212d-6;
@@ -106,8 +102,16 @@ static inline double vexp(double initial_x) {
     qx *= xx;
     qx += QX4exp;
 
-    x = px / (qx - px);
-    x = 1.0d + 2.0d * x;
+    return 2.0d*px / (qx - px);
+}
+
+/// double precision exp function
+static inline double vexp(double initial_x) {
+    double x = initial_x;
+    double px = dpfloor(LOG2E * x + 0.5d);
+    const int32 n = px;
+
+    x = 1.0d + expgm1(x, px);
     x *= uint642dp((((unsigned int64) n) + 1023) << 52);
 
     if (initial_x > EXP_LIMIT)
@@ -118,17 +122,9 @@ static inline double vexp(double initial_x) {
     return x;
 }
 
-/// single prevision exp function
-static inline float vexp(float initial_x) {
-    float x = initial_x;
-    float z = spfloor(LOG2EF * x + 0.5f);
+static inline float expgm1(float x) {
 
-    x -= z * C1F;
-    x -= z * C2F;
-    const int32 n = z;
-    const float x2 = x * x;
-
-    z = x * PX1expf;
+    float z = x * PX1expf;
     z += PX2expf;
     z *= x;
     z += PX3expf;
@@ -138,8 +134,22 @@ static inline float vexp(float initial_x) {
     z += PX5expf;
     z *= x;
     z += PX6expf;
-    z *= x2;
-    z += x + 1.0f;
+    z *= x*x;
+    z += x;
+
+    return z;
+}
+
+/// single precision exp function
+static inline float vexp(float initial_x) {
+    float x = initial_x;
+    float z = spfloor(LOG2EF * x + 0.5f);
+
+    x -= z * C1F;
+    x -= z * C2F;
+    const int32 n = z;
+
+    z = 1.0f + expgm1(x);
 
     z *= uint322sp((n + 0x7f) << 23);
 

--- a/src/codegen/fast_math.ispc
+++ b/src/codegen/fast_math.ispc
@@ -81,7 +81,7 @@ static const uniform float PX6expf = 5.0000001201E-1f;
 
 static const uniform float LOG2EF = 1.44269504088896341f; // 1/ln(2)
 
-static inline double expgm1(double x, double px) {
+static inline double vexpgm1(double x, double px) {
 
     x -= px * 6.93145751953125d-1;
     x -= px * 1.42860682030941723212d-6;
@@ -112,7 +112,7 @@ static inline double vexp(double initial_x) {
     double px = dpfloor(LOG2E * x + 0.5d);
     const int32 n = px;
 
-    x = 1.0d + expgm1(x, px);
+    x = 1.0d + vexpgm1(x, px);
     x *= uint642dp((((unsigned int64) n) + 1023) << 52);
 
     if (initial_x > EXP_LIMIT)
@@ -128,9 +128,9 @@ static inline double vexpm1(double initial_x) {
     double x = initial_x;
     double px = dpfloor(LOG2E * x + 0.5d);
 
-    const int32 n = px * ((px > 0.5) || (px >= -0.5));
+    const int32 n = ((px > 0.5) || (px >= -0.5)) ? px : 0;
 
-    x = expgm1(x, px);
+    x = vexpgm1(x, px);
     const double pow2nm1 = uint642dp((((unsigned int64) n-1) + 1023) << 52);
     x *= pow2nm1;
     x += pow2nm1-1;
@@ -150,10 +150,10 @@ static inline double vexprelr(double initial_x) {
         return 1.0;
     }
 
-    return initial_x/expm1(initial_x);
+    return initial_x/vexpm1(initial_x);
 }
 
-static inline float expgm1(float x) {
+static inline float vexpgm1(float x) {
 
     float z = x * PX1expf;
     z += PX2expf;
@@ -180,7 +180,7 @@ static inline float vexp(float initial_x) {
     x -= z * C2F;
     const int32 n = z;
 
-    z = 1.0f + expgm1(x);
+    z = 1.0f + vexpgm1(x);
 
     z *= uint322sp((n + 0x7f) << 23);
 
@@ -201,7 +201,7 @@ static inline float vexpm1(float initial_x) {
     x -= z * C2F;
     const int32 n = z;
 
-    z = expgm1(x);
+    z = vexpgm1(x);
     const double pow2nm1 = uint322sp((n-1 + 0x7f) << 23);
     z *= pow2nm1;
     z += pow2nm1-1;
@@ -221,7 +221,7 @@ static inline float vexprelr(float initial_x) {
         return 1.0;
     }
 
-    return initial_x/expm1(initial_x);
+    return initial_x/vexpm1(initial_x);
 }
 
 

--- a/src/codegen/fast_math.ispc
+++ b/src/codegen/fast_math.ispc
@@ -7,7 +7,7 @@
  * Note that the fast ISPC exponentials Based on VDT implementation of
  * D. Piparo et al. See https://github.com/dpiparo/vdt for additional
  * license information.
- * exprelr and expm1 are based on https://arbor.readthedocs.io/en/latest/internals/simd_api.html?highlight=exprelr#operatorname-expm1-x
+ * exprelr and expm1 are based on https://arbor.readthedocs.io/en/latest/internals/simd_api.html#implementation-of-vector-transcendental-functions
  *************************************************************************/
 
 /**
@@ -219,6 +219,5 @@ static inline float exprelr(float initial_x) {
 
     return initial_x/vexpm1(initial_x);
 }
-
 
 

--- a/src/codegen/fast_math.ispc
+++ b/src/codegen/fast_math.ispc
@@ -122,6 +122,27 @@ static inline double vexp(double initial_x) {
     return x;
 }
 
+/// double precision expm1 function
+static inline double vexpm1(double initial_x) {
+    double x = initial_x;
+    double px = dpfloor(LOG2E * x + 0.5d);
+
+    const int32 n = px * ((px > 0.5) || (px >= -0.5));
+
+    x = expgm1(x, px);
+    const double pow2nm1 = uint642dp((((unsigned int64) n-1) + 1023) << 52);
+    x *= pow2nm1;
+    x += pow2nm1-1;
+    x *= 2;
+
+    if (initial_x > EXP_LIMIT)
+        x = inf();
+    if (initial_x < -EXP_LIMIT)
+        x = -1.d;
+
+    return x;
+}
+
 static inline float expgm1(float x) {
 
     float z = x * PX1expf;
@@ -160,3 +181,28 @@ static inline float vexp(float initial_x) {
 
     return z;
 }
+
+/// single precision expm1 function
+static inline float vexpm1(float initial_x) {
+    float x = initial_x;
+    float z = spfloor(LOG2EF * x + 0.5f);
+
+    x -= z * C1F;
+    x -= z * C2F;
+    const int32 n = z;
+
+    z = expgm1(x);
+    const double pow2nm1 = uint322sp((n-1 + 0x7f) << 23);
+    z *= pow2nm1;
+    z += pow2nm1-1;
+    z *= 2;
+
+    if (initial_x > MAXLOGF)
+        z = f_inf();
+    if (initial_x < MINLOGF)
+        z = -1.f;
+
+    return z;
+}
+
+

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(
 add_executable(testprinter printer/printer.cpp)
 add_executable(testsymtab symtab/symbol_table.cpp)
 add_executable(testnewton newton/newton.cpp ${SOLVER_SOURCE_FILES})
+add_executable(testfast_math fast_math/fast_math.cpp ${SOLVER_SOURCE_FILES})
 add_executable(testunitlexer units/lexer.cpp)
 add_executable(testunitparser units/parser.cpp)
 add_executable(testcodegen codegen/main.cpp codegen/codegen_ispc.cpp codegen/codegen_helper.cpp
@@ -115,6 +116,7 @@ foreach(
   testprinter
   testsymtab
   testnewton
+  testfast_math
   testunitlexer
   testunitparser)
 

--- a/test/unit/fast_math/fast_math.cpp
+++ b/test/unit/fast_math/fast_math.cpp
@@ -1,0 +1,119 @@
+/*************************************************************************
+ * Copyright (C) 2018-2019 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#define CATCH_CONFIG_MAIN
+
+#include "codegen/fast_math.hpp"
+#include <cmath>
+
+#include <catch/catch.hpp>
+
+float check_over_span_float(float f1(float),
+                            float f2(float),
+                            const float low_limit,
+                            const float span,
+                            const size_t npoints) {
+    float x = 0.0;
+    float val = f1(x) - f2(x);
+    float err = val * val;  // 0.0 is an edge case
+
+
+    for (size_t i = 0; i < npoints; ++i) {
+        x = low_limit + span * i / npoints;
+        val = f1(x) - f2(x);
+        err += val * val;
+    }
+    err /= npoints + 1;
+    return err;
+}
+
+double check_over_span_double(double f1(double),
+                              double f2(double),
+                              const double low_limit,
+                              const double span,
+                              const size_t npoints) {
+    double x = 0.0;
+    double val = f1(x) - f2(x);
+    double err = val * val;  // 0.0 is an edge case
+
+    for (size_t i = 0; i < npoints; ++i) {
+        x = low_limit + span * i / npoints;
+        val = f1(x) - f2(x);
+        err += val * val;
+    }
+    err /= npoints + 1;
+    return err;
+}
+
+SCENARIO("Check fast_math") {
+    constexpr double low_limit = -5.0;
+    constexpr double span = 10.0;
+    constexpr size_t npoints = 1000;
+    constexpr double err_threshold = 1e-10;
+    GIVEN("vexp (double)") {
+        const double err = check_over_span_double(std::exp, vexp, low_limit, span, npoints);
+
+        THEN("error inside threshold") {
+            REQUIRE(err < err_threshold);
+        }
+    }
+    GIVEN("vexp (float)") {
+        const double err = check_over_span_float(std::exp, vexp, low_limit, span, npoints);
+
+        THEN("error inside threshold") {
+            REQUIRE(err < err_threshold);
+        }
+    }
+    GIVEN("expm1 (double)") {
+        const double err =
+            check_over_span_double([](const double x) -> double { return std::exp(x) - 1; },
+                                   vexpm1,
+                                   low_limit,
+                                   span,
+                                   npoints);
+
+        THEN("error inside threshold") {
+            REQUIRE(err < err_threshold);
+        }
+    }
+    GIVEN("expm1 (float)") {
+        const double err =
+            check_over_span_float([](const float x) -> float { return std::exp(x) - 1; },
+                                  vexpm1,
+                                  low_limit,
+                                  span,
+                                  npoints);
+
+        THEN("error inside threshold") {
+            REQUIRE(err < err_threshold);
+        }
+    }
+    GIVEN("exprelr (double)") {
+        const double err = check_over_span_double(
+            [](const double x) -> double { return (1.0 + x == 1.0) ? 1.0 : x / (std::exp(x) - 1); },
+            exprelr,
+            low_limit,
+            span,
+            npoints);
+
+        THEN("error inside threshold") {
+            REQUIRE(err < err_threshold);
+        }
+    }
+    GIVEN("exprelr (float)") {
+        const float err = check_over_span_float(
+            [](const float x) -> float { return (1.0 + x == 1.0) ? 1.0 : x / (std::exp(x) - 1); },
+            exprelr,
+            low_limit,
+            span,
+            npoints);
+
+        THEN("error inside threshold") {
+            REQUIRE(err < err_threshold);
+        }
+    }
+}


### PR DESCRIPTION
Add support for exprrelr and expm1 as implemented in [arbor](https://arbor.readthedocs.io/en/latest/internals/simd_api.html?highlight=exprelr#operatorname-expm1-x)