### PR TITLE
Bug fix in codegen helper: delete LOCAL statement

### DIFF
--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -473,12 +473,13 @@ void CodegenLLVMHelperVisitor::convert_local_statement(ast::StatementBlock& node
         }
 
         /// remove local list statement now
-        const auto& statements = node.get_statements();
-        node.erase_statement(statements.begin());
+        std::unordered_set<nmodl::ast::Statement*> to_delete({local_statement.get()});
+        node.erase_statement(to_delete);
 
         /// create new codegen variable statement and insert at the beginning of the block
         auto type = new ast::CodegenVarType(FLOAT_TYPE);
         auto statement = std::make_shared<ast::CodegenVarListStatement>(type, variables);
+        const auto& statements = node.get_statements();
         node.insert_statement(statements.begin(), statement);
     }
 }


### PR DESCRIPTION
- LOCAL statement was not deletected correctly
- TODO: IR generation still fails with

@georgemitenkov : I fixed LOCAL node deletion but IR generation still fails with below error:

```bash
$ ./bin/nmodl ../test.mod --output tmp llvm --ir --vector-width 8 passes
...
VOID nrn_state_hh(INSTANCE_STRUCT *mech){
    INTEGER id
    INTEGER node_id
    DOUBLE v
    for(id = 0; id<mech->node_count-7; id = id+8) {
        DOUBLE yyy
        node_id = mech->node_index[id]
        v = mech->voltage[node_id]
        yyy = 12
    }
    INTEGER epilogue_node_id
    DOUBLE epilogue_v
    for(; id<mech->node_count; id = id+1) {
        DOUBLE yyy
        epilogue_node_id = mech->node_index[id]
        epilogue_v = mech->voltage[epilogue_node_id]
        yyy = 12
    }
}
terminate called after throwing an instance of 'std::runtime_error'
  what():  Error: incorrect IR has been generated!
Stored value type does not match pointer operand type!
  store double 1.200000e+01, <8 x double>* %yyy, align 8
 <8 x double>
Aborted
```

If you have quick fix, feel free to push to this branch.

fixes #594