### PR TITLE
Gather support and vectorisation fixes for LLVM code generation

### DIFF
--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -23,11 +23,6 @@ namespace codegen {
 
 static constexpr const char instance_struct_type_name[] = "__instance_var__type";
 
-// The prefix is used to create a vectorised id that can be used as index to GEPs. However, for
-// simple aligned vector loads and stores vector id is not needed. This is because we can bitcast
-// the pointer to the vector pointer! \todo: Consider removing this.
-static constexpr const char kernel_id_prefix[] = "__vec_";
-
 
 /****************************************************************************************/
 /*                            Helper routines                                           */
@@ -88,12 +83,11 @@ llvm::Value* CodegenLLVMVisitor::codegen_instance_var(const ast::CodegenInstance
     // Proceed to creating a GEP instruction to get the pointer to the member's element.
     auto member_indexed_name = std::dynamic_pointer_cast<ast::IndexedName>(
         member_var_name->get_name());
+
+    if (!member_indexed_name->get_length()->is_name())
+        throw std::runtime_error("Error: " + member_name + " must be indexed with a variable!");
+
     llvm::Value* i64_index = get_array_index(*member_indexed_name);
-
-
-    // Create a indices vector for GEP to return the pointer to the element at the specified index.
-    std::vector<llvm::Value*> member_indices;
-    member_indices.push_back(i64_index);
 
     // The codegen variable type is always a scalar, so we need to transform it to a pointer. Then
     // load the member which would be indexed later.
@@ -101,6 +95,14 @@ llvm::Value* CodegenLLVMVisitor::codegen_instance_var(const ast::CodegenInstance
     llvm::Value* instance_member =
         builder.CreateLoad(llvm::PointerType::get(type, /*AddressSpace=*/0), member_ptr);
 
+    // Check if the code is vectorised and the index is indirect.
+    std::string id = member_indexed_name->get_length()->get_node_name();
+    if (id != kernel_id && is_kernel_code && vector_width > 1) {
+        // Calculate a vector of addresses via GEP instruction, and then created a gather to load
+        // indirectly.
+        llvm::Value* addresses = builder.CreateInBoundsGEP(instance_member, {i64_index});
+        return builder.CreateMaskedGather(addresses, llvm::Align());
+    }
 
     // If the code is vectorised, then bitcast to a vector pointer.
     if (is_kernel_code && vector_width > 1) {
@@ -109,10 +111,10 @@ llvm::Value* CodegenLLVMVisitor::codegen_instance_var(const ast::CodegenInstance
                                    /*AddressSpace=*/0);
         llvm::Value* instance_member_bitcasted = builder.CreateBitCast(instance_member,
                                                                        vector_type);
-        return builder.CreateInBoundsGEP(instance_member_bitcasted, member_indices);
+        return builder.CreateInBoundsGEP(instance_member_bitcasted, {i64_index});
     }
 
-    return builder.CreateInBoundsGEP(instance_member, member_indices);
+    return builder.CreateInBoundsGEP(instance_member, {i64_index});
 }
 
 llvm::Value* CodegenLLVMVisitor::get_array_index(const ast::IndexedName& node) {
@@ -135,12 +137,19 @@ llvm::Value* CodegenLLVMVisitor::get_array_index(const ast::IndexedName& node) {
         throw std::runtime_error("Error: only integer indexing is supported!");
 
     // Conventionally, in LLVM array indices are 64 bit.
-    auto index_type = llvm::cast<llvm::IntegerType>(index_value->getType());
     llvm::Type* i64_type = llvm::Type::getInt64Ty(*context);
-    if (index_type->getBitWidth() == i64_type->getIntegerBitWidth())
-        return index_value;
+    if (auto index_type = llvm::dyn_cast<llvm::IntegerType>(index_value->getType())) {
+        if (index_type->getBitWidth() == i64_type->getIntegerBitWidth())
+            return index_value;
+        return builder.CreateSExtOrTrunc(index_value, i64_type);
+    }
 
-    return builder.CreateSExtOrTrunc(index_value, i64_type);
+    auto vector_type = llvm::cast<llvm::FixedVectorType>(index_value->getType());
+    auto element_type = llvm::cast<llvm::IntegerType>(vector_type->getElementType());
+    if (element_type->getBitWidth() == i64_type->getIntegerBitWidth())
+        return index_value;
+    return builder.CreateSExtOrTrunc(index_value,
+                                     llvm::FixedVectorType::get(i64_type, vector_width));
 }
 
 int CodegenLLVMVisitor::get_array_length(const ast::IndexedName& node) {
@@ -167,8 +176,6 @@ llvm::Type* CodegenLLVMVisitor::get_codegen_var_type(const ast::CodegenVarType& 
         return llvm::Type::getInt32Ty(*context);
     case ast::AstNodeType::VOID:
         return llvm::Type::getVoidTy(*context);
-    // TODO :: George/Ioannis : Here we have to also return INSTANCE_STRUCT type
-    //         as it is used as an argument to nrn_state function
     default:
         throw std::runtime_error("Error: expecting a type in CodegenVarType node\n");
     }
@@ -581,26 +588,6 @@ void CodegenLLVMVisitor::visit_codegen_for_statement(const ast::CodegenForStatem
         node.get_initialization()->accept(*this);
     }
 
-    // If the loop is to be vectorised, create a separate vector induction variable.
-    // \todo: See the comment for `kernel_id_prefix`.
-    if (vector_width > 1) {
-        // First, create a vector type and alloca for it.
-        llvm::Type* i32_type = llvm::Type::getInt32Ty(*context);
-        llvm::Type* vec_type = llvm::FixedVectorType::get(i32_type, vector_width);
-        llvm::Value* vec_alloca = builder.CreateAlloca(vec_type,
-                                                       /*ArraySize=*/nullptr,
-                                                       /*Name=*/kernel_id_prefix + kernel_id);
-
-        // Then, store the initial value of <0, 1, ..., [W-1]> o the alloca pointer, where W is the
-        // vector width.
-        std::vector<llvm::Constant*> constants;
-        for (unsigned i = 0; i < vector_width; ++i) {
-            const auto& element = llvm::ConstantInt::get(i32_type, i);
-            constants.push_back(element);
-        }
-        llvm::Value* vector_id = llvm::ConstantVector::get(constants);
-        builder.CreateStore(vector_id, vec_alloca);
-    }
     // Branch to condition basic block and insert condition code there.
     builder.CreateBr(for_cond);
     builder.SetInsertPoint(for_cond);
@@ -622,20 +609,6 @@ void CodegenLLVMVisitor::visit_codegen_for_statement(const ast::CodegenForStatem
     // Process increment.
     builder.SetInsertPoint(for_inc);
     node.get_increment()->accept(*this);
-
-    // If the code is vectorised, then increment the vector id by <W, W, ..., W> where W is the
-    // vector width.
-    // \todo: See the comment for `kernel_id_prefix`.
-    if (vector_width > 1) {
-        // First, create an increment vector.
-        llvm::Value* vector_inc = get_constant_int_vector(vector_width);
-
-        // Increment the kernel id elements by a constant vector width.
-        llvm::Value* vector_id_ptr = lookup(kernel_id_prefix + kernel_id);
-        llvm::Value* vector_id = builder.CreateLoad(vector_id_ptr);
-        llvm::Value* incremented = builder.CreateAdd(vector_id, vector_inc);
-        builder.CreateStore(incremented, vector_id_ptr);
-    }
 
     // Create a branch to condition block, then generate exit code out of the loop.
     builder.CreateBr(for_cond);
@@ -707,8 +680,12 @@ void CodegenLLVMVisitor::visit_codegen_var_list_statement(
             int length = get_array_length(*indexed_name);
             var_type = llvm::ArrayType::get(scalar_var_type, length);
         } else if (identifier->is_name()) {
-            // This case corresponds to a scalar local variable. Its type is double by default.
-            var_type = scalar_var_type;
+            // This case corresponds to a scalar or vector local variable.
+            if (is_kernel_code && vector_width > 1) {
+                var_type = llvm::FixedVectorType::get(scalar_var_type, vector_width);
+            } else {
+                var_type = scalar_var_type;
+            }
         } else {
             throw std::runtime_error("Error: Unsupported local variable type");
         }
@@ -881,10 +858,11 @@ void CodegenLLVMVisitor::visit_unary_expression(const ast::UnaryExpression& node
 void CodegenLLVMVisitor::visit_var_name(const ast::VarName& node) {
     llvm::Value* ptr = get_variable_ptr(node);
 
-    // Finally, load the variable from the pointer value.
-    llvm::Value* var = builder.CreateLoad(ptr);
+    // Finally, load the variable from the pointer value unless it has already been loaded (e.g. via
+    // gather instruction).
+    llvm::Value* var = ptr->getType()->isPointerTy() ? builder.CreateLoad(ptr) : ptr;
 
-    // If the vale should not be vectorised, or it is already a vector, add it to the stack.
+    // If the value should not be vectorised, or it is already a vector, add it to the stack.
     if (!is_kernel_code || vector_width <= 1 || var->getType()->isVectorTy()) {
         values.push_back(var);
         return;

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -29,8 +29,8 @@ static double EPSILON = 1e-15;
 //=============================================================================
 
 struct InstanceTestInfo {
-    codegen::CodegenInstanceData& instance;
-    codegen::CodegenLLVMVisitor& visitor;
+    codegen::CodegenInstanceData* instance;
+    codegen::InstanceVarHelper helper;
     int num_elements;
 };
 
@@ -39,11 +39,11 @@ bool check_instance_variable(InstanceTestInfo& instance_info,
                              std::vector<T>& expected,
                              const std::string& variable_name) {
     std::vector<T> actual;
-    int variable_index = instance_info.visitor.get_instance_var_helper().get_variable_index(
-        variable_name);
-    actual.assign(static_cast<T*>(instance_info.instance.members[variable_index]),
-                  static_cast<T*>(instance_info.instance.members[variable_index]) +
+    int variable_index = instance_info.helper.get_variable_index(variable_name);
+    actual.assign(static_cast<T*>(instance_info.instance->members[variable_index]),
+                  static_cast<T*>(instance_info.instance->members[variable_index]) +
                       instance_info.num_elements);
+
     // While we are comparing double types as well, for simplicity the test cases are hand-crafted
     // so that no floating-point arithmetic is really involved.
     return actual == expected;
@@ -53,9 +53,8 @@ template <typename T>
 void initialise_instance_variable(InstanceTestInfo& instance_info,
                                   std::vector<T>& data,
                                   const std::string& variable_name) {
-    int variable_index = instance_info.visitor.get_instance_var_helper().get_variable_index(
-        variable_name);
-    T* data_start = static_cast<T*>(instance_info.instance.members[variable_index]);
+    int variable_index = instance_info.helper.get_variable_index(variable_name);
+    T* data_start = static_cast<T*>(instance_info.instance->members[variable_index]);
     for (int i = 0; i < instance_info.num_elements; ++i)
         *(data_start + i) = data[i];
 }
@@ -317,7 +316,9 @@ SCENARIO("Simple scalar kernel", "[llvm][runner]") {
         std::vector<double> x0 = {5.0, 5.0, 5.0, 5.0};
         std::vector<double> x1 = {1.0, 1.0, 1.0, 1.0};
 
-        InstanceTestInfo instance_info{instance_data, llvm_visitor, num_elements};
+        InstanceTestInfo instance_info{&instance_data,
+                                       llvm_visitor.get_instance_var_helper(),
+                                       num_elements};
         initialise_instance_variable(instance_info, x, "x");
         initialise_instance_variable(instance_info, x0, "x0");
         initialise_instance_variable(instance_info, x1, "x1");
@@ -331,6 +332,88 @@ SCENARIO("Simple scalar kernel", "[llvm][runner]") {
                                                  instance_data.base_ptr);
             std::vector<double> x_expected = {4.0, 3.0, 2.0, 1.0};
             REQUIRE(check_instance_variable(instance_info, x_expected, "x"));
+        }
+    }
+}
+
+//=============================================================================
+// State vectorised kernel with optimisations on.
+//=============================================================================
+
+SCENARIO("Simple vectorised kernel", "[llvm][runner]") {
+    GIVEN("Simple MOD file with a state update") {
+        std::string nmodl_text = R"(
+            NEURON {
+                SUFFIX test
+                NONSPECIFIC_CURRENT i
+                RANGE x0, x1
+            }
+
+            STATE {
+                x
+            }
+
+            ASSIGNED {
+                v
+                x0
+                x1
+            }
+
+            BREAKPOINT {
+                SOLVE states METHOD cnexp
+                i = 0
+            }
+
+            DERIVATIVE states {
+                x = (x0 - x) / x1
+            }
+        )";
+
+
+        NmodlDriver driver;
+        const auto& ast = driver.parse_string(nmodl_text);
+
+        // Run passes on the AST to generate LLVM.
+        SymtabVisitor().visit_program(*ast);
+        NeuronSolveVisitor().visit_program(*ast);
+        SolveBlockVisitor().visit_program(*ast);
+        codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
+                                                 /*output_dir=*/".",
+                                                 /*opt_passes=*/true,
+                                                 /*use_single_precision=*/false,
+                                                 /*vector_width=*/4);
+        llvm_visitor.visit_program(*ast);
+        llvm_visitor.wrap_kernel_function("nrn_state_test");
+
+        // Create the instance struct data.
+        int num_elements = 10;
+        const auto& generated_instance_struct = llvm_visitor.get_instance_struct_ptr();
+        auto codegen_data = codegen::CodegenDataHelper(ast, generated_instance_struct);
+        auto instance_data = codegen_data.create_data(num_elements, /*seed=*/1);
+
+        // Fill the instance struct data with some values for unit testing.
+        std::vector<double> x = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+        std::vector<double> x0 = {11.0, 11.0, 11.0, 11.0, 11.0, 11.0, 11.0, 11.0, 11.0, 11.0};
+        std::vector<double> x1 = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+
+        InstanceTestInfo instance_info{&instance_data,
+                                       llvm_visitor.get_instance_var_helper(),
+                                       num_elements};
+        initialise_instance_variable<double>(instance_info, x, "x");
+        initialise_instance_variable<double>(instance_info, x0, "x0");
+        initialise_instance_variable<double>(instance_info, x1, "x1");
+
+        // Set up the JIT runner.
+        std::unique_ptr<llvm::Module> module = llvm_visitor.get_module();
+        Runner runner(std::move(module));
+
+        THEN("Values in struct have changed according to the formula") {
+            runner.run_with_argument<int, void*>("__nrn_state_test_wrapper",
+                                                 instance_data.base_ptr);
+            std::vector<double> x_expected = {10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0};
+
+            // Check that the main and remainder loops correctly change the data stored in x.
+            REQUIRE(check_instance_variable<double>(instance_info, x_expected, "x"));
         }
     }
 }


### PR DESCRIPTION
This PR fixes vector code generation, particularly now:

- The pointer to the element in the array inside instance struct
id bitcasted to vector *after* the GEP instruction.
- Local variables in the loop are vectorised, and the array
indexing can now be performed with a vector of indices.
- Gather instruction support has been added.

The tests for IR and vectorised code execution are created
accordingly.

- [x] TODO: add IR tests for gather instruction