### PR TITLE
Fixup! ctest fail when looking for F[

### DIFF
--- a/test/unit/visitor/sympy_solver.cpp
+++ b/test/unit/visitor/sympy_solver.cpp
@@ -567,7 +567,7 @@ SCENARIO("Solve ODEs with derivimplicit method using SympySolverVisitor",
                 run_sympy_solver_visitor(nmodl_text, false, false, AstNodeType::DERIVATIVE_BLOCK);
 
             REQUIRE(result.size() == 1);
-            REQUIRE(result[0].find("F[") == std::string::npos);
+            REQUIRE(result[0].find("F_") != std::string::npos);
         }
     }
 


### PR DESCRIPTION
The CI fails if it finds `F[`. However, the replaced var `F_****[`
(* is a random char) can still present a trailing `F[` making the CI fail even if the var
was correctly replaced

Fix #521 