### PR TITLE
Fix build issue on Apple M1 with AppleClang

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -46,6 +46,12 @@ Make sure to have latest flex/bison in $PATH :
 export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:/usr/local/bin/:$PATH
 ```
 
+On Apple M1, corresponding brew paths are under `/opt/homebrew/opt/`:
+
+```sh
+export PATH=/opt/homebrew/opt/flex/bin:/opt/homebrew/opt/bison/bin:$PATH
+```
+
 ### On Ubuntu
 
 On Ubuntu (>=16.04) flex/bison versions are recent enough and are installed along with the system toolchain:

--- a/ext/catch/catch.hpp
+++ b/ext/catch/catch.hpp
@@ -1368,7 +1368,11 @@ namespace Catch {
 
 #ifdef CATCH_PLATFORM_MAC
 
-    #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+    #if defined(__i386__) || defined(__x86_64__)
+        #define CATCH_TRAP() __asm__("int $3\n" : : ) /* NOLINT */
+    #elif defined(__aarch64__)
+        #define CATCH_TRAP()  __asm__(".inst 0xd4200000")
+    #endif
 
 #elif defined(CATCH_PLATFORM_LINUX)
     // If we can use inline assembler, do it because this allows us to break


### PR DESCRIPTION
 - Currently catch2 is header directly added in the project
 - Before switching to submodule (in separate PR), copying
   minimal fix from the upstream: https://github.com/catchorg/Catch2/pull/1971/

Fixes #527