### PR TITLE
Update CI with LLVM v13 (trunk)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,9 +50,10 @@ jobs:
       wget -O ispc.tar.gz $url;
       mkdir $(pwd)/$CMAKE_PKG/ispc && tar -xvzf ispc.tar.gz -C $(pwd)/$CMAKE_PKG/ispc --strip 1;
       # install llvm nightly (future v13)
-      curl https://apt.llvm.org/llvm-snapshot.gpg.key | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 sudo apt-key add -
-      sudo apt-get update
-      sudo apt-get -y  install libllvm13 llvm-13 llvm-13-dev
+      wget https://apt.llvm.org/llvm.sh
+      chmod +x llvm.sh
+      sudo ./llvm.sh 13
+
     env:
       CMAKE_PKG: 'cmake-3.10.2-Linux-x86_64'
     displayName: 'Install Dependencies'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,10 +123,14 @@ jobs:
       python3 -m pip install --user 'Jinja2>=2.9.3' 'PyYAML>=3.13' pytest 'sympy>=1.3'
     displayName: 'Install Dependencies'
   - script: |
+      cd $HOME
+      git clone https://github.com/pramodk/llvm-nightly.git
+    displayName: 'Setup LLVM v13'
+  - script: |
       export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
       mkdir -p $(Build.Repository.LocalPath)/build
       cd $(Build.Repository.LocalPath)/build
-      cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DNMODL_ENABLE_PYTHON_BINDINGS=OFF -DLLVM_DIR=`brew --prefix llvm`/lib/cmake/llvm -DNMODL_ENABLE_LLVM=ON
+      cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DNMODL_ENABLE_PYTHON_BINDINGS=OFF -DLLVM_DIR=$HOME/llvm-nightly/0421/osx/lib/cmake/llvm -DNMODL_ENABLE_LLVM=ON
       make -j 2
       if [ $? -ne 0 ]
       then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,7 +130,7 @@ jobs:
       export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
       mkdir -p $(Build.Repository.LocalPath)/build
       cd $(Build.Repository.LocalPath)/build
-      cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DNMODL_ENABLE_PYTHON_BINDINGS=OFF -DLLVM_DIR=$HOME/llvm-nightly/0421/osx/lib/cmake/llvm -DNMODL_ENABLE_LLVM=OFF
+      cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DNMODL_ENABLE_PYTHON_BINDINGS=OFF -DLLVM_DIR=$HOME/llvm-nightly/0421/osx/lib/cmake/llvm -DNMODL_ENABLE_LLVM=ON
       make -j 2
       if [ $? -ne 0 ]
       then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,7 +130,7 @@ jobs:
       export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
       mkdir -p $(Build.Repository.LocalPath)/build
       cd $(Build.Repository.LocalPath)/build
-      cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DNMODL_ENABLE_PYTHON_BINDINGS=OFF -DLLVM_DIR=$HOME/llvm-nightly/0421/osx/lib/cmake/llvm -DNMODL_ENABLE_LLVM=ON
+      cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DNMODL_ENABLE_PYTHON_BINDINGS=OFF -DLLVM_DIR=$HOME/llvm-nightly/0421/osx/lib/cmake/llvm -DNMODL_ENABLE_LLVM=OFF
       make -j 2
       if [ $? -ne 0 ]
       then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,9 +50,9 @@ jobs:
       wget -O ispc.tar.gz $url;
       mkdir $(pwd)/$CMAKE_PKG/ispc && tar -xvzf ispc.tar.gz -C $(pwd)/$CMAKE_PKG/ispc --strip 1;
       # install llvm nightly (future v13)
-      wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+      curl https://apt.llvm.org/llvm-snapshot.gpg.key | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 sudo apt-key add -
       sudo apt-get update
-      sudo apt-get install libllvm13 llvm-13 llvm-13-dev
+      sudo apt-get -y  install libllvm13 llvm-13 llvm-13-dev
     env:
       CMAKE_PKG: 'cmake-3.10.2-Linux-x86_64'
     displayName: 'Install Dependencies'
@@ -62,7 +62,7 @@ jobs:
       mkdir -p $(Build.Repository.LocalPath)/build
       cd $(Build.Repository.LocalPath)/build
       cmake --version
-      cmake .. -DPYTHON_EXECUTABLE=$(which python3.7) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=Release -DNMODL_ENABLE_LLVM=ON
+      cmake .. -DPYTHON_EXECUTABLE=$(which python3.7) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=Release -DNMODL_ENABLE_LLVM=ON -DLLVM_DIR=/usr/lib/llvm-13/share/llvm/cmake/
       make -j 2
       if [ $? -ne 0 ]
       then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,10 +110,10 @@ jobs:
     env:
       CMAKE_PKG: 'cmake-3.10.2-Linux-x86_64'
     displayName: 'Build CoreNEURON and Run Integration Tests with ISPC compiler'
