### PR TITLE
sympy var clashes

### DIFF
--- a/src/pybind/pyembed.hpp
+++ b/src/pybind/pyembed.hpp
@@ -32,6 +32,8 @@ struct SolveLinearSystemExecutor: public PythonExecutor {
     std::set<std::string> vars;
     bool small_system;
     bool elimination;
+    // This is used only if elimination is true. It gives the root for the tmp variables
+    std::string tmp_unique_prefix;
     std::set<std::string> function_calls;
     // output
     // returns a vector of solutions, i.e. new statements to add to block:
@@ -40,7 +42,6 @@ struct SolveLinearSystemExecutor: public PythonExecutor {
     std::vector<std::string> new_local_vars;
     // may also return a python exception message:
     std::string exception_message;
-
     // executor function
     virtual void operator()() override;
 };

--- a/src/pybind/wrapper.cpp
+++ b/src/pybind/wrapper.cpp
@@ -27,7 +27,8 @@ void SolveLinearSystemExecutor::operator()() {
                                  "vars"_a = vars,
                                  "small_system"_a = small_system,
                                  "do_cse"_a = elimination,
-                                 "function_calls"_a = function_calls);
+                                 "function_calls"_a = function_calls,
+                                 "tmp_unique_prefix"_a = tmp_unique_prefix);
     py::exec(R"(
                 from nmodl.ode import solve_lin_system
                 exception_message = ""
@@ -36,6 +37,7 @@ void SolveLinearSystemExecutor::operator()() {
                                                                  state_vars,
                                                                  vars,
                                                                  function_calls,
+                                                                 tmp_unique_prefix,
                                                                  small_system,
                                                                  do_cse)
                 except Exception as e:

--- a/src/visitors/sympy_replace_solutions_visitor.cpp
+++ b/src/visitors/sympy_replace_solutions_visitor.cpp
@@ -38,16 +38,23 @@ SympyReplaceSolutionsVisitor::SympyReplaceSolutionsVisitor(
     const std::vector<std::string>& solutions,
     const std::unordered_set<ast::Statement*>& to_be_removed,
     const ReplacePolicy policy,
-    const size_t n_next_equations)
+    const size_t n_next_equations,
+    const std::string& tmp_unique_prefix)
     : pre_solve_statements(pre_solve_statements.begin(), pre_solve_statements.end(), 2)
     , to_be_removed(&to_be_removed)
     , policy(policy)
     , n_next_equations(n_next_equations)
     , replaced_statements_range(-1, -1) {
+    // if tmp_unique_prefix we do not expect tmp_statements
     const auto ss_tmp_delimeter =
-        std::find_if(solutions.begin(), solutions.end(), [](const std::string& statement) {
-            return statement.substr(0, 3) != "tmp";
-        });
+        tmp_unique_prefix.empty()
+            ? solutions.begin()
+            : std::find_if(solutions.begin(),
+                           solutions.end(),
+                           [&tmp_unique_prefix](const std::string& statement) {
+                               return statement.substr(0, tmp_unique_prefix.size()) !=
+                                      tmp_unique_prefix;
+                           });
     tmp_statements = StatementDispenser(solutions.begin(), ss_tmp_delimeter, -1);
     solution_statements = StatementDispenser(ss_tmp_delimeter, solutions.end(), -1);
 

--- a/src/visitors/sympy_replace_solutions_visitor.hpp
+++ b/src/visitors/sympy_replace_solutions_visitor.hpp
@@ -224,7 +224,8 @@ class SympyReplaceSolutionsVisitor: public AstVisitor {
                                  const std::vector<std::string>& solutions,
                                  const std::unordered_set<ast::Statement*>& to_be_removed,
                                  const ReplacePolicy policy,
-                                 size_t n_next_equations);
+                                 size_t n_next_equations,
+                                 const std::string& tmp_unique_prefix);
 
     /// idx (in the new statementVector) of the first statement that was added. -1 if nothing was
     /// added

--- a/src/visitors/sympy_solver_visitor.cpp
+++ b/src/visitors/sympy_solver_visitor.cpp
@@ -196,7 +196,8 @@ void SympySolverVisitor::construct_eigen_solver_block(
         solutions_filtered,
         expression_statements,
         visitor::SympyReplaceSolutionsVisitor::ReplacePolicy::GREEDY,
-        state_vars.size() + 1);
+        state_vars.size() + 1,
+        "");
     solution_replacer.visit_statement_block(*block_with_expression_statements);
 
     // split in the various blocks for eigen
