### PR TITLE
Indexed name codegen improvements

### DIFF
--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -119,12 +119,6 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
         , builder(*context)
         , fpm(module.get()) {}
 
-    /**
-     * Checks if array index specified by the given IndexedName is within bounds
-     * \param node IndexedName representing array
-     * \return     \c true if the index is within bounds
-     */
-    bool check_array_bounds(const ast::IndexedName& node, unsigned index);
 
     /**
      * Generates LLVM code for the given IndexedName
@@ -146,14 +140,21 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
      * \param index element index
      * \return GEP instruction value
      */
-    llvm::Value* create_gep(const std::string& name, unsigned index);
+    llvm::Value* create_gep(const std::string& name, llvm::Value* index);
 
     /**
-     * Returns array index or length from given IndexedName
+     * Returns array index from given IndexedName
      * \param node IndexedName representing array
-     * \return array index or length
+     * \return array index
      */
-    unsigned get_array_index_or_length(const ast::IndexedName& node);
+    llvm::Value* get_array_index(const ast::IndexedName& node);
+
+    /**
+     * Returns array length from given IndexedName
+     * \param node IndexedName representing array
+     * \return array length
+     */
+    int get_array_length(const ast::IndexedName& node);
 
     /**
      * Returns LLVM type for the given CodegenVarType node

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -561,7 +561,7 @@ SCENARIO("Indexed name", "[visitor][llvm]") {
 
             // Check GEP is created correctly to pint at array element.
             std::regex GEP(
-                R"(%1 = getelementptr inbounds \[2 x double\], \[2 x double\]\* %x, i32 0, i32 1)");
+                R"(%1 = getelementptr inbounds \[2 x double\], \[2 x double\]\* %x, i64 0, i64 1)");
             REQUIRE(std::regex_search(module_string, m, GEP));
 
             // Check the value is stored to the pointer.
@@ -585,7 +585,7 @@ SCENARIO("Indexed name", "[visitor][llvm]") {
 
             // Check GEP is created correctly to pint at array element.
             std::regex GEP(
-                R"(%2 = getelementptr inbounds \[2 x double\], \[2 x double\]\* %x, i32 0, i32 1)");
+                R"(%2 = getelementptr inbounds \[2 x double\], \[2 x double\]\* %x, i64 0, i64 1)");
             REQUIRE(std::regex_search(module_string, m, GEP));
 
             // Check the value is loaded from the pointer.
@@ -595,19 +595,6 @@ SCENARIO("Indexed name", "[visitor][llvm]") {
             // Check the value is stored to the the variable.
             std::regex store(R"(store double %3, double\* %y)");
             REQUIRE(std::regex_search(module_string, m, store));
-        }
-    }
-
-    GIVEN("Array with out of bounds access") {
-        std::string nmodl_text = R"(
-            PROCEDURE foo() {
-                LOCAL x[2]
-                x[5] = 3
-            }
-        )";
-
-        THEN("error is thrown") {
-            REQUIRE_THROWS_AS(run_llvm_visitor(nmodl_text), std::runtime_error);
         }
     }
 }

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -551,6 +551,7 @@ SCENARIO("Indexed name", "[visitor][llvm]") {
         std::string nmodl_text = R"(
             PROCEDURE foo() {
                 LOCAL x[2]
+                x[10 - 10] = 1
                 x[1] = 3
             }
         )";
@@ -559,14 +560,19 @@ SCENARIO("Indexed name", "[visitor][llvm]") {
             std::string module_string = run_llvm_visitor(nmodl_text);
             std::smatch m;
 
-            // Check GEP is created correctly to pint at array element.
-            std::regex GEP(
-                R"(%1 = getelementptr inbounds \[2 x double\], \[2 x double\]\* %x, i64 0, i64 1)");
-            REQUIRE(std::regex_search(module_string, m, GEP));
+            // Check GEPs are created correctly to get the addresses of array elements.
+            std::regex GEP1(
+                R"(%1 = getelementptr inbounds \[2 x double\], \[2 x double\]\* %x, i64 0, i64 0)");
+            std::regex GEP2(
+                R"(%2 = getelementptr inbounds \[2 x double\], \[2 x double\]\* %x, i64 0, i64 1)");
+            REQUIRE(std::regex_search(module_string, m, GEP1));
+            REQUIRE(std::regex_search(module_string, m, GEP2));
 
-            // Check the value is stored to the pointer.
-            std::regex store(R"(store double 3.000000e\+00, double\* %1)");
-            REQUIRE(std::regex_search(module_string, m, store));
+            // Check the value is stored to the correct addresses.
+            std::regex store1(R"(store double 1.000000e\+00, double\* %1)");
+            std::regex store2(R"(store double 3.000000e\+00, double\* %2)");
+            REQUIRE(std::regex_search(module_string, m, store1));
+            REQUIRE(std::regex_search(module_string, m, store2));
         }
     }
 


### PR DESCRIPTION
This PR improves index code generation within the LLVM
pipeline. The following issues were addressed:

- Array indices are `i64` per LLVM's addressing convention.
This means that if the value is not a constant, an additional
`sext` instruction must be created.

- `IndexedName` code generation is separated into 2 functions
The first, `get_array_length()` is responsible for array initialisation,
the second, `get_array_index()`, for indexing. In latter case, we
support the following cases:

```c
...
// Indexing with an integer constant
k[0] = ...

// Indexing with an integer expression
k[10 - 10] 

// Indexing with a `Name` AST node that is an integer
// (in our case a FOR loop induction variable or a variable
// with `CodegenVarType` == `Integer`
k[id] = ...      
k[ena_id] = ...
```

Note that the case:
```
// id := loop integer induction variable
k[id + 1] = ...      
```
is not supported for 2 reasons:

1. On the AST level, as per #545 the expression would
contain a `Name` and not `VarName` node that fails the
code generation.

2. The case only arises in the kernel functions like `state_update`,
where indexing is "artificially" created with indexing by a `Name`
**only**.

fixes #541 