### PR TITLE
Fixed bug with replacing external function when in-lining

### DIFF
--- a/src/visitors/inline_visitor.cpp
+++ b/src/visitors/inline_visitor.cpp
@@ -74,7 +74,8 @@ bool InlineVisitor::can_replace_statement(const std::shared_ptr<Statement>& stat
         auto wrapped_expression = static_cast<WrappedExpression*>(e.get());
         if (wrapped_expression->get_expression()->is_function_call()) {
             // if caller is external function (i.e. neuron function) don't replace it
-            const auto& function_call = std::static_pointer_cast<FunctionCall>(wrapped_expression->get_expression());
+            const auto& function_call = std::static_pointer_cast<FunctionCall>(
+                wrapped_expression->get_expression());
             const auto& function_name = function_call->get_node_name();
             const auto& symbol = program_symtab->lookup_in_scope(function_name);
             to_replace = !symbol->is_external_variable();

--- a/src/visitors/inline_visitor.cpp
+++ b/src/visitors/inline_visitor.cpp
@@ -4,7 +4,6 @@
  * This file is part of NMODL distributed under the terms of the GNU
  * Lesser General Public License. See top-level LICENSE file for details.
  *************************************************************************/
-#include <memory>
 
 #include "visitors/inline_visitor.hpp"
 
@@ -201,7 +200,7 @@ void InlineVisitor::visit_function_call(FunctionCall& node) {
     const auto& function_name = node.get_name()->get_node_name();
     auto symbol = program_symtab->lookup_in_scope(function_name);
 
-    /// nothing to do if called function is not defined
+    /// nothing to do if called function is not defined or it's external
     if (symbol == nullptr || symbol->is_external_variable()) {
         return;
     }

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -3,6 +3,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 include_directories(${PYBIND11_INCLUDE_DIR} ${PYTHON_INCLUDE_DIRS})
 include_directories(${NMODL_PROJECT_SOURCE_DIR}/ext/catch ${NMODL_PROJECT_SOURCE_DIR}/test)
 include_directories(${NMODL_PROJECT_SOURCE_DIR}/src/solver)
+include_directories(${NMODL_PROJECT_SOURCE_DIR}/src/utils)
 include_directories(${NMODL_PROJECT_SOURCE_DIR}/ext/eigen)
 
 # =============================================================================


### PR DESCRIPTION
An example, to test this is invlfire.mod.
in the function net_receive_IntervalFire, there is the call of artcell_net_move(firetime())