### PR TITLE
Generate compute kernels with correct instance variable 

### DIFF
--- a/src/codegen/codegen_naming.hpp
+++ b/src/codegen/codegen_naming.hpp
@@ -80,6 +80,12 @@ static constexpr char VOLTAGE_UNUSED_VARIABLE[] = "v_unused";
 /// variable t indicating last execution time of net receive block
 static constexpr char T_SAVE_VARIABLE[] = "tsave";
 
+/// global variable celsius
+static constexpr char CELSIUS_VARIABLE[] = "celsius";
+
+/// global variable second_order
+static constexpr char SECOND_ORDER_VARIABLE[] = "secondorder";
+
 /// shadow rhs variable in neuron thread structure
 static constexpr char NTHREAD_RHS_SHADOW[] = "_shadow_rhs";
 

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -141,12 +141,12 @@ void CodegenLLVMHelperVisitor::create_function_for_node(ast::Block& node) {
     block->emplace_back_statement(return_statement);
 
     /// prepare function arguments based original node arguments
-    ast::CodegenArgumentVector arguments;
+    ast::CodegenVarWithTypeVector arguments;
     for (const auto& param: node.get_parameters()) {
         /// create new type and name for creating new ast node
         auto type = new ast::CodegenVarType(FLOAT_TYPE);
         auto var = param->get_name()->clone();
-        arguments.emplace_back(new ast::CodegenArgument(type, var));
+        arguments.emplace_back(new ast::CodegenVarWithType(type, 0, var));
     }
 
     /// return type of the function is same as return variable type
@@ -159,19 +159,43 @@ void CodegenLLVMHelperVisitor::create_function_for_node(ast::Block& node) {
 }
 
 std::shared_ptr<ast::InstanceStruct> CodegenLLVMHelperVisitor::create_instance_struct() {
-    ast::CodegenVarVector codegen_vars;
+    ast::CodegenVarWithTypeVector codegen_vars;
+
+    auto add_var_with_type =
+        [&](const std::string& name, const ast::AstNodeType type, int is_pointer) {
+            auto var_name = new ast::Name(new ast::String(name));
+            auto var_type = new ast::CodegenVarType(type);
+            auto codegen_var = new ast::CodegenVarWithType(var_type, is_pointer, var_name);
+            codegen_vars.emplace_back(codegen_var);
+        };
+
     /// float variables are standard pointers to float vectors
     for (auto& float_var: info.codegen_float_variables) {
-        auto name = new ast::Name(new ast::String(float_var->get_name()));
-        auto codegen_var = new ast::CodegenVar(1, name);
-        codegen_vars.emplace_back(codegen_var);
+        add_var_with_type(float_var->get_name(), FLOAT_TYPE, 1);
     }
+
     /// int variables are pointers to indexes for other vectors
     for (auto& int_var: info.codegen_int_variables) {
-        auto name = new ast::Name(new ast::String(int_var.symbol->get_name()));
-        auto codegen_var = new ast::CodegenVar(1, name);
-        codegen_vars.emplace_back(codegen_var);
+        add_var_with_type(int_var.symbol->get_name(), FLOAT_TYPE, 1);
     }
+
+    // for integer variables, there should be index
+    for (auto& int_var: info.codegen_int_variables) {
+        std::string var_name = int_var.symbol->get_name() + "_index";
+        add_var_with_type(var_name, INTEGER_TYPE, 1);
+    }
+
+    // add voltage and node index
+    add_var_with_type("voltage", FLOAT_TYPE, 1);
+    add_var_with_type("node_index", INTEGER_TYPE, 1);
+
+    // add dt, t, celsius
+    add_var_with_type(naming::NTHREAD_T_VARIABLE, FLOAT_TYPE, 0);
+    add_var_with_type(naming::NTHREAD_DT_VARIABLE, FLOAT_TYPE, 0);
+    add_var_with_type(naming::CELSIUS_VARIABLE, FLOAT_TYPE, 0);
+    add_var_with_type(naming::SECOND_ORDER_VARIABLE, INTEGER_TYPE, 0);
+    add_var_with_type(MECH_NODECOUNT_VAR, INTEGER_TYPE, 0);
+
     return std::make_shared<ast::InstanceStruct>(codegen_vars);
 }
 
@@ -362,12 +386,23 @@ void CodegenLLVMHelperVisitor::convert_to_instance_variable(ast::Node& node,
     auto variables = collect_nodes(node, {ast::AstNodeType::VAR_NAME});
     for (auto& v: variables) {
         auto variable = std::dynamic_pointer_cast<ast::VarName>(v);
-        /// if variable is of type instance then convert it to index
-        if (info.is_an_instance_variable(variable->get_node_name())) {
+        auto variable_name = variable->get_node_name();
+
+        /// all instance variables defined in the mod file should be converted to
+        /// indexed variables based on the loop iteration variable
+        if (info.is_an_instance_variable(variable_name)) {
             auto name = variable->get_name()->clone();
             auto index = new ast::Name(new ast::String(index_var));
             auto indexed_name = std::make_shared<ast::IndexedName>(name, index);
             variable->set_name(indexed_name);
+        }
+
+        /// instance_var_helper check of instance variables from mod file as well
+        /// as extra variables like ion index variables added for code generation
+        if (instance_var_helper.is_an_instance_variable(variable_name)) {
+            auto name = new ast::Name(new ast::String(MECH_INSTANCE_VAR));
+            auto var = std::make_shared<ast::CodegenInstanceVar>(name, variable->clone());
+            variable->set_name(var);
         }
     }
 }
@@ -438,7 +473,7 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     /// loop constructs : initialization, condition and increment
     const auto& initialization = create_statement_as_expression("id = 0");
     const auto& condition = create_expression("id < node_count");
-    const auto& increment = create_statement_as_expression("id = id + 1");
+    const auto& increment = create_statement_as_expression("id = id + {}"_format(vector_width));
 
     /// loop body : initialization + solve blocks
     ast::StatementVector loop_def_statements;
@@ -496,9 +531,6 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     /// now construct a new code block which will become the body of the loop
     auto loop_block = std::make_shared<ast::StatementBlock>(loop_body);
 
-    /// convert all variables inside loop body to instance variables
-    convert_to_instance_variable(*loop_block, loop_index_var);
-
     /// convert local statement to codegenvar statement
     convert_local_statement(*loop_block);
 
@@ -507,6 +539,9 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
                                                                          condition,
                                                                          increment,
                                                                          loop_block);
+
+    /// convert all variables inside loop body to instance variables
+    convert_to_instance_variable(*for_loop_statement, loop_index_var);
 
     /// loop itself becomes one of the statement in the function
     function_statements.push_back(for_loop_statement);
@@ -520,7 +555,12 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     auto return_type = new ast::CodegenVarType(ast::AstNodeType::VOID);
 
     /// \todo : currently there are no arguments
-    ast::CodegenArgumentVector code_arguments;
+    ast::CodegenVarWithTypeVector code_arguments;
+
+    auto instance_var_type = new ast::CodegenVarType(ast::AstNodeType::INSTANCE_STRUCT);
+    auto instance_var_name = new ast::Name(new ast::String("mech"));
+    auto instance_var = new ast::CodegenVarWithType(instance_var_type, 1, instance_var_name);
+    code_arguments.emplace_back(instance_var);
 
     /// finally, create new function
     auto function =
@@ -535,14 +575,16 @@ void CodegenLLVMHelperVisitor::visit_program(ast::Program& node) {
     CodegenHelperVisitor v;
     info = v.analyze(node);
 
+    instance_var_helper.instance = create_instance_struct();
+    node.emplace_back_node(instance_var_helper.instance);
+
     logger->info("Running CodegenLLVMHelperVisitor");
     node.visit_children(*this);
     for (auto& fun: codegen_functions) {
         node.emplace_back_node(fun);
     }
 
-    auto llvm_instance_struct = create_instance_struct();
-    node.emplace_back_node(llvm_instance_struct);
+    std::cout << nmodl::to_nmodl(node);
 }
 
 

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -120,6 +120,9 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
     const std::string MECH_INSTANCE_VAR = "mech";
     const std::string MECH_NODECOUNT_VAR = "node_count";
 
+    /// name of induction variable used in the kernel.
+    const std::string INDUCTION_VAR = "id";
+
     /// create new function for FUNCTION or PROCEDURE block
     void create_function_for_node(ast::Block& node);
 
@@ -132,6 +135,10 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
 
     const InstanceVarHelper& get_instance_var_helper() {
         return instance_var_helper;
+    }
+
+    std::string get_kernel_id() {
+        return INDUCTION_VAR;
     }
 
     /// run visitor and return code generation functions

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -18,6 +18,7 @@
 #include <ostream>
 #include <string>
 
+#include "codegen/llvm/codegen_llvm_helper_visitor.hpp"
 #include "symtab/symbol_table.hpp"
 #include "utils/logger.hpp"
 #include "visitors/ast_visitor.hpp"
@@ -56,6 +57,8 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     std::string output_dir;
 
   private:
+    InstanceVarHelper instance_var_helper;
+
     std::unique_ptr<llvm::LLVMContext> context = std::make_unique<llvm::LLVMContext>();
 
     std::unique_ptr<llvm::Module> module = std::make_unique<llvm::Module>(mod_filename, *context);
@@ -79,6 +82,9 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     // Use 32-bit floating-point type if true. Otherwise, use deafult 64-bit.
     bool use_single_precision;
 
+    // explicit vectorisation width
+    int vector_width;
+
     // LLVM mechanism struct
     llvm::StructType* llvm_struct;
 
@@ -100,11 +106,13 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     CodegenLLVMVisitor(const std::string& mod_filename,
                        const std::string& output_dir,
                        bool opt_passes,
+                       int vector_width = 1,
                        bool use_single_precision = false)
         : mod_filename(mod_filename)
         , output_dir(output_dir)
         , opt_passes(opt_passes)
         , use_single_precision(use_single_precision)
+        , vector_width(vector_width)
         , builder(*context)
         , fpm(module.get()) {}
 

--- a/src/language/code_generator.cmake
+++ b/src/language/code_generator.cmake
@@ -65,15 +65,16 @@ set(AST_GENERATED_SOURCES
     ${PROJECT_BINARY_DIR}/src/ast/block_comment.hpp
     ${PROJECT_BINARY_DIR}/src/ast/boolean.hpp
     ${PROJECT_BINARY_DIR}/src/ast/breakpoint_block.hpp
-    ${PROJECT_BINARY_DIR}/src/ast/codegen_argument.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_atomic_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_for_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_function.hpp
+    ${PROJECT_BINARY_DIR}/src/ast/codegen_instance_var.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_return_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_struct.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_var.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_var_list_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_var_type.hpp
+    ${PROJECT_BINARY_DIR}/src/ast/codegen_var_with_type.hpp
     ${PROJECT_BINARY_DIR}/src/ast/compartment.hpp
     ${PROJECT_BINARY_DIR}/src/ast/conductance_hint.hpp
     ${PROJECT_BINARY_DIR}/src/ast/conserve.hpp

--- a/src/language/codegen.yaml
+++ b/src/language/codegen.yaml
@@ -49,17 +49,30 @@
                                   brief: "Name of the variable"
                                   type: Identifier
                                   node_name: true
-                        - CodegenArgument:
-                            brief: "Represent argument to a function"
+                        - CodegenVarWithType:
+                            brief: "Represent variable used for code generation"
                             members:
                               - type:
-                                  brief: "Type of the argument"
+                                  brief: "Type of the variable"
                                   type: CodegenVarType
                                   suffix: {value: " "}
+                              - is_pointer:
+                                  brief: "If variable is pointer type"
+                                  type: int
                               - name:
-                                  brief: "Name of the argument"
+                                  brief: "Name of the variable"
                                   type: Identifier
                                   node_name: true
+                        - CodegenInstanceVar:
+                            brief: "Represent instance variable"
+                            members:
+                              - instance_var:
+                                  brief: "Instance variable"
+                                  type: Name
+                                  suffix: {value: "->"}
+                              - member_var:
+                                  brief: "Member variable within instance"
+                                  type: Identifier
                   - Block:
                       children:
                         - NrnStateBlock:
@@ -134,7 +147,7 @@
                                   node_name: true
                               - arguments:
                                   brief: "Vector of the parameters to the function"
-                                  type: CodegenArgument
+                                  type: CodegenVarWithType
                                   vector: true
                                   prefix: {value: "(", force: true}
                                   suffix: {value: ")", force: true}
@@ -148,7 +161,7 @@
                             members:
                               - codegen_vars:
                                   brief: "Vector of CodegenVars"
-                                  type: CodegenVar
+                                  type: CodegenVarWithType
                                   vector: true
                                   add: true
                                   separator: "\\n    "

--- a/src/language/node_info.py
+++ b/src/language/node_info.py
@@ -170,6 +170,7 @@ STRING_NODE = "String"
 UNIT_BLOCK = "UnitBlock"
 AST_NODETYPE_NODE= "AstNodeType"
 CODEGEN_VAR_TYPE_NODE = "CodegenVarType"
+CODEGEN_VAR_WITH_TYPE_NODE = "CodegenVarWithType"
 
 # name of variable in prime node which represent order of derivative
 ORDER_VAR_NAME = "order"

--- a/src/language/nodes.py
+++ b/src/language/nodes.py
@@ -156,6 +156,10 @@ class BaseNode:
         return self.class_name == node_info.CODEGEN_VAR_TYPE_NODE
 
     @property
+    def is_codegen_var_with_type_node(self):
+        return self.class_name == node_info.CODEGEN_VAR_WITH_TYPE_NODE
+
+    @property
     def is_enum_node(self):
         data_type = node_info.DATA_TYPES[self.class_name]
         return data_type in node_info.ENUM_BASE_TYPES

--- a/src/language/templates/visitors/nmodl_visitor.cpp
+++ b/src/language/templates/visitors/nmodl_visitor.cpp
@@ -115,7 +115,12 @@ void NmodlPrintVisitor::visit_{{ node.class_name|snake_case}}(const {{ node.clas
     {% endif %}
     {% for child in node.children %}
         {% call guard(child.force_prefix, child.force_suffix) -%}
-        {% if child.is_base_type_node %}
+
+        {% if node.is_codegen_var_with_type_node and child.varname == "is_pointer" %}
+             if(node.get_{{ child.varname }}()) {
+                printer->add_element("*");
+             }
+        {% elif child.is_base_type_node %}
             {% if child.is_ast_nodetype_node %}
                printer->add_element(ast::to_string(node.get_{{child.varname}}()));
             {% endif %}

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -590,7 +590,7 @@ int main(int argc, const char* argv[]) {
             if (llvm_ir) {
                 logger->info("Running LLVM backend code generator");
                 CodegenLLVMVisitor visitor(
-                    modfile, output_dir, llvm_opt_passes, llvm_vec_width, llvm_float_type);
+                    modfile, output_dir, llvm_opt_passes, llvm_float_type, llvm_vec_width);
                 visitor.visit_program(*ast);
                 ast_to_nmodl(*ast, filepath("llvm", "mod"));
                 ast_to_json(*ast, filepath("llvm", "json"));

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -175,6 +175,9 @@ int main(int argc, const char* argv[]) {
 
     /// run llvm optimisation passes
     bool llvm_opt_passes(false);
+
+    /// llvm vector width;
+    int llvm_vec_width = 1;
 #endif
 
     app.get_formatter()->column_width(40);
@@ -295,6 +298,9 @@ int main(int argc, const char* argv[]) {
     llvm_opt->add_flag("--single-precision",
                        llvm_float_type,
                        "Use single precision floating-point types ({})"_format(llvm_float_type))->ignore_case();
+    llvm_opt->add_option("--vector-width",
+        llvm_vec_width,
+        "LLVM explicit vectorisation width ({})"_format(llvm_vec_width))->ignore_case();
 #endif
     // clang-format on
 
@@ -324,15 +330,24 @@ int main(int argc, const char* argv[]) {
         }
     };
 
+    /// write ast to nmodl
+    const auto ast_to_json = [json_ast](ast::Program& ast, const std::string& filepath) {
+        if (json_ast) {
+            JSONVisitor(filepath).write(ast);
+            logger->info("AST to JSON transformation written to {}", filepath);
+        }
+    };
+
     for (const auto& file: mod_files) {
         logger->info("Processing {}", file);
 
         const auto modfile = utils::remove_extension(utils::base_name(file));
 
         /// create file path for nmodl file
-        auto filepath = [scratch_dir, modfile](const std::string& suffix) {
+        auto filepath = [scratch_dir, modfile](const std::string& suffix, const std::string& ext) {
             static int count = 0;
-            return "{}/{}.{}.{}.mod"_format(scratch_dir, modfile, std::to_string(count++), suffix);
+            return "{}/{}.{}.{}.{}"_format(
+                scratch_dir, modfile, std::to_string(count++), suffix, ext);
         };
 
         /// driver object creates lexer and parser, just call parser method
@@ -358,7 +373,7 @@ int main(int argc, const char* argv[]) {
         {
             logger->info("Running CVode to cnexp visitor");
             AfterCVodeToCnexpVisitor().visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("after_cvode_to_cnexp"));
+            ast_to_nmodl(*ast, filepath("after_cvode_to_cnexp", "mod"));
         }
 
         /// Rename variables that match ISPC compiler double constants
@@ -366,7 +381,7 @@ int main(int argc, const char* argv[]) {
             logger->info("Running ISPC variables rename visitor");
             IspcRenameVisitor(ast).visit_program(*ast);
             SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("ispc_double_rename"));
+            ast_to_nmodl(*ast, filepath("ispc_double_rename", "mod"));
         }
 
         /// GLOBAL to RANGE rename visitor
@@ -379,7 +394,7 @@ int main(int argc, const char* argv[]) {
             logger->info("Running GlobalToRange visitor");
             GlobalToRangeVisitor(ast).visit_program(*ast);
             SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("global_to_range"));
+            ast_to_nmodl(*ast, filepath("global_to_range", "mod"));
         }
 
         /// LOCAL to ASSIGNED visitor
@@ -388,7 +403,7 @@ int main(int argc, const char* argv[]) {
             PerfVisitor().visit_program(*ast);
             LocalToAssignedVisitor().visit_program(*ast);
             SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("local_to_assigned"));
+            ast_to_nmodl(*ast, filepath("local_to_assigned", "mod"));
         }
 
         {
@@ -414,31 +429,26 @@ int main(int argc, const char* argv[]) {
             symtab->print(std::cout);
         }
 
-        ast_to_nmodl(*ast, filepath("ast"));
-
-        if (json_ast) {
-            auto file = scratch_dir + "/" + modfile + ".ast.json";
-            logger->info("Writing AST into {}", file);
-            JSONVisitor(file).write(*ast);
-        }
+        ast_to_nmodl(*ast, filepath("ast", "mod"));
+        ast_to_json(*ast, filepath("ast", "json"));
 
         if (verbatim_rename) {
             logger->info("Running verbatim rename visitor");
             VerbatimVarRenameVisitor().visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("verbatim_rename"));
+            ast_to_nmodl(*ast, filepath("verbatim_rename", "mod"));
         }
 
         if (nmodl_const_folding) {
             logger->info("Running nmodl constant folding visitor");
             ConstantFolderVisitor().visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("constfold"));
+            ast_to_nmodl(*ast, filepath("constfold", "mod"));
         }
 
         if (nmodl_unroll) {
             logger->info("Running nmodl loop unroll visitor");
             LoopUnrollVisitor().visit_program(*ast);
             ConstantFolderVisitor().visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("unroll"));
+            ast_to_nmodl(*ast, filepath("unroll", "mod"));
             SymtabVisitor(update_symtab).visit_program(*ast);
         }
 
@@ -450,7 +460,7 @@ int main(int argc, const char* argv[]) {
             auto kineticBlockVisitor = KineticBlockVisitor();
             kineticBlockVisitor.visit_program(*ast);
             SymtabVisitor(update_symtab).visit_program(*ast);
-            const auto filename = filepath("kinetic");
+            const auto filename = filepath("kinetic", "mod");
             ast_to_nmodl(*ast, filename);
             if (nmodl_ast && kineticBlockVisitor.get_conserve_statement_count()) {
                 logger->warn(
@@ -463,7 +473,7 @@ int main(int argc, const char* argv[]) {
             logger->info("Running STEADYSTATE visitor");
             SteadystateVisitor().visit_program(*ast);
             SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("steadystate"));
+            ast_to_nmodl(*ast, filepath("steadystate", "mod"));
         }
 
         /// Parsing units fron "nrnunits.lib" and mod files
@@ -480,14 +490,14 @@ int main(int argc, const char* argv[]) {
         if (nmodl_inline) {
             logger->info("Running nmodl inline visitor");
             InlineVisitor().visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("inline"));
+            ast_to_nmodl(*ast, filepath("inline", "mod"));
         }
 
         if (local_rename) {
             logger->info("Running local variable rename visitor");
             LocalVarRenameVisitor().visit_program(*ast);
             SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("local_rename"));
+            ast_to_nmodl(*ast, filepath("local_rename", "mod"));
         }
 
         if (nmodl_localize) {
@@ -496,33 +506,33 @@ int main(int argc, const char* argv[]) {
             LocalizeVisitor(localize_verbatim).visit_program(*ast);
             LocalVarRenameVisitor().visit_program(*ast);
             SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("localize"));
+            ast_to_nmodl(*ast, filepath("localize", "mod"));
         }
 
         if (sympy_conductance) {
             logger->info("Running sympy conductance visitor");
             SympyConductanceVisitor().visit_program(*ast);
             SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("sympy_conductance"));
+            ast_to_nmodl(*ast, filepath("sympy_conductance", "mod"));
         }
 
         if (sympy_analytic) {
             logger->info("Running sympy solve visitor");
             SympySolverVisitor(sympy_pade, sympy_cse).visit_program(*ast);
             SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("sympy_solve"));
+            ast_to_nmodl(*ast, filepath("sympy_solve", "mod"));
         }
 
         {
             logger->info("Running cnexp visitor");
             NeuronSolveVisitor().visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("cnexp"));
+            ast_to_nmodl(*ast, filepath("cnexp", "mod"));
         }
 
         {
             SolveBlockVisitor().visit_program(*ast);
             SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("solveblock"));
+            ast_to_nmodl(*ast, filepath("solveblock", "mod"));
         }
 
         if (json_perfstat) {
@@ -579,9 +589,11 @@ int main(int argc, const char* argv[]) {
 #ifdef NMODL_LLVM_BACKEND
             if (llvm_ir) {
                 logger->info("Running LLVM backend code generator");
-                CodegenLLVMVisitor visitor(modfile, output_dir, llvm_opt_passes, llvm_float_type);
+                CodegenLLVMVisitor visitor(
+                    modfile, output_dir, llvm_opt_passes, llvm_vec_width, llvm_float_type);
                 visitor.visit_program(*ast);
-                ast_to_nmodl(*ast, filepath("llvm"));
+                ast_to_nmodl(*ast, filepath("llvm", "mod"));
+                ast_to_json(*ast, filepath("llvm", "json"));
             }
 #endif
         }

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -794,39 +794,3 @@ SCENARIO("Dead code removal", "[visitor][llvm][opt]") {
         }
     }
 }
