### PR TITLE
Handle CodegenVarType type in JSON printer 

### DIFF
--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -123,6 +123,9 @@ void CodegenLLVMHelperVisitor::create_function_for_node(ast::Block& node) {
     auto block = node.get_statement_block()->clone();
     const auto& statements = block->get_statements();
 
+    /// convert local statement to codegenvar statement
+    convert_local_statement(*block);
+
     /// insert return variable at the start of the block
     ast::CodegenVarVector codegen_vars;
     codegen_vars.emplace_back(new ast::CodegenVar(0, return_var->clone()));
@@ -356,7 +359,7 @@ void CodegenLLVMHelperVisitor::convert_to_instance_variable(ast::Node& node,
  * first statement in the vector. We have to remove LOCAL statement and convert
  * it to CodegenVarListStatement that will represent all variables as double.
  */
-void CodegenLLVMHelperVisitor::visit_statement_block(ast::StatementBlock& node) {
+void CodegenLLVMHelperVisitor::convert_local_statement(ast::StatementBlock& node) {
     /// first process all children blocks if any
     node.visit_children(*this);
 
@@ -474,6 +477,9 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
 
     /// convert all variables inside loop body to instance variables
     convert_to_instance_variable(*loop_block, loop_index_var);
+
+    /// convert local statement to codegenvar statement
+    convert_local_statement(*loop_block);
 
     /// create for loop node
     auto for_loop_statement = std::make_shared<ast::CodegenForStatement>(initialization,

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -75,7 +75,8 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
 
     void convert_to_instance_variable(ast::Node& node, std::string& index_var);
 
-    void visit_statement_block(ast::StatementBlock& node) override;
+    void convert_local_statement(ast::StatementBlock& node);
+
     void visit_procedure_block(ast::ProcedureBlock& node) override;
     void visit_function_block(ast::FunctionBlock& node) override;
     void visit_nrn_state_block(ast::NrnStateBlock& node) override;

--- a/src/language/node_info.py
+++ b/src/language/node_info.py
@@ -169,6 +169,7 @@ STATEMENT_BLOCK_NODE = "StatementBlock"
 STRING_NODE = "String"
 UNIT_BLOCK = "UnitBlock"
 AST_NODETYPE_NODE= "AstNodeType"
+CODEGEN_VAR_TYPE_NODE = "CodegenVarType"
 
 # name of variable in prime node which represent order of derivative
 ORDER_VAR_NAME = "order"

--- a/src/language/nodes.py
+++ b/src/language/nodes.py
@@ -152,6 +152,10 @@ class BaseNode:
         return self.class_name == node_info.AST_NODETYPE_NODE
 
     @property
+    def is_codegen_var_type_node(self):
+        return self.class_name == node_info.CODEGEN_VAR_TYPE_NODE
+
+    @property
     def is_enum_node(self):
         data_type = node_info.DATA_TYPES[self.class_name]
         return data_type in node_info.ENUM_BASE_TYPES

--- a/src/language/templates/visitors/json_visitor.cpp
+++ b/src/language/templates/visitors/json_visitor.cpp
@@ -22,33 +22,36 @@ using namespace ast;
 {% for node in nodes %}
 void JSONVisitor::visit_{{ node.class_name|snake_case }}(const {{ node.class_name }}& node) {
     {% if node.has_children() %}
-    printer->push_block(node.get_node_type_name());
-    if (embed_nmodl) {
-        printer->add_block_property("nmodl", to_nmodl(node));
-    }
-    node.visit_children(*this);
-    {% if node.is_data_type_node %}
+        printer->push_block(node.get_node_type_name());
+        if (embed_nmodl) {
+            printer->add_block_property("nmodl", to_nmodl(node));
+        }
+        node.visit_children(*this);
+        {% if node.is_data_type_node %}
             {% if node.is_integer_node %}
-    if(!node.get_macro()) {
-        std::stringstream ss;
-        ss << node.eval();
-        printer->add_node(ss.str());
-    }
+                if(!node.get_macro()) {
+                    std::stringstream ss;
+                    ss << node.eval();
+                    printer->add_node(ss.str());
+                }
             {% else %}
-    std::stringstream ss;
-    ss << node.eval();
-    printer->add_node(ss.str());
+                std::stringstream ss;
+                ss << node.eval();
+                printer->add_node(ss.str());
             {% endif %}
         {% endif %}
-    printer->pop_block();
+
+        printer->pop_block();
+
         {% if node.is_program_node %}
-    if (node.get_parent() == nullptr) {
-        flush();
-    }
+            if (node.get_parent() == nullptr) {
+                flush();
+            }
         {% endif %}
+
     {% else %}
-    (void)node;
-    printer->add_node("{{ node.class_name }}");
+        (void)node;
+        printer->add_node("{{ node.class_name }}");
     {% endif %}
 }
 

--- a/src/language/templates/visitors/json_visitor.cpp
+++ b/src/language/templates/visitors/json_visitor.cpp
@@ -41,6 +41,10 @@ void JSONVisitor::visit_{{ node.class_name|snake_case }}(const {{ node.class_nam
             {% endif %}
         {% endif %}
 
+        {% if node.is_codegen_var_type_node %}
+            printer->add_node(ast::to_string(node.get_type()));
+        {% endif %}
+
         printer->pop_block();
 
         {% if node.is_program_node %}


### PR DESCRIPTION
- As AstNodeType is enum type and not AST node itself,
   we need to print this member variable explicitly in
   JSON visitor
- Note that most of the changes are from indenting. Actual
   change is in second commit 0786e90b79472a4a5e5291683c6236f4f331d83c

fixes #493

With this PR, we get:

```
     {
       "CodegenFunction": [
         {
           "CodegenVarType": [
             {
               "name": "VOID"
             }
           ]
         },
         {
           "Name": [
             {
               "String": [
                 {
                   "name": "nrn_state_hh"
                 }
               ]
             }
           ]
         },
         {
           "StatementBlock": [
             {
               "CodegenVarListStatement": [
                 {
                   "CodegenVarType": [
                     {
                       "name": "INTEGER"
                     }
                   ]
                 },
                 {
                   "CodegenVar": [
                     {
                       "Name": [
                         {
                           "String": [
                             {
                               "name": "id"
                             }
```