@@ -304,6 +305,9 @@ void SympySolverVisitor::solve_linear_system(const std::vector<std::string>& pre
     solver->vars = vars;
     solver->small_system = small_system;
     solver->elimination = elimination;
+    // this is necessary after we destroy the solver
+    const auto tmp_unique_prefix = suffix_random_string(vars, "tmp");
+    solver->tmp_unique_prefix = tmp_unique_prefix;
     solver->function_calls = function_calls;
     (*solver)();
     // returns a vector of solutions, i.e. new statements to add to block:
@@ -312,6 +316,7 @@ void SympySolverVisitor::solve_linear_system(const std::vector<std::string>& pre
     auto new_local_vars = solver->new_local_vars;
     // may also return a python exception message:
     auto exception_message = solver->exception_message;
+    // destroy solver
     pywrap::EmbeddedPythonLoader::get_instance().api()->destroy_sls_executor(solver);
     if (!exception_message.empty()) {
         logger->warn("SympySolverVisitor :: solve_lin_system python exception: " +
@@ -338,7 +343,8 @@ void SympySolverVisitor::solve_linear_system(const std::vector<std::string>& pre
             solutions,
             expression_statements,
             visitor::SympyReplaceSolutionsVisitor::ReplacePolicy::VALUE,
-            1);
+            1,
+            tmp_unique_prefix);
         solution_replacer.visit_statement_block(*block_with_expression_statements);
     } else {
         // otherwise it returns a linear matrix system to solve

--- a/src/visitors/sympy_solver_visitor.cpp
+++ b/src/visitors/sympy_solver_visitor.cpp
@@ -533,8 +533,9 @@ void SympySolverVisitor::visit_derivative_block(ast::DerivativeBlock& node) {
             } else {
                 // no CONSERVE equation, construct Euler equation
                 auto dxdt = stringutils::trim(split_eq[1]);
-                auto old_x = "old_" + x + x_array_index_i;  // TODO: do this properly,
-                // check name is unique
+
+
+                const auto old_x = suffix_random_string(vars, "old_" + x + x_array_index_i);
                 // declare old_x
                 logger->debug("SympySolverVisitor :: -> declaring new local variable: {}", old_x);
                 add_local_variable(*block_with_expression_statements, old_x);

--- a/src/visitors/visitor_utils.cpp
+++ b/src/visitors/visitor_utils.cpp
@@ -33,9 +33,12 @@ std::string suffix_random_string(const std::set<std::string>& vars,
     std::string new_string = original_string;
     std::string random_string;
     auto& singleton_random_string_class = nmodl::utils::SingletonRandomString<4>::instance();
-    // Check if there is a variable defined in the mod file as original_string and if yes
+    // Check if there is a variable defined in the mod file as original_string or that
+    // has original_string as prefix and, if yes,
     // try to use a different string in the form "original_string"_"random_string"
-    while (vars.find(new_string) != vars.end()) {
+
+    const auto it = vars.lower_bound(new_string);
+    while ((it != vars.end()) && new_string == it->substr(0, new_string.size())) {
         random_string = singleton_random_string_class.reset_random_string(original_string, use_num);
         new_string = original_string;
         new_string += "_" + random_string;

--- a/src/visitors/visitor_utils.cpp
+++ b/src/visitors/visitor_utils.cpp
@@ -43,11 +43,6 @@ std::string suffix_random_string(const std::set<std::string>& vars,
     return new_string;
 }
 
-std::string suffix_random_string(const std::set<std::string>& vars,
-                                 const std::string& original_string) {
-    return suffix_random_string(vars, original_string, UseNumbersInString::WithNumbers);
-}
-
 std::string get_new_name(const std::string& name,
                          const std::string& suffix,
                          std::map<std::string, int>& variables) {

--- a/src/visitors/visitor_utils.hpp
+++ b/src/visitors/visitor_utils.hpp
@@ -30,6 +30,9 @@ using nmodl::utils::UseNumbersInString;
 /// for the original_string. Vars is a const ref to std::set<std::string> which
 /// holds the names that need to be checked for uniqueness. Choose if the
 /// "random_string" will include numbers using "use_num"
+/// We make sure that the new string does not match any string in vars AND is not
+/// a prefix for any string in vars. In this way, appending to the result
+/// will always create new unique strings
 std::string suffix_random_string(
     const std::set<std::string>& vars,
     const std::string& original_string,

--- a/src/visitors/visitor_utils.hpp
+++ b/src/visitors/visitor_utils.hpp
@@ -32,15 +32,7 @@ using nmodl::utils::UseNumbersInString;
 /// "random_string" will include numbers using "use_num"
 std::string suffix_random_string(const std::set<std::string>& vars,
                                  const std::string& original_string,
-                                 const UseNumbersInString use_num);
-
-/// Return a std::string in the form "original_string"_"random_string", where
-/// random_string is a string defined in the nmodl::utils::SingletonRandomString
-/// for the original_string. Vars is a const ref to std::set<std::string> which
-/// holds the names that need to be checked for uniqueness. Adds numbers in the
-/// "random_string"
-std::string suffix_random_string(const std::set<std::string>& vars,
-                                 const std::string& original_string);
+                                 const UseNumbersInString use_num = nmodl::utils::UseNumbersInString::WithNumbers);
 
 /// Return new name variable by appending `_suffix_COUNT` where `COUNT` is
 /// number of times the given variable is already used.

--- a/src/visitors/visitor_utils.hpp
+++ b/src/visitors/visitor_utils.hpp
@@ -30,9 +30,10 @@ using nmodl::utils::UseNumbersInString;
 /// for the original_string. Vars is a const ref to std::set<std::string> which
 /// holds the names that need to be checked for uniqueness. Choose if the
 /// "random_string" will include numbers using "use_num"
-std::string suffix_random_string(const std::set<std::string>& vars,
-                                 const std::string& original_string,
-                                 const UseNumbersInString use_num = nmodl::utils::UseNumbersInString::WithNumbers);
+std::string suffix_random_string(
+    const std::set<std::string>& vars,
+    const std::string& original_string,
+    const UseNumbersInString use_num = nmodl::utils::UseNumbersInString::WithNumbers);
 
 /// Return new name variable by appending `_suffix_COUNT` where `COUNT` is
 /// number of times the given variable is already used.

--- a/test/unit/ode/test_ode.py
+++ b/test/unit/ode/test_ode.py
@@ -5,7 +5,7 @@
 # Lesser General Public License. See top-level LICENSE file for details.
 # ***********************************************************************
 
-from nmodl.ode import _make_unique_prefix, differentiate2c, integrate2c
+from nmodl.ode import differentiate2c, integrate2c
 
 import sympy as sp
 
@@ -38,19 +38,6 @@ def _equivalent(
         if difference != 0:
             return False
     return True
-
-
-def test_make_unique_prefix():
-
-    assert _make_unique_prefix(["a", "b", "ccc", "tmp"], "z") == "z"
-    assert _make_unique_prefix(["a", "b", "ccc", "tmp"], "a") == "a_"
-    assert _make_unique_prefix(["a", "b", "ccc", "tmp"], "az") == "az"
-    assert _make_unique_prefix(["a", "b", "ccc", "tmp"], "cc") == "cc_"
-    assert _make_unique_prefix(["a", "b", "ccc", "tmp"], "ccc") == "ccc_"
-    assert _make_unique_prefix(["a", "b", "ccc", "tmp"], "tmp") == "tmp_"
-    assert _make_unique_prefix(["a", "b", "tmp_", "tmp"], "tmp") == "tmp__"
-    assert _make_unique_prefix(["a", "tmp2", "ccc", "x"], "tmp") == "tmp_"
-    assert _make_unique_prefix(["a", "tmp2", "ccc", "x"], "tmpvar") == "tmpvar"
 
 
 def test_differentiate2c():


### PR DESCRIPTION
- `old_*` is checked with `suffix_random_string`
- `suffix_random_string` now also checks if the `new_string` is a prefix of another variable (already in `vars`)
- removed `_make_unique_prefix` as it was duplicated code
   - removed its tests
- added tests for name-clash prevention methods

Fix #515

Ready for review as soon as CI passes :D