### PR TITLE
Remove support of AoS layout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,9 +127,9 @@ setup(
         "nbconvert<6.0",  # prevents issues with nbsphinx
         "nbsphinx>=0.3.2",
         "pytest>=3.7.2",
-        "sphinx-rtd-theme",
         "sphinx>=2.0",
         "sphinx<3.0",  # prevents issue with m2r where m2r uses an old API no more supported with sphinx>=3.0
+        "sphinx-rtd-theme",
     ]
     + install_requirements,
     install_requires=install_requirements,

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -98,17 +98,15 @@ class CodegenAccVisitor: public CodegenCVisitor {
   public:
     CodegenAccVisitor(const std::string& mod_file,
                       const std::string& output_dir,
-                      LayoutType layout,
                       const std::string& float_type,
                       bool optimize_ionvar_copies)
-        : CodegenCVisitor(mod_file, output_dir, layout, float_type, optimize_ionvar_copies) {}
+        : CodegenCVisitor(mod_file, output_dir, float_type, optimize_ionvar_copies) {}
 
     CodegenAccVisitor(const std::string& mod_file,
                       std::ostream& stream,
-                      LayoutType layout,
                       const std::string& float_type,
                       bool optimize_ionvar_copies)
-        : CodegenCVisitor(mod_file, stream, layout, float_type, optimize_ionvar_copies) {}
+        : CodegenCVisitor(mod_file, stream, float_type, optimize_ionvar_copies) {}
 };
 
 /** @} */  // end of codegen_backends

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -133,20 +133,6 @@ struct IndexVariableInfo {
 
 
 /**
- * \enum LayoutType
- * \brief Represents memory layout to use for code generation
- *
- */
-enum class LayoutType {
-    /// array of structure
-    aos,
-
-    /// structure of array
-    soa
-};
-
-
-/**
  * \class ShadowUseStatement
  * \brief Represents ion write statement during code generation
  *
@@ -269,11 +255,6 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      * Data type of floating point variables
      */
     std::string float_type = codegen::naming::DEFAULT_FLOAT_TYPE;
-
-    /**
-     * Memory layout for code generation
-     */
-    LayoutType layout;
 
     /**
      * All ast information for code generation
@@ -1122,13 +1103,6 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
 
 
     /**
-     * Print the getter method for memory layout
-     *
-     */
-    void print_memory_layout_getter();
-
-
-    /**
      * Print the getter method for index position of first pointer variable
      *
      */
@@ -1312,12 +1286,6 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      * Print backend specific channel instance iteration block end
      */
     virtual void print_channel_iteration_block_end();
-
-
-    /**
-     * Print common code post channel instance iteration
-     */
-    void print_post_channel_iteration_common_code();
 
 
     /**
@@ -1644,7 +1612,6 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
 
     CodegenCVisitor(const std::string& mod_filename,
                     const std::string& output_dir,
-                    LayoutType layout,
                     const std::string& float_type,
                     const bool optimize_ionvar_copies,
                     const std::string& extension,
@@ -1653,13 +1620,11 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
         , wrapper_printer(new CodePrinter(output_dir + "/" + mod_filename + wrapper_ext))
         , printer(target_printer)
         , mod_filename(mod_filename)
-        , layout(layout)
         , float_type(float_type)
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
 
     CodegenCVisitor(const std::string& mod_filename,
                     std::ostream& stream,
-                    LayoutType layout,
                     const std::string& float_type,
                     const bool optimize_ionvar_copies,
                     const std::string& extension,
@@ -1668,7 +1633,6 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
         , wrapper_printer(new CodePrinter(stream))
         , printer(target_printer)
         , mod_filename(mod_filename)
-        , layout(layout)
         , float_type(float_type)
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
 
@@ -1687,21 +1651,18 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      * \param mod_filename The name of the model for which code should be generated.
      *                     It is used for constructing an output filename.
      * \param output_dir   The directory where target C file should be generated.
-     * \param layout       The memory layout to be used for data structure generation.
      * \param float_type   The float type to use in the generated code. The string will be used
      *                     as-is in the target code. This defaults to \c double.
      * \param extension    The file extension to use. This defaults to \c .cpp .
      */
     CodegenCVisitor(const std::string& mod_filename,
                     const std::string& output_dir,
-                    LayoutType layout,
                     std::string float_type,
                     const bool optimize_ionvar_copies,
                     const std::string& extension = ".cpp")
         : target_printer(new CodePrinter(output_dir + "/" + mod_filename + extension))
         , printer(target_printer)
         , mod_filename(mod_filename)
-        , layout(layout)
         , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
 
@@ -1718,19 +1679,16 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      * \param mod_filename The name of the model for which code should be generated.
      *                     It is used for constructing an output filename.
      * \param stream       The output stream onto which to write the generated code
-     * \param layout       The memory layout to be used for data structure generation.
      * \param float_type   The float type to use in the generated code. The string will be used
      *                     as-is in the target code. This defaults to \c double.
      */
     CodegenCVisitor(const std::string& mod_filename,
                     std::ostream& stream,
-                    LayoutType layout,
                     const std::string& float_type,
                     const bool optimize_ionvar_copies)
         : target_printer(new CodePrinter(stream))
         , printer(target_printer)
         , mod_filename(mod_filename)
-        , layout(layout)
         , float_type(float_type)
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
 
@@ -1747,21 +1705,18 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      *
      * \param mod_filename   The name of the model for which code should be generated.
      *                       It is used for constructing an output filename.
-     * \param layout         The memory layout to be used for data structure generation.
      * \param float_type     The float type to use in the generated code. The string will be used
      *                       as-is in the target code. This defaults to \c double.
      * \param target_printer A printer defined outside this visitor to be used for the code
      *                       generation
      */
     CodegenCVisitor(std::string mod_filename,
-                    LayoutType layout,
                     std::string float_type,
                     const bool optimize_ionvar_copies,
                     std::shared_ptr<CodePrinter>& target_printer)
         : target_printer(target_printer)
         , printer(target_printer)
         , mod_filename(mod_filename)
-        , layout(layout)
         , float_type(float_type)
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
 

--- a/src/codegen/codegen_cuda_visitor.hpp
+++ b/src/codegen/codegen_cuda_visitor.hpp
@@ -106,18 +106,15 @@ class CodegenCudaVisitor: public CodegenCVisitor {
   public:
     CodegenCudaVisitor(const std::string& mod_file,
                        const std::string& output_dir,
-                       LayoutType layout,
                        const std::string& float_type,
                        const bool optimize_ionvar_copies)
-        : CodegenCVisitor(mod_file, output_dir, layout, float_type, optimize_ionvar_copies, ".cu") {
-    }
+        : CodegenCVisitor(mod_file, output_dir, float_type, optimize_ionvar_copies, ".cu") {}
 
     CodegenCudaVisitor(const std::string& mod_file,
                        std::ostream& stream,
-                       LayoutType layout,
                        const std::string& float_type,
                        const bool optimize_ionvar_copies)
-        : CodegenCVisitor(mod_file, stream, layout, float_type, optimize_ionvar_copies) {}
+        : CodegenCVisitor(mod_file, stream, float_type, optimize_ionvar_copies) {}
 };
 
 /** @} */  // end of codegen_backends

--- a/src/codegen/codegen_ispc_visitor.hpp
+++ b/src/codegen/codegen_ispc_visitor.hpp
@@ -220,32 +220,18 @@ class CodegenIspcVisitor: public CodegenCVisitor {
   public:
     CodegenIspcVisitor(const std::string& mod_file,
                        const std::string& output_dir,
-                       LayoutType layout,
                        const std::string& float_type,
                        const bool optimize_ionvar_copies)
-        : CodegenCVisitor(mod_file,
-                          output_dir,
-                          layout,
-                          float_type,
-                          optimize_ionvar_copies,
-                          ".ispc",
-                          ".cpp")
-        , fallback_codegen(mod_file, layout, float_type, optimize_ionvar_copies, wrapper_printer) {}
+        : CodegenCVisitor(mod_file, output_dir, float_type, optimize_ionvar_copies, ".ispc", ".cpp")
+        , fallback_codegen(mod_file, float_type, optimize_ionvar_copies, wrapper_printer) {}
 
 
     CodegenIspcVisitor(const std::string& mod_file,
                        std::ostream& stream,
-                       LayoutType layout,
                        const std::string& float_type,
                        const bool optimize_ionvar_copies)
-        : CodegenCVisitor(mod_file,
-                          stream,
-                          layout,
-                          float_type,
-                          optimize_ionvar_copies,
-                          ".ispc",
-                          ".cpp")
-        , fallback_codegen(mod_file, layout, float_type, optimize_ionvar_copies, wrapper_printer) {}
+        : CodegenCVisitor(mod_file, stream, float_type, optimize_ionvar_copies, ".ispc", ".cpp")
+        , fallback_codegen(mod_file, float_type, optimize_ionvar_copies, wrapper_printer) {}
 
     void visit_function_call(const ast::FunctionCall& node) override;
     void visit_var_name(const ast::VarName& node) override;

--- a/src/codegen/codegen_omp_visitor.hpp
+++ b/src/codegen/codegen_omp_visitor.hpp
@@ -72,17 +72,15 @@ class CodegenOmpVisitor: public CodegenCVisitor {
   public:
     CodegenOmpVisitor(std::string mod_file,
                       std::string output_dir,
-                      LayoutType layout,
                       std::string float_type,
                       const bool optimize_ionvar_copies)
-        : CodegenCVisitor(mod_file, output_dir, layout, float_type, optimize_ionvar_copies) {}
+        : CodegenCVisitor(mod_file, output_dir, float_type, optimize_ionvar_copies) {}
 
     CodegenOmpVisitor(std::string mod_file,
                       std::stringstream& stream,
-                      LayoutType layout,
                       std::string float_type,
                       const bool optimize_ionvar_copies)
-        : CodegenCVisitor(mod_file, stream, layout, float_type, optimize_ionvar_copies) {}
+        : CodegenCVisitor(mod_file, stream, float_type, optimize_ionvar_copies) {}
 };
 
 /** @} */  // end of codegen_backends

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -152,9 +152,6 @@ int main(int argc, const char* argv[]) {
     /// true if symbol table should be printed
     bool show_symtab(false);
 
-    /// memory layout for code generation
-    std::string layout("soa");
-
     /// floating point data type
     std::string data_type("double");
 
@@ -247,14 +244,6 @@ int main(int argc, const char* argv[]) {
         "Write symbol table to stdout ({})"_format(show_symtab))->ignore_case();
 
     auto codegen_opt = app.add_subcommand("codegen", "Code generation options")->ignore_case();
-    codegen_opt->add_option("--layout",
-        layout,
-        "Memory layout for code generation",
-        true)->ignore_case()->check(CLI::IsMember({"aos", "soa"}));
-    codegen_opt->add_option("--datatype",
-        layout,
-        "Data type for floating point variables",
-        true)->ignore_case()->check(CLI::IsMember({"float", "double"}));
     codegen_opt->add_flag("--force",
         force_codegen,
         "Force code generation even if there is any incompatibility");
@@ -507,41 +496,48 @@ int main(int argc, const char* argv[]) {
         }
 
         {
-            auto mem_layout = layout == "aos" ? codegen::LayoutType::aos : codegen::LayoutType::soa;
-
-
             if (ispc_backend) {
                 logger->info("Running ISPC backend code generator");
-                CodegenIspcVisitor visitor(
-                    modfile, output_dir, mem_layout, data_type, optimize_ionvar_copies_codegen);
+                CodegenIspcVisitor visitor(modfile,
+                                           output_dir,
+                                           data_type,
+                                           optimize_ionvar_copies_codegen);
                 visitor.visit_program(*ast);
             }
 
             else if (oacc_backend) {
                 logger->info("Running OpenACC backend code generator");
-                CodegenAccVisitor visitor(
-                    modfile, output_dir, mem_layout, data_type, optimize_ionvar_copies_codegen);
+                CodegenAccVisitor visitor(modfile,
+                                          output_dir,
+                                          data_type,
+                                          optimize_ionvar_copies_codegen);
                 visitor.visit_program(*ast);
             }
 
             else if (omp_backend) {
                 logger->info("Running OpenMP backend code generator");
-                CodegenOmpVisitor visitor(
-                    modfile, output_dir, mem_layout, data_type, optimize_ionvar_copies_codegen);
+                CodegenOmpVisitor visitor(modfile,
+                                          output_dir,
+                                          data_type,
+                                          optimize_ionvar_copies_codegen);
                 visitor.visit_program(*ast);
             }
 
             else if (c_backend) {
                 logger->info("Running C backend code generator");
-                CodegenCVisitor visitor(
-                    modfile, output_dir, mem_layout, data_type, optimize_ionvar_copies_codegen);
+                CodegenCVisitor visitor(modfile,
+                                        output_dir,
+                                        data_type,
+                                        optimize_ionvar_copies_codegen);
                 visitor.visit_program(*ast);
             }
 
             if (cuda_backend) {
                 logger->info("Running CUDA backend code generator");
-                CodegenCudaVisitor visitor(
-                    modfile, output_dir, mem_layout, data_type, optimize_ionvar_copies_codegen);
+                CodegenCudaVisitor visitor(modfile,
+                                           output_dir,
+                                           data_type,
+                                           optimize_ionvar_copies_codegen);
                 visitor.visit_program(*ast);
             }
         }

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -244,6 +244,10 @@ int main(int argc, const char* argv[]) {
         "Write symbol table to stdout ({})"_format(show_symtab))->ignore_case();
 
     auto codegen_opt = app.add_subcommand("codegen", "Code generation options")->ignore_case();
+    codegen_opt->add_option("--datatype",
+        data_type,
+        "Data type for floating point variables",
+        true)->ignore_case()->check(CLI::IsMember({"float", "double"}));
     codegen_opt->add_flag("--force",
         force_codegen,
         "Force code generation even if there is any incompatibility");

--- a/test/unit/codegen/codegen_ispc.cpp
+++ b/test/unit/codegen/codegen_ispc.cpp
@@ -69,8 +69,8 @@ class IspcCodegenTestHelper {
 
         /// initialize CodegenIspcVisitor
         std::ostream oss(&strbuf);
-        codegen_ispc_visitor = std::make_shared<CodegenIspcVisitor>(
-            "unit_test", oss, codegen::LayoutType::soa, "double", false);
+        codegen_ispc_visitor =
+            std::make_shared<CodegenIspcVisitor>("unit_test", oss, "double", false);
         codegen_ispc_visitor->setup(*ast);
     }
 


### PR DESCRIPTION
Consider that we always use SoA.

NMODL currently has support for AoS layout. This was added for compatibility and testing with MOD2C and CoreNEURON.
We remove AoS support due to following reasons:

    In practice, we never use AoS layout for CPU vectorisation or GPUs
    This part remains untested because of the same reason
    Simplify the code

What have been done:
    Remove CLI option in nmodl for layout
    Remove all logic in src/codegen where we we are using LayoutType::aos.

Fix #563 