### PR TITLE
nrn_state function generation in NMODL AST to help LLVM codegen

### DIFF
--- a/src/ast/ast_common.hpp
+++ b/src/ast/ast_common.hpp
@@ -43,9 +43,12 @@ namespace ast {
  *
  * NMODL support different binary operators and this
  * type is used to store their value in the AST.
+ *
+ * \note `+=` and `-=` are not supported by NMODL but they
+ * are added for code generation nodes.
  */
 typedef enum {
-    BOP_ADDITION,        ///< \+
+    BOP_ADDITION = 0,    ///< \+
     BOP_SUBTRACTION,     ///< --
     BOP_MULTIPLICATION,  ///< \c *
     BOP_DIVISION,        ///< \/
@@ -58,7 +61,9 @@ typedef enum {
     BOP_LESS_EQUAL,      ///< <=
     BOP_ASSIGN,          ///< =
     BOP_NOT_EQUAL,       ///< !=
-    BOP_EXACT_EQUAL      ///< ==
+    BOP_EXACT_EQUAL,     ///< ==
+    BOP_ADD_ASSIGN,      ///< \+=
+    BOP_SUB_ASSIGN       ///< \-=
 } BinaryOp;
 
 /**
@@ -68,7 +73,7 @@ typedef enum {
  * is used to lookup the corresponding symbol for the operator.
  */
 static const std::string BinaryOpNames[] =
-    {"+", "-", "*", "/", "^", "&&", "||", ">", "<", ">=", "<=", "=", "!=", "=="};
+    {"+", "-", "*", "/", "^", "&&", "||", ">", "<", ">=", "<=", "=", "!=", "==", "+=", "-="};
 
 /// enum type for unary operators
 typedef enum { UOP_NOT, UOP_NEGATION } UnaryOp;
@@ -106,6 +111,20 @@ typedef enum { LTMINUSGT, LTLT, MINUSGT } ReactionOp;
 /// string representation of ast::ReactionOp
 static const std::string ReactionOpNames[] = {"<->", "<<", "->"};
 
+/**
+ * Get corresponding ast::BinaryOp for given string
+ * @param op Binary operator in string format
+ * @return ast::BinaryOp for given string
+ */
+static inline BinaryOp string_to_binaryop(const std::string& op) {
+    /// check if binary operator supported otherwise error
+    auto it = std::find(std::begin(BinaryOpNames), std::end(BinaryOpNames), op);
+    if (it == std::end(BinaryOpNames)) {
+        throw std::runtime_error("Error in string_to_binaryop, can't find " + op);
+    }
+    int pos = std::distance(std::begin(BinaryOpNames), it);
+    return static_cast<BinaryOp>(pos);
+}
 /** @} */  // end of ast_prop
 
 }  // namespace ast

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -46,36 +46,6 @@ namespace codegen {
  * @{
  */
 
-/**
- * \enum BlockType
- * \brief Helper to represent various block types
- *
- * Note: do not assign integers to these enums
- *
- */
-enum BlockType {
-    /// initial block
-    Initial,
-
-    /// breakpoint block
-    Equation,
-
-    /// ode_* routines block (not used)
-    Ode,
-
-    /// derivative block
-    State,
-
-    /// watch block
-    Watch,
-
-    /// net_receive block
-    NetReceive,
-
-    /// fake ending block type for loops on the enums. Keep it at the end
-    BlockTypeEnd
-};
-
 
 /**
  * \enum MemberType
@@ -143,22 +113,6 @@ enum class LayoutType {
 
     /// structure of array
     soa
-};
-
-
-/**
- * \class ShadowUseStatement
- * \brief Represents ion write statement during code generation
- *
- * Ion update statement needs use of shadow vectors for certain backends
- * as atomics operations are not supported on cpu backend.
- *
- * \todo If shadow_lhs is empty then we assume shadow statement not required
- */
-struct ShadowUseStatement {
-    std::string lhs;
-    std::string op;
-    std::string rhs;
 };
 
 /** @} */  // end of codegen_details

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -28,19 +28,57 @@ namespace codegen {
 
 /**
  * \class CodegenLLVMHelperVisitor
- * \brief Helper visitor to gather AST information to help LLVM code generation
+ * \brief Helper visitor for AST information to help code generation backends
+ *
+ * Code generation backends convert NMODL AST to C++ code. But during this
+ * C++ code generation, various transformations happens and final code generated
+ * is quite different / large than actual kernel represented in MOD file ro
+ * NMODL AST.
+ *
+ * Currently, these transformations are embedded into code generation backends
+ * like ast::CodegenCVisitor. If we have to generate code for new simulator, there
+ * will be duplication of these transformations. Also, for completely new
+ * backends like NEURON simulator or SIMD library, we will have code duplication.
+ *
+ * In order to avoid this, we perform maximum transformations in this visitor.
+ * Currently we focus on transformations that will help LLVM backend but later
+ * these will be common across all backends.
  */
 class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
+    /// newly generated code generation specific functions
     std::vector<std::shared_ptr<ast::CodegenFunction>> codegen_functions;
 
-    void add_function_procedure_node(ast::Block& node);
+    /// ast information for code generation
+    codegen::CodegenInfo info;
+
+    /// default integer and float node type
+    const ast::AstNodeType INTEGER_TYPE = ast::AstNodeType::INTEGER;
+    const ast::AstNodeType FLOAT_TYPE = ast::AstNodeType::DOUBLE;
+
+    /// create new function for FUNCTION or PROCEDURE block
+    void create_function_for_node(ast::Block& node);
 
   public:
     CodegenLLVMHelperVisitor() = default;
 
+    void ion_read_statements(BlockType type,
+                             std::vector<std::string>& int_variables,
+                             std::vector<std::string>& double_variables,
+                             ast::StatementVector& index_statements,
+                             ast::StatementVector& body_statements);
+
+    void ion_write_statements(BlockType type,
+                              std::vector<std::string>& int_variables,
+                              std::vector<std::string>& double_variables,
+                              ast::StatementVector& index_statements,
+                              ast::StatementVector& body_statements);
+
+    void convert_to_instance_variable(ast::Node& node, std::string& index_var);
+
     void visit_statement_block(ast::StatementBlock& node) override;
     void visit_procedure_block(ast::ProcedureBlock& node) override;
     void visit_function_block(ast::FunctionBlock& node) override;
+    void visit_nrn_state_block(ast::NrnStateBlock& node) override;
     void visit_program(ast::Program& node) override;
 };
 

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -350,7 +350,7 @@ void CodegenLLVMVisitor::visit_program(const ast::Program& node) {
     // Keep this for easier development (maybe move to debug mode later).
     std::cout << print_module();
 
-    // not used yet
+    // not used yet : this will be used at the beginning of this function
     {
         CodegenLLVMHelperVisitor v;
         v.visit_program(const_cast<ast::Program&>(node));

--- a/src/language/code_generator.cmake
+++ b/src/language/code_generator.cmake
@@ -66,6 +66,7 @@ set(AST_GENERATED_SOURCES
     ${PROJECT_BINARY_DIR}/src/ast/boolean.hpp
     ${PROJECT_BINARY_DIR}/src/ast/breakpoint_block.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_argument.hpp
+    ${PROJECT_BINARY_DIR}/src/ast/codegen_atomic_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_for_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_function.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_return_statement.hpp
@@ -193,6 +194,7 @@ set(AST_GENERATED_SOURCES
     ${PROJECT_BINARY_DIR}/src/ast/valence.hpp
     ${PROJECT_BINARY_DIR}/src/ast/var_name.hpp
     ${PROJECT_BINARY_DIR}/src/ast/verbatim.hpp
+    ${PROJECT_BINARY_DIR}/src/ast/void.hpp
     ${PROJECT_BINARY_DIR}/src/ast/watch.hpp
     ${PROJECT_BINARY_DIR}/src/ast/watch_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/while_statement.hpp

--- a/src/language/codegen.yaml
+++ b/src/language/codegen.yaml
@@ -28,6 +28,9 @@
             - Expression:
                 children:
                   - Number:
+                  - Void:
+                      nmodl: "VOID"
+                      brief: "Represent void type in code generation"
                   - Identifier:
                       children:
                         - CodegenVarType:
@@ -185,7 +188,7 @@
                             brief: "condition expression for the loop"
                             type: Expression
                             optional: true
-                            prefix: {value: ";"}
+                            prefix: {value: "; "}
                             suffix: {value: "; "}
                         - increment:
                             brief: "increment or decrement expression for the loop"
@@ -217,3 +220,35 @@
                             vector: true
                             separator: ", "
                             add: true
+                  - CodegenAtomicStatement:
+                      brief: "Represent atomic operation"
+                      description: |
+                        During code generation certain operations like ion updates, vec_rhs or
+                        vec_d updates (for synapse) needs to be atomic operations if executed by
+                        multiple threads. In case of SIMD, there are conflicts for `vec_d` and
+                        `vec_rhs` for synapse types. Here are some statements from C++ backend:
+
+                        \code{.cpp}
+                            vec_d[node_id] += g
+                            vec_rhs[node_id] -= rhs
+                            ion_ina[indexes[some_index]] += ina[id]
+                            ion_cai[indexes[some_index]] = cai[id]  // cai here is state variable
+                        \endcode
+
+                        These operations will be represented by atomic statement node type:
+                        * `vec_d[node_id]` : lhs
+                        * `+=` : atomic_op
+                        * `g` : rhs
+
+                      members:
+                        - lhs:
+                            brief: "Variable to be updated atomically"
+                            type: Identifier
+                        - atomic_op:
+                            brief: "Operator"
+                            type: BinaryOperator
+                            prefix: {value: " "}
+                            suffix: {value: " "}
+                        - rhs:
+                            brief: "Expression for atomic operation"
+                            type: Expression


### PR DESCRIPTION
  * Added new BinaryOp for += and -=
  * Added string_to_binaryop function
  * Added Void node type to represent void return type
  * Added CodegenAtomicStatement for ion write statements
  * llvm helper started handling visit_nrn_state_block
    - NrnStateBlock is being converted into CodegenFunction
    - for loop body with solution blocks created
    - voltage and node index initialization code added
    - read and write ion statements are handled
  * Some of the functions are now moved into CodegenInfo

Co-authored-by: Ioannis Magkanaris <iomagkanaris@gmail.com>

Same as #476 but it was previously merged to wrong branch 