### PR TITLE
Fix instance struct data generation for testing/benchmarking

### DIFF
--- a/test/unit/codegen/codegen_data_helper.cpp
+++ b/test/unit/codegen/codegen_data_helper.cpp
@@ -115,7 +115,14 @@ CodegenInstanceData CodegenDataHelper::create_data(size_t num_elements, size_t s
         // allocate memory and setup a pointer
         void* member;
         posix_memalign(&member, NBYTE_ALIGNMENT, member_size * num_elements);
-        initialize_variable(var, member, variable_index, num_elements);
+
+        // integer values are often offsets so they must start from
+        // 0 to num_elements-1 to avoid out of bound accesses.
+        int initial_value = variable_index;
+        if (type == ast::AstNodeType::INTEGER) {
+            initial_value = 0;
+        }
+        initialize_variable(var, member, initial_value, num_elements);
         data.num_bytes += member_size * num_elements;
 
         // copy address at specific location in the struct

--- a/test/unit/codegen/codegen_data_helper.hpp
+++ b/test/unit/codegen/codegen_data_helper.hpp
@@ -61,7 +61,7 @@ struct CodegenInstanceData {
  *                  with an increment of 1e-5. The increment can be any other
  *                  value but 1e-5 is chosen because when we benchmark with
  *                  a million elements then the values are in the range of
- *                  <initial_value, initial_value + 10).
+ *                  <initial_value, initial_value + 10>.
  * For int type:    generate vector starting from initial_value with an
  *                  increments of 1
  *

--- a/test/unit/codegen/codegen_data_helper.hpp
+++ b/test/unit/codegen/codegen_data_helper.hpp
@@ -57,11 +57,12 @@ struct CodegenInstanceData {
 /**
  * Generate vector of dummy data according to the template type specified
  *
- * For double type: generate vector starting from (initial_value + 1e-15)
- *                  with increments of 1e-15
- * For float type:  generate vector starting from (initial_value + 1e-6)
- *                  with increments of 1e-6
- * For int type:    generate vector starting from (initial_value + 1) with
+ * For double or float type: generate vector starting from `initial_value`
+ *                  with an increment of 1e-5. The increment can be any other
+ *                  value but 1e-5 is chosen because when we benchmark with
+ *                  a million elements then the values are in the range of
+ *                  <initial_value, initial_value + 10).
+ * For int type:    generate vector starting from initial_value with an
  *                  increments of 1
  *
  * \param inital_value Base value for initializing the data
@@ -71,16 +72,14 @@ struct CodegenInstanceData {
 template <typename T>
 std::vector<T> generate_dummy_data(size_t initial_value, size_t num_elements) {
     std::vector<T> data(num_elements);
-    T precision;
-    if (std::is_same<T, double>::value) {
-        precision = 1e-15;
-    } else if (std::is_same<T, float>::value) {
-        precision = 1e-6;
+    T increment;
+    if (std::is_same<T, int>::value) {
+        increment = 1;
     } else {
-        precision = 1;
+        increment = 1e-5;
     }
     for (size_t i = 0; i < num_elements; i++) {
-        data[i] = initial_value + precision * (i + 1);
+        data[i] = initial_value + increment * i;
     }
     return data;
 }

--- a/test/unit/codegen/codegen_llvm_instance_struct.cpp
+++ b/test/unit/codegen/codegen_llvm_instance_struct.cpp
@@ -132,8 +132,12 @@ SCENARIO("Instance Struct creation", "[visitor][llvm][instance_struct]") {
                             generate_dummy_data<double>(ena_index, num_elements)));
             REQUIRE(compare(instance_data.members[ion_ena_index],
                             generate_dummy_data<double>(ion_ena_index, num_elements)));
+            // index variables are offsets, they start from 0
+            REQUIRE(compare(instance_data.members[ion_ena_index_index],
+                            generate_dummy_data<int>(0, num_elements)));
             REQUIRE(compare(instance_data.members[node_index_index],
-                            generate_dummy_data<int>(node_index_index, num_elements)));
+                            generate_dummy_data<int>(0, num_elements)));
+
             REQUIRE(*static_cast<double*>(instance_data.members[t_index]) ==
                     default_nthread_t_value);
             REQUIRE(*static_cast<int*>(instance_data.members[node_count_index]) == num_elements);
@@ -165,7 +169,7 @@ SCENARIO("Instance Struct creation", "[visitor][llvm][instance_struct]") {
             REQUIRE(compare(instance->ion_ena,
                             generate_dummy_data<double>(ion_ena_index, num_elements)));
             REQUIRE(compare(instance->node_index,
-                            generate_dummy_data<int>(node_index_index, num_elements)));
+                            generate_dummy_data<int>(0, num_elements)));
             REQUIRE(instance->t == default_nthread_t_value);
             REQUIRE(instance->celsius == default_celsius_value);
             REQUIRE(instance->secondorder == default_second_order_value);

--- a/test/unit/codegen/codegen_llvm_instance_struct.cpp
+++ b/test/unit/codegen/codegen_llvm_instance_struct.cpp
@@ -168,8 +168,7 @@ SCENARIO("Instance Struct creation", "[visitor][llvm][instance_struct]") {
             REQUIRE(compare(instance->ena, generate_dummy_data<double>(ena_index, num_elements)));
             REQUIRE(compare(instance->ion_ena,
                             generate_dummy_data<double>(ion_ena_index, num_elements)));
-            REQUIRE(compare(instance->node_index,
-                            generate_dummy_data<int>(0, num_elements)));
+            REQUIRE(compare(instance->node_index, generate_dummy_data<int>(0, num_elements)));
             REQUIRE(instance->t == default_nthread_t_value);
             REQUIRE(instance->celsius == default_celsius_value);
             REQUIRE(instance->secondorder == default_second_order_value);


### PR DESCRIPTION
* Instance data structure initialization had following bug
   - instance struct has int member variables which act as
     offsets to other vectors (e.g. node_index, na_ion_index)
   - these variables were initialized from 1 to N where N was
     incremented always without considering the upper bound on
     for offset.
* With this fix
   - index / integer variables are always initialized from
     0 to N-1.
   - Variables are initialised 1e-5 prevision so that we have
     reaosanbly bigger values
   - Update tests to check offset from 0 to N-1


#### Before this PR

* Using following mod file section

```python
DERIVATIVE states {
     m = minf + mtau + 0.1
     printf("%lf %d %lf", m, ion_nai_id, nai)
}
```

was giving:

```console
→ ./bin/nmodl ../test.mod -o tmp  llvm --ir benchmark --run --instance-size 10 --repeat 5 passes --nmodl-ast
...
VOID nrn_state_hh(INSTANCE_STRUCT *mech){
    INTEGER id
    INTEGER node_id, nai_id, ion_nai_id
    DOUBLE v
    for(id = 0; id<mech->node_count; id = id+1) {
        node_id = mech->node_index[id]
        nai_id = mech->ion_nai_index[id]
        ion_nai_id = mech->ion_nai_index[id]
        v = mech->voltage[node_id]
        mech->nai[id] = mech->ion_nai[nai_id]
        mech->m[id] = mech->minf[id]+mech->mtau[id]+0.1
        printf("%lf %d %lf", mech->m[id], ion_nai_id, mech->nai[id])
        ion_nai[ion_nai_id] = mech->nai[id]
    }
}
"1.100000 10 0.000000"
"1.100000 11 0.000000"
"1.100000 12 646336755223884745735328114412200101893866835352611174334569092060399490557310180854335030311700229111186702343527410589048895891774782015716682450349536140348815096938496.000000"
"1.100000 13 56113581110706065155469802347281086104035612223141610723150121361654672141371116480794833160254391059392508483626541548717310424202026534195442344680366989953895547911629570900739698253757508839538688.000000"
...
```
notice garbage values.

#### After this PR

```console
...
VOID nrn_state_hh(INSTANCE_STRUCT *mech){
    INTEGER id
    INTEGER node_id, nai_id, ion_nai_id
    DOUBLE v
    for(id = 0; id<mech->node_count; id = id+1) {
        node_id = mech->node_index[id]
        nai_id = mech->ion_nai_index[id]
        ion_nai_id = mech->ion_nai_index[id]
        v = mech->voltage[node_id]
        mech->nai[id] = mech->ion_nai[nai_id]
        mech->m[id] = mech->minf[id]+mech->mtau[id]+0.1
        printf("%lf %d %lf", mech->m[id], ion_nai_id, mech->nai[id])
        ion_nai[ion_nai_id] = mech->nai[id]
    }
}
"1.100000 0 7.000000"
"1.100020 1 7.000010"
"1.100040 2 7.000020"
"1.100060 3 7.000030"
"1.100080 4 7.000040"
"1.100100 5 7.000050"
"1.100120 6 7.000060"
...
```