### PR TITLE
Fixes to upload wheels to pypi.org from Azure CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 variables:
   # defined in UI
   #- ReleaseWheelBuild: False
-  #- NightlyWheelBuild: False
+  #- UploadWheel: False
   buildWheel: ${{ or(in(variables['Build.Reason'], 'Schedule'), in(variables['Build.Reason'], 'Manual')) }}
 
 # Nightly build master for pypi upload
@@ -192,7 +192,7 @@ jobs:
     submodules: True
     condition: succeeded()
   - script: |
-      if [ "$(buildWheel)" == "True" ]; then
+      if [[ "$(RELEASEWHEELBUILD)" != "True" ]]; then
         export TAG="-nightly"
       else
         export TAG=""
@@ -261,7 +261,7 @@ jobs:
       export MACOSX_DEPLOYMENT_TARGET=10.9
       export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH
       export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
-      if [ "$(buildWheel)" == "True" ]; then
+      if [[ "$(RELEASEWHEELBUILD)" != "True" ]]; then
         export NMODL_NIGHTLY_TAG="-nightly"
       else
         export NMODL_NIGHTLY_TAG=""

--- a/ci/upload-wheels.yml
+++ b/ci/upload-wheels.yml
@@ -10,14 +10,14 @@ steps:
       python -m pip install twine
       cat $(PYPIRC_PATH)
       python -m twine upload --verbose --skip-existing -r NMODLPypiNightly --config-file $(PYPIRC_PATH) wheelhouse/*.whl
-    condition: and(succeeded(), eq(variables.buildWheel, true))
+    condition: and(succeeded(), eq(variables.buildWheel, true), ne(variables['UploadWheel'], false))
     displayName: 'Upload nightly wheel to pypi.org'
   - task: TwineAuthenticate@1
     inputs:
       pythonUploadServiceConnection: AzureNMODLPypi
-    condition: and(succeeded(), in(variables['Build.Reason'], 'Manual'), eq(variables.releaseWheelBuild, true))
+    condition: and(succeeded(), in(variables['Build.Reason'], 'Manual'), eq(variables.ReleaseWheelBuild, true))
   - script: |
       python -m pip install twine
       python -m twine upload --verbose --skip-existing -r NMODLPypi --config-file $(PYPIRC_PATH) wheelhouse/*.whl
-    condition: and(succeeded(), in(variables['Build.Reason'], 'Manual'), eq(variables.releaseWheelBuild, true))
+    condition: and(succeeded(), in(variables['Build.Reason'], 'Manual'), eq(variables.ReleaseWheelBuild, true), ne(variables['UploadWheel'], false))
     displayName: 'Upload release wheel to pypi.org'

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,9 @@ try:
         .decode()
     )
     __version__ = v[: v.rfind("-")].replace("-", ".") if "-" in v else v
+    # allow to override version during development/testing
+    if "NMODL_WHEEL_VERSION" in os.environ:
+        __version__ = os.environ['NMODL_WHEEL_VERSION']
 except Exception as e:
     raise RuntimeError("Could not get version from Git repo") from e
 


### PR DESCRIPTION
 * Azure CI can be launched manually to upload wheels
   to nmodl-nightly or nmodl projects on pypi.org
 * Open Azure Web UI and set following variables:
   - `ReleaseWheelBuild = True` to build the wheels
     without nightly tag i.e. release wheel
   - `UploadWheel = False` to disable uploading wheels
     to pypi.org. This is useful for testing where
     wheels are built but they are not uploaded
   - `NMODL_WHEEL_VERSION = x.y` to override the version
     number created by `git describe --tags` command.
     This is helpful for testing/development purpose
     as pypi.org doesn't allow to upload same version
     wheels.