### PR TITLE
Loop epilogue fix for LLVM visitor helper

### DIFF
--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -26,7 +26,7 @@ const std::string CodegenLLVMHelperVisitor::NODECOUNT_VAR = "node_count";
 const std::string CodegenLLVMHelperVisitor::VOLTAGE_VAR = "voltage";
 const std::string CodegenLLVMHelperVisitor::NODE_INDEX_VAR = "node_index";
 
-static constexpr const char epilogue_variable_prefix[] = "__epilogue__";
+static constexpr const char epilogue_variable_prefix[] = "epilogue_";
 
 /// Create asr::Varname node with given a given variable name
 static ast::VarName* create_varname(const std::string& varname) {

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -11,6 +11,7 @@
 #include "ast/all.hpp"
 #include "codegen/codegen_helper_visitor.hpp"
 #include "utils/logger.hpp"
+#include "visitors/rename_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
 
 namespace nmodl {
@@ -24,6 +25,8 @@ const ast::AstNodeType CodegenLLVMHelperVisitor::FLOAT_TYPE = ast::AstNodeType::
 const std::string CodegenLLVMHelperVisitor::NODECOUNT_VAR = "node_count";
 const std::string CodegenLLVMHelperVisitor::VOLTAGE_VAR = "voltage";
 const std::string CodegenLLVMHelperVisitor::NODE_INDEX_VAR = "node_index";
+
+static constexpr const char epilogue_variable_prefix[] = "__epilogue__";
 
 /// Create asr::Varname node with given a given variable name
 static ast::VarName* create_varname(const std::string& varname) {
@@ -522,8 +525,9 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
 
     /// create variable definition for loop index and insert at the beginning
     std::string loop_index_var = "id";
-    std::vector<std::string> int_variables{"id"};
-    function_statements.push_back(create_local_variable_statement(int_variables, INTEGER_TYPE));
+    std::vector<std::string> induction_variables{"id"};
+    function_statements.push_back(
+        create_local_variable_statement(induction_variables, INTEGER_TYPE));
 
     /// create now main compute part : for loop over channel instances
 
@@ -531,10 +535,10 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     ast::StatementVector loop_def_statements;
     ast::StatementVector loop_index_statements;
     ast::StatementVector loop_body_statements;
-    {
-        std::vector<std::string> int_variables{"node_id"};
-        std::vector<std::string> double_variables{"v"};
 
+    std::vector<std::string> int_variables{"node_id"};
+    std::vector<std::string> double_variables{"v"};
+    {
         /// access node index and corresponding voltage
         loop_index_statements.push_back(
             visitor::create_statement("node_id = node_index[{}]"_format(INDUCTION_VAR)));
@@ -614,13 +618,25 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     {
         /// loop constructs : initialization, condition and increment
         const auto& condition = create_expression("{} < {}"_format(INDUCTION_VAR, NODECOUNT_VAR));
-        const auto& increment = loop_increment_expression(INDUCTION_VAR, 1);
+        const auto& increment = loop_increment_expression(INDUCTION_VAR, /*vector_width=*/1);
 
         /// convert local statement to codegenvar statement
         convert_local_statement(*loop_block);
 
         auto for_loop_statement_remainder =
             std::make_shared<ast::CodegenForStatement>(nullptr, condition, increment, loop_block);
+
+        const auto& loop_statements = for_loop_statement_remainder->get_statement_block();
+        // \todo: Change RenameVisitor to take a vector of names to which it would append a single
+        // prefix.
+        for (const auto& name: int_variables) {
+            visitor::RenameVisitor v(name, epilogue_variable_prefix + name);
+            loop_statements->accept(v);
+        }
+        for (const auto& name: double_variables) {
+            visitor::RenameVisitor v(name, epilogue_variable_prefix + name);
+            loop_statements->accept(v);
+        }
 
         /// convert all variables inside loop body to instance variables
         convert_to_instance_variable(*for_loop_statement_remainder, loop_index_var);

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -512,6 +512,12 @@ static std::shared_ptr<ast::Expression> loop_increment_expression(const std::str
 
 /**
  * Create loop count comparison expression
+ *
+ * Based on if loop is vectorised or not, the condition for loop
+ * is different. For example:
+ *  - serial loop : `id < node_count`
+ *  - vector loop : `id < (node_count - vector_width + 1)`
+ *
  * \todo : same as int_initialization_expression()
  */
 static std::shared_ptr<ast::Expression> loop_count_expression(const std::string& induction_var,

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -511,7 +511,7 @@ static std::shared_ptr<ast::Expression> loop_increment_expression(const std::str
 }
 
 /**
- * Create loop increment expression
+ * Create loop count comparison expression
  * \todo : same as int_initialization_expression()
  */
 static std::shared_ptr<ast::Expression> loop_count_expression(const std::string& induction_var,

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -54,19 +54,21 @@ std::string run_llvm_visitor(const std::string& text,
 }
 
 //=============================================================================
-// Utility to get specific LLVM nodes
+// Utility to get specific NMODL AST nodes
 //=============================================================================
 
-std::vector<std::shared_ptr<ast::Ast>> run_codegen_visitor_helper(const std::string& text) {
+std::vector<std::shared_ptr<ast::Ast>> run_llvm_visitor_helper(
+    const std::string& text,
+    int vector_width,
+    const std::vector<ast::AstNodeType>& nodes_to_collect) {
     NmodlDriver driver;
     const auto& ast = driver.parse_string(text);
 
-    /// construct symbol table and run codegen helper visitor
     SymtabVisitor().visit_program(*ast);
     SolveBlockVisitor().visit_program(*ast);
-    CodegenLLVMHelperVisitor(8).visit_program(*ast);
+    CodegenLLVMHelperVisitor(vector_width).visit_program(*ast);
 
-    const auto& nodes = collect_nodes(*ast, {ast::AstNodeType::CODEGEN_FOR_STATEMENT});
+    const auto& nodes = collect_nodes(*ast, nodes_to_collect);
 
     return nodes;
 }
@@ -903,11 +905,12 @@ SCENARIO("Scalar state kernel", "[visitor][llvm]") {
 // Derivative block : test optimization
 //=============================================================================
 
-SCENARIO("Derivative block", "[visitor][llvm][derivative]") {
-    GIVEN("After helper visitor") {
+SCENARIO("Scalar derivative block", "[visitor][llvm][derivative]") {
+    GIVEN("After LLVM helper visitor transformations") {
         std::string nmodl_text = R"(
             NEURON {
                 SUFFIX hh
+                NONSPECIFIC_CURRENT il
                 RANGE minf, mtau
             }
             STATE {
@@ -920,6 +923,53 @@ SCENARIO("Derivative block", "[visitor][llvm][derivative]") {
             }
             BREAKPOINT {
                 SOLVE states METHOD cnexp
+                il = 2
+            }
+            DERIVATIVE states {
+                m = (minf-m)/mtau
+            }
+        )";
+
+        std::string expected_loop = R"(
+            for(id = 0; id<mech->node_count; id = id+1) {
+                INTEGER node_id
+                DOUBLE v
+                node_id = mech->node_index[id]
+                v = mech->voltage[node_id]
+                mech->m[id] = (mech->minf[id]-mech->m[id])/mech->mtau[id]
+            })";
+
+        THEN("a single scalar loops is constructed") {
+            auto result = run_llvm_visitor_helper(nmodl_text,
+                                                  /*vector_width=*/1,
+                                                  {ast::AstNodeType::CODEGEN_FOR_STATEMENT});
+            REQUIRE(result.size() == 1);
+
+            auto main_loop = reindent_text(to_nmodl(result[0]));
+            REQUIRE(main_loop == reindent_text(expected_loop));
+        }
+    }
+}
+
+SCENARIO("Vectorised derivative block", "[visitor][llvm][derivative]") {
+    GIVEN("After LLVM helper visitor transformations") {
+        std::string nmodl_text = R"(
+            NEURON {
+                SUFFIX hh
+                NONSPECIFIC_CURRENT il
+                RANGE minf, mtau
+            }
+            STATE {
+                m
+            }
+            ASSIGNED {
+                v (mV)
+                minf
+                mtau (ms)
+            }
+            BREAKPOINT {
+                SOLVE states METHOD cnexp
+                il = 2
             }
             DERIVATIVE states {
                 m = (minf-m)/mtau
@@ -927,13 +977,12 @@ SCENARIO("Derivative block", "[visitor][llvm][derivative]") {
         )";
 
         std::string expected_main_loop = R"(
-            for(id = 0; id<mech->node_count; id = id+8) {
+            for(id = 0; id<mech->node_count-7; id = id+8) {
                 INTEGER node_id
                 DOUBLE v
                 node_id = mech->node_index[id]
                 v = mech->voltage[node_id]
                 mech->m[id] = (mech->minf[id]-mech->m[id])/mech->mtau[id]
-                SOLVE states METHOD cnexp
             })";
         std::string expected_reminder_loop = R"(
             for(; id<mech->node_count; id = id+1) {
@@ -942,12 +991,13 @@ SCENARIO("Derivative block", "[visitor][llvm][derivative]") {
                 __epilogue__node_id = mech->node_index[id]
                 __epilogue__v = mech->voltage[__epilogue__node_id]
                 mech->m[id] = (mech->minf[id]-mech->m[id])/mech->mtau[id]
-                SOLVE states METHOD cnexp
             })";
 
 
-        THEN("should contains 2 for loops") {
-            auto result = run_codegen_visitor_helper(nmodl_text);
+        THEN("vector and epilogue scalar loops are constructed") {
+            auto result = run_llvm_visitor_helper(nmodl_text,
+                                                  /*vector_width=*/8,
+                                                  {ast::AstNodeType::CODEGEN_FOR_STATEMENT});
             REQUIRE(result.size() == 2);
 
             auto main_loop = reindent_text(to_nmodl(result[0]));

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -937,10 +937,10 @@ SCENARIO("Derivative block", "[visitor][llvm][derivative]") {
             })";
         std::string expected_reminder_loop = R"(
             for(; id<mech->node_count; id = id+1) {
-                INTEGER node_id
-                DOUBLE v
-                node_id = mech->node_index[id]
-                v = mech->voltage[node_id]
+                INTEGER __epilogue__node_id
+                DOUBLE __epilogue__v
+                __epilogue__node_id = mech->node_index[id]
+                __epilogue__v = mech->voltage[__epilogue__node_id]
                 mech->m[id] = (mech->minf[id]-mech->m[id])/mech->mtau[id]
                 SOLVE states METHOD cnexp
             })";

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -984,7 +984,7 @@ SCENARIO("Vectorised derivative block", "[visitor][llvm][derivative]") {
                 v = mech->voltage[node_id]
                 mech->m[id] = (mech->minf[id]-mech->m[id])/mech->mtau[id]
             })";
-        std::string expected_reminder_loop = R"(
+        std::string expected_epilogue_loop = R"(
             for(; id<mech->node_count; id = id+1) {
                 INTEGER epilogue_node_id
                 DOUBLE epilogue_v
@@ -1003,8 +1003,8 @@ SCENARIO("Vectorised derivative block", "[visitor][llvm][derivative]") {
             auto main_loop = reindent_text(to_nmodl(result[0]));
             REQUIRE(main_loop == reindent_text(expected_main_loop));
 
-            auto reminder_loop = reindent_text(to_nmodl(result[1]));
-            REQUIRE(reminder_loop == reindent_text(expected_reminder_loop));
+            auto epilogue_loop = reindent_text(to_nmodl(result[1]));
+            REQUIRE(epilogue_loop == reindent_text(expected_epilogue_loop));
         }
     }
 }

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -986,10 +986,10 @@ SCENARIO("Vectorised derivative block", "[visitor][llvm][derivative]") {
             })";
         std::string expected_reminder_loop = R"(
             for(; id<mech->node_count; id = id+1) {
-                INTEGER __epilogue__node_id
-                DOUBLE __epilogue__v
-                __epilogue__node_id = mech->node_index[id]
-                __epilogue__v = mech->voltage[__epilogue__node_id]
+                INTEGER epilogue_node_id
+                DOUBLE epilogue_v
+                epilogue_node_id = mech->node_index[id]
+                epilogue_v = mech->voltage[epilogue_node_id]
                 mech->m[id] = (mech->minf[id]-mech->m[id])/mech->mtau[id]
             })";
 


### PR DESCRIPTION
LLVM IR code generation relies on unique SSA value names
within function blocks. In order to improve readability, certain
variable names are preserved. This poses a problem when two
for loops declare local variables with the same name.

This PR introduces basic renaming to LLVM helper visitor. All
loop epilogue local variable declarations are prefixed with
`__epilogue__` to avoid symbolic conflicts.

Also, this PR fixes the following issues:
- Loop epilogue is NOT generated for the scalar case anymore

- Vector width within LLVM visitor is adjusted to reflect the scalar
case

- Vectorised loop trip count is now set to
`node_count - vector_width + 1` to prevent accesses out of bounds

The tests for the `nrn_state` to loop transformation have been
refactored and a test for scalar case has been added.