-
-//=============================================================================
-// Create Instance Struct
-//=============================================================================
-
-SCENARIO("Creation of Instance Struct", "[visitor][llvm][instance_struct]") {
-    GIVEN("NEURON block with RANGE variables and IONS") {
-        std::string nmodl_text = R"(
-            NEURON {
-                USEION na READ ena WRITE ina
-                NONSPECIFIC_CURRENT il
-                RANGE minf, hinf
-            }
-
-            STATE {
-                m
-            }
-
-            ASSIGNED {
-                v (mV)
-                celsius (degC)
-                minf
-                hinf
-            }
-        )";
-
-        THEN("create struct with the declared variables") {
-            std::string module_string = run_llvm_visitor(nmodl_text, true);
-            std::smatch m;
-
-            std::regex instance_struct_declaration(
-                R"(%unknown_Instance = type \{ double\*, double\*, double\*, double\*, double\*, double\*, double\*, double\*, double\*, double\* \})");
-            REQUIRE(std::regex_search(module_string, m, instance_struct_declaration));
-        }
-    }
-}


### PR DESCRIPTION
* Improvements to codegen helper
     - instance structure now contains all global variables
     - instance structure now contains index variables for ions
     - nrn_state kernel now has all variables converted to instance
     - InstanceVarHelper added to query variable and it's location
