### PR TITLE
Add log10 function to ISPC

### DIFF
--- a/src/codegen/fast_math.hpp
+++ b/src/codegen/fast_math.hpp
@@ -217,11 +217,11 @@ static inline float exprelr(float x) {
 }
 
 /// double precision log10 function
-inline double log10(double f) {
+inline double log10(double f) noexcept {
     return log(f) / log(10.0);
 }
 
 /// single precision log10 function
-inline float log10(float f) {
+inline float log10(float f) noexcept {
     return log(f) / log(10.0f);
 }

--- a/src/codegen/fast_math.hpp
+++ b/src/codegen/fast_math.hpp
@@ -215,3 +215,13 @@ static inline float exprelr(float x) {
 
     return x / vexpm1(x);
 }
+
+/// double precision log10 function
+inline double log10(double f) {
+    return log(f) / log(10.0);
+}
+
+/// single precision log10 function
+inline float log10(float f) {
+    return log(f) / log(10.0f);
+}

--- a/src/codegen/fast_math.hpp
+++ b/src/codegen/fast_math.hpp
@@ -18,6 +18,9 @@
  * \brief Implementation of different math functions
  */
 
+namespace nmodl {
+namespace fast_math {
+
 static inline double uint642dp(uint64_t ll) {
     return *((double*) (&ll));
 }
@@ -74,6 +77,9 @@ static constexpr float PX5expf = 1.6666665459E-1f;
 static constexpr float PX6expf = 5.0000001201E-1f;
 
 static constexpr float LOG2EF = 1.44269504088896341f;  // 1/ln(2)
+
+static constexpr double LOG10E = 2.302585092994046;  // log(10)
+static constexpr float LOG10F = 2.302585f;           // log(10)
 
 static inline double egm1(double x, double n) {
     // this cannot be reordered for the double-double trick to work
@@ -217,11 +223,14 @@ static inline float exprelr(float x) {
 }
 
 /// double precision log10 function
-inline double log10(double f) noexcept {
-    return log(f) / log(10.0);
+static inline double log10(double f) {
+    return std::log(f) / LOG10E;
 }
 
 /// single precision log10 function
-inline float log10(float f) noexcept {
-    return log(f) / log(10.0f);
+static inline float log10(float f) {
+    return std::log(f) / LOG10F;
 }
+
+}  // namespace fast_math
+}  // namespace nmodl

--- a/src/codegen/fast_math.ispc
+++ b/src/codegen/fast_math.ispc
@@ -220,12 +220,12 @@ static inline float exprelr(float initial_x) {
     return initial_x/vexpm1(initial_x);
 }
 
-/// single precision log10 function
-static inline float log10(float f) {
-    return log(f)/log(10.0f);
-}
-
 /// double precision log10 function
 static inline double log10(double f) {
     return log(f)/log(10.0d);
+}
+
+/// single precision log10 function
+static inline float log10(float f) {
+    return log(f)/log(10.0f);
 }

--- a/src/codegen/fast_math.ispc
+++ b/src/codegen/fast_math.ispc
@@ -81,6 +81,9 @@ static const uniform float PX6expf = 5.0000001201E-1f;
 
 static const uniform float LOG2EF = 1.44269504088896341f; // 1/ln(2)
 
+static const uniform double LOG10E = 2.302585092994046d;   // log(10) double
+static const uniform float LOG10F = 2.3025851f;   // log(10) float
+
 static inline double egm1(double x, double px) {
 
     x -= px * 6.93145751953125d-1;
@@ -222,10 +225,10 @@ static inline float exprelr(float initial_x) {
 
 /// double precision log10 function
 static inline double log10(double f) {
-    return log(f)/log(10.0d);
+    return log(f)/LOG10E;
 }
 
 /// single precision log10 function
 static inline float log10(float f) {
-    return log(f)/log(10.0f);
+    return log(f)/LOG10F;
 }

--- a/src/codegen/fast_math.ispc
+++ b/src/codegen/fast_math.ispc
@@ -220,4 +220,12 @@ static inline float exprelr(float initial_x) {
     return initial_x/vexpm1(initial_x);
 }
 
+/// single precision log10 function
+static inline float log10(float f) {
+    return log(f)/log(10.0f);
+}
 
+/// double precision log10 function
+static inline double log10(double f) {
+    return log(f)/log(10.0d);
+}

--- a/test/unit/fast_math/fast_math.cpp
+++ b/test/unit/fast_math/fast_math.cpp
@@ -100,4 +100,18 @@ SCENARIO("Check fast_math") {
             REQUIRE(test);
         }
     }
+    GIVEN("log10 (double)") {
+        auto test = check_over_span(std::log10, log10, low_limit, high_limit, npoints);
+
+        THEN("error inside threshold") {
+            REQUIRE(test);
+        }
+    }
+    GIVEN("log10 (float)") {
+        auto test = check_over_span(std::log10, log10, low_limit_f, high_limit_f, npoints);
+
+        THEN("error inside threshold") {
+            REQUIRE(test);
+        }
+    }
 }

--- a/test/unit/fast_math/fast_math.cpp
+++ b/test/unit/fast_math/fast_math.cpp
@@ -11,6 +11,8 @@
 
 #include <catch/catch.hpp>
 
+namespace nmodl {
+namespace fast_math {
 
 template <class T, class = typename std::enable_if<std::is_floating_point<T>::value>::type>
 bool check_over_span(T f_ref(T),
@@ -57,6 +59,10 @@ SCENARIO("Check fast_math") {
     constexpr float low_limit_f = -87.0f;
     constexpr float high_limit_f = 88.0f;
     constexpr size_t npoints = 2000;
+    constexpr double min_double = std::numeric_limits<double>::min();
+    constexpr double max_double = std::numeric_limits<double>::max();
+    constexpr double min_float = std::numeric_limits<float>::min();
+    constexpr double max_float = std::numeric_limits<float>::max();
 
     GIVEN("vexp (double)") {
         auto test = check_over_span(std::exp, vexp, low_limit, high_limit, npoints);
@@ -101,17 +107,20 @@ SCENARIO("Check fast_math") {
         }
     }
     GIVEN("log10 (double)") {
-        auto test = check_over_span(std::log10, log10, low_limit, high_limit, npoints);
+        auto test = check_over_span(std::log10, log10, min_double, max_double, npoints);
 
         THEN("error inside threshold") {
             REQUIRE(test);
         }
     }
     GIVEN("log10 (float)") {
-        auto test = check_over_span(std::log10, log10, low_limit_f, high_limit_f, npoints);
+        auto test = check_over_span(std::log10, log10, min_float, max_float, npoints);
 
         THEN("error inside threshold") {
             REQUIRE(test);
         }
     }
 }
+
+}  // namespace fast_math
+}  // namespace nmodl


### PR DESCRIPTION
Some mod files use `log10` function which is not defined by `ISPC`.
This PR takes care of:
- [x] Add `log10` functions in `ISPC`
- [x] Add `log10` functions in `fast_math.hpp` (`static` cannot be used because of clash of declaration with `std::log10`)
- [x] Add tests for the new functions

Fixes #464  