### PR TITLE
Move code gen specific InstanceStruct node to codegen.yaml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,35 +1,33 @@
-cache: &global_cache
-  key: ${CI_COMMIT_REF_SLUG}
-  paths:
-  - venv/
-  - build_gcc/
+.common:
+  tags: [bb5]
+  script: ci/bb5-pr
+  only:
+    - external_pull_requests
+  variables:
+    # Just run everything in the same, persistent, directory.
+    bb5_build_dir: pipeline
 
 setup virtualenv:
+  extends: .common
   stage: .pre
-  tags: [bb5]
-  script:
-  - export
-  - ci/bb5-pr
-  only:
-  - external_pull_requests
+  before_script:
+    - export
 
-build gcc:
+build intel:
+  extends: .common
   stage: build
-  tags: [bb5]
-  script: ci/bb5-pr
-  only:
-  - external_pull_requests
+  resource_group: build
+  variables:
+    # We cloned in .pre
+    GIT_STRATEGY: none
 
-test gcc: &common_test_gcc
+test intel: &test_config
+  extends: .common
   stage: test
-  tags: [bb5]
-  script: ci/bb5-pr
   resource_group: test
-  only:
-  - external_pull_requests
-  cache:
-    <<: *global_cache
-    policy: pull
+  variables:
+    # We cloned in .pre
+    GIT_STRATEGY: none
 
-cmake format: *common_test_gcc
-clang format: *common_test_gcc
+cmake format: *test_config
+clang format: *test_config

--- a/ci/bb5-pr
+++ b/ci/bb5-pr
@@ -10,13 +10,13 @@ module use /gpfs/bbp.cscs.ch/apps/tools/modules/tcl/linux-rhel7-x86_64/
 module load archive/2020-10 cmake bison flex python-dev doxygen
 module list
 
