### PR TITLE
Avoid converting LOCAL statement in all StatementBlocks

### DIFF
--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -123,6 +123,9 @@ void CodegenLLVMHelperVisitor::create_function_for_node(ast::Block& node) {
     auto block = node.get_statement_block()->clone();
     const auto& statements = block->get_statements();
 
+    /// convert local statement to codegenvar statement
+    convert_local_statement(*block);
+
     /// insert return variable at the start of the block
     ast::CodegenVarVector codegen_vars;
     codegen_vars.emplace_back(new ast::CodegenVar(0, return_var->clone()));
@@ -356,7 +359,7 @@ void CodegenLLVMHelperVisitor::convert_to_instance_variable(ast::Node& node,
  * first statement in the vector. We have to remove LOCAL statement and convert
  * it to CodegenVarListStatement that will represent all variables as double.
  */
-void CodegenLLVMHelperVisitor::visit_statement_block(ast::StatementBlock& node) {
+void CodegenLLVMHelperVisitor::convert_local_statement(ast::StatementBlock& node) {
     /// first process all children blocks if any
     node.visit_children(*this);
 
@@ -474,6 +477,9 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
 
     /// convert all variables inside loop body to instance variables
     convert_to_instance_variable(*loop_block, loop_index_var);
+
+    /// convert local statement to codegenvar statement
+    convert_local_statement(*loop_block);
 
     /// create for loop node
     auto for_loop_statement = std::make_shared<ast::CodegenForStatement>(initialization,

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -75,7 +75,8 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
 
     void convert_to_instance_variable(ast::Node& node, std::string& index_var);
 
-    void visit_statement_block(ast::StatementBlock& node) override;
+    void convert_local_statement(ast::StatementBlock& node);
+
     void visit_procedure_block(ast::ProcedureBlock& node) override;
     void visit_function_block(ast::FunctionBlock& node) override;
     void visit_nrn_state_block(ast::NrnStateBlock& node) override;


### PR DESCRIPTION
  * visit_statement_block of all FUNCTION and PROCEDURE
    blocks was called resulting in changing LOCAL
    statement to DOUBLE statement
  * As statement block doesn't need to be visited for this
    purpose, rename function to convert_local_statement
  * Call convert_local_statement only when required i.e.
    only when codegen function creation time.

fixes #491