### PR TITLE
Running a kernel with NMODL-LLVM JIT

### DIFF
--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -923,5 +923,41 @@ void CodegenLLVMVisitor::visit_while_statement(const ast::WhileStatement& node) 
     builder.SetInsertPoint(exit);
 }
 
+void CodegenLLVMVisitor::wrap_kernel_function(const std::string& kernel_name) {
+    // Get the kernel function and the instance struct type.
+    auto kernel = module->getFunction(kernel_name);
+    if (!kernel)
+        throw std::runtime_error("Kernel " + kernel_name + " is not found!");
+
+    if (kernel->getNumOperands() != 0)
+        throw std::runtime_error("Kernel " + kernel_name + " has too many arguments!");
+
+    auto instance_struct_ptr_type = llvm::dyn_cast<llvm::PointerType>(kernel->getArg(0)->getType());
+    if (!instance_struct_ptr_type)
+        throw std::runtime_error("Kernel " + kernel_name +
+                                 " does not have an instance struct pointer argument!");
+
+    // Create a wrapper void function that takes a void pointer as a single argument.
+    llvm::Type* void_type = llvm::Type::getVoidTy(*context);
+    llvm::Type* i32_type = llvm::Type::getInt32Ty(*context);
+    llvm::Type* void_ptr_type = llvm::PointerType::get(void_type, /*AddressSpace=*/0);
+    llvm::Function* wrapper_func = llvm::Function::Create(
+        llvm::FunctionType::get(i32_type, {void_ptr_type}, /*isVarArg=*/false),
+        llvm::Function::ExternalLinkage,
+        "__" + kernel_name + "_wrapper",
+        *module);
+    llvm::BasicBlock* body = llvm::BasicBlock::Create(*context, /*Name=*/"", wrapper_func);
+    builder.SetInsertPoint(body);
+
+    // Proceed with bitcasting the void pointer to the struct pointer type, calling the kernel and
+    // adding a terminator.
+    llvm::Value* bitcasted = builder.CreateBitCast(wrapper_func->getArg(0),
+                                                   instance_struct_ptr_type);
+    std::vector<llvm::Value*> args;
+    args.push_back(bitcasted);
+    builder.CreateCall(kernel, args);
+    builder.CreateRet(llvm::ConstantInt::get(i32_type, 0));
+}
+
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -929,8 +929,8 @@ void CodegenLLVMVisitor::wrap_kernel_function(const std::string& kernel_name) {
     if (!kernel)
         throw std::runtime_error("Kernel " + kernel_name + " is not found!");
 
-    if (kernel->getNumOperands() != 0)
-        throw std::runtime_error("Kernel " + kernel_name + " has too many arguments!");
+    if (std::distance(kernel->args().begin(), kernel->args().end()) != 1)
+        throw std::runtime_error("Kernel " + kernel_name + " must have a single argument!");
 
     auto instance_struct_ptr_type = llvm::dyn_cast<llvm::PointerType>(kernel->getArg(0)->getType());
     if (!instance_struct_ptr_type)

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -321,6 +321,12 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
         os.flush();
         return str;
     }
+
+    /**
+     * For the given kernel function, wraps it into another function that uses void* to pass the data to the kernel
+     * \param kernel_name kernel name to be wrapped
+     */
+    void wrap_kernel_function(const std::string& kernel_name);
 };
 
 /** \} */  // end of llvm_backends

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -331,8 +331,8 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     }
 
     /**
-     * For the given kernel function, wraps it into another function that uses void* to pass the data to the kernel
-     * \param kernel_name kernel name to be wrapped
+     * For the given kernel function, wraps it into another function that uses void* to pass the
+     * data to the kernel \param kernel_name kernel name to be wrapped
      */
     void wrap_kernel_function(const std::string& kernel_name);
 };

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -238,6 +238,14 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     void emit_procedure_or_function_declaration(const ast::CodegenFunction& node);
 
     /**
+     * Return InstanceVarHelper
+     * \return InstanceVarHelper
+     */
+    InstanceVarHelper get_instance_var_helper() {
+        return instance_var_helper;
+    }
+
+    /**
      * Return module pointer
      * \return LLVM IR module pointer
      */

