### PR TITLE
sympy substitute inplace instead of reordering

### DIFF
--- a/src/language/nodes.py
+++ b/src/language/nodes.py
@@ -306,6 +306,11 @@ class ChildNode(BaseNode):
                           * \\brief Reset member to {self.varname}
                           */
                          void reset_{to_snake_case(self.class_name)}({self.class_name}Vector::const_iterator position, std::shared_ptr<{self.class_name}> n);
+
+                         /**
+                          * \\brief Reset non-consecutive members to {self.varname}
+                          */
+                         size_t reset_{to_snake_case(self.class_name)}(const std::unordered_map<{self.class_name}*, std::shared_ptr<{self.class_name}>>& to_be_reset);
                     """
             s = textwrap.dedent(method)
         return s
@@ -408,6 +413,22 @@ class ChildNode(BaseNode):
                              {set_parent}
 
                             {self.varname}[position - {self.varname}.begin()] = n;
+                         }}
+
+                         /**
+                          * \\brief Reset non-consecutive members to {self.varname}
+                          */
+                         size_t {parent.class_name}::reset_{to_snake_case(self.class_name)}(const std::unordered_map<{self.class_name}*, std::shared_ptr<{self.class_name}>>& to_be_reset) {{
+                            size_t n_resets = 0;
+                            for (auto it = {self.varname}.begin(); it != {self.varname}.end(); ++it) {{
+                                    auto reset_this_pair = to_be_reset.find(&(*(*it)));
+                                    if (reset_this_pair != to_be_reset.end()) {{
+                                        reset_{to_snake_case(self.class_name)}(it, reset_this_pair->second);
+                                        ++n_resets;
+                                    }}
+                                }}
+
+                            return n_resets;
                          }}
                     """
             s = textwrap.dedent(method)

--- a/src/visitors/sympy_solver_visitor.hpp
+++ b/src/visitors/sympy_solver_visitor.hpp
@@ -81,6 +81,11 @@ class SympySolverVisitor: public AstVisitor {
     ast::StatementVector::const_iterator get_solution_location_iterator(
         const ast::StatementVector& statements);
 
+    /// return iterator pointing to where the pre solution statements should be inserted in
+    /// statement block
+    ast::StatementVector::const_iterator get_pre_solve_statements_location_iterator(
+        const ast::StatementVector& statements);
+
     /// construct solver block
     void construct_eigen_solver_block(const std::vector<std::string>& pre_solve_statements,
                                       const std::vector<std::string>& solutions,


### PR DESCRIPTION
Necessary to enable control flow and redefinitions

Possibly fix #60, #55