### PR TITLE
Fixed addition of SOLVE block to kernel's FOR loop

### DIFF
--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -248,7 +248,12 @@ std::shared_ptr<ast::InstanceStruct> CodegenLLVMHelperVisitor::create_instance_s
 static void append_statements_from_block(ast::StatementVector& statements,
                                          const std::shared_ptr<ast::StatementBlock>& block) {
     const auto& block_statements = block->get_statements();
-    statements.insert(statements.end(), block_statements.begin(), block_statements.end());
+    for (const auto& statement: block_statements) {
+        const auto& expression_statement = std::dynamic_pointer_cast<ast::ExpressionStatement>(
+            statement);
+        if (!expression_statement->get_expression()->is_solve_block())
+            statements.push_back(statement);
+    }
 }
 
 static std::shared_ptr<ast::CodegenAtomicStatement> create_atomic_statement(std::string& lhs_str,
@@ -638,7 +643,6 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
         /// add breakpoint block if no current
         if (info.currents.empty() && info.breakpoint_node != nullptr) {
             auto block = info.breakpoint_node->get_statement_block();
-            // \todo this automatically adds `SOLVE states METHOD ...`
             append_statements_from_block(loop_body_statements, block);
         }
 


### PR DESCRIPTION
This is a small PR to fix `append_statements_from_block` function in LLVM helper visitor. Before, if nonspecific current was not specified, the whole `BREAKPOINT` block would be added to the kernel body. This led to cases when `SOLVE` block was together with the actual solution to `DERIVATIVE`:

```c++
VOID nrn_state_test(INSTANCE_STRUCT *mech){
    INTEGER id
    INTEGER node_id
    DOUBLE v
    for(id = 0; id<mech->node_count-1; id = id+2) {
        node_id = mech->node_index[id]
        v = mech->voltage[node_id]
        mech->m[id] = mech->m[id]+(1.0-exp(mech->dt*(1.0)))*(-(0.0)/(1.0)-mech->m[id])
        SOLVE states METHOD cnexp
        // Rest of BREAKPOINT code
    }
    // Rest of kernel
}
```

Now, a statement expression is checked before appending so that `SOLVE` is not added.