--- a/src/codegen/llvm/main.cpp
+++ b/src/codegen/llvm/main.cpp
@@ -67,7 +67,7 @@ int main(int argc, const char* argv[]) {
     Runner runner(std::move(module));
 
     // Since only double type is supported, provide explicit double type to the running function.
-    auto r = runner.run<double>(entry_point_name);
+    auto r = runner.run_without_arguments<double>(entry_point_name);
     fprintf(stderr, "Result: %f\n", r);
 
     return 0;

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -98,7 +98,8 @@ if(NMODL_ENABLE_LLVM)
   include_directories(${LLVM_INCLUDE_DIRS} codegen)
   add_executable(testllvm visitor/main.cpp codegen/codegen_llvm_ir.cpp
                           codegen/codegen_data_helper.cpp codegen/codegen_llvm_instance_struct.cpp)
-  add_executable(test_llvm_runner visitor/main.cpp codegen/codegen_data_helper.cpp codegen/codegen_llvm_execution.cpp)
+  add_executable(test_llvm_runner visitor/main.cpp codegen/codegen_data_helper.cpp
+                                  codegen/codegen_llvm_execution.cpp)
   target_link_libraries(
     testllvm
     llvm_codegen

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -98,7 +98,7 @@ if(NMODL_ENABLE_LLVM)
   include_directories(${LLVM_INCLUDE_DIRS} codegen)
   add_executable(testllvm visitor/main.cpp codegen/codegen_llvm_ir.cpp
                           codegen/codegen_data_helper.cpp codegen/codegen_llvm_instance_struct.cpp)
-  add_executable(test_llvm_runner visitor/main.cpp codegen/codegen_llvm_execution.cpp)
+  add_executable(test_llvm_runner visitor/main.cpp codegen/codegen_data_helper.cpp codegen/codegen_llvm_execution.cpp)
   target_link_libraries(
     testllvm
     llvm_codegen

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -321,7 +321,7 @@ SCENARIO("Simple scalar kernel", "[llvm][runner]") {
         initialise_instance_variable(instance_info, x, "x");
         initialise_instance_variable(instance_info, x0, "x0");
         initialise_instance_variable(instance_info, x1, "x1");
-        
+
         // Set up the JIT runner.
         std::unique_ptr<llvm::Module> module = llvm_visitor.get_module();
         Runner runner(std::move(module));

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -249,9 +249,7 @@ SCENARIO("Simple scalar kernel", "[llvm][runner]") {
             }
 
             DERIVATIVE states {
-                printf("%.2f", m)
                 m = (minf - m) / mtau
-                printf("%.2f", m)
             }
         )";
 
@@ -320,7 +318,12 @@ SCENARIO("Simple scalar kernel", "[llvm][runner]") {
         ptr = &s;
 
         THEN("Values in struct have changed!") {
+            // 10 and 10
+            printf("Before: %.1f and %.1f\n", s.m[0], s.m[1]);
             runner.run_with_argument<int, void*>("__nrn_state_hh_wrapper", ptr);
+            // (10 - 5) / 1 and (10 - 2) / 1
+            // 5            and 8
+            printf("After: %.1f and %.1f\n", s.m[0], s.m[1]);
         }
     }
 }

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -306,10 +306,6 @@ SCENARIO("Simple scalar kernel", "[llvm][runner]") {
         llvm_visitor.visit_program(*ast);
         llvm_visitor.wrap_kernel_function("nrn_state_test");
 
-        // Set up the JIT runner.
-        std::unique_ptr<llvm::Module> module = llvm_visitor.get_module();
-        Runner runner(std::move(module));
-
         // Create the instance struct data.
         int num_elements = 4;
         const auto& generated_instance_struct = llvm_visitor.get_instance_struct_ptr();
@@ -325,6 +321,10 @@ SCENARIO("Simple scalar kernel", "[llvm][runner]") {
         initialise_instance_variable(instance_info, x, "x");
         initialise_instance_variable(instance_info, x0, "x0");
         initialise_instance_variable(instance_info, x1, "x1");
+        
+        // Set up the JIT runner.
+        std::unique_ptr<llvm::Module> module = llvm_visitor.get_module();
+        Runner runner(std::move(module));
 
         THEN("Values in struct have changed according to the formula") {
             runner.run_with_argument<int, void*>("__nrn_state_test_wrapper",


### PR DESCRIPTION
This PR handles the LLVM side of testing and the NMODL kernels.
The following is added:

- A utility in LLVM visitor to create a wrapper function for kernel
execution. It takes a `void*` data, casts it to appropriate instance struct
type and calls the kernel.

- JIT runner now supports functions without arguments and with a single
argument. The latter is useful to verify `FUNCTION` results and pass the
instance struct data to the kernel.

- A simple scalar kernel test  is added.