* nmodl_to_json helper added in main.cpp
* added --vector-width CLI option
* Add argument to nrn_state_hh
*  [x] WIP progress :: add comments as TODOs to support LLVM IR generation
*  [x] : fix cmake-format
*  [x] : fix clang-format
*  [x] : fix tests

Using : 

```
make -j && ./bin/nmodl hh.mod llvm --ir --vector-width 8 passes --json-ast
```

We get now

```
INSTANCE_STRUCT {
    DOUBLE *gnabar
    DOUBLE *gkbar
    DOUBLE *gl
    DOUBLE *el
    DOUBLE *gna
    DOUBLE *gk
    DOUBLE *il
    DOUBLE *minf
    DOUBLE *hinf
    DOUBLE *ninf
    DOUBLE *mtau
    DOUBLE *htau
    DOUBLE *ntau
    DOUBLE *m
    DOUBLE *h
    DOUBLE *n
    DOUBLE *Dm
    DOUBLE *Dh
    DOUBLE *Dn
    DOUBLE *ena
    DOUBLE *ek
    DOUBLE *ina
    DOUBLE *ik
    DOUBLE *v_unused
    DOUBLE *g_unused
    DOUBLE *ion_ena
    DOUBLE *ion_ina
    DOUBLE *ion_dinadv
    DOUBLE *ion_ek
    DOUBLE *ion_ik
    DOUBLE *ion_dikdv
    INTEGER *ion_ena_index
    INTEGER *ion_ina_index
    INTEGER *ion_dinadv_index
    INTEGER *ion_ek_index
    INTEGER *ion_ik_index
    INTEGER *ion_dikdv_index
    DOUBLE *voltage
    INTEGER *node_index
    DOUBLE t
    DOUBLE dt
    DOUBLE celsius
    INTEGER secondorder
    INTEGER node_count
}

VOID nrn_state_hh(INSTANCE_STRUCT *mech){
    INTEGER id
    for(id = 0; id<mech->node_count; id = id+8) {
        INTEGER node_id, ena_id, ek_id
        DOUBLE v
        node_id = mech->node_index[id]
        ena_id = mech->ion_ena_index[id]
        ek_id = mech->ion_ek_index[id]
        v = mech->voltage[node_id]
        mech->ena[id] = mech->ion_ena[ena_id]
        mech->ek[id] = mech->ion_ek[ek_id]
        mech->m[id] = mech->m[id]+(1.0-exp(mech->dt*((((-1.0)))/mech->mtau[id])))*(-(((mech->minf[id]))/mech->mtau[id])/((((-1.0)))/mech->mtau[id])-mech->m[id])
        mech->h[id] = mech->h[id]+(1.0-exp(mech->dt*((((-1.0)))/mech->htau[id])))*(-(((mech->hinf[id]))/mech->htau[id])/((((-1.0)))/mech->htau[id])-mech->h[id])
        mech->n[id] = mech->n[id]+(1.0-exp(mech->dt*((((-1.0)))/mech->ntau[id])))*(-(((mech->ninf[id]))/mech->ntau[id])/((((-1.0)))/mech->ntau[id])-mech->n[id])
    }
}
```

Note that running this branch result into

```
libc++abi.dylib: terminating with uncaught exception of type std::runtime_error: Error: expecting a type in CodegenVarType node
Abort trap: 6
```

This is because various fixes in LLVM IR generation are pending.

@georgemitenkov : Could you look at various TODO's mentioned in this 2da2bc4e5829091c9b28f356731646db5209a9a7 commit?  I will do some improvements to this PR but you can get an idea of what is current structure and if you would like to change other things.