### PR TITLE
Always initialize return variable in function block

### DIFF
--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -39,7 +39,8 @@ static ast::VarName* create_varname(const std::string& varname) {
  *         including Integer. See #542.
  */
 static std::shared_ptr<ast::Expression> int_initialization_expression(
-    const std::string& induction_var, int value = 0) {
+    const std::string& induction_var,
+    int value = 0) {
     // create id = 0
     const auto& id = create_varname(induction_var);
     const auto& zero = new ast::Integer(value, nullptr);
@@ -161,7 +162,8 @@ void CodegenLLVMHelperVisitor::create_function_for_node(ast::Block& node) {
 
     if (node.get_node_type() == ast::AstNodeType::PROCEDURE_BLOCK) {
         block->insert_statement(statements.begin(),
-            std::make_shared<ast::ExpressionStatement>(int_initialization_expression(return_var_name)));
+                                std::make_shared<ast::ExpressionStatement>(
+                                    int_initialization_expression(return_var_name)));
     }
     /// insert return variable at the start of the block
     ast::CodegenVarVector codegen_vars;

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -25,6 +25,27 @@ const std::string CodegenLLVMHelperVisitor::NODECOUNT_VAR = "node_count";
 const std::string CodegenLLVMHelperVisitor::VOLTAGE_VAR = "voltage";
 const std::string CodegenLLVMHelperVisitor::NODE_INDEX_VAR = "node_index";
 
+/// Create asr::Varname node with given a given variable name
+static ast::VarName* create_varname(const std::string& varname) {
+    return new ast::VarName(new ast::Name(new ast::String(varname)), nullptr, nullptr);
+}
+
+/**
+ * Create initialization expression
+ * @param code Usually "id = 0" as a string
+ * @return Expression representing code
+ * \todo : we can not use `create_statement_as_expression` function because
+ *         NMODL parser is using `ast::Double` type to represent all variables
+ *         including Integer. See #542.
+ */
+static std::shared_ptr<ast::Expression> int_initialization_expression(
+    const std::string& induction_var, int value = 0) {
+    // create id = 0
+    const auto& id = create_varname(induction_var);
+    const auto& zero = new ast::Integer(value, nullptr);
+    return std::make_shared<ast::BinaryExpression>(id, ast::BinaryOperator(ast::BOP_ASSIGN), zero);
+}
+
 /**
  * \brief Create variable definition statement
  *
@@ -120,7 +141,8 @@ void CodegenLLVMHelperVisitor::create_function_for_node(ast::Block& node) {
     auto name = new ast::Name(new ast::String(function_name));
 
     /// return variable name has "ret_" prefix
-    auto return_var = new ast::Name(new ast::String("ret_" + function_name));
+    std::string return_var_name = "ret_{}"_format(function_name);
+    auto return_var = new ast::Name(new ast::String(return_var_name));
 
     /// return type based on node type
     ast::CodegenVarType* ret_var_type = nullptr;
@@ -137,6 +159,10 @@ void CodegenLLVMHelperVisitor::create_function_for_node(ast::Block& node) {
     /// convert local statement to codegenvar statement
     convert_local_statement(*block);
 
+    if (node.get_node_type() == ast::AstNodeType::PROCEDURE_BLOCK) {
+        block->insert_statement(statements.begin(),
+            std::make_shared<ast::ExpressionStatement>(int_initialization_expression(return_var_name)));
+    }
     /// insert return variable at the start of the block
     ast::CodegenVarVector codegen_vars;
     codegen_vars.emplace_back(new ast::CodegenVar(0, return_var->clone()));
@@ -462,30 +488,9 @@ void CodegenLLVMHelperVisitor::visit_function_block(ast::FunctionBlock& node) {
     create_function_for_node(node);
 }
 
-/// Create asr::Varname node with given a given variable name
-static ast::VarName* create_varname(const std::string& varname) {
-    return new ast::VarName(new ast::Name(new ast::String(varname)), nullptr, nullptr);
-}
-
-/**
- * Create for loop initialization expression
- * @param code Usually "id = 0" as a string
- * @return Expression representing code
- * \todo : we can not use `create_statement_as_expression` function because
- *         NMODL parser is using `ast::Double` type to represent all variables
- *         including Integer. See #542.
- */
-static std::shared_ptr<ast::Expression> loop_initialization_expression(
-    const std::string& induction_var) {
-    // create id = 0
-    const auto& id = create_varname(induction_var);
-    const auto& zero = new ast::Integer(0, nullptr);
-    return std::make_shared<ast::BinaryExpression>(id, ast::BinaryOperator(ast::BOP_ASSIGN), zero);
-}
-
 /**
  * Create loop increment expression `id = id + width`
- * \todo : same as loop_initialization_expression()
+ * \todo : same as int_initialization_expression()
  */
 static std::shared_ptr<ast::Expression> loop_increment_expression(const std::string& induction_var,
                                                                   int vector_width) {
@@ -581,7 +586,7 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     /// main loop possibly vectorized on vector_width
     {
         /// loop constructs : initialization, condition and increment
-        const auto& initialization = loop_initialization_expression(INDUCTION_VAR);
+        const auto& initialization = int_initialization_expression(INDUCTION_VAR);
         const auto& condition = create_expression("{} < {}"_format(INDUCTION_VAR, NODECOUNT_VAR));
         const auto& increment = loop_increment_expression(INDUCTION_VAR, vector_width);
 

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -713,15 +713,6 @@ void CodegenLLVMVisitor::visit_codegen_var_list_statement(
             throw std::runtime_error("Error: Unsupported local variable type");
         }
         llvm::Value* alloca = builder.CreateAlloca(var_type, /*ArraySize=*/nullptr, name);
-
-        // Check if the variable we process is a procedure return variable (i.e. it has a name
-        // "ret_<current_function_name>" and the function return type is integer). If so, initialise
-        // it to 0.
-        std::string ret_val_name = "ret_" + current_func->getName().str();
-        if (name == ret_val_name && current_func->getReturnType()->isIntegerTy()) {
-            llvm::Value* zero = llvm::ConstantInt::get(llvm::Type::getInt32Ty(*context), 0);
-            builder.CreateStore(zero, alloca);
-        }
     }
 }
 

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -686,6 +686,7 @@ SCENARIO("Procedure", "[visitor][llvm]") {
             REQUIRE(std::regex_search(module_string, m, signature));
             REQUIRE(std::regex_search(module_string, m, alloc));
             REQUIRE(std::regex_search(module_string, m, store));
+            REQUIRE(std::regex_search(module_string, m, load));
             REQUIRE(std::regex_search(module_string, m, ret));
         }
     }


### PR DESCRIPTION
Fix #530 

It was already fixed when generating llvm IR. FIx it earlier, so when looking at intermediate AST the variable is added in the same time that the initialization.

Delete the code that fix it in IR