-function setup_virtualenv() {
+function bb5_pr_setup_virtualenv() {
     # latest version of breathe from 21st April has issue with 4.13.0, see https://github.com/michaeljones/breathe/issues/431
     # temporary workaround
     virtualenv venv
     . venv/bin/activate
     pip3 install "breathe<=4.12.0"
-    pip3 install "cmake-format==0.6.0"
+    pip3 install "cmake-format==0.6.13"
 }
 
 function find_clang_format() {
@@ -42,7 +42,7 @@ function build_with() {
              -DNMODL_FORMATTING:BOOL=ON \
              -DClangFormat_EXECUTABLE=$clang_format_exe \
              -DLLVM_DIR=/gpfs/bbp.cscs.ch/apps/hpc/jenkins/merge/deploy/externals/latest/linux-rhel7-x86_64/gcc-9.3.0/llvm-11.0.0-kzl4o5/lib/cmake/llvm
-    make -j
+    make -j6
     popd
 }
 
@@ -62,29 +62,43 @@ function make_target() {
     make $target
 }
 
-function cmake_format() {
-    make_target gcc check-cmake-format
+function bb5_pr_cmake_format() {
+    make_target intel check-cmake-format
 }
 
-function clang_format() {
-    make_target gcc check-clang-format
+function bb5_pr_clang_format() {
+    make_target intel check-clang-format
 }
 
-function build_gcc() {
+function bb5_pr_build_gcc() {
     build_with gcc
 }
 
-function test_gcc() {
+function bb5_pr_build_intel() {
+    build_with intel
+}
+
+function bb5_pr_test_gcc() {
     test_with gcc
 }
 
-function build_llvm() {
+function bb5_pr_test_intel() {
+    test_with intel
+}
+
+function bb5_pr_build_llvm() {
     build_with llvm
 }
 
-function test_llvm() {
+function bb5_pr_test_llvm() {
     test_with llvm
 }
 
 action=$(echo "$CI_BUILD_NAME" | tr ' ' _)
-$action
+if [ -z "$action" ] ; then
+    for action in "$@" ; do
+        "bb5_pr_$action"
+    done
+else
+    "bb5_pr_$action"
+fi

--- a/cmake/Catch.cmake
+++ b/cmake/Catch.cmake
@@ -116,7 +116,8 @@ function(catch_discover_tests TARGET)
     TARGET ${TARGET}
     PROPERTY CROSSCOMPILING_EMULATOR)
   add_custom_command(
-    TARGET ${TARGET} POST_BUILD
+    TARGET ${TARGET}
+    POST_BUILD
     BYPRODUCTS "${ctest_tests_file}"
     COMMAND
       "${CMAKE_COMMAND}" -D "TEST_TARGET=${TARGET}" -D "TEST_EXECUTABLE=$<TARGET_FILE:${TARGET}>" -D

--- a/src/language/codegen.yaml
+++ b/src/language/codegen.yaml
@@ -143,6 +143,18 @@
                                   brief: "Body of the function"
                                   type: StatementBlock
                                   getter: {override: true}
+                        - InstanceStruct:
+                            nmodl: "INSTANCE_STRUCT "
+                            members:
+                              - codegen_vars:
+                                  brief: "Vector of CodegenVars"
+                                  type: CodegenVar
+                                  vector: true
+                                  add: true
+                                  separator: "\\n    "
+                                  prefix: {value: "{\\n    ", force: true}
+                                  suffix: {value: "\\n}", force: true}
+                            brief: "LLVM IR Struct that holds the mechanism instance's variables"
                   - WrappedExpression:
                       brief: "Wrap any other expression type"
                       members:

--- a/src/language/nmodl.yaml
+++ b/src/language/nmodl.yaml
@@ -438,18 +438,6 @@
                               is base class and defines common interface for these nodes.
 
                       children:
-                        - InstanceStruct:
-                            nmodl: "INSTANCE_STRUCT "
-                            members:
-                              - codegen_vars:
-                                  brief: "Vector of CodegenVars"
-                                  type: CodegenVar
-                                  vector: true
-                                  add: true
-                                  separator: "\\n    "
-                                  prefix: {value: "{\\n    ", force: true}
-                                  suffix: {value: "\\n}", force: true}
-                            brief: "LLVM IR Struct that holds the mechanism instance's variables"
 
                         - ParamBlock:
                             nmodl: "PARAMETER "

--- a/src/lexer/CMakeLists.txt
+++ b/src/lexer/CMakeLists.txt
@@ -192,9 +192,18 @@ endif()
 # Install executable
 # =============================================================================
 if(NOT NMODL_AS_SUBPROJECT)
-  install(TARGETS nmodl_lexer DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/lexer CONFIGURATIONS Debug)
-  install(TARGETS c_lexer DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/lexer CONFIGURATIONS Debug)
-  install(TARGETS units_lexer DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/lexer CONFIGURATIONS Debug)
+  install(
+    TARGETS nmodl_lexer
+    DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/lexer
+    CONFIGURATIONS Debug)
+  install(
+    TARGETS c_lexer
+    DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/lexer
+    CONFIGURATIONS Debug)
+  install(
+    TARGETS units_lexer
+    DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/lexer
+    CONFIGURATIONS Debug)
 endif()
 
 add_custom_target(parser-gen DEPENDS ${BISON_GENERATED_SOURCE_FILES})

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -18,9 +18,16 @@ endif()
 # Install executable
 # =============================================================================
 if(NOT NMODL_AS_SUBPROJECT)
-  install(TARGETS nmodl_parser DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/parser CONFIGURATIONS
-                  Debug)
-  install(TARGETS c_parser DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/parser CONFIGURATIONS Debug)
-  install(TARGETS units_parser DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/parser CONFIGURATIONS
-                  Debug)
+  install(
+    TARGETS nmodl_parser
+    DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/parser
+    CONFIGURATIONS Debug)
+  install(
+    TARGETS c_parser
+    DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/parser
+    CONFIGURATIONS Debug)
+  install(
+    TARGETS units_parser
+    DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/parser
+    CONFIGURATIONS Debug)
 endif()

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -6,14 +6,7 @@ set_source_files_properties(${PYBIND_GENERATED_SOURCES} PROPERTIES GENERATED TRU
 # build nmodl python module under lib/nmodl
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/nmodl)
 
-foreach(
-  file
-  ast.py
-  dsl.py
-  ode.py
-  symtab.py
-  visitor.py
-  __init__.py)
+foreach(file ast.py dsl.py ode.py symtab.py visitor.py __init__.py)
   list(APPEND NMODL_PYTHON_FILES_IN ${NMODL_PROJECT_SOURCE_DIR}/nmodl/${file})
   list(APPEND NMODL_PYTHON_FILES_OUT ${PROJECT_BINARY_DIR}/lib/nmodl/${file})
 endforeach()

--- a/src/visitors/CMakeLists.txt
+++ b/src/visitors/CMakeLists.txt
@@ -92,6 +92,8 @@ endif()
 # Install executable
 # =============================================================================
 if(NOT NMODL_AS_SUBPROJECT)
-  install(TARGETS nmodl_visitor DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/visitor CONFIGURATIONS
-                  Debug)
+  install(
+    TARGETS nmodl_visitor
+    DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin/visitor
+    CONFIGURATIONS Debug)
 endif()

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -132,10 +132,8 @@ endif()
 set(testvisitor_env "PYTHONPATH=${PROJECT_BINARY_DIR}/lib:$ENV{PYTHONPATH}")
 if(NOT LINK_AGAINST_PYTHON)
   list(APPEND testvisitor_env "NMODL_PYLIB=$ENV{NMODL_PYLIB}")
-  list(
-    APPEND
-      testvisitor_env
-      "NMODL_WRAPLIB=${PROJECT_BINARY_DIR}/lib/nmodl/libpywrapper${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  list(APPEND testvisitor_env
+       "NMODL_WRAPLIB=${PROJECT_BINARY_DIR}/lib/nmodl/libpywrapper${CMAKE_SHARED_LIBRARY_SUFFIX}")
 endif()
 
 foreach(


### PR DESCRIPTION
  - nmodl.yaml file is more for language constructs
  - InstanceStruct is specific for code generation and hence
    move it to codegen.yaml