### PR TITLE
Basic scatter support

### DIFF
--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -165,7 +165,7 @@ void CodegenLLVMVisitor::find_kernel_names(std::vector<std::string>& container) 
     // By convention, only kernel functions have a return type of void.
     const auto& functions = module->getFunctionList();
     for (const auto& func: functions) {
-        if (func.getReturnType()->isVoidTy()) {
+        if (func.getReturnType()->isVoidTy() && llvm::hasSingleElement(func.args())) {
             container.push_back(func.getName().str());
         }
     }
@@ -366,7 +366,7 @@ void CodegenLLVMVisitor::wrap_kernel_functions() {
         if (!kernel)
             throw std::runtime_error("Error: kernel " + kernel_name + " is not found\n");
 
-        if (std::distance(kernel->args().begin(), kernel->args().end()) != 1)
+        if (!llvm::hasSingleElement(kernel->args()))
             throw std::runtime_error("Error: kernel " + kernel_name +
                                      " must have a single argument\n");
 

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -37,9 +37,9 @@ static constexpr const char instance_struct_type_name[] = "__instance_var__type"
 
 /// A utility to check for supported Statement AST nodes.
 static bool is_supported_statement(const ast::Statement& statement) {
-    return statement.is_codegen_atomic_statement() || statement.is_codegen_var_list_statement() ||
-           statement.is_expression_statement() || statement.is_codegen_for_statement() ||
-           statement.is_codegen_return_statement() || statement.is_if_statement() ||
+    return statement.is_codegen_atomic_statement() || statement.is_codegen_for_statement() ||
+           statement.is_if_statement() || statement.is_codegen_return_statement() ||
+           statement.is_codegen_var_list_statement() || statement.is_expression_statement() ||
            statement.is_while_statement();
 }
 
@@ -449,6 +449,7 @@ void CodegenLLVMVisitor::visit_codegen_atomic_statement(const ast::CodegenAtomic
     // difference here is that the writes to the LHS variable must be atomic. These has a particular
     // use case in synapse kernels. For simplicity, we choose not to support atomic writes at this
     // stage and emit a warning.
+    // TODO: support this properly.
     if (vector_width > 1)
         logger->warn("Atomic operations are not supported");
 

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -37,9 +37,10 @@ static constexpr const char instance_struct_type_name[] = "__instance_var__type"
 
 /// A utility to check for supported Statement AST nodes.
 static bool is_supported_statement(const ast::Statement& statement) {
-    return statement.is_codegen_var_list_statement() || statement.is_expression_statement() ||
-           statement.is_codegen_for_statement() || statement.is_codegen_return_statement() ||
-           statement.is_if_statement() || statement.is_while_statement();
+    return statement.is_codegen_atomic_statement() || statement.is_codegen_var_list_statement() ||
+           statement.is_expression_statement() || statement.is_codegen_for_statement() ||
+           statement.is_codegen_return_statement() || statement.is_if_statement() ||
+           statement.is_while_statement();
 }
 
 /// A utility to check that the kernel body can be vectorised.
@@ -441,6 +442,29 @@ void CodegenLLVMVisitor::visit_statement_block(const ast::StatementBlock& node) 
 
 void CodegenLLVMVisitor::visit_boolean(const ast::Boolean& node) {
     ir_builder.create_boolean_constant(node.get_value());
+}
+
+void CodegenLLVMVisitor::visit_codegen_atomic_statement(const ast::CodegenAtomicStatement& node) {
+    // Currently, this functions is very similar to visiting the binary operator. However, the
+    // difference here is that the writes to the LHS variable must be atomic. These has a particular
+    // use case in synapse kernels. For simplicity, we choose not to support atomic writes at this
+    // stage and emit a warning.
+    if (vector_width > 1)
+        logger->warn("Atomic operations are not supported");
+
+    // Support only assignment for now.
+    llvm::Value* rhs = accept_and_get(node.get_rhs());
+    if (node.get_atomic_op().get_value() != ast::BinaryOp::BOP_ASSIGN)
+        throw std::runtime_error(
+            "Error: only assignment is supported for CodegenAtomicStatement\n");
+    const auto& var = dynamic_cast<ast::VarName*>(node.get_lhs().get());
+    if (!var)
+        throw std::runtime_error("Error: only 'VarName' assignment is supported\n");
+
+    // Process the assignment as if it was non-atomic.
+    if (vector_width > 1)
+        logger->warn("Treating write as non-atomic");
+    write_to_variable(*var, rhs);
 }
 
 // Generating FOR loop in LLVM IR creates the following structure:

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -155,6 +155,7 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     // Visitors.
     void visit_binary_expression(const ast::BinaryExpression& node) override;
     void visit_boolean(const ast::Boolean& node) override;
+    void visit_codegen_atomic_statement(const ast::CodegenAtomicStatement& node) override;
     void visit_codegen_for_statement(const ast::CodegenForStatement& node) override;
     void visit_codegen_function(const ast::CodegenFunction& node) override;
     void visit_codegen_return_statement(const ast::CodegenReturnStatement& node) override;

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -349,8 +349,11 @@ llvm::Value* IRBuilder::load_to_or_store_from_array(const std::string& id_name,
     // If the vector code is generated, we need to distinguish between two cases. If the array is
     // indexed indirectly (i.e. not by an induction variable `kernel_id`), create a gather
     // instruction.
-    if (id_name != kernel_id && vectorize && instruction_width > 1)
-        return builder.CreateMaskedGather(element_ptr, llvm::Align());
+    if (id_name != kernel_id && vectorize && instruction_width > 1) {
+        return maybe_value_to_store
+                   ? builder.CreateMaskedScatter(maybe_value_to_store, element_ptr, llvm::Align())
+                   : builder.CreateMaskedGather(element_ptr, llvm::Align());
+    }
 
     llvm::Value* ptr;
     if (vectorize && instruction_width > 1) {

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -445,15 +445,9 @@ SCENARIO("Vectorised kernel with scatter instruction", "[llvm][runner]") {
                 USEION ca WRITE cai
             }
 
-            ASSIGNED {
-                v
-            }
-
             BREAKPOINT {
                 SOLVE states METHOD cnexp
             }
-
-            STATE {}
 
             DERIVATIVE states {
                 : increment cai to test scatter

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -432,3 +432,85 @@ SCENARIO("Simple vectorised kernel", "[llvm][runner]") {
         }
     }
 }
+
+//=============================================================================
+// Vectorised kernel with ion writes.
+//=============================================================================
+
+SCENARIO("Vectorised kernel with scatter instruction", "[llvm][runner]") {
+    GIVEN("Simple MOD file with ion writes") {
+        std::string nmodl_text = R"(
+            NEURON {
+                SUFFIX test
+                USEION ca WRITE cai
+            }
+
+            ASSIGNED {
+                v
+            }
+
+            BREAKPOINT {
+                SOLVE states METHOD cnexp
+            }
+
+            STATE {}
+
+            DERIVATIVE states {
+                : increment cai to test scatter
+                cai = cai + 1
+            }
+        )";
+
+
+        NmodlDriver driver;
+        const auto& ast = driver.parse_string(nmodl_text);
+
+        // Run passes on the AST to generate LLVM.
+        SymtabVisitor().visit_program(*ast);
+        NeuronSolveVisitor().visit_program(*ast);
+        SolveBlockVisitor().visit_program(*ast);
+        codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
+                                                 /*output_dir=*/".",
+                                                 /*opt_passes=*/false,
+                                                 /*use_single_precision=*/false,
+                                                 /*vector_width=*/2);
+        llvm_visitor.visit_program(*ast);
+        llvm_visitor.wrap_kernel_functions();
+
+        // Create the instance struct data.
+        int num_elements = 5;
+        const auto& generated_instance_struct = llvm_visitor.get_instance_struct_ptr();
+        auto codegen_data = codegen::CodegenDataHelper(ast, generated_instance_struct);
+        auto instance_data = codegen_data.create_data(num_elements, /*seed=*/1);
+
+        // Fill the instance struct data with some values.
+        std::vector<double> cai = {1.0, 2.0, 3.0, 4.0, 5.0};
+        std::vector<double> ion_cai = {1.0, 2.0, 3.0, 4.0, 5.0};
+        std::vector<int> ion_cai_index = {4, 2, 3, 0, 1};
+
+        InstanceTestInfo instance_info{&instance_data,
+                                       llvm_visitor.get_instance_var_helper(),
+                                       num_elements};
+        initialise_instance_variable(instance_info, cai, "cai");
+        initialise_instance_variable(instance_info, ion_cai, "ion_cai");
+        initialise_instance_variable(instance_info, ion_cai_index, "ion_cai_index");
+
+        // Set up the JIT runner.
+        std::unique_ptr<llvm::Module> module = llvm_visitor.get_module();
+        TestRunner runner(std::move(module));
+        runner.initialize_driver();
+
+        THEN("Ion values in struct have been updated correctly") {
+            runner.run_with_argument<int, void*>("__nrn_state_test_wrapper",
+                                                 instance_data.base_ptr);
+            // cai[id] = ion_cai[ion_cai_index[id]]
+            // cai[id] += 1
+            std::vector<double> cai_expected = {6.0, 4.0, 5.0, 2.0, 3.0};
+            REQUIRE(check_instance_variable(instance_info, cai_expected, "cai"));
+
+            // ion_cai[ion_cai_index[id]] = cai[id]
+            std::vector<double> ion_cai_expected = {2.0, 3.0, 4.0, 5.0, 6.0};
+            REQUIRE(check_instance_variable(instance_info, ion_cai_expected, "ion_cai"));
+        }
+    }
+}

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -957,6 +957,59 @@ SCENARIO("Vectorised simple kernel", "[visitor][llvm]") {
 }
 
 //=============================================================================
+// Scatter for vectorised kernel
+//=============================================================================
+
+SCENARIO("Vectorised simple kernel with ion writes", "[visitor][llvm]") {
+    GIVEN("An indirect indexing of ca ion") {
+        std::string nmodl_text = R"(
+            NEURON {
+                SUFFIX hh
+                USEION ca WRITE cai
+            }
+
+            STATE {}
+
+            ASSIGNED {
+                v
+            }
+
+            BREAKPOINT {
+                SOLVE states METHOD cnexp
+            }
+
+            DERIVATIVE states {}
+        )";
+
+        THEN("a scatter instructions is created") {
+            std::string module_string = run_llvm_visitor(nmodl_text,
+                                                         /*opt=*/false,
+                                                         /*use_single_precision=*/false,
+                                                         /*vector_width=*/4);
+            std::smatch m;
+
+            // Check scatter intrinsic is correctly declared.
+            std::regex declaration(
+                R"(declare void @llvm\.masked\.scatter\.v4f64\.v4p0f64\(<4 x double>, <4 x double\*>, i32 immarg, <4 x i1>\))");
+            REQUIRE(std::regex_search(module_string, m, declaration));
+
+            // Check that the indices vector is created correctly and extended to i64.
+            std::regex index_load(R"(load <4 x i32>, <4 x i32>\* %ion_cai_id)");
+            std::regex sext(R"(sext <4 x i32> %.* to <4 x i64>)");
+            REQUIRE(std::regex_search(module_string, m, index_load));
+            REQUIRE(std::regex_search(module_string, m, sext));
+
+            // Check that store to `ion_cai` is performed via gather instruction.
+            //      mech->ion_cai[ion_cai_id] = mech->cai[id]
+            std::regex scatter(
+                "call void @llvm\\.masked\\.scatter\\.v4f64\\.v4p0f64\\(<4 x double> %.*, <4 x "
+                "double\\*> %.*, i32 1, <4 x i1> <i1 true, i1 true, i1 true, i1 true>\\)");
+            REQUIRE(std::regex_search(module_string, m, scatter));
+        }
+    }
+}
+
+//=============================================================================
 // Derivative block : test optimization
 //=============================================================================
 

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -968,12 +968,6 @@ SCENARIO("Vectorised simple kernel with ion writes", "[visitor][llvm]") {
                 USEION ca WRITE cai
             }
 
-            STATE {}
-
-            ASSIGNED {
-                v
-            }
-
             BREAKPOINT {
                 SOLVE states METHOD cnexp
             }
@@ -999,8 +993,8 @@ SCENARIO("Vectorised simple kernel with ion writes", "[visitor][llvm]") {
             REQUIRE(std::regex_search(module_string, m, index_load));
             REQUIRE(std::regex_search(module_string, m, sext));
 
-            // Check that store to `ion_cai` is performed via gather instruction.
-            //      mech->ion_cai[ion_cai_id] = mech->cai[id]
+            // Check that store to `ion_cai` is performed via scatter instruction.
+            //      ion_cai[ion_cai_id] = cai[id]
             std::regex scatter(
                 "call void @llvm\\.masked\\.scatter\\.v4f64\\.v4p0f64\\(<4 x double> %.*, <4 x "
                 "double\\*> %.*, i32 1, <4 x i1> <i1 true, i1 true, i1 true, i1 true>\\)");


### PR DESCRIPTION
This PR adds basic support for scatter instruction. Currently, the scatter functionality is limited to non-atomic writes and assignment (Left  case: `+=`). A warning is logged to the console indicating all limitations.

Corresponding tests were added.

fixes #539 