### PR TITLE
Improved vexp (and friends) test 

### DIFF
--- a/src/codegen/fast_math.hpp
+++ b/src/codegen/fast_math.hpp
@@ -10,8 +10,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <cmath>
+#include <cstdint>
 
 /**
  * \file
@@ -189,7 +189,7 @@ static inline float vexpm1(float x) {
     // this cannot be reordered for the cancellation trick to work
     volatile float g = x - z * C1F;
     g -= z * C2F;
-    
+
     const int32_t n = z;
 
     const int32_t twopnm1 = ((n - 1) + 0x7f) << 23;

--- a/src/codegen/fast_math.hpp
+++ b/src/codegen/fast_math.hpp
@@ -56,35 +56,35 @@ static inline double inf() {
 }
 
 
-static const double EXP_LIMIT = 708.0;
+static constexpr double EXP_LIMIT = 708.0;
 
-static const double C1 = 6.93145751953125E-1;
-static const double C2 = 1.42860682030941723212E-6;
+static constexpr double C1 = 6.93145751953125E-1;
+static constexpr double C2 = 1.42860682030941723212E-6;
 
-static const double PX1exp = 1.26177193074810590878E-4;
-static const double PX2exp = 3.02994407707441961300E-2;
-static const double PX3exp = 9.99999999999999999910E-1;
-static const double QX1exp = 3.00198505138664455042E-6;
-static const double QX2exp = 2.52448340349684104192E-3;
-static const double QX3exp = 2.27265548208155028766E-1;
-static const double QX4exp = 2.00000000000000000009;
+static constexpr double PX1exp = 1.26177193074810590878E-4;
+static constexpr double PX2exp = 3.02994407707441961300E-2;
+static constexpr double PX3exp = 9.99999999999999999910E-1;
+static constexpr double QX1exp = 3.00198505138664455042E-6;
+static constexpr double QX2exp = 2.52448340349684104192E-3;
+static constexpr double QX3exp = 2.27265548208155028766E-1;
+static constexpr double QX4exp = 2.00000000000000000009;
 
-static const double LOG2E = 1.4426950408889634073599;  // 1/ln(2)
+static constexpr double LOG2E = 1.4426950408889634073599;  // 1/ln(2)
 
-static const float MAXLOGF = 88.72283905206835f;
-static const float MINLOGF = -88.f;
+static constexpr float MAXLOGF = 88.72283905206835f;
+static constexpr float MINLOGF = -88.f;
 
-static const float C1F = 0.693359375f;
-static const float C2F = -2.12194440e-4f;
+static constexpr float C1F = 0.693359375f;
+static constexpr float C2F = -2.12194440e-4f;
 
-static const float PX1expf = 1.9875691500E-4f;
-static const float PX2expf = 1.3981999507E-3f;
-static const float PX3expf = 8.3334519073E-3f;
-static const float PX4expf = 4.1665795894E-2f;
-static const float PX5expf = 1.6666665459E-1f;
-static const float PX6expf = 5.0000001201E-1f;
+static constexpr float PX1expf = 1.9875691500E-4f;
+static constexpr float PX2expf = 1.3981999507E-3f;
+static constexpr float PX3expf = 8.3334519073E-3f;
+static constexpr float PX4expf = 4.1665795894E-2f;
+static constexpr float PX5expf = 1.6666665459E-1f;
+static constexpr float PX6expf = 5.0000001201E-1f;
 
-static const float LOG2EF = 1.44269504088896341f;  // 1/ln(2)
+static constexpr float LOG2EF = 1.44269504088896341f;  // 1/ln(2)
 
 static inline double egm1(double x, double px) {
     x -= px * C1;

--- a/src/codegen/fast_math.hpp
+++ b/src/codegen/fast_math.hpp
@@ -76,7 +76,11 @@ static constexpr float PX6expf = 5.0000001201E-1f;
 static constexpr float LOG2EF = 1.44269504088896341f;  // 1/ln(2)
 
 static inline double egm1(double x, double n) {
-    // this cannot be reordered for the cancellation trick to work
+    // this cannot be reordered for the double-double trick to work
+    // i.e., it cannot be re-written as g = x - n * (C1+C2)
+    // the loss of accuracy comes from the different magnitudes of ln(2) and n
+    // max(|n|) ~ 2^9
+    // ln(2) ~ 2^-1
     volatile double g = x - n * C1;
     g -= n * C2;
 
@@ -165,7 +169,7 @@ static inline float egm1(float x) {
 static inline float vexp(float x) {
     float z = std::floor(LOG2EF * x + 0.5f);
 
-    // this cannot be reordered for the cancellation trick to work
+    // this cannot be reordered for the double-double trick to work
     float volatile g = x - z * C1F;
     g -= z * C2F;
     const int32_t n = z;
@@ -186,7 +190,7 @@ static inline float vexp(float x) {
 static inline float vexpm1(float x) {
     float z = std::floor(LOG2EF * x + 0.5f);
 
-    // this cannot be reordered for the cancellation trick to work
+    // this cannot be reordered for the double-double trick to work
     volatile float g = x - z * C1F;
     g -= z * C2F;
 

--- a/test/unit/fast_math/fast_math.cpp
+++ b/test/unit/fast_math/fast_math.cpp
@@ -12,108 +12,87 @@
 
 #include <catch/catch.hpp>
 
-float check_over_span_float(float f1(float),
-                            float f2(float),
-                            const float low_limit,
-                            const float span,
-                            const size_t npoints) {
-    float x = 0.0;
-    float val = f1(x) - f2(x);
-    float err = val * val;  // 0.0 is an edge case
 
+template <class T, class = typename std::enable_if<
+    std::is_floating_point<T>::value>::type>
+bool check_over_span(T f_ref(T), T f_test(T),
+    const T low_limit, const T high_limit,
+    const size_t npoints) {
 
+    constexpr uint nULP = 4;
+    constexpr T eps = std::numeric_limits<T>::epsilon();
+
+    T range = high_limit - low_limit;
+
+    bool ret = true;
     for (size_t i = 0; i < npoints; ++i) {
-        x = low_limit + span * i / npoints;
-        val = f1(x) - f2(x);
-        err += val * val;
+        T x = low_limit + range * i / npoints;
+        T ref = f_ref(x);
+        T test = f_test(x);
+        T diff = std::abs(ref - test);
+        T max = std::max(std::abs(ref), std::abs(test));
+        T tol = max * nULP * eps;
+        if (diff > tol && diff != 0.0) {
+            ret = false;
+        }
     }
-    err /= npoints + 1;
-    return err;
+    return ret;
 }
 
-double check_over_span_double(double f1(double),
-                              double f2(double),
-                              const double low_limit,
-                              const double span,
-                              const size_t npoints) {
-    double x = 0.0;
-    double val = f1(x) - f2(x);
-    double err = val * val;  // 0.0 is an edge case
-
-    for (size_t i = 0; i < npoints; ++i) {
-        x = low_limit + span * i / npoints;
-        val = f1(x) - f2(x);
-        err += val * val;
-    }
-    err /= npoints + 1;
-    return err;
-}
+template <class T, class = typename std::enable_if<
+    std::is_floating_point<T>::value>::type>
+T exprelr_ref(const T x) { return (1.0 + x == 1.0) ? 1.0 : x / (std::exp(x) - 1.0); };
 
 SCENARIO("Check fast_math") {
-    constexpr double low_limit = -5.0;
-    constexpr double span = 10.0;
-    constexpr size_t npoints = 1000;
-    constexpr double err_threshold = 1e-10;
+    constexpr double low_limit = -700.0; // limit is 708
+    constexpr double high_limit = 700.0;
+    constexpr float low_limit_f = -70.0; // limit is 88
+    constexpr float high_limit_f = 70.0;
+    constexpr size_t npoints = 2000;
+
     GIVEN("vexp (double)") {
-        const double err = check_over_span_double(std::exp, vexp, low_limit, span, npoints);
+
+        auto test = check_over_span(std::exp, vexp, low_limit, high_limit, npoints);
 
         THEN("error inside threshold") {
-            REQUIRE(err < err_threshold);
+            REQUIRE(test);
         }
     }
     GIVEN("vexp (float)") {
-        const double err = check_over_span_float(std::exp, vexp, low_limit, span, npoints);
+        auto test = check_over_span(std::exp, vexp, low_limit_f, high_limit_f, npoints);
 
         THEN("error inside threshold") {
-            REQUIRE(err < err_threshold);
+            REQUIRE(test);
         }
     }
     GIVEN("expm1 (double)") {
-        const double err =
-            check_over_span_double([](const double x) -> double { return std::exp(x) - 1; },
-                                   vexpm1,
-                                   low_limit,
-                                   span,
-                                   npoints);
+        auto test =
+            check_over_span(std::expm1, vexpm1, low_limit, high_limit, npoints);
 
         THEN("error inside threshold") {
-            REQUIRE(err < err_threshold);
+            REQUIRE(test);
         }
     }
     GIVEN("expm1 (float)") {
-        const double err =
-            check_over_span_float([](const float x) -> float { return std::exp(x) - 1; },
-                                  vexpm1,
-                                  low_limit,
-                                  span,
-                                  npoints);
+        auto test =
+            check_over_span(std::expm1, vexpm1, low_limit_f, high_limit_f, npoints);
 
         THEN("error inside threshold") {
-            REQUIRE(err < err_threshold);
+            REQUIRE(test);
         }
     }
     GIVEN("exprelr (double)") {
-        const double err = check_over_span_double(
-            [](const double x) -> double { return (1.0 + x == 1.0) ? 1.0 : x / (std::exp(x) - 1); },
-            exprelr,
-            low_limit,
-            span,
-            npoints);
+        auto test = check_over_span(exprelr_ref, exprelr, low_limit, high_limit, npoints);
 
         THEN("error inside threshold") {
-            REQUIRE(err < err_threshold);
+            REQUIRE(test);
         }
     }
-    GIVEN("exprelr (float)") {
-        const float err = check_over_span_float(
-            [](const float x) -> float { return (1.0 + x == 1.0) ? 1.0 : x / (std::exp(x) - 1); },
-            exprelr,
-            low_limit,
-            span,
-            npoints);
+    GIVEN("exprelr (double)") {
+        auto test = check_over_span(exprelr_ref, exprelr, low_limit_f, high_limit_f, npoints);
 
         THEN("error inside threshold") {
-            REQUIRE(err < err_threshold);
+            REQUIRE(test);
         }
     }
 }

--- a/test/unit/fast_math/fast_math.cpp
+++ b/test/unit/fast_math/fast_math.cpp
@@ -13,12 +13,12 @@
 #include <catch/catch.hpp>
 
 
-template <class T, class = typename std::enable_if<
-    std::is_floating_point<T>::value>::type>
-bool check_over_span(T f_ref(T), T f_test(T),
-    const T low_limit, const T high_limit,
-    const size_t npoints) {
-
+template <class T, class = typename std::enable_if<std::is_floating_point<T>::value>::type>
+bool check_over_span(T f_ref(T),
+                     T f_test(T),
+                     const T low_limit,
+                     const T high_limit,
+                     const size_t npoints) {
     constexpr uint nULP = 4;
     constexpr T eps = std::numeric_limits<T>::epsilon();
 
@@ -39,19 +39,19 @@ bool check_over_span(T f_ref(T), T f_test(T),
     return ret;
 }
 
-template <class T, class = typename std::enable_if<
-    std::is_floating_point<T>::value>::type>
-T exprelr_ref(const T x) { return (1.0 + x == 1.0) ? 1.0 : x / (std::exp(x) - 1.0); };
+template <class T, class = typename std::enable_if<std::is_floating_point<T>::value>::type>
+T exprelr_ref(const T x) {
+    return (1.0 + x == 1.0) ? 1.0 : x / (std::exp(x) - 1.0);
+};
 
 SCENARIO("Check fast_math") {
-    constexpr double low_limit = -700.0; // limit is 708
+    constexpr double low_limit = -700.0;  // limit is 708
     constexpr double high_limit = 700.0;
-    constexpr float low_limit_f = -70.0; // limit is 88
+    constexpr float low_limit_f = -70.0;  // limit is 88
     constexpr float high_limit_f = 70.0;
     constexpr size_t npoints = 2000;
 
     GIVEN("vexp (double)") {
-
         auto test = check_over_span(std::exp, vexp, low_limit, high_limit, npoints);
 
         THEN("error inside threshold") {
@@ -66,16 +66,14 @@ SCENARIO("Check fast_math") {
         }
     }
     GIVEN("expm1 (double)") {
-        auto test =
-            check_over_span(std::expm1, vexpm1, low_limit, high_limit, npoints);
+        auto test = check_over_span(std::expm1, vexpm1, low_limit, high_limit, npoints);
 
         THEN("error inside threshold") {
             REQUIRE(test);
         }
     }
     GIVEN("expm1 (float)") {
-        auto test =
-            check_over_span(std::expm1, vexpm1, low_limit_f, high_limit_f, npoints);
+        auto test = check_over_span(std::expm1, vexpm1, low_limit_f, high_limit_f, npoints);
 
         THEN("error inside threshold") {
             REQUIRE(test);

--- a/test/unit/fast_math/fast_math.cpp
+++ b/test/unit/fast_math/fast_math.cpp
@@ -88,7 +88,7 @@ SCENARIO("Check fast_math") {
             REQUIRE(test);
         }
     }
-    GIVEN("exprelr (double)") {
+    GIVEN("exprelr (float)") {
         auto test = check_over_span(exprelr_ref, exprelr, low_limit_f, high_limit_f, npoints);
 
         THEN("error inside threshold") {

--- a/test/unit/fast_math/fast_math.cpp
+++ b/test/unit/fast_math/fast_math.cpp
@@ -36,8 +36,7 @@ bool check_over_span(T f_ref(T),
         // normalize based on range
         if (tol > low) {
             tol *= eps;
-        }
-        else {
+        } else {
             diff *= one_o_eps;
         }
         if (diff > tol && diff != 0.0) {


### PR DESCRIPTION
Modified `vexp` test and related functions to have tighter tolerance (4ULP) on a wider range of inputs

- improved test
- changed constant to `constepxr`