### PR TITLE
Minor benchmarking improvement

### DIFF
--- a/src/codegen/llvm/llvm_benchmark.cpp
+++ b/src/codegen/llvm/llvm_benchmark.cpp
@@ -107,14 +107,15 @@ void LLVMBenchmark::run_benchmark(codegen::CodegenLLVMVisitor& visitor,
 
     // Benchmark every kernel.
     for (const auto& kernel_name: kernel_names) {
-        *log_stream << "Benchmarking kernel '" << kernel_name << "'\n";
+        // Initialise the data.
+        auto instance_data = codegen_data.create_data(instance_size, /*seed=*/1);
+
+        double size_mbs = instance_data.num_bytes / (1024.0 * 1024.0);
+        *log_stream << "Benchmarking kernel '" << kernel_name << ", with " << size_mbs << " MBs\n";
 
         // For every kernel run the benchmark `num_experiments` times.
         double time_sum = 0.0;
         for (int i = 0; i < num_experiments; ++i) {
-            // Initialise the data.
-            auto instance_data = codegen_data.create_data(instance_size, /*seed=*/1);
-
             // Record the execution time of the kernel.
             std::string wrapper_name = "__" + kernel_name + "_wrapper";
             auto start = std::chrono::high_resolution_clock::now();

--- a/test/unit/codegen/codegen_data_helper.cpp
+++ b/test/unit/codegen/codegen_data_helper.cpp
@@ -88,6 +88,7 @@ CodegenInstanceData CodegenDataHelper::create_data(size_t num_elements, size_t s
     // allocate instance object with memory alignment
     posix_memalign(&base, NBYTE_ALIGNMENT, member_size * variables.size());
     data.base_ptr = base;
+    data.num_bytes += member_size * variables.size();
 
     size_t offset = 0;
     void* ptr = base;
@@ -115,6 +116,7 @@ CodegenInstanceData CodegenDataHelper::create_data(size_t num_elements, size_t s
         void* member;
         posix_memalign(&member, NBYTE_ALIGNMENT, member_size * num_elements);
         initialize_variable(var, member, variable_index, num_elements);
+        data.num_bytes += member_size * num_elements;
 
         // copy address at specific location in the struct
         memcpy(ptr, &member, sizeof(double*));

--- a/test/unit/codegen/codegen_data_helper.hpp
+++ b/test/unit/codegen/codegen_data_helper.hpp
@@ -46,6 +46,9 @@ struct CodegenInstanceData {
     /// i.e. *(base_ptr + offsets[0]) will be members[0]
     std::vector<void*> members;
 
+    /// size in bytes
+    size_t num_bytes = 0;
+
     // cleanup all memory allocated for type and member variables
     ~CodegenInstanceData();
 };


### PR DESCRIPTION
 - allocate instance data only once
 - store memory size with instance data
 - print memory size while running benchmarking kernel 