### PR TITLE
Using shared libraries in LLVM JIT

### DIFF
--- a/cmake/LLVMHelper.cmake
+++ b/cmake/LLVMHelper.cmake
@@ -10,6 +10,7 @@ llvm_map_components_to_libnames(
   analysis
   codegen
   core
+  executionengine
   instcombine
   mc
   native

--- a/src/codegen/llvm/jit_driver.cpp
+++ b/src/codegen/llvm/jit_driver.cpp
@@ -111,7 +111,7 @@ std::unique_ptr<llvm::TargetMachine> JITDriver::create_target(
 }
 
 void JITDriver::set_triple_and_data_layout(const std::string& features) {
-    // Get the deafult target triple for the host.
+    // Get the default target triple for the host.
     auto target_triple = llvm::sys::getDefaultTargetTriple();
     std::string error_msg;
     auto* target = llvm::TargetRegistry::lookupTarget(target_triple, error_msg);

--- a/src/codegen/llvm/jit_driver.cpp
+++ b/src/codegen/llvm/jit_driver.cpp
@@ -11,9 +11,11 @@
 #include "llvm/ExecutionEngine/JITEventListener.h"
 #include "llvm/ExecutionEngine/ObjectCache.h"
 #include "llvm/ExecutionEngine/Orc/CompileUtils.h"
+#include "llvm/ExecutionEngine/Orc/Core.h"
 #include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
 #include "llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h"
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
+#include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
 #include "llvm/ExecutionEngine/SectionMemoryManager.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Support/TargetRegistry.h"
@@ -22,27 +24,57 @@
 namespace nmodl {
 namespace runner {
 
-void JITDriver::init(std::string features) {
+void JITDriver::init(std::string features, std::vector<std::string>& lib_paths) {
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();
+
+    // Set the target triple and the data layout for the module.
+    set_triple_and_data_layout(features);
+    auto data_layout = module->getDataLayout();
+
+    // Create object linking function callback.
+    auto object_linking_layer_creator = [&](llvm::orc::ExecutionSession& session,
+                                            const llvm::Triple& TT) {
+        // Create linking layer.
+        auto layer = std::make_unique<llvm::orc::RTDyldObjectLinkingLayer>(session, []() {
+            return std::make_unique<llvm::SectionMemoryManager>();
+        });
+        for (const auto& lib_path: lib_paths) {
+            // For every library path, create a corresponding memory buffer.
+            auto memory_buffer = llvm::MemoryBuffer::getFile(lib_path);
+            if (!memory_buffer) {
+                logger->warn("Unable to create memory buffer for " + lib_path);
+                continue;
+            }
+            // Create a new JIT library instance for this session and resolve symbols.
+            auto& jd = session.createBareJITDylib(std::string(lib_path));
+            auto loaded =
+                llvm::orc::DynamicLibrarySearchGenerator::Load(lib_path.data(),
+                                                               data_layout.getGlobalPrefix());
+            if (!loaded) {
+                logger->warn("Unable to load " + lib_path);
+                continue;
+            }
+            jd.addGenerator(std::move(*loaded));
+            cantFail(layer->add(jd, std::move(*memory_buffer)));
+        }
+
+        return layer;
+    };
 
     // Create IR compile function callback.
     auto compile_function_creator = [&](llvm::orc::JITTargetMachineBuilder tm_builder)
         -> llvm::Expected<std::unique_ptr<llvm::orc::IRCompileLayer::IRCompiler>> {
         // Create target machine with some features possibly turned off.
         auto tm = create_target(&tm_builder, features);
-
-        // Set the target triple and the data layout for the module.
-        module->setDataLayout(tm->createDataLayout());
-        module->setTargetTriple(tm->getTargetTriple().getTriple());
-
         return std::make_unique<llvm::orc::TMOwningSimpleCompiler>(std::move(tm));
     };
 
     // Set JIT instance and extract the data layout from the module.
-    auto jit_instance = cantFail(
-        llvm::orc::LLJITBuilder().setCompileFunctionCreator(compile_function_creator).create());
-    auto data_layout = module->getDataLayout();
+    auto jit_instance = cantFail(llvm::orc::LLJITBuilder()
+                                     .setCompileFunctionCreator(compile_function_creator)
+                                     .setObjectLinkingLayerCreator(object_linking_layer_creator)
+                                     .create());
 
     // Add a ThreadSafeModule to the driver.
     llvm::orc::ThreadSafeModule tsm(std::move(module), std::make_unique<llvm::LLVMContext>());
@@ -80,5 +112,26 @@ std::unique_ptr<llvm::TargetMachine> JITDriver::create_target(
     return std::unique_ptr<llvm::TargetMachine>(tm);
 }
 
+bool JITDriver::set_triple_and_data_layout(const std::string& features) {
+    // Get the deafult target triple for the host.
+    auto target_triple = llvm::sys::getDefaultTargetTriple();
+    std::string error_msg;
+    auto* target = llvm::TargetRegistry::lookupTarget(target_triple, error_msg);
+    if (!target)
+        throw std::runtime_error("Error " + error_msg + "\n");
+
+    // Get the CPU information and set a target machine to create the data layout.
+    std::string cpu(llvm::sys::getHostCPUName());
+
+    std::unique_ptr<llvm::TargetMachine> tm(
+        target->createTargetMachine(target_triple, cpu, features, {}, {}));
+    if (!tm)
+        throw std::runtime_error("Error: could not create the target machine\n");
+
+    // Set data layout and the target triple to the module.
+    module->setDataLayout(tm->createDataLayout());
+    module->setTargetTriple(target_triple);
+    return false;
+}
 }  // namespace runner
 }  // namespace nmodl

--- a/src/codegen/llvm/jit_driver.hpp
+++ b/src/codegen/llvm/jit_driver.hpp
@@ -37,7 +37,7 @@ class JITDriver {
         : module(std::move(m)) {}
 
     /// Initialize the JIT.
-    void init(std::string features);
+    void init(std::string features, std::vector<std::string>& lib_paths);
 
     /// Lookup the entry-point without arguments in the JIT and execute it, returning the result.
     template <typename ReturnType>
@@ -66,6 +66,9 @@ class JITDriver {
     /// A wrapper around llvm::createTargetMachine to turn on/off certain CPU features.
     std::unique_ptr<llvm::TargetMachine> create_target(llvm::orc::JITTargetMachineBuilder* builder,
                                                        const std::string& features);
+
+    /// Sets the triple and the data layout for the module.
+    bool set_triple_and_data_layout(const std::string& features);
 };
 
 /**
@@ -79,9 +82,9 @@ class Runner {
     std::unique_ptr<JITDriver> driver = std::make_unique<JITDriver>(std::move(module));
 
   public:
-    Runner(std::unique_ptr<llvm::Module> m, std::string features = "")
-        : module(std::move(m)) {
-        driver->init(features);
+    Runner(std::unique_ptr<llvm::Module> m, std::string features = "", std::vector<std::string> lib_paths = {})
+            : module(std::move(m)) {
+        driver->init(features, lib_paths);
     }
 
     /// Run the entry-point function without arguments.

--- a/src/codegen/llvm/jit_driver.hpp
+++ b/src/codegen/llvm/jit_driver.hpp
@@ -68,7 +68,7 @@ class JITDriver {
                                                        const std::string& features);
 
     /// Sets the triple and the data layout for the module.
-    bool set_triple_and_data_layout(const std::string& features);
+    void set_triple_and_data_layout(const std::string& features);
 };
 
 /**

--- a/src/codegen/llvm/jit_driver.hpp
+++ b/src/codegen/llvm/jit_driver.hpp
@@ -83,7 +83,7 @@ class Runner {
 
   public:
     Runner(std::unique_ptr<llvm::Module> m, std::string features = "", std::vector<std::string> lib_paths = {})
-            : module(std::move(m)) {
+        : module(std::move(m)) {
         driver->init(features, lib_paths);
     }
 

--- a/src/codegen/llvm/jit_driver.hpp
+++ b/src/codegen/llvm/jit_driver.hpp
@@ -82,7 +82,9 @@ class Runner {
     std::unique_ptr<JITDriver> driver = std::make_unique<JITDriver>(std::move(module));
 
   public:
-    Runner(std::unique_ptr<llvm::Module> m, std::string features = "", std::vector<std::string> lib_paths = {})
+    Runner(std::unique_ptr<llvm::Module> m,
+           std::string features = "",
+           std::vector<std::string> lib_paths = {})
         : module(std::move(m)) {
         driver->init(features, lib_paths);
     }

--- a/src/codegen/llvm/llvm_benchmark.cpp
+++ b/src/codegen/llvm/llvm_benchmark.cpp
@@ -43,7 +43,8 @@ void LLVMBenchmark::benchmark(const std::shared_ptr<ast::Program>& node) {
                                         output_dir,
                                         llvm_build_info.opt_passes,
                                         llvm_build_info.use_single_precision,
-                                        llvm_build_info.vector_width);
+                                        llvm_build_info.vector_width,
+                                        llvm_build_info.vec_lib);
     generate_llvm(visitor, node);
 
     // Finally, run the benchmark and log the measurements.
@@ -103,7 +104,7 @@ void LLVMBenchmark::run_benchmark(codegen::CodegenLLVMVisitor& visitor,
 
     std::string features_str = llvm::join(features.begin(), features.end(), ",");
     std::unique_ptr<llvm::Module> m = visitor.get_module();
-    runner::Runner runner(std::move(m), features_str);
+    runner::Runner runner(std::move(m), features_str, shared_libs);
 
     // Benchmark every kernel.
     for (const auto& kernel_name: kernel_names) {

--- a/src/codegen/llvm/llvm_benchmark.hpp
+++ b/src/codegen/llvm/llvm_benchmark.hpp
@@ -20,6 +20,7 @@ struct LLVMBuildInfo {
     int vector_width;
     bool opt_passes;
     bool use_single_precision;
+    std::string vec_lib;
 };
 
 /**
@@ -32,6 +33,8 @@ class LLVMBenchmark {
     std::string mod_filename;
 
     std::string output_dir;
+
+    std::vector<std::string> shared_libs;
 
     int num_experiments;
 
@@ -65,12 +68,14 @@ class LLVMBenchmark {
   public:
     LLVMBenchmark(const std::string& mod_filename,
                   const std::string& output_dir,
+                  std::vector<std::string> shared_libs,
                   LLVMBuildInfo info,
                   int num_experiments,
                   int instance_size,
                   const std::string& backend)
         : mod_filename(mod_filename)
         , output_dir(output_dir)
+        , shared_libs(shared_libs)
         , num_experiments(num_experiments)
         , instance_size(instance_size)
         , backend(backend)

--- a/src/nmodl/main.cpp
+++ b/src/nmodl/main.cpp
@@ -180,8 +180,11 @@ int main(int argc, const char* argv[]) {
     /// llvm vector width
     int llvm_vec_width = 1;
 
-    /// vector library
+    /// vector library name
     std::string vec_lib("none");
+
+    /// list of shared libraries to link
+    std::vector<std::string> libs;
 
     /// run llvm benchmark
     bool run_benchmark(false);
@@ -328,6 +331,9 @@ int main(int argc, const char* argv[]) {
     benchmark_opt->add_flag("--run",
                        run_benchmark,
                        "Run LLVM benchmark ({})"_format(run_benchmark))->ignore_case();
+    benchmark_opt->add_option("--libs", libs, "Shared libraries to link IR against")
+            ->ignore_case()
+            ->check(CLI::ExistingFile);
     benchmark_opt->add_option("--instance-size",
                        instance_size,
                        "Instance struct size ({})"_format(instance_size))->ignore_case();
@@ -626,9 +632,12 @@ int main(int argc, const char* argv[]) {
 
             if (run_benchmark) {
                 logger->info("Running LLVM benchmark");
-                benchmark::LLVMBuildInfo info{llvm_vec_width, llvm_ir_opt_passes, llvm_float_type};
+                benchmark::LLVMBuildInfo info{llvm_vec_width,
+                                              llvm_ir_opt_passes,
+                                              llvm_float_type,
+                                              vec_lib};
                 benchmark::LLVMBenchmark bench(
-                    modfile, output_dir, info, repeat, instance_size, backend);
+                    modfile, output_dir, libs, info, repeat, instance_size, backend);
                 bench.benchmark(ast);
             }
 


### PR DESCRIPTION
This PR adds support for using shared libraries in the JIT runner.
The current implementation uses the benchmark as the entry-point:
```
$ bin/nmodl file.mod llvm --ir --vector-width 4 --veclib SVML benchmark --run --libs <...>.dylib <...>.dylib <...>.dylib
```

Also, the benchmark also takes the vector library into account.