### PR TITLE
Avoid local std::ofstream object causing segfault

### DIFF
--- a/src/codegen/llvm/llvm_benchmark.cpp
+++ b/src/codegen/llvm/llvm_benchmark.cpp
@@ -145,8 +145,6 @@ void LLVMBenchmark::set_log_output() {
 
     // Otherwise, dump logs to the specified file.
     std::string filename = output_dir + "/" + mod_filename + ".log";
-    std::ofstream ofs;
-
     ofs.open(filename.c_str());
 
     if (ofs.fail())

--- a/src/codegen/llvm/llvm_benchmark.hpp
+++ b/src/codegen/llvm/llvm_benchmark.hpp
@@ -46,6 +46,8 @@ class LLVMBenchmark {
 
     std::shared_ptr<std::ostream> log_stream;
 
+    std::ofstream ofs;
+
     /// Disable the specified feature.
     void disable(const std::string& feature, std::vector<std::string>& host_features);
 


### PR DESCRIPTION
 - std::ofstream().rdbuf() was used but as it was a local object,
   it becomes invalid at the end of function scope
 - make std::ofstream as member variable

Without this, if `-o <dir_name>` was used then we were getting segfault:

```console
$./bin/nmodl ../test.mod -o xx  llvm --ir --vector-width 1  --opt benchmark --run --instance-size 10000000 --repeat 4
[  1%] Built target config
...
VOID nrn_state_hh(INSTANCE_STRUCT *mech){
    INTEGER id
    INTEGER node_id
    DOUBLE v
    for(id = 0; id<mech->node_count; id = id+1) {
        node_id = mech->node_index[id]
        v = mech->voltage[node_id]
        mech->m[id] = exp(mech->minf[id])
    }
}
[NMODL] [info] :: Running LLVM optimisation passes
Segmentation fault: 11
```