### PR TITLE
Automatically enable sympy_analytics pass if there is a sparse solver

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -468,7 +468,11 @@ int main(int argc, const char* argv[]) {
             ast_to_nmodl(*ast, filepath("sympy_conductance"));
         }
 
-        if (sympy_analytic) {
+        if (sympy_analytic || sparse_solver_exists(*ast)) {
+            if (!sympy_analytic) {
+                logger->info(
+                    "Automatically enable sympy_analytic because it exists solver of type sparse");
+            }
             logger->info("Running sympy solve visitor");
             SympySolverVisitor(sympy_pade, sympy_cse).visit_program(*ast);
             SymtabVisitor(update_symtab).visit_program(*ast);

--- a/src/visitors/neuron_solve_visitor.cpp
+++ b/src/visitors/neuron_solve_visitor.cpp
@@ -88,8 +88,6 @@ void NeuronSolveVisitor::visit_binary_expression(ast::BinaryExpression& node) {
                 symbol->created_from_state();
                 program_symtab->insert(symbol);
             }
-        } else if (solve_method == codegen::naming::SPARSE_METHOD) {
-            logger->info("NeuronSolveVisitor :: solver method 'sparse' is handled by sympy");
         } else {
             logger->error("NeuronSolveVisitor :: solver method '{}' not supported", solve_method);
         }

--- a/src/visitors/neuron_solve_visitor.cpp
+++ b/src/visitors/neuron_solve_visitor.cpp
@@ -88,6 +88,8 @@ void NeuronSolveVisitor::visit_binary_expression(ast::BinaryExpression& node) {
                 symbol->created_from_state();
                 program_symtab->insert(symbol);
             }
+        } else if (solve_method == codegen::naming::SPARSE_METHOD) {
+            logger->info("NeuronSolveVisitor :: solver method 'sparse' is handled by sympy");
         } else {
             logger->error("NeuronSolveVisitor :: solver method '{}' not supported", solve_method);
         }

--- a/src/visitors/visitor_utils.cpp
+++ b/src/visitors/visitor_utils.cpp
@@ -209,10 +209,10 @@ std::vector<std::shared_ptr<ast::Ast>> collect_nodes(ast::Ast& node,
 bool sparse_solver_exists(const ast::Ast& node) {
     const auto solve_blocks = collect_nodes(node, {ast::AstNodeType::SOLVE_BLOCK});
     for (const auto& solve_block: solve_blocks) {
-        if (dynamic_cast<const ast::SolveBlock*>(solve_block.get())
-                ->get_method()
-                ->get_node_name() == "sparse")
+        const auto& method = dynamic_cast<const ast::SolveBlock*>(solve_block.get())->get_method();
+        if (method && method->get_node_name() == "sparse") {
             return true;
+        }
     }
     return false;
 }

--- a/src/visitors/visitor_utils.cpp
+++ b/src/visitors/visitor_utils.cpp
@@ -206,6 +206,17 @@ std::vector<std::shared_ptr<ast::Ast>> collect_nodes(ast::Ast& node,
     return visitor.lookup(node, types);
 }
 
+bool sparse_solver_exists(const ast::Ast& node) {
+    const auto solve_blocks = collect_nodes(node, {ast::AstNodeType::SOLVE_BLOCK});
+    for (const auto& solve_block: solve_blocks) {
+        if (dynamic_cast<const ast::SolveBlock*>(solve_block.get())
+                ->get_method()
+                ->get_node_name() == "sparse")
+            return true;
+    }
+    return false;
+}
+
 std::string to_nmodl(const ast::Ast& node, const std::set<ast::AstNodeType>& exclude_types) {
     std::stringstream stream;
     visitor::NmodlPrintVisitor v(stream, exclude_types);

--- a/src/visitors/visitor_utils.hpp
+++ b/src/visitors/visitor_utils.hpp
@@ -97,6 +97,8 @@ std::vector<std::shared_ptr<ast::Ast>> collect_nodes(
     ast::Ast& node,
     const std::vector<ast::AstNodeType>& types = {});
 
+bool sparse_solver_exists(const ast::Ast& node);
+
 /// Given AST node, return the NMODL string representation
 std::string to_nmodl(const ast::Ast& node, const std::set<ast::AstNodeType>& exclude_types = {});
 


### PR DESCRIPTION
* Those kind of solvers always need a sympy pass because they contains ODE.
* Enable it for user if he didn't ask for.