### PR TITLE
LLVM 13 compatibility and fixing void* type

### DIFF
--- a/cmake/LLVMHelper.cmake
+++ b/cmake/LLVMHelper.cmake
@@ -5,7 +5,14 @@
 find_package(LLVM REQUIRED CONFIG)
 
 # include LLVM header and core library
-llvm_map_components_to_libnames(LLVM_LIBS_TO_LINK core orcjit native)
+llvm_map_components_to_libnames(LLVM_LIBS_TO_LINK
+    core
+    instcombine
+    native
+    orcjit
+    scalaropts
+    support
+)
 set(CMAKE_REQUIRED_INCLUDES ${LLVM_INCLUDE_DIRS})
 set(CMAKE_REQUIRED_LIBRARIES ${LLVM_LIBS_TO_LINK})
 

--- a/cmake/LLVMHelper.cmake
+++ b/cmake/LLVMHelper.cmake
@@ -5,14 +5,14 @@
 find_package(LLVM REQUIRED CONFIG)
 
 # include LLVM header and core library
-llvm_map_components_to_libnames(LLVM_LIBS_TO_LINK
-    core
-    instcombine
-    native
-    orcjit
-    scalaropts
-    support
-)
+llvm_map_components_to_libnames(
+  LLVM_LIBS_TO_LINK
+  core
+  instcombine
+  native
+  orcjit
+  scalaropts
+  support)
 set(CMAKE_REQUIRED_INCLUDES ${LLVM_INCLUDE_DIRS})
 set(CMAKE_REQUIRED_LIBRARIES ${LLVM_LIBS_TO_LINK})
 

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -1007,9 +1007,8 @@ void CodegenLLVMVisitor::wrap_kernel_functions() {
                                      " does not have an instance struct pointer argument!");
 
         // Create a wrapper void function that takes a void pointer as a single argument.
-        llvm::Type* void_type = llvm::Type::getVoidTy(*context);
         llvm::Type* i32_type = llvm::Type::getInt32Ty(*context);
-        llvm::Type* void_ptr_type = llvm::PointerType::get(void_type, /*AddressSpace=*/0);
+        llvm::Type* void_ptr_type = llvm::Type::getInt8PtrTy(*context);
         llvm::Function* wrapper_func = llvm::Function::Create(
             llvm::FunctionType::get(i32_type, {void_ptr_type}, /*isVarArg=*/false),
             llvm::Function::ExternalLinkage,


### PR DESCRIPTION
This PR fixes:

1. cmake LLVM libraries to be compatible with
LLVM 13 (trunk).

2. `void*` type is illegal in LLVM, and hence is
replaced with `i8*`.