### PR TITLE
defuse with pointers to the statement in a variable is used/defined

### DIFF
--- a/src/visitors/defuse_analyze_visitor.cpp
+++ b/src/visitors/defuse_analyze_visitor.cpp
@@ -219,12 +219,23 @@ void DefUseAnalyzeVisitor::visit_statement_block(const ast::StatementBlock& node
  *  and hence not necessary to keep track of assignment operator using stack.
  */
 void DefUseAnalyzeVisitor::visit_binary_expression(const ast::BinaryExpression& node) {
+    // only the outermost binary expression is important
+    const bool is_outer_binary_expression = !current_binary_expression;
+    if (is_outer_binary_expression) {
+        current_binary_expression = std::static_pointer_cast<const ast::BinaryExpression>(
+            node.get_shared_ptr());
+    }
+
     node.get_rhs()->visit_children(*this);
     if (node.get_op().get_value() == ast::BOP_ASSIGN) {
         visiting_lhs = true;
     }
     node.get_lhs()->visit_children(*this);
     visiting_lhs = false;
+
+    if (is_outer_binary_expression) {
+        current_binary_expression = nullptr;
+    }
 }
 
 void DefUseAnalyzeVisitor::visit_if_statement(const ast::IfStatement& node) {
@@ -232,7 +243,7 @@ void DefUseAnalyzeVisitor::visit_if_statement(const ast::IfStatement& node) {
     auto previous_chain = current_chain;
 
     /// starting new if block
-    previous_chain->push_back(DUInstance(DUState::CONDITIONAL_BLOCK, current_expression_statement));
+    previous_chain->push_back(DUInstance(DUState::CONDITIONAL_BLOCK, current_binary_expression));
     current_chain = &(previous_chain->back().children);
 
     /// visiting if sub-block
@@ -267,15 +278,8 @@ void DefUseAnalyzeVisitor::visit_if_statement(const ast::IfStatement& node) {
  */
 void DefUseAnalyzeVisitor::visit_verbatim(const ast::Verbatim& node) {
     if (!ignore_verbatim) {
-        current_chain->push_back(DUInstance(DUState::U, current_expression_statement));
+        current_chain->push_back(DUInstance(DUState::U, current_binary_expression));
     }
-}
-
-void DefUseAnalyzeVisitor::visit_expression_statement(const ast::ExpressionStatement& node) {
-
-    current_expression_statement = std::static_pointer_cast<const ast::ExpressionStatement>(node.get_shared_ptr());
-    ConstAstVisitor::visit_expression_statement(node);
-    current_expression_statement = nullptr;
 }
 
 
@@ -366,18 +370,18 @@ void DefUseAnalyzeVisitor::update_defuse_chain(const std::string& name) {
     const auto is_local = symbol->has_any_property(properties);
 
     if (unsupported_node) {
-        current_chain->push_back(DUInstance(DUState::U, current_expression_statement));
+        current_chain->push_back(DUInstance(DUState::U, current_binary_expression));
     } else if (visiting_lhs) {
         if (is_local) {
-            current_chain->push_back(DUInstance(DUState::LD, current_expression_statement));
+            current_chain->push_back(DUInstance(DUState::LD, current_binary_expression));
         } else {
-            current_chain->push_back(DUInstance(DUState::D, current_expression_statement));
+            current_chain->push_back(DUInstance(DUState::D, current_binary_expression));
         }
     } else {
         if (is_local) {
-            current_chain->push_back(DUInstance(DUState::LU, current_expression_statement));
+            current_chain->push_back(DUInstance(DUState::LU, current_binary_expression));
         } else {
-            current_chain->push_back(DUInstance(DUState::U, current_expression_statement));
+            current_chain->push_back(DUInstance(DUState::U, current_binary_expression));
         }
     }
 }
@@ -404,7 +408,7 @@ void DefUseAnalyzeVisitor::visit_with_new_chain(const ast::Node& node, DUState s
 }
 
 void DefUseAnalyzeVisitor::start_new_chain(DUState state) {
-    current_chain->push_back(DUInstance(state, current_expression_statement));
+    current_chain->push_back(DUInstance(state, current_binary_expression));
     current_chain = &current_chain->back().children;
 }
 

--- a/src/visitors/defuse_analyze_visitor.hpp
+++ b/src/visitors/defuse_analyze_visitor.hpp
@@ -82,8 +82,8 @@ class DUInstance {
     /// usage of variable in case of if like statements
     std::vector<DUInstance> children;
 
-    explicit DUInstance(DUState state)
-        : state(state) {}
+    explicit DUInstance(DUState state, const std::shared_ptr<const ast::ExpressionStatement> expression_statement)
+        : state(state), expression_statement(expression_statement) {}
 
     /// analyze all children and return "effective" usage
     DUState eval() const;
@@ -95,6 +95,9 @@ class DUInstance {
     DUState conditional_block_eval() const;
 
     void print(printer::JSONPrinter& printer) const;
+
+    /// statement in which the variable is used
+    std::shared_ptr<const ast::ExpressionStatement> expression_statement;
 };
 
 
@@ -208,6 +211,8 @@ class DefUseAnalyzeVisitor: protected ConstAstVisitor {
     /// starting visiting lhs of assignment statement
     bool visiting_lhs = false;
 
+    std::shared_ptr<const ast::ExpressionStatement> current_expression_statement = nullptr;
+
     void process_variable(const std::string& name);
     void process_variable(const std::string& name, int index);
 
@@ -238,6 +243,8 @@ class DefUseAnalyzeVisitor: protected ConstAstVisitor {
      * used in any of the below statements are handled separately
      * \{
      */
+
+    void visit_expression_statement(const ast::ExpressionStatement& node) override;
 
     void visit_reaction_statement(const ast::ReactionStatement& node) override;
 

--- a/src/visitors/defuse_analyze_visitor.hpp
+++ b/src/visitors/defuse_analyze_visitor.hpp
@@ -82,8 +82,10 @@ class DUInstance {
     /// usage of variable in case of if like statements
     std::vector<DUInstance> children;
 
-    explicit DUInstance(DUState state, const std::shared_ptr<const ast::ExpressionStatement> expression_statement)
-        : state(state), expression_statement(expression_statement) {}
+    explicit DUInstance(DUState state,
+                        const std::shared_ptr<const ast::BinaryExpression> binary_expression)
+        : state(state)
+        , binary_expression(binary_expression) {}
 
     /// analyze all children and return "effective" usage
     DUState eval() const;
@@ -96,8 +98,21 @@ class DUInstance {
 
     void print(printer::JSONPrinter& printer) const;
 
-    /// statement in which the variable is used
-    std::shared_ptr<const ast::ExpressionStatement> expression_statement;
+    /** \brief binary expression in which the variable is used/defined
+     *
+     * We use the binary expression because it is used in both:
+     *
+     * - x = ... // expression statement, binary expression
+     * - IF (x == 0) // not an expression statement, binary expression
+     *
+     * We also want the outermost binary expression. Thus, we do not keep track
+     * of the interior ones. For example:
+     *
+     * \f tau = tau + 1 \f
+     *
+     * we want to return the full statement, not only \f tau + 1 \f
+     */
+    std::shared_ptr<const ast::BinaryExpression> binary_expression;
 };
 
 
@@ -211,7 +226,7 @@ class DefUseAnalyzeVisitor: protected ConstAstVisitor {
     /// starting visiting lhs of assignment statement
     bool visiting_lhs = false;
 
-    std::shared_ptr<const ast::ExpressionStatement> current_expression_statement = nullptr;
+    std::shared_ptr<const ast::BinaryExpression> current_binary_expression = nullptr;
 
     void process_variable(const std::string& name);
     void process_variable(const std::string& name, int index);
@@ -243,8 +258,6 @@ class DefUseAnalyzeVisitor: protected ConstAstVisitor {
      * used in any of the below statements are handled separately
      * \{
      */
-
-    void visit_expression_statement(const ast::ExpressionStatement& node) override;
 
     void visit_reaction_statement(const ast::ReactionStatement& node) override;
 

--- a/test/unit/visitor/defuse_analyze.cpp
+++ b/test/unit/visitor/defuse_analyze.cpp
@@ -7,7 +7,8 @@
 
 #include <catch/catch.hpp>
 
-#include "ast/all.hpp"
+#include "ast/binary_expression.hpp"
+#include "ast/program.hpp"
 #include "parser/nmodl_driver.hpp"
 #include "test/unit/utils/test_utils.hpp"
 #include "visitors/checkparent_visitor.hpp"


### PR DESCRIPTION
In this PR we expand DUInstance to also return the ... "line" in which defuse is used/defined. In particular, we return a pointer to the outermost `binary_expression`. Why not returning an `expression_statement` pointer? In this way we handle these 2 cases:

- `IF (tau == 0)` \\ not expression statement, binary expression
- `x = x + 1`  \\ binary expression and expression statement

This is propedeutic for using the defuse visitor inside #495 .

Addresses #513 

PS: I also included a few corner cases in the unit tests for defuse that were not checked