### PR TITLE
Verification and file utilities for LLVM codegen

### DIFF
--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -321,8 +321,10 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     void visit_var_name(const ast::VarName& node) override;
     void visit_while_statement(const ast::WhileStatement& node) override;
 
-    // \todo: move this to debug mode (e.g. -v option or --dump-ir)
-    std::string print_module() const {
+    /**
+     * Dumps the generated LLVM IR module to string.
+     */
+    std::string dump_module() const {
         std::string str;
         llvm::raw_string_ostream os(str);
         os << *module;

--- a/test/unit/codegen/codegen_llvm_instance_struct.cpp
+++ b/test/unit/codegen/codegen_llvm_instance_struct.cpp
@@ -45,7 +45,7 @@ codegen::CodegenInstanceData generate_instance_data(const std::string& text,
                                              use_single_precision,
                                              vector_width);
     llvm_visitor.visit_program(*ast);
-    llvm_visitor.print_module();
+    llvm_visitor.dump_module();
     const auto& generated_instance_struct = llvm_visitor.get_instance_struct_ptr();
     auto codegen_data = codegen::CodegenDataHelper(ast, generated_instance_struct);
     auto instance_data = codegen_data.create_data(num_elements, seed);

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -50,7 +50,7 @@ std::string run_llvm_visitor(const std::string& text,
                                              use_single_precision,
                                              vector_width);
     llvm_visitor.visit_program(*ast);
-    return llvm_visitor.print_module();
+    return llvm_visitor.dump_module();
 }
 
 //=============================================================================


### PR DESCRIPTION
This PR is a minor improvement of the current pipeline infrastructure.
Particularly, it addresses the following:

- The generated IR module is now verified after running the visitor
- The kernel is checked if it can be vectorised or not
- The generated IR can be dumped to `.ll` file with `-o <filename>`
- Printing LLVM IR is moved to debug mode