### PR TITLE
Added error handling for values not in scope

### DIFF
--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -181,6 +181,12 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     }
 
     /**
+     * Lookup the given name in the current function's symbol table
+     * \return LLVM value
+     */
+    llvm::Value* lookup(const std::string& name);
+
+    /**
      * Visit nmodl arithmetic binary operator
      * \param lhs LLVM value of evaluated lhs expression
      * \param rhs LLVM value of evaluated rhs expression


### PR DESCRIPTION
A small PR to add error handling when a non-scope value is looked up. Before, such a lookup would yield a `nullptr`, therefore leading to a segfault. This PR adds a `lookup` function that wraps around symbol lookup, and throws an error with a message if `nullptr` is returned.