### PR TITLE
Add GitLab CI/CD configuration to test PRs on BB5

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,35 @@
+cache: &global_cache
+  key: ${CI_COMMIT_REF_SLUG}
+  paths:
+  - venv/
+  - build_gcc/
+
+setup virtualenv:
+  stage: .pre
+  tags: [bb5]
+  script:
+  - export
+  - ci/bb5-pr
+  only:
+  - external_pull_requests
+
+build gcc:
+  stage: build
+  tags: [bb5]
+  script: ci/bb5-pr
+  only:
+  - external_pull_requests
+
+test gcc: &common_test_gcc
+  stage: test
+  tags: [bb5]
+  script: ci/bb5-pr
+  resource_group: test
+  only:
+  - external_pull_requests
+  cache:
+    <<: *global_cache
+    policy: pull
+
+cmake format: *common_test_gcc
+clang format: *common_test_gcc

--- a/ci/bb5-pr
+++ b/ci/bb5-pr
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -xe
+
+git show HEAD
+
+source /gpfs/bbp.cscs.ch/apps/hpc/jenkins/config/modules.sh
+module use /gpfs/bbp.cscs.ch/apps/tools/modules/tcl/linux-rhel7-x86_64/
+
+module load archive/2020-10 cmake bison flex python-dev doxygen
+module list
+
+function setup_virtualenv() {
+    # latest version of breathe from 21st April has issue with 4.13.0, see https://github.com/michaeljones/breathe/issues/431
+    # temporary workaround
+    virtualenv venv
+    . venv/bin/activate
+    pip3 install "breathe<=4.12.0"
+    pip3 install "cmake-format==0.6.0"
+}
+
+function find_clang_format() {
+    module load llvm
+    clang_format_exe=$(which clang-format)
+    module unload llvm
+}
+
+function build_with() {
+    compiler="$1"
+    module load $compiler
+    . venv/bin/activate
+    find_clang_format
+
+    echo "Building NMODL with $compiler"
+    module load $compiler
+    rm -rf build_$compiler
+    mkdir build_$compiler
+    pushd build_$compiler
+    cmake .. -DCMAKE_C_COMPILER=$MPICC_CC \
+             -DCMAKE_CXX_COMPILER=$MPICXX_CXX \
+             -DPYTHON_EXECUTABLE=$(which python3) \
+             -DNMODL_FORMATTING:BOOL=ON \
+             -DClangFormat_EXECUTABLE=$clang_format_exe \
+             -DLLVM_DIR=/gpfs/bbp.cscs.ch/apps/hpc/jenkins/merge/deploy/externals/latest/linux-rhel7-x86_64/gcc-9.3.0/llvm-11.0.0-kzl4o5/lib/cmake/llvm
+    make -j
+    popd
+}
+
+function test_with() {
+    compiler="$1"
+    module load $compiler
+    . venv/bin/activate
+    cd build_$compiler
+    env CTEST_OUTPUT_ON_FAILURE=1 make test
+}
+
+function make_target() {
+    compiler=$1
+    target=$2
+    . venv/bin/activate
+    cd build_$compiler
+    make $target
+}
+
+function cmake_format() {
+    make_target gcc check-cmake-format
+}
+
+function clang_format() {
+    make_target gcc check-clang-format
+}
+
+function build_gcc() {
+    build_with gcc
+}
+
+function test_gcc() {
+    test_with gcc
+}
+
+function build_llvm() {
+    build_with llvm
+}
+
+function test_llvm() {
+    test_with llvm
+}
+
+action=`echo "$CI_BUILD_NAME" | tr ' ' _`
+$action

--- a/ci/bb5-pr
+++ b/ci/bb5-pr
@@ -86,5 +86,5 @@ function test_llvm() {
     test_with llvm
 }
 
-action=`echo "$CI_BUILD_NAME" | tr ' ' _`
+action=$(echo "$CI_BUILD_NAME" | tr ' ' _)
 $action


### PR DESCRIPTION
This change provides the GitLab CI/CD pipeline configuration to replace the [hpc/nmodl](https://bbpcode.epfl.ch/ci/job/hpc.nmodl/) Jenkins project.

After merging this PR, I suggest we:
* [ ] bump cmake-format from 0.6.0 to 0.6.10 to match the spack version
* [ ] also build and test with llvm