### PR TITLE
Azure wheels : build only for schedule or manual triggers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,8 +5,7 @@ variables:
   # defined in UI
   #- ReleaseWheelBuild: False
   #- NightlyWheelBuild: False
-  buildWheel: ${{ or(in(variables['Build.Reason'], 'Schedule'),
-              and(in(variables['Build.Reason'], 'Manual'), eq(variables.NightlyWheelBuild, True))) }}
+  buildWheel: ${{ or(in(variables['Build.Reason'], 'Schedule'), in(variables['Build.Reason'], 'Manual')) }}
 
 # Nightly build master for pypi upload
 schedules:


### PR DESCRIPTION
  * User defined variables can not be referred in compile
    time evaluation using `${{ }}` syntax
  * Also, user defined variables are not available at compile
    time evaluation
  * Stick to use of "predefined variables".
  * With this PR, all wheels are built if CI is launched via
    schedule or mnually in web UI of Azure.
  * More complex scheme based on branch name etc. can be implemented