### PR TITLE
Printf support in LLVM IR codegen

### DIFF
--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -150,20 +150,14 @@ void CodegenLLVMVisitor::create_function_call(llvm::Function* func,
                                               const std::string& name,
                                               const ast::ExpressionVector& arguments) {
     // Check that function is called with the expected number of arguments.
-    if (arguments.size() != func->arg_size()) {
+    if (!func->isVarArg() && arguments.size() != func->arg_size()) {
         throw std::runtime_error("Error: Incorrect number of arguments passed");
     }
 
-    // Process each argument and add it to a vector to pass to the function call instruction. Note
-    // that type checks are not needed here as NMODL operates on doubles by default.
+    // Pack function call arguments to vector and create a call instruction.
     std::vector<llvm::Value*> argument_values;
-    for (const auto& arg: arguments) {
-        arg->accept(*this);
-        llvm::Value* value = values.back();
-        values.pop_back();
-        argument_values.push_back(value);
-    }
-
+    argument_values.reserve(arguments.size());
+    pack_function_call_arguments(arguments, argument_values);
     llvm::Value* call = builder.CreateCall(func, argument_values);
     values.push_back(call);
 }
@@ -184,20 +178,8 @@ void CodegenLLVMVisitor::create_printf_call(const ast::ExpressionVector& argumen
 
     // Create a call instruction.
     std::vector<llvm::Value*> argument_values;
-    for (const auto& arg: arguments) {
-        if (arg->is_string()) {
-            // If the argument is a string, create a global i8* variable with it.
-            auto string_arg = std::dynamic_pointer_cast<ast::String>(arg);
-            llvm::Value* str = builder.CreateGlobalStringPtr(string_arg->get_value());
-            argument_values.push_back(str);
-        } else {
-            arg->accept(*this);
-            llvm::Value* value = values.back();
-            values.pop_back();
-            argument_values.push_back(value);
-        }
-    }
-
+    argument_values.reserve(arguments.size());
+    pack_function_call_arguments(arguments, argument_values);
     builder.CreateCall(printf, argument_values);
 }
 
@@ -224,6 +206,23 @@ llvm::Value* CodegenLLVMVisitor::lookup(const std::string& name) {
     if (!val)
         throw std::runtime_error("Error: variable " + name + " is not in scope\n");
     return val;
+}
+
+void CodegenLLVMVisitor::pack_function_call_arguments(const ast::ExpressionVector& arguments,
+                                                      std::vector<llvm::Value*>& arg_values) {
+    for (const auto& arg: arguments) {
+        if (arg->is_string()) {
+            // If the argument is a string, create a global i8* variable with it.
+            auto string_arg = std::dynamic_pointer_cast<ast::String>(arg);
+            llvm::Value* str = builder.CreateGlobalStringPtr(string_arg->get_value());
+            arg_values.push_back(str);
+        } else {
+            arg->accept(*this);
+            llvm::Value* value = values.back();
+            values.pop_back();
+            arg_values.push_back(value);
+        }
+    }
 }
 
 llvm::Value* CodegenLLVMVisitor::visit_arithmetic_bin_op(llvm::Value* lhs,

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -205,7 +205,8 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
      * \param arguments expression vector
      * \param arg_values vector of LLVM IR values to fill
      */
-    void pack_function_call_arguments(const ast::ExpressionVector& arguments, std::vector<llvm::Value*>& arg_values);
+    void pack_function_call_arguments(const ast::ExpressionVector& arguments,
+                                      std::vector<llvm::Value*>& arg_values);
 
     /**
      * Visit nmodl arithmetic binary operator

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -249,7 +249,6 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     void visit_integer(const ast::Integer& node) override;
     void visit_procedure_block(const ast::ProcedureBlock& node) override;
     void visit_program(const ast::Program& node) override;
-    void visit_string(const ast::String& node) override;
     void visit_unary_expression(const ast::UnaryExpression& node) override;
     void visit_var_name(const ast::VarName& node) override;
     void visit_instance_struct(const ast::InstanceStruct& node) override;

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -201,6 +201,13 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     llvm::Value* lookup(const std::string& name);
 
     /**
+     * Fills values vector with processed NMODL function call arguments
+     * \param arguments expression vector
+     * \param arg_values vector of LLVM IR values to fill
+     */
+    void pack_function_call_arguments(const ast::ExpressionVector& arguments, std::vector<llvm::Value*>& arg_values);
+
+    /**
      * Visit nmodl arithmetic binary operator
      * \param lhs LLVM value of evaluated lhs expression
      * \param rhs LLVM value of evaluated rhs expression

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -173,6 +173,11 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     void create_function_call(llvm::Function* func,
                               const std::string& name,
                               const ast::ExpressionVector& arguments);
+    /**
+     * Create a function call to printf function
+     * \param arguments expressions passed as arguments to the printf call
+     */
+    void create_printf_call(const ast::ExpressionVector& arguments);
 
     /**
      * Emit function or procedure declaration in LLVM given the node
@@ -229,11 +234,6 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
      */
     llvm::Value* visit_comparison_bin_op(llvm::Value* lhs, llvm::Value* rhs, unsigned op);
 
-    /**
-     * Visit nmodl function or procedure
-     * \param node the AST node representing the function or procedure in NMODL
-     */
-    void visit_procedure_or_function(const ast::Block& node);
 
     // Visitors
     void visit_binary_expression(const ast::BinaryExpression& node) override;
@@ -249,6 +249,7 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     void visit_integer(const ast::Integer& node) override;
     void visit_procedure_block(const ast::ProcedureBlock& node) override;
     void visit_program(const ast::Program& node) override;
+    void visit_string(const ast::String& node) override;
     void visit_unary_expression(const ast::UnaryExpression& node) override;
     void visit_var_name(const ast::VarName& node) override;
     void visit_instance_struct(const ast::InstanceStruct& node) override;

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -504,7 +504,7 @@ SCENARIO("Function call", "[visitor][llvm]") {
             std::regex call1(
                 R"(call i32 \(i8\*, \.\.\.\) @printf\(i8\* getelementptr inbounds \(\[6 x i8\], \[6 x i8\]\* @[0-9]+, i32 0, i32 0\)\))");
             std::regex call2(
-                R"(call i32 \(i8\*, \.\.\.) @printf(i8\* getelementptr inbounds \(\[9 x i8\], \[9 x i8\]\* @[0-9]+, i32 0, i32 0\), double %[0-9]+\))");
+                R"(call i32 \(i8\*, \.\.\.\) @printf\(i8\* getelementptr inbounds \(\[9 x i8\], \[9 x i8\]\* @[0-9]+, i32 0, i32 0\), double %[0-9]+\))");
             REQUIRE(std::regex_search(module_string, m, call1));
             REQUIRE(std::regex_search(module_string, m, call2));
         }


### PR DESCRIPTION
This PR adds support for `printf` code generation within LLVM IR pipeline. This will be useful for easier/better testing.