### PR TITLE
Integrating vector maths library into LLVM codegen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,9 @@ if(NMODL_ENABLE_LLVM)
   include(LLVMHelper)
   include_directories(${LLVM_INCLUDE_DIRS})
   add_definitions(-DNMODL_LLVM_BACKEND)
+  if(LLVM_VERSION VERSION_LESS_EQUAL 12)
+    add_definitions(-DLLVM_VERSION_LESS_THAN_13)
+  endif()
 endif()
 
 # =============================================================================

--- a/cmake/LLVMHelper.cmake
+++ b/cmake/LLVMHelper.cmake
@@ -7,8 +7,11 @@ find_package(LLVM REQUIRED CONFIG)
 # include LLVM header and core library
 llvm_map_components_to_libnames(
   LLVM_LIBS_TO_LINK
+  analysis
+  codegen
   core
   instcombine
+  mc
   native
   orcjit
   scalaropts

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -11,6 +11,8 @@
 #include "visitors/rename_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
 
+#include "llvm/Analysis/TargetLibraryInfo.h"
+#include "llvm/CodeGen/ReplaceWithVeclib.h"
 #include "llvm/IR/AssemblyAnnotationWriter.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Constants.h"
@@ -19,6 +21,7 @@
 #include "llvm/IR/Type.h"
 #include "llvm/IR/ValueSymbolTable.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Host.h"
 #include "llvm/Support/ToolOutputFile.h"
 
 namespace nmodl {
@@ -292,21 +295,21 @@ std::shared_ptr<ast::InstanceStruct> CodegenLLVMVisitor::get_instance_struct_ptr
     return instance_var_helper.instance;
 }
 
-void CodegenLLVMVisitor::run_llvm_opt_passes() {
+void CodegenLLVMVisitor::run_ir_opt_passes() {
     /// run some common optimisation passes that are commonly suggested
-    fpm.add(llvm::createInstructionCombiningPass());
-    fpm.add(llvm::createReassociatePass());
-    fpm.add(llvm::createGVNPass());
-    fpm.add(llvm::createCFGSimplificationPass());
+    opt_pm.add(llvm::createInstructionCombiningPass());
+    opt_pm.add(llvm::createReassociatePass());
+    opt_pm.add(llvm::createGVNPass());
+    opt_pm.add(llvm::createCFGSimplificationPass());
 
     /// initialize pass manager
-    fpm.doInitialization();
+    opt_pm.doInitialization();
 
     /// iterate over all functions and run the optimisation passes
     auto& functions = module->getFunctionList();
     for (auto& function: functions) {
         llvm::verifyFunction(function);
-        fpm.run(function);
+        opt_pm.run(function);
     }
 }
 
@@ -892,7 +895,28 @@ void CodegenLLVMVisitor::visit_program(const ast::Program& node) {
 
     if (opt_passes) {
         logger->info("Running LLVM optimisation passes");
-        run_llvm_opt_passes();
+        run_ir_opt_passes();
+    }
+
+    // Optionally, replace LLVM's maths intrinsics with vector library calls.
+    if (vector_library != llvm::TargetLibraryInfoImpl::NoLibrary) {
+        // First, get the target library information.
+        llvm::Triple triple(llvm::sys::getDefaultTargetTriple());
+        llvm::TargetLibraryInfoImpl target_lib_info = llvm::TargetLibraryInfoImpl(triple);
+
+        if (vector_library != llvm::TargetLibraryInfoImpl::LIBMVEC_X86 ||
+            (triple.isX86() && triple.isArch64Bit())) {
+            target_lib_info.addVectorizableFunctionsFromVecLib(vector_library);
+        }
+
+        // Run the codegen optimisation passes.
+        codegen_pm.add(new llvm::TargetLibraryInfoWrapperPass(target_lib_info));
+        codegen_pm.add(new llvm::ReplaceWithVeclibLegacy);
+        codegen_pm.doInitialization();
+        for (auto& function: module->getFunctionList()) {
+            if (!function.isDeclaration())
+                codegen_pm.run(function);
+        }
     }
 
     // If the output directory is specified, save the IR to .ll file.

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -904,12 +904,14 @@ void CodegenLLVMVisitor::visit_program(const ast::Program& node) {
         llvm::Triple triple(llvm::sys::getDefaultTargetTriple());
         llvm::TargetLibraryInfoImpl target_lib_info = llvm::TargetLibraryInfoImpl(triple);
 
+        // Populate target library information with vectorisable functions. Since libmvec is
+        // supported for x86_64 only, have a check to catch other architectures.
         if (vector_library != llvm::TargetLibraryInfoImpl::LIBMVEC_X86 ||
             (triple.isX86() && triple.isArch64Bit())) {
             target_lib_info.addVectorizableFunctionsFromVecLib(vector_library);
         }
 
-        // Run the codegen optimisation passes.
+        // Run the codegen optimisation passes that replace maths intrinsics.
         codegen_pm.add(new llvm::TargetLibraryInfoWrapperPass(target_lib_info));
         codegen_pm.add(new llvm::ReplaceWithVeclibLegacy);
         codegen_pm.doInitialization();

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -917,6 +917,7 @@ void CodegenLLVMVisitor::visit_program(const ast::Program& node) {
             if (!function.isDeclaration())
                 codegen_pm.run(function);
         }
+        codegen_pm.doFinalization();
     }
 
     // If the output directory is specified, save the IR to .ll file.

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -49,7 +49,9 @@ namespace codegen {
 /// A map to query vector library by its string value.
 static const std::map<std::string, llvm::TargetLibraryInfoImpl::VectorLibrary> veclib_map = {
             {"Accelerate", llvm::TargetLibraryInfoImpl::Accelerate},
+#ifndef LLVM_VERSION_LESS_THAN_13
             {"libmvec", llvm::TargetLibraryInfoImpl::LIBMVEC_X86},
+#endif
             {"MASSV", llvm::TargetLibraryInfoImpl::MASSV},
             {"SVML", llvm::TargetLibraryInfoImpl::SVML},
             {"none", llvm::TargetLibraryInfoImpl::NoLibrary}

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -48,14 +48,13 @@ namespace codegen {
 
 /// A map to query vector library by its string value.
 static const std::map<std::string, llvm::TargetLibraryInfoImpl::VectorLibrary> veclib_map = {
-            {"Accelerate", llvm::TargetLibraryInfoImpl::Accelerate},
+    {"Accelerate", llvm::TargetLibraryInfoImpl::Accelerate},
 #ifndef LLVM_VERSION_LESS_THAN_13
-            {"libmvec", llvm::TargetLibraryInfoImpl::LIBMVEC_X86},
+    {"libmvec", llvm::TargetLibraryInfoImpl::LIBMVEC_X86},
 #endif
-            {"MASSV", llvm::TargetLibraryInfoImpl::MASSV},
-            {"SVML", llvm::TargetLibraryInfoImpl::SVML},
-            {"none", llvm::TargetLibraryInfoImpl::NoLibrary}
-};
+    {"MASSV", llvm::TargetLibraryInfoImpl::MASSV},
+    {"SVML", llvm::TargetLibraryInfoImpl::SVML},
+    {"none", llvm::TargetLibraryInfoImpl::NoLibrary}};
 
 /**
  * \class CodegenLLVMVisitor

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -175,10 +175,13 @@ int main(int argc, const char* argv[]) {
     bool llvm_float_type(false);
 
     /// run llvm optimisation passes
-    bool llvm_opt_passes(false);
+    bool llvm_ir_opt_passes(false);
 
     /// llvm vector width
     int llvm_vec_width = 1;
+
+    /// vector library
+    std::string vec_lib("none");
 
     /// run llvm benchmark
     bool run_benchmark(false);
@@ -308,14 +311,17 @@ int main(int argc, const char* argv[]) {
         llvm_ir,
         "Generate LLVM IR ({})"_format(llvm_ir))->ignore_case();
     llvm_opt->add_flag("--opt",
-        llvm_opt_passes,
-        "Run LLVM optimisation passes ({})"_format(llvm_opt_passes))->ignore_case();
+                       llvm_ir_opt_passes,
+                       "Run LLVM optimisation passes ({})"_format(llvm_ir_opt_passes))->ignore_case();
     llvm_opt->add_flag("--single-precision",
                        llvm_float_type,
                        "Use single precision floating-point types ({})"_format(llvm_float_type))->ignore_case();
     llvm_opt->add_option("--vector-width",
         llvm_vec_width,
         "LLVM explicit vectorisation width ({})"_format(llvm_vec_width))->ignore_case();
+    llvm_opt->add_option("--veclib",
+                         vec_lib,
+                         "Vector library for maths functions ({})"_format(vec_lib))->check(CLI::IsMember({"Accelerate", "libmvec", "MASSV", "SVML", "none"}));
 
     // LLVM IR benchmark options.
     auto benchmark_opt = app.add_subcommand("benchmark", "LLVM benchmark option")->ignore_case();
@@ -330,7 +336,7 @@ int main(int argc, const char* argv[]) {
                        "Number of experiments for benchmarking ({})"_format(repeat))->ignore_case();
     benchmark_opt->add_option("--backend",
                        backend,
-                       "Target's backend ({})"_format(backend))->ignore_case()->check(CLI::IsMember({"avx2", "default", "sse2"}));;
+                       "Target's backend ({})"_format(backend))->ignore_case()->check(CLI::IsMember({"avx2", "default", "sse2"}));
 #endif
     // clang-format on
 
@@ -620,7 +626,7 @@ int main(int argc, const char* argv[]) {
 
             if (run_benchmark) {
                 logger->info("Running LLVM benchmark");
-                benchmark::LLVMBuildInfo info{llvm_vec_width, llvm_opt_passes, llvm_float_type};
+                benchmark::LLVMBuildInfo info{llvm_vec_width, llvm_ir_opt_passes, llvm_float_type};
                 benchmark::LLVMBenchmark bench(
                     modfile, output_dir, info, repeat, instance_size, backend);
                 bench.benchmark(ast);
@@ -628,8 +634,12 @@ int main(int argc, const char* argv[]) {
 
             else if (llvm_ir) {
                 logger->info("Running LLVM backend code generator");
-                CodegenLLVMVisitor visitor(
-                    modfile, output_dir, llvm_opt_passes, llvm_float_type, llvm_vec_width);
+                CodegenLLVMVisitor visitor(modfile,
+                                           output_dir,
+                                           llvm_ir_opt_passes,
+                                           llvm_float_type,
+                                           llvm_vec_width,
+                                           vec_lib);
                 visitor.visit_program(*ast);
                 ast_to_nmodl(*ast, filepath("llvm", "mod"));
                 ast_to_json(*ast, filepath("llvm", "json"));

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -1097,6 +1097,7 @@ SCENARIO("Vector library calls", "[visitor][llvm][vector_lib]") {
             REQUIRE(std::regex_search(no_library_module_str, m, exp_decl));
             REQUIRE(std::regex_search(no_library_module_str, m, exp_call));
 
+#ifndef LLVM_VERSION_LESS_THAN_13
             // Check exponential calls are replaced with calls to SVML library.
             std::string svml_library_module_str = run_llvm_visitor(nmodl_text,
                                                                    /*opt=*/false,
@@ -1144,6 +1145,7 @@ SCENARIO("Vector library calls", "[visitor][llvm][vector_lib]") {
             REQUIRE(std::regex_search(accelerate_library_module_str, m, accelerate_exp_decl));
             REQUIRE(std::regex_search(accelerate_library_module_str, m, accelerate_exp_call));
             REQUIRE(!std::regex_search(accelerate_library_module_str, m, fexp_call));
+#endif
         }
     }
 }

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -1068,22 +1068,19 @@ SCENARIO("Vector library calls", "[visitor][llvm][vector_lib]") {
             NEURON {
                 SUFFIX hh
                 NONSPECIFIC_CURRENT il
-                RANGE minf, mtau
             }
             STATE {
                 m
             }
             ASSIGNED {
                 v (mV)
-                minf
-                mtau (ms)
             }
             BREAKPOINT {
                 SOLVE states METHOD cnexp
                 il = 2
             }
             DERIVATIVE states {
-                m' = (minf-m) / mtau
+                m = exp(m)
             }
         )";
 


### PR DESCRIPTION
This PR adds support of using vector maths functions
from Accelerate, libmvec, MASSV, and SVML.

- Added extra `veclib` option to LLVM IR code
generation to specify the vector library.

- Added another pass manager that would handle
target-specific optimisations. (@pramodk: In the future,
I think it would be nice to split LLVM visitor + IR
optimisations and target generation + target specific
optimisations)

- Added tests to check replacements.

How to use:
```bash
$ bin/nmodl hh.mod llvm --ir --vector-width 4 --veclib SVML
```

**Note**: Integration of the vector library support in
JIT runner will be done in the next PR.

fixes #589