-- job: 'osx1014'
+- job: 'osx1015'
   pool:
-    vmImage: 'macOS-10.14'
-  displayName: 'MacOS (10.14), AppleClang 10.0'
+    vmImage: 'macOS-10.15'
+  displayName: 'MacOS (10.15), AppleClang 11.0'
   steps:
   - checkout: self
     submodules: True

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,10 +24,10 @@ trigger:
 - releases/*
 
 jobs:
-- job: 'ubuntu1604'
+- job: 'ubuntu1804'
   pool:
-    vmImage: 'ubuntu-16.04'
-  displayName: 'Ubuntu (16.04), GCC 8.3'
+    vmImage: 'ubuntu-18.04'
+  displayName: 'Ubuntu (18.04), GCC 8.4'
   steps:
   - checkout: self
     submodules: False
@@ -35,7 +35,7 @@ jobs:
       sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
       sudo apt-add-repository -y ppa:deadsnakes/ppa
       sudo apt update
-      sudo apt install -y g++-8 flex bison
+      sudo apt install -y g++-8 flex bison libfl-dev
       sudo apt-get install -y python3.7 python3.7-dev python3.7-venv
       python3.7 -m pip install -U pip setuptools
       python3.7 -m pip install --user 'Jinja2>=2.9.3' 'PyYAML>=3.13' pytest 'sympy>=1.3,<1.6'
@@ -49,6 +49,10 @@ jobs:
       url="https://github.com/ispc/ispc/releases/download/${ispc_version}/ispc-${ispc_version}${ispc_version_suffix}-${url_os}.tar.gz";
       wget -O ispc.tar.gz $url;
       mkdir $(pwd)/$CMAKE_PKG/ispc && tar -xvzf ispc.tar.gz -C $(pwd)/$CMAKE_PKG/ispc --strip 1;
+      # install llvm nightly (future v13)
+      wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+      sudo apt-get update
+      sudo apt-get install libllvm13 llvm-13 llvm-13-dev
     env:
       CMAKE_PKG: 'cmake-3.10.2-Linux-x86_64'
     displayName: 'Install Dependencies'
@@ -58,7 +62,7 @@ jobs:
       mkdir -p $(Build.Repository.LocalPath)/build
       cd $(Build.Repository.LocalPath)/build
       cmake --version
-      cmake .. -DPYTHON_EXECUTABLE=$(which python3.7) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=Release -DNMODL_ENABLE_LLVM=OFF
+      cmake .. -DPYTHON_EXECUTABLE=$(which python3.7) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=Release -DNMODL_ENABLE_LLVM=ON
       make -j 2
       if [ $? -ne 0 ]
       then

--- a/ci/bb5-pr
+++ b/ci/bb5-pr
@@ -41,7 +41,7 @@ function build_with() {
              -DPYTHON_EXECUTABLE=$(which python3) \
              -DNMODL_FORMATTING:BOOL=ON \
              -DClangFormat_EXECUTABLE=$clang_format_exe \
-             -DLLVM_DIR=/gpfs/bbp.cscs.ch/apps/hpc/jenkins/merge/deploy/externals/latest/linux-rhel7-x86_64/gcc-9.3.0/llvm-11.0.0-kzl4o5/lib/cmake/llvm
+             -DLLVM_DIR=/gpfs/bbp.cscs.ch/data/project/proj16/software/llvm/install/0421/lib/cmake/llvm
     make -j6
     popd
 }

--- a/ci/bb5-pr
+++ b/ci/bb5-pr
@@ -7,7 +7,7 @@ git show HEAD
 source /gpfs/bbp.cscs.ch/apps/hpc/jenkins/config/modules.sh
 module use /gpfs/bbp.cscs.ch/apps/tools/modules/tcl/linux-rhel7-x86_64/
 
-module load archive/2020-10 cmake bison flex python-dev doxygen
+module load unstable cmake bison flex python-dev doxygen
 module list
 
 function bb5_pr_setup_virtualenv() {


### PR DESCRIPTION
 * In order to use VecLibReplace pass, we need LLVM 13 / trunk
 * Change ubuntu image on azure from 16.04 to 18.04
 * Install llvm-13 nightly snapshot
 * Enable LLVM build on Ubuntu
 * For Mac OS use pre-built binary package from https://github.com/pramodk/llvm-nightly
 * We will see if we get OS X bottle from BlueBrain/homebrew-tap/pull/7
