### PR TITLE
Fix conversion to int if the double is bigger than INT_MAX

### DIFF
--- a/src/utils/string_utils.hpp
+++ b/src/utils/string_utils.hpp
@@ -137,8 +137,10 @@ static inline std::string tolower(std::string text) {
  */
 static inline std::string to_string(double value, const std::string& format_spec = "{:.16g}") {
     // double containing integer value
-    if (std::ceil(value) == value) {
-        return std::to_string(static_cast<int>(value));
+    if (std::ceil(value) == value &&
+        value < static_cast<double>(std::numeric_limits<long long>::max()) &&
+        value > static_cast<double>(std::numeric_limits<long long>::min())) {
+        return std::to_string(static_cast<long long>(value));
     }
 
     // actual float value


### PR DESCRIPTION
* Due to gap between number, if number is big, std::ceil(value) == value, but it cannot fit an int
* Test before printing and use long long to take the biggest integer possible