### PR TITLE
Fix ci for old pip version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,9 +127,9 @@ setup(
         "nbconvert<6.0",  # prevents issues with nbsphinx
         "nbsphinx>=0.3.2",
         "pytest>=3.7.2",
-        "sphinx-rtd-theme",
         "sphinx>=2.0",
         "sphinx<3.0",  # prevents issue with m2r where m2r uses an old API no more supported with sphinx>=3.0
+        "sphinx-rtd-theme",
     ]
     + install_requirements,
     install_requires=install_requirements,


### PR DESCRIPTION
sphinx ask for docutils > 0.12
sphinx-rtd-theme for docutils < 0.17

if sphinx-rtd-theme is installed first it seems that sphinx install a upper version of docutils.

With newer version of python or pip (I don't know), it takes care of it, but not on ubuntu 18.04 and/or macos