### PR TITLE
Benchmarking LLVM code generation

### DIFF
--- a/src/codegen/llvm/CMakeLists.txt
+++ b/src/codegen/llvm/CMakeLists.txt
@@ -7,7 +7,9 @@ set(LLVM_CODEGEN_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_llvm_helper_visitor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_llvm_helper_visitor.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/jit_driver.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/jit_driver.hpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/jit_driver.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/llvm_benchmark.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/llvm_benchmark.hpp)
 
 # =============================================================================
 # LLVM codegen library and executable

--- a/src/codegen/llvm/CMakeLists.txt
+++ b/src/codegen/llvm/CMakeLists.txt
@@ -31,6 +31,7 @@ if(NOT NMODL_AS_SUBPROJECT)
     nmodl_llvm_runner
     llvm_codegen
     codegen
+    llvm_benchmark
     visitor
     symtab
     lexer

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -338,7 +338,8 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     void find_kernel_names(std::vector<std::string>& container);
 
     /**
-     * Wraps all kernel function calls into wrapper functions that use void* to pass the data to the kernel.
+     * Wraps all kernel function calls into wrapper functions that use void* to pass the data to the
+     * kernel.
      */
     void wrap_kernel_functions();
 };

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -333,10 +333,14 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     }
 
     /**
-     * For the given kernel function, wraps it into another function that uses void* to pass the
-     * data to the kernel \param kernel_name kernel name to be wrapped
+     * Fills the container with the names of kernel functions from the MOD file.
      */
-    void wrap_kernel_function(const std::string& kernel_name);
+    void find_kernel_names(std::vector<std::string>& container);
+
+    /**
+     * Wraps all kernel function calls into wrapper functions that use void* to pass the data to the kernel.
+     */
+    void wrap_kernel_functions();
 };
 
 /** \} */  // end of llvm_backends

--- a/src/codegen/llvm/jit_driver.cpp
+++ b/src/codegen/llvm/jit_driver.cpp
@@ -22,7 +22,7 @@
 namespace nmodl {
 namespace runner {
 
-void JITDriver::init() {
+void JITDriver::init(std::string features) {
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();
 
@@ -30,7 +30,7 @@ void JITDriver::init() {
     auto compile_function_creator = [&](llvm::orc::JITTargetMachineBuilder tm_builder)
         -> llvm::Expected<std::unique_ptr<llvm::orc::IRCompileLayer::IRCompiler>> {
         // Create target machine with some features possibly turned off.
-        auto tm = create_target(&tm_builder, /*features=*/"");
+        auto tm = create_target(&tm_builder, features);
 
         // Set the target triple and the data layout for the module.
         module->setDataLayout(tm->createDataLayout());

--- a/src/codegen/llvm/jit_driver.hpp
+++ b/src/codegen/llvm/jit_driver.hpp
@@ -63,8 +63,9 @@ class JITDriver {
         return result;
     }
 
-    /// Set the target triple on the module.
-    static void set_target_triple(llvm::Module* module);
+    /// A wrapper around llvm::createTargetMachine to turn on/off certain CPU features.
+    std::unique_ptr<llvm::TargetMachine> create_target(llvm::orc::JITTargetMachineBuilder* builder,
+                                                       const std::string& features);
 };
 
 /**

--- a/src/codegen/llvm/jit_driver.hpp
+++ b/src/codegen/llvm/jit_driver.hpp
@@ -85,7 +85,7 @@ class Runner {
     }
 
     Runner(std::unique_ptr<llvm::Module> m, std::string features)
-            : module(std::move(m)) {
+        : module(std::move(m)) {
         driver->init(features);
     }
 

--- a/src/codegen/llvm/jit_driver.hpp
+++ b/src/codegen/llvm/jit_driver.hpp
@@ -79,12 +79,7 @@ class Runner {
     std::unique_ptr<JITDriver> driver = std::make_unique<JITDriver>(std::move(module));
 
   public:
-    Runner(std::unique_ptr<llvm::Module> m)
-        : module(std::move(m)) {
-        driver->init(/*features=*/"");
-    }
-
-    Runner(std::unique_ptr<llvm::Module> m, std::string features)
+    Runner(std::unique_ptr<llvm::Module> m, std::string features = "")
         : module(std::move(m)) {
         driver->init(features);
     }

--- a/src/codegen/llvm/jit_driver.hpp
+++ b/src/codegen/llvm/jit_driver.hpp
@@ -37,7 +37,7 @@ class JITDriver {
         : module(std::move(m)) {}
 
     /// Initialize the JIT.
-    void init();
+    void init(std::string features);
 
     /// Lookup the entry-point without arguments in the JIT and execute it, returning the result.
     template <typename ReturnType>
@@ -81,7 +81,12 @@ class Runner {
   public:
     Runner(std::unique_ptr<llvm::Module> m)
         : module(std::move(m)) {
-        driver->init();
+        driver->init(/*features=*/"");
+    }
+
+    Runner(std::unique_ptr<llvm::Module> m, std::string features)
+            : module(std::move(m)) {
+        driver->init(features);
     }
 
     /// Run the entry-point function without arguments.

--- a/src/codegen/llvm/llvm_benchmark.cpp
+++ b/src/codegen/llvm/llvm_benchmark.cpp
@@ -9,7 +9,7 @@
 #include "codegen/llvm/codegen_llvm_visitor.hpp"
 #include "codegen/llvm/jit_driver.hpp"
 
-#include "../test/unit/codegen/codegen_data_helper.hpp"
+#include "test/unit/codegen/codegen_data_helper.hpp"
 
 #include <chrono>
 #include <fstream>

--- a/src/codegen/llvm/llvm_benchmark.cpp
+++ b/src/codegen/llvm/llvm_benchmark.cpp
@@ -7,6 +7,9 @@
 
 #include "llvm_benchmark.hpp"
 #include "codegen/llvm/codegen_llvm_visitor.hpp"
+#include "codegen/llvm/jit_driver.hpp"
+
+#include "../test/unit/codegen/codegen_data_helper.hpp"
 
 #include <chrono>
 
@@ -14,7 +17,7 @@
 namespace nmodl {
 namespace benchmark {
 
-void LLVMBenchmark::benchmark(const ast::Program& node) {
+void LLVMBenchmark::benchmark(const std::shared_ptr<ast::Program>& node) {
     // Run the LLVM visitor first.
     auto llvm_visitor_start = std::chrono::high_resolution_clock::now();
     codegen::CodegenLLVMVisitor visitor(mod_filename,
@@ -22,11 +25,10 @@ void LLVMBenchmark::benchmark(const ast::Program& node) {
                                         llvm_info.opt_passes,
                                         llvm_info.use_single_precision,
                                         llvm_info.vector_width);
-    visitor.visit_program(node);
+    visitor.visit_program(*node);
+    visitor.wrap_kernel_function("nrn_state_" + mod_filename);
     auto llvm_visitor_end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> llvm_visitor_diff = llvm_visitor_end - llvm_visitor_start;
-
-    // todo: add runtime benchmark
 
     if (output_dir != ".") {
         // If the output directory is specified, dump logs to the file.
@@ -36,6 +38,34 @@ void LLVMBenchmark::benchmark(const ast::Program& node) {
 
     std::cout << "Created LLVM IR module from NMODL AST in " << std::setprecision(9)
               << llvm_visitor_diff.count() << "\n";
+
+    const auto& generated_instance_struct = visitor.get_instance_struct_ptr();
+    auto codegen_data = codegen::CodegenDataHelper(node, generated_instance_struct);
+
+    std::unique_ptr<llvm::Module> m = visitor.get_module();
+    runner::Runner runner(std::move(m));
+
+    // Todo: create a switch for the backend arch.
+
+    // Todo: add information about target triple
+
+    double runtime_sum = 0.0;
+    for (int i = 0; i < num_experiments; ++i) {
+        auto instance_data = codegen_data.create_data(instance_size, /*seed=*/1);
+
+        auto runner_start = std::chrono::high_resolution_clock::now();
+        runner.run_with_argument<int, void*>("__nrn_state_" + mod_filename + "_wrapper",
+                                             instance_data.base_ptr);
+        auto runner_end = std::chrono::high_resolution_clock::now();
+        std::chrono::duration<double> runner_diff = runner_end - runner_start;
+
+        std::cout << "Experiment " << i << ": runtime is " << std::setprecision(9)
+                  << runner_diff.count() << "\n";
+
+        runtime_sum += runner_diff.count();
+    }
+    std::cout << "The average runtime is " << std::setprecision(9) << runtime_sum / num_experiments
+              << "\n";
 }
 
 }  // namespace benchmark

--- a/src/codegen/llvm/llvm_benchmark.cpp
+++ b/src/codegen/llvm/llvm_benchmark.cpp
@@ -1,0 +1,42 @@
+/*************************************************************************
+ * Copyright (C) 2018-2021 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#include "llvm_benchmark.hpp"
+#include "codegen/llvm/codegen_llvm_visitor.hpp"
+
+#include <chrono>
+
+
+namespace nmodl {
+namespace benchmark {
+
+void LLVMBenchmark::benchmark(const ast::Program& node) {
+    // Run the LLVM visitor first.
+    auto llvm_visitor_start = std::chrono::high_resolution_clock::now();
+    codegen::CodegenLLVMVisitor visitor(mod_filename,
+                                        output_dir,
+                                        llvm_info.opt_passes,
+                                        llvm_info.use_single_precision,
+                                        llvm_info.vector_width);
+    visitor.visit_program(node);
+    auto llvm_visitor_end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> llvm_visitor_diff = llvm_visitor_end - llvm_visitor_start;
+
+    // todo: add runtime benchmark
+
+    if (output_dir != ".") {
+        // If the output directory is specified, dump logs to the file.
+        std::string filename = output_dir + "/" + mod_filename + ".log";
+        std::freopen(filename.c_str(), "w", stdout);
+    }
+
+    std::cout << "Created LLVM IR module from NMODL AST in " << std::setprecision(9)
+              << llvm_visitor_diff.count() << "\n";
+}
+
+}  // namespace benchmark
+}  // namespace nmodl

--- a/src/codegen/llvm/llvm_benchmark.hpp
+++ b/src/codegen/llvm/llvm_benchmark.hpp
@@ -1,0 +1,65 @@
+/*************************************************************************
+ * Copyright (C) 2018-2021 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#pragma once
+
+#include "codegen/llvm/codegen_llvm_visitor.hpp"
+
+#include<string>
+
+
+namespace nmodl {
+namespace benchmark {
+
+/// A struct to hold LLVM visitor information.
+struct LLVMInfo {
+    int vector_width;
+    bool opt_passes;
+    bool use_single_precision;
+};
+
+/**
+ * \class LLVMBenchmark
+ * \brief A wrapper to execute MOD file kernels via LLVM IR backend, and
+ * benchmark compile-time and runtime.
+ */
+class LLVMBenchmark {
+  private:
+
+    std::string mod_filename;
+
+    std::string output_dir;
+
+    int num_experiments;
+
+    int instance_size;
+
+    std::string backend;
+
+    LLVMInfo llvm_info;
+
+  public:
+    LLVMBenchmark(const std::string& mod_filename,
+                  const std::string& output_dir,
+                  LLVMInfo info,
+                  int num_experiments,
+                  int instance_size,
+                  const std::string& backend)
+        : mod_filename(mod_filename)
+        , output_dir(output_dir)
+        , num_experiments(num_experiments)
+        , instance_size(instance_size)
+        , backend(backend)
+        , llvm_info(info) {}
+
+    /// Runs the benchmark.
+    void benchmark(const ast::Program& node);
+};
+
+
+}  // namespace runner
+}  // namespace nmodl

--- a/src/codegen/llvm/llvm_benchmark.hpp
+++ b/src/codegen/llvm/llvm_benchmark.hpp
@@ -45,7 +45,12 @@ class LLVMBenchmark {
     std::shared_ptr<std::ostream> log_stream;
 
     /// Visits the AST to construct the LLVM IR module.
-    void generate_llvm(codegen::CodegenLLVMVisitor& visitor, const std::shared_ptr<ast::Program>& node);
+    void generate_llvm(codegen::CodegenLLVMVisitor& visitor,
+                       const std::shared_ptr<ast::Program>& node);
+
+    /// Runs the main body of the benchmark, executing the compute kernels.
+    void run_benchmark(codegen::CodegenLLVMVisitor& visitor,
+                       const std::shared_ptr<ast::Program>& node);
 
     /// Sets the log output stream (file or console).
     void set_log_output();

--- a/src/codegen/llvm/llvm_benchmark.hpp
+++ b/src/codegen/llvm/llvm_benchmark.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include<string>
+#include <string>
 
 #include "codegen/llvm/codegen_llvm_visitor.hpp"
 
@@ -29,7 +29,6 @@ struct LLVMBuildInfo {
  */
 class LLVMBenchmark {
   private:
-
     std::string mod_filename;
 
     std::string output_dir;
@@ -82,5 +81,5 @@ class LLVMBenchmark {
 };
 
 
-}  // namespace runner
+}  // namespace benchmark
 }  // namespace nmodl

--- a/src/codegen/llvm/llvm_benchmark.hpp
+++ b/src/codegen/llvm/llvm_benchmark.hpp
@@ -16,7 +16,7 @@ namespace nmodl {
 namespace benchmark {
 
 /// A struct to hold LLVM visitor information.
-struct LLVMInfo {
+struct LLVMBuildInfo {
     int vector_width;
     bool opt_passes;
     bool use_single_precision;
@@ -40,12 +40,20 @@ class LLVMBenchmark {
 
     std::string backend;
 
-    LLVMInfo llvm_info;
+    LLVMBuildInfo llvm_build_info;
+
+    std::shared_ptr<std::ostream> log_stream;
+
+    /// Visits the AST to construct the LLVM IR module.
+    void generate_llvm(codegen::CodegenLLVMVisitor& visitor, const std::shared_ptr<ast::Program>& node);
+
+    /// Sets the log output stream (file or console).
+    void set_log_output();
 
   public:
     LLVMBenchmark(const std::string& mod_filename,
                   const std::string& output_dir,
-                  LLVMInfo info,
+                  LLVMBuildInfo info,
                   int num_experiments,
                   int instance_size,
                   const std::string& backend)
@@ -54,7 +62,7 @@ class LLVMBenchmark {
         , num_experiments(num_experiments)
         , instance_size(instance_size)
         , backend(backend)
-        , llvm_info(info) {}
+        , llvm_build_info(info) {}
 
     /// Runs the benchmark.
     void benchmark(const std::shared_ptr<ast::Program>& node);

--- a/src/codegen/llvm/llvm_benchmark.hpp
+++ b/src/codegen/llvm/llvm_benchmark.hpp
@@ -57,7 +57,7 @@ class LLVMBenchmark {
         , llvm_info(info) {}
 
     /// Runs the benchmark.
-    void benchmark(const ast::Program& node);
+    void benchmark(const std::shared_ptr<ast::Program>& node);
 };
 
 

--- a/src/codegen/llvm/llvm_benchmark.hpp
+++ b/src/codegen/llvm/llvm_benchmark.hpp
@@ -7,9 +7,9 @@
 
 #pragma once
 
-#include "codegen/llvm/codegen_llvm_visitor.hpp"
-
 #include<string>
+
+#include "codegen/llvm/codegen_llvm_visitor.hpp"
 
 
 namespace nmodl {
@@ -44,9 +44,17 @@ class LLVMBenchmark {
 
     std::shared_ptr<std::ostream> log_stream;
 
+    /// Disable the specified feature.
+    void disable(const std::string& feature, std::vector<std::string>& host_features);
+
     /// Visits the AST to construct the LLVM IR module.
     void generate_llvm(codegen::CodegenLLVMVisitor& visitor,
                        const std::shared_ptr<ast::Program>& node);
+
+    /// Get the host CPU features in the format:
+    ///   +feature,+feature,-feature,+feature,...
+    /// where `+` indicates that the feature is enabled.
+    std::vector<std::string> get_cpu_features();
 
     /// Runs the main body of the benchmark, executing the compute kernels.
     void run_benchmark(codegen::CodegenLLVMVisitor& visitor,

--- a/src/nmodl/CMakeLists.txt
+++ b/src/nmodl/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(
   ${NMODL_WRAPPER_LIBS})
 
 if(NMODL_ENABLE_LLVM)
-  target_link_libraries(nmodl llvm_codegen ${LLVM_LIBS_TO_LINK})
+  target_link_libraries(nmodl llvm_codegen llvm_benchmark ${LLVM_LIBS_TO_LINK})
 endif()
 
 # =============================================================================

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -330,7 +330,7 @@ int main(int argc, const char* argv[]) {
                        "Number of experiments for benchmarking ({})"_format(repeat))->ignore_case();
     benchmark_opt->add_option("--backend",
                        backend,
-                       "Target's backend ({})"_format(backend))->ignore_case()->check(CLI::IsMember({"default", "avx2"}));;
+                       "Target's backend ({})"_format(backend))->ignore_case()->check(CLI::IsMember({"default"}));;
 #endif
     // clang-format on
 

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -623,7 +623,7 @@ int main(int argc, const char* argv[]) {
                 benchmark::LLVMInfo info{llvm_vec_width, llvm_opt_passes, llvm_float_type};
                 benchmark::LLVMBenchmark bench(
                     modfile, output_dir, info, repeat, instance_size, backend);
-                bench.benchmark(*ast);
+                bench.benchmark(ast);
             }
 
             else if (llvm_ir) {

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -330,7 +330,7 @@ int main(int argc, const char* argv[]) {
                        "Number of experiments for benchmarking ({})"_format(repeat))->ignore_case();
     benchmark_opt->add_option("--backend",
                        backend,
-                       "Target's backend ({})"_format(backend))->ignore_case()->check(CLI::IsMember({"default"}));;
+                       "Target's backend ({})"_format(backend))->ignore_case()->check(CLI::IsMember({"avx2", "default", "sse2"}));;
 #endif
     // clang-format on
 

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -620,7 +620,7 @@ int main(int argc, const char* argv[]) {
 
             if (run_benchmark) {
                 logger->info("Running LLVM benchmark");
-                benchmark::LLVMInfo info{llvm_vec_width, llvm_opt_passes, llvm_float_type};
+                benchmark::LLVMBuildInfo info{llvm_vec_width, llvm_opt_passes, llvm_float_type};
                 benchmark::LLVMBenchmark bench(
                     modfile, output_dir, info, repeat, instance_size, backend);
                 bench.benchmark(ast);

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -96,6 +96,9 @@ target_link_libraries(
 
 if(NMODL_ENABLE_LLVM)
   include_directories(${LLVM_INCLUDE_DIRS} codegen)
+
+  add_library(llvm_benchmark STATIC codegen/codegen_data_helper.cpp)
+
   add_executable(testllvm visitor/main.cpp codegen/codegen_llvm_ir.cpp
                           codegen/codegen_data_helper.cpp codegen/codegen_llvm_instance_struct.cpp)
   add_executable(test_llvm_runner visitor/main.cpp codegen/codegen_data_helper.cpp

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -83,6 +83,7 @@ target_link_libraries(
   test_util
   printer
   ${NMODL_WRAPPER_LIBS})
+
 target_link_libraries(
   testcodegen
   codegen
@@ -98,6 +99,7 @@ if(NMODL_ENABLE_LLVM)
   include_directories(${LLVM_INCLUDE_DIRS} codegen)
 
   add_library(llvm_benchmark STATIC codegen/codegen_data_helper.cpp)
+  add_dependencies(llvm_benchmark lexer)
 
   add_executable(testllvm visitor/main.cpp codegen/codegen_llvm_ir.cpp
                           codegen/codegen_data_helper.cpp codegen/codegen_llvm_instance_struct.cpp)

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -303,7 +303,7 @@ SCENARIO("Simple scalar kernel", "[llvm][runner]") {
                                                  /*use_single_precision=*/false,
                                                  /*vector_width=*/1);
         llvm_visitor.visit_program(*ast);
-        llvm_visitor.wrap_kernel_function("nrn_state_test");
+        llvm_visitor.wrap_kernel_functions();
 
         // Create the instance struct data.
         int num_elements = 4;
@@ -383,7 +383,7 @@ SCENARIO("Simple vectorised kernel", "[llvm][runner]") {
                                                  /*use_single_precision=*/false,
                                                  /*vector_width=*/4);
         llvm_visitor.visit_program(*ast);
-        llvm_visitor.wrap_kernel_function("nrn_state_test");
+        llvm_visitor.wrap_kernel_functions();
 
         // Create the instance struct data.
         int num_elements = 10;


### PR DESCRIPTION
This PR is to introduce the benchmarking for LLVM code
generation pipeline. For that, new options have been added:

```
benchmark
  LLVM benchmark option
  Options:
    --run                                           Run LLVM benchmark (false)
    --instance-size INT                   Instance struct size (10000)
    --repeat INT                               Number of experiments for benchmarking (100)
    --backend TEXT:{avx2, default, sse2}         Target's backend (default)
```

The `backend` option does not work yet (as LLVM can
automatically set up the target/data layout information).

Example:
```bash
$ nmodl hh.mod llvm --ir --vector-width 1 benchmark --run --instance-size 100000 --repeat 10 --backend default

Created LLVM IR module from NMODL AST in 0.006765817

Benchmarking kernel 'nrn_state_hh'
Experiment 0: compute time = 0.013977749
Experiment 1: compute time = 0.004847989
Experiment 2: compute time = 0.004739051
Experiment 3: compute time = 0.004801505
Experiment 4: compute time = 0.005540785
Experiment 5: compute time = 0.004965192
Experiment 6: compute time = 0.004840146
Experiment 7: compute time = 0.00485995
Experiment 8: compute time = 0.005134093
Experiment 9: compute time = 0.004844469
Average compute time = 0.0058550929
```