### PR TITLE
Support for Breakpoint block (nrn_cur) for code generation

### DIFF
--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -200,8 +200,8 @@ void CodegenAccVisitor::print_net_init_acc_serial_annotation_block_end() {
 }
 
 void CodegenAccVisitor::print_nrn_cur_matrix_shadow_update() {
-    auto rhs_op = operator_for_rhs();
-    auto d_op = operator_for_d();
+    const auto& rhs_op = info.operator_for_rhs();
+    const auto& d_op = info.operator_for_d();
     print_atomic_reduction_pragma();
     printer->add_line("vec_rhs[node_id] {} rhs;"_format(rhs_op));
     print_atomic_reduction_pragma();
@@ -213,8 +213,8 @@ void CodegenAccVisitor::print_fast_imem_calculation() {
         return;
     }
 
-    auto rhs_op = operator_for_rhs();
-    auto d_op = operator_for_d();
+    const auto& rhs_op = info.operator_for_rhs();
+    const auto& d_op = info.operator_for_d();
     printer->start_block("if (nt->nrn_fast_imem)");
     print_atomic_reduction_pragma();
     printer->add_line("nt->nrn_fast_imem->nrn_sav_rhs[node_id] {} rhs;"_format(rhs_op));

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -325,37 +325,6 @@ void CodegenCVisitor::visit_update_dt(const ast::UpdateDt& node) {
 /*                               Common helper routines                                 */
 /****************************************************************************************/
 
-
-/**
- * \details Certain statements like unit, comment, solve can/need to be skipped
- * during code generation. Note that solve block is wrapped in expression
- * statement and hence we have to check inner expression. It's also true
- * for the initial block defined inside net receive block.
- */
-bool CodegenCVisitor::statement_to_skip(const Statement& node) const {
-    // clang-format off
-    if (node.is_unit_state()
-        || node.is_line_comment()
-        || node.is_block_comment()
-        || node.is_solve_block()
-        || node.is_conductance_hint()
-        || node.is_table_statement()) {
-        return true;
-    }
-    // clang-format on
-    if (node.is_expression_statement()) {
-        auto expression = dynamic_cast<const ExpressionStatement*>(&node)->get_expression();
-        if (expression->is_solve_block()) {
-            return true;
-        }
-        if (expression->is_initial_block()) {
-            return true;
-        }
-    }
-    return false;
-}
-
-
 /**
  * \details When floating point data type is not default (i.e. double) then we
  * have to copy old array to new type (for range variables).
@@ -974,8 +943,8 @@ void CodegenCVisitor::print_nrn_cur_matrix_shadow_update() {
             printer->add_line("shadow_rhs[id] = rhs;");
             printer->add_line("shadow_d[id] = g;");
         } else {
-            auto rhs_op = operator_for_rhs();
-            auto d_op = operator_for_d();
+            const auto& rhs_op = info.operator_for_rhs();
+            const auto& d_op = info.operator_for_d();
             print_atomic_reduction_pragma();
             printer->add_line("vec_rhs[node_id] {} rhs;"_format(rhs_op));
             print_atomic_reduction_pragma();
@@ -986,8 +955,8 @@ void CodegenCVisitor::print_nrn_cur_matrix_shadow_update() {
 
 
 void CodegenCVisitor::print_nrn_cur_matrix_shadow_reduction() {
-    auto rhs_op = operator_for_rhs();
-    auto d_op = operator_for_d();
+    const auto& rhs_op = info.operator_for_rhs();
+    const auto& d_op = info.operator_for_d();
     if (channel_task_dependency_enabled()) {
         auto rhs = get_variable_name("ml_rhs");
         auto d = get_variable_name("ml_d");
@@ -1167,7 +1136,7 @@ void CodegenCVisitor::print_statement_block(const ast::StatementBlock& node,
 
     auto statements = node.get_statements();
     for (const auto& statement: statements) {
-        if (statement_to_skip(*statement)) {
+        if (info.statement_to_skip(*statement)) {
             continue;
         }
         /// not necessary to add indent for verbatim block (pretty-printing)
@@ -4337,8 +4306,8 @@ void CodegenCVisitor::print_fast_imem_calculation() {
         return;
     }
     std::string rhs, d;
-    auto rhs_op = operator_for_rhs();
-    auto d_op = operator_for_d();
+    const auto& rhs_op = info.operator_for_rhs();
+    const auto& d_op = info.operator_for_d();
     if (channel_task_dependency_enabled()) {
         rhs = get_variable_name("ml_rhs");
         d = get_variable_name("ml_d");

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -218,23 +218,6 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
         return "\"" + text + "\"";
     }
 
-
-    /**
-     * Operator for rhs vector update (matrix update)
-     */
-    std::string operator_for_rhs() const noexcept {
-        return info.electrode_current ? "+=" : "-=";
-    }
-
-
-    /**
-     * Operator for diagonal vector update (matrix update)
-     */
-    std::string operator_for_d() const noexcept {
-        return info.electrode_current ? "-=" : "+=";
-    }
-
-
     /**
      * Data type for the local variables
      */

--- a/src/codegen/codegen_cuda_visitor.cpp
+++ b/src/codegen/codegen_cuda_visitor.cpp
@@ -96,8 +96,8 @@ void CodegenCudaVisitor::print_device_method_annotation() {
 
 
 void CodegenCudaVisitor::print_nrn_cur_matrix_shadow_update() {
-    auto rhs_op = operator_for_rhs();
-    auto d_op = operator_for_d();
+    auto rhs_op = info.operator_for_rhs();
+    auto d_op = info.operator_for_d();
     stringutils::remove_character(rhs_op, '=');
     stringutils::remove_character(d_op, '=');
     print_atomic_op("vec_rhs[node_id]", rhs_op, "rhs");
@@ -109,8 +109,8 @@ void CodegenCudaVisitor::print_fast_imem_calculation() {
         return;
     }
 
-    auto rhs_op = operator_for_rhs();
-    auto d_op = operator_for_d();
+    auto rhs_op = info.operator_for_rhs();
+    auto d_op = info.operator_for_d();
     stringutils::remove_character(rhs_op, '=');
     stringutils::remove_character(d_op, '=');
     printer->start_block("if (nt->nrn_fast_imem)");

--- a/src/codegen/codegen_driver.cpp
+++ b/src/codegen/codegen_driver.cpp
@@ -180,7 +180,7 @@ bool CodegenDriver::prepare_mod(std::shared_ptr<ast::Program> node) {
     /// that old symbols (e.g. prime variables) are not lost
     update_symtab = true;
 
-    if (cfg.nmodl_inline) {
+    if (cfg.nmodl_inline || cfg.llvm_ir) {
         logger->info("Running nmodl inline visitor");
         InlineVisitor().visit_program(*node);
         ast_to_nmodl(*node, filepath("inline", "mod"));

--- a/src/codegen/codegen_info.cpp
+++ b/src/codegen/codegen_info.cpp
@@ -404,5 +404,34 @@ void CodegenInfo::get_float_variables() {
     }
 }
 
+/**
+ * \details Certain statements like unit, comment, solve can/need to be skipped
+ * during code generation. Note that solve block is wrapped in expression
+ * statement and hence we have to check inner expression. It's also true
+ * for the initial block defined inside net receive block.
+ */
+bool CodegenInfo::statement_to_skip(const ast::Statement& node) const {
+    // clang-format off
+    if (node.is_unit_state()
+        || node.is_line_comment()
+        || node.is_block_comment()
+        || node.is_solve_block()
+        || node.is_conductance_hint()
+        || node.is_table_statement()) {
+        return true;
+    }
+    // clang-format on
+    if (node.is_expression_statement()) {
+        auto expression = dynamic_cast<const ast::ExpressionStatement*>(&node)->get_expression();
+        if (expression->is_solve_block()) {
+            return true;
+        }
+        if (expression->is_initial_block()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/codegen_info.hpp
+++ b/src/codegen/codegen_info.hpp
@@ -591,6 +591,29 @@ struct CodegenInfo {
 
 
     /**
+     * Operator for rhs vector update (matrix update)
+     *
+     * Note that we only rely on following two syntax for
+     * increment and decrement. Code generation backends
+     * are relying on this convention.
+     */
+    std::string operator_for_rhs() const noexcept {
+        return electrode_current ? "+=" : "-=";
+    }
+
+
+    /**
+     * Operator for diagonal vector update (matrix update)
+     *
+     * Note that we only rely on following two syntax for
+     * increment and decrement. Code generation backends
+     * are relying on this convention.
+     */
+    std::string operator_for_d() const noexcept {
+        return electrode_current ? "-=" : "+=";
+    }
+
+    /**
      * Check if net_receive function is required
      */
     bool net_receive_required() const noexcept {
@@ -657,6 +680,13 @@ struct CodegenInfo {
      * \return A \c vector of \c float variables
      */
     void get_float_variables();
+
+    /**
+     * Check if statement should be skipped for code generation
+     * @param node Statement to be checked for code generation
+     * @return True if statement should be skipped otherwise false
+     */
+    bool statement_to_skip(const ast::Statement& node) const;
 };
 
 /** @} */  // end of codegen_backends

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -248,8 +248,8 @@ void CodegenIspcVisitor::print_atomic_op(const std::string& lhs,
 
 
 void CodegenIspcVisitor::print_nrn_cur_matrix_shadow_reduction() {
-    auto rhs_op = operator_for_rhs();
-    auto d_op = operator_for_d();
+    const auto& rhs_op = info.operator_for_rhs();
+    const auto& d_op = info.operator_for_d();
     if (info.point_process) {
         printer->add_line("uniform int node_id = node_index[id];");
         printer->add_line("vec_rhs[node_id] {} shadow_rhs[id];"_format(rhs_op));

--- a/src/codegen/codegen_naming.hpp
+++ b/src/codegen/codegen_naming.hpp
@@ -92,6 +92,12 @@ static constexpr char NTHREAD_RHS_SHADOW[] = "_shadow_rhs";
 /// shadow d variable in neuron thread structure
 static constexpr char NTHREAD_D_SHADOW[] = "_shadow_d";
 
+/// rhs variable in neuron thread structure
+static constexpr char NTHREAD_RHS[] = "vec_rhs";
+
+/// d variable in neuron thread structure
+static constexpr char NTHREAD_D[] = "vec_d";
+
 /// t variable in neuron thread structure
 static constexpr char NTHREAD_T_VARIABLE[] = "t";
 

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -389,6 +389,8 @@ void CodegenLLVMHelperVisitor::ion_write_statements(BlockType type,
         std::string lhs = "{}[{}] "_format(ion_varname, index_varname);
 
         // lets turn a += b into a = a + b if applicable
+        // note that this is done in order to facilitate existing implementation in the llvm
+        // backend which doesn't support += or -= operators.
         std::string statement;
         if (!op.compare("+=")) {
             statement = "{} = {} + {}"_format(lhs, lhs, rhs);
@@ -825,8 +827,6 @@ void CodegenLLVMHelperVisitor::remove_inlined_nodes(ast::Program& node) {
  * \brief Convert ast::BreakpointBlock to corresponding code generation function nrn_cur
  * @param node AST node representing ast::BreakpointBlock
  *
- * \todo : This is work-in-progress. We need to refactor visit_nrn_state_block and
- *         visit_breakpoint_block to avoid code duplication.
  */
 void CodegenLLVMHelperVisitor::visit_breakpoint_block(ast::BreakpointBlock& node) {
     if (!info.nrn_cur_required()) {
@@ -870,7 +870,7 @@ void CodegenLLVMHelperVisitor::visit_breakpoint_block(ast::BreakpointBlock& node
                              index_statements,
                              body_statements);
 
-        // \todo handle nrn_current calls, see how it's done in C visitor!
+        // \todo handle nrn_current calls similar to C codegen backend
     }
 
     /// create target-specific compute body
@@ -897,7 +897,6 @@ void CodegenLLVMHelperVisitor::visit_breakpoint_block(ast::BreakpointBlock& node
     auto name = new ast::Name(new ast::String(function_name));
     auto return_type = new ast::CodegenVarType(ast::AstNodeType::VOID);
 
-    /// \todo : currently there are no arguments
     ast::CodegenVarWithTypeVector code_arguments;
 
     auto instance_var_type = new ast::CodegenVarType(ast::AstNodeType::INSTANCE_STRUCT);

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -840,7 +840,6 @@ void CodegenLLVMHelperVisitor::create_compute_body_loop(std::shared_ptr<ast::Sta
     function_statements.push_back(for_loop);
 }
 
-
 void CodegenLLVMHelperVisitor::remove_inlined_nodes(ast::Program& node) {
     auto program_symtab = node.get_model_symbol_table();
     const auto& func_proc_nodes =
@@ -1053,6 +1052,10 @@ void CodegenLLVMHelperVisitor::visit_breakpoint_block(ast::BreakpointBlock& node
 
         /// as multiple point processes can exist at same node, with simd or gpu execution we have
         /// to create atomic statements that will be handled by llvm ir generation
+        // \todo note that we are not creating rhs and d updates based on the shadow vectors. This
+        //       is because llvm backend for cpu as well as gpu is going to take care for
+        //       reductions. if these codegen functions will be used for C backend then we will need
+        //       to implement separate reduction loop like mod2c or nmodl's c backend.
         if (info.point_process && (platform.is_gpu() || platform.is_cpu_with_simd())) {
             body_statements.emplace_back(create_atomic_statement(
                 naming::NTHREAD_RHS, "node_id", info.operator_for_rhs(), "rhs"));

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -92,18 +92,18 @@ static std::shared_ptr<ast::Expression> create_statement_as_expression(const std
 }
 
 /**
- * \brief Create expression for given NMODL code expression
+ * \brief Create an expression for a given NMODL expression in string form
  * @param code NMODL code expression
- * @return Expression representing NMODL code
+ * @return Expression ast node representing NMODL code
  */
-std::shared_ptr<ast::Expression> create_expression(const std::string& code) {
+static ast::Expression* create_expression(const std::string& code) {
     /// as provided code is only expression and not a full statement, create
     /// a temporary assignment statement
     const auto& wrapped_expr = create_statement_as_expression("some_var = " + code);
     /// now extract RHS (representing original code) and return it as expression
     auto expr = std::dynamic_pointer_cast<ast::WrappedExpression>(wrapped_expr)->get_expression();
     auto rhs = std::dynamic_pointer_cast<ast::BinaryExpression>(expr)->get_rhs();
-    return std::make_shared<ast::WrappedExpression>(rhs->clone());
+    return new ast::WrappedExpression(rhs->clone());
 }
 
 CodegenFunctionVector CodegenLLVMHelperVisitor::get_codegen_functions(const ast::Program& node) {
@@ -246,35 +246,72 @@ std::shared_ptr<ast::InstanceStruct> CodegenLLVMHelperVisitor::create_instance_s
     add_var_with_type(naming::SECOND_ORDER_VARIABLE, INTEGER_TYPE, /*is_pointer=*/0);
     add_var_with_type(naming::MECH_NODECOUNT_VAR, INTEGER_TYPE, /*is_pointer=*/0);
 
+    // As we do not have `NrnThread` object as an argument, we store points to rhs
+    // and d to in the instance struct as well. Also need their respective shadow variables
+    // in case of point process mechanism.
+    // Note: shadow variables are not used at the moment because reduction will be taken care
+    // by LLVM backend (even on CPU via sequential add like ISPC).
+    add_var_with_type(naming::NTHREAD_RHS, FLOAT_TYPE, /*is_pointer=*/1);
+    add_var_with_type(naming::NTHREAD_D, FLOAT_TYPE, /*is_pointer=*/1);
+    add_var_with_type(naming::NTHREAD_RHS_SHADOW, FLOAT_TYPE, /*is_pointer=*/1);
+    add_var_with_type(naming::NTHREAD_D_SHADOW, FLOAT_TYPE, /*is_pointer=*/1);
+
     return std::make_shared<ast::InstanceStruct>(codegen_vars);
 }
 
+/**
+ * Append all code specific statements from StatementBlock to given StatementVector
+ * @param statements Statement vector to which statements to be added
+ * @param block Statement block from which statetments should be appended
+ * @param info CodegenInfo object with necessary data and helper functions
+ */
 static void append_statements_from_block(ast::StatementVector& statements,
-                                         const std::shared_ptr<ast::StatementBlock>& block) {
-    const auto& block_statements = block->get_statements();
-    for (const auto& statement: block_statements) {
-        const auto& expression_statement = std::dynamic_pointer_cast<ast::ExpressionStatement>(
-            statement);
-        if (!expression_statement || !expression_statement->get_expression()->is_solve_block())
-            statements.push_back(statement);
+                                         const std::shared_ptr<ast::StatementBlock> block,
+                                         const codegen::CodegenInfo& info) {
+    for (const auto& statement: block->get_statements()) {
+        if (!info.statement_to_skip(*statement)) {
+            statements.emplace_back(statement->clone());
+        }
     }
 }
 
+/**
+ * Create atomic statement for given expression of the form a[i] += expression
+ * @param var Name of the variable on the LHS (it's an array), e.g. `a`
+ * @param var_index Name of the index variable to access variable `var` e.g. `i`
+ * @param op_str Operators like += or -=
+ * @param rhs_str expression that will be added or subtracted from `var[var_index]`
+ * @return A statement representing atomic operation using `ast::CodegenAtomicStatement`
+ */
 static std::shared_ptr<ast::CodegenAtomicStatement> create_atomic_statement(
-    std::string& ion_varname,
-    std::string& index_varname,
-    std::string& op_str,
-    std::string& rhs_str) {
+    const std::string& var,
+    const std::string& var_index,
+    const std::string& op_str,
+    const std::string& rhs_str) {
     // create lhs expression
-    auto varname = new ast::Name(new ast::String(ion_varname));
-    auto index = new ast::Name(new ast::String(index_varname));
-    auto lhs = std::make_shared<ast::VarName>(new ast::IndexedName(varname, index),
-                                              /*at=*/nullptr,
-                                              /*index=*/nullptr);
+    auto varname = new ast::Name(new ast::String(var));
+    auto index = new ast::Name(new ast::String(var_index));
+    auto lhs = new ast::VarName(new ast::IndexedName(varname, index),
+                                /*at=*/nullptr,
+                                /*index=*/nullptr);
 
-    auto op = ast::BinaryOperator(ast::string_to_binaryop(op_str));
-    auto rhs = create_expression(rhs_str);
-    return std::make_shared<ast::CodegenAtomicStatement>(lhs, op, rhs);
+    // LLVM IR generation is now only supporting assignment (=) and not += or -=
+    // So we need to write increment operation a += b as an assignment operation
+    // a = a + b.
+    // See https://github.com/BlueBrain/nmodl/issues/851
+
+    std::string op(op_str);
+    stringutils::remove_character(op, '=');
+
+    // make sure only + or - operator is used
+    if (op_str != "-" && op_str != "+") {
+        throw std::runtime_error("Unsupported binary operator for atomic statement");
+    }
+
+    auto* rhs = create_expression("{}[{}] {} {} "_format(var, var_index, op, rhs_str));
+    return std::make_shared<ast::CodegenAtomicStatement>(lhs,
+                                                         ast::BinaryOperator{ast::BOP_ASSIGN},
+                                                         rhs);
 }
 
 /**
@@ -289,7 +326,7 @@ static std::shared_ptr<ast::CodegenAtomicStatement> create_atomic_statement(
  * @param type The type of code block being generated
  * @param int_variables Index variables to be created
  * @param double_variables Floating point variables to be created
- * @param index_statements Statements for loading indexes (typically for ions)
+ * @param index_statements Statements for loading indexes (typically for ions, rhs, d)
  * @param body_statements main compute/update statements
  *
  * \todo After looking into mod2c and neuron implementation, it seems like
@@ -380,11 +417,6 @@ void CodegenLLVMHelperVisitor::ion_write_statements(BlockType type,
 
         // pass ion variable to write and its index
 
-        // \todo: for ionic variable we don't need atomic operation for single threaded
-        //        execution. So let's skip this for now. See below comment for details:
-        //        https://github.com/BlueBrain/nmodl/pull/645#issuecomment-1095567789
-        // body_statements.push_back(create_atomic_statement(ion_varname, index_varname, op, rhs));
-
         // lhs variable
         std::string lhs = "{}[{}] "_format(ion_varname, index_varname);
 
@@ -418,7 +450,7 @@ void CodegenLLVMHelperVisitor::ion_write_statements(BlockType type,
                     // for synapse type
                     if (info.point_process) {
                         auto area = codegen::naming::NODE_AREA_VARIABLE;
-                        rhs += "*(1.e2/{})"_format(area);
+                        rhs += "*(1.e2/{0}[{0}_id])"_format(area);
                     }
                     create_write_statements(lhs, op, rhs);
                 }
@@ -648,19 +680,17 @@ std::shared_ptr<ast::Expression> CodegenLLVMHelperVisitor::loop_count_expression
  * create new code generation function.
  */
 void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
-    /// statements for new function to be generated
-    ast::StatementVector function_statements;
-
-    /// create vectors of local variables that would be used in compute part
+    // create vectors of local variables that would be used in compute part
     std::vector<std::string> int_variables{"node_id"};
     std::vector<std::string> double_variables{"v"};
 
-    /// create now main compute part
-
-    /// compute body : initialization + solve blocks
-    ast::StatementVector def_statements;
+    // statements to load indexes for gather/scatter like variables
     ast::StatementVector index_statements;
+
+    // statements for the main body of nrn_state
     ast::StatementVector body_statements;
+
+    // prepare main body of the compute function
     {
         /// access node index and corresponding voltage
         index_statements.push_back(
@@ -677,13 +707,13 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
             const auto& solution = std::dynamic_pointer_cast<ast::SolutionExpression>(statement);
             const auto& block = std::dynamic_pointer_cast<ast::StatementBlock>(
                 solution->get_node_to_solve());
-            append_statements_from_block(body_statements, block);
+            append_statements_from_block(body_statements, block, info);
         }
 
         /// add breakpoint block if no current
         if (info.currents.empty() && info.breakpoint_node != nullptr) {
             auto block = info.breakpoint_node->get_statement_block();
-            append_statements_from_block(body_statements, block);
+            append_statements_from_block(body_statements, block, info);
         }
 
         /// write ion statements
@@ -695,9 +725,11 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
 
     /// create target-specific compute body
     ast::StatementVector compute_body;
-    compute_body.insert(compute_body.end(), def_statements.begin(), def_statements.end());
     compute_body.insert(compute_body.end(), index_statements.begin(), index_statements.end());
     compute_body.insert(compute_body.end(), body_statements.begin(), body_statements.end());
+
+    /// statements for new function to be generated
+    ast::StatementVector function_statements;
 
     std::vector<std::string> induction_variables{naming::INDUCTION_VAR};
     function_statements.push_back(
@@ -717,9 +749,8 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     auto name = new ast::Name(new ast::String(function_name));
     auto return_type = new ast::CodegenVarType(ast::AstNodeType::VOID);
 
-    /// \todo : currently there are no arguments
+    // argument to function: currently only instance structure
     ast::CodegenVarWithTypeVector code_arguments;
-
     auto instance_var_type = new ast::CodegenVarType(ast::AstNodeType::INSTANCE_STRUCT);
     auto instance_var_name = new ast::Name(new ast::String(naming::MECH_INSTANCE_VAR));
     auto instance_var = new ast::CodegenVarWithType(instance_var_type, 1, instance_var_name);
@@ -730,7 +761,8 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
         std::make_shared<ast::CodegenFunction>(return_type, name, code_arguments, function_block);
     codegen_functions.push_back(function);
 
-    std::cout << nmodl::to_nmodl(function) << std::endl;
+    // todo: remove this, temporary
+    std::cout << nmodl::to_nmodl(*function) << std::endl;
 }
 
 void CodegenLLVMHelperVisitor::create_gpu_compute_body(ast::StatementVector& body,
@@ -808,6 +840,7 @@ void CodegenLLVMHelperVisitor::create_compute_body_loop(std::shared_ptr<ast::Sta
     function_statements.push_back(for_loop);
 }
 
+
 void CodegenLLVMHelperVisitor::remove_inlined_nodes(ast::Program& node) {
     auto program_symtab = node.get_model_symbol_table();
     const auto& func_proc_nodes =
@@ -824,28 +857,162 @@ void CodegenLLVMHelperVisitor::remove_inlined_nodes(ast::Program& node) {
 }
 
 /**
+ * Print `nrn_cur` kernel with`CONDUCTANCE` statements in the BREAKPOINT block
+ * @param node Ast node representing BREAKPOINT block
+ * @param int_variables Vector of integer variables in the kernel being generated
+ * @param double_variables Vector of double variables in the kernel being generated
+ * @param index_statements Statements for loading indexes (typically for ions, rhs, d)
+ * @param body_statements Vector of statements representing loop body of the `nrn_cur` kernel
+ */
+void CodegenLLVMHelperVisitor::print_nrn_cur_conductance_kernel(
+    const ast::BreakpointBlock& node,
+    std::vector<std::string>& int_variables,
+    std::vector<std::string>& double_variables,
+    ast::StatementVector& index_statements,
+    ast::StatementVector& body_statements) {
+    // TODO: this is not used by default but only with sympy --conductance option. This should be
+    // implemented later and hence just throw an error for now.
+    throw std::runtime_error(
+        "BREAKPOINT block with CONDUCTANCE statements is not supported in the LLVM backend yet");
+}
+
+/**
+ * Print `nrn_current` function that is typically generated as part of `nrn_cur()`
+ * @param node Ast node representing BREAKPOINT block
+ * @param body_statements Vector of statements representing loop body of the `nrn_cur` kernel
+ * @param variable Variable to which computed current will be assigned
+ */
+void CodegenLLVMHelperVisitor::print_nrn_current_body(const ast::BreakpointBlock& node,
+                                                      ast::StatementVector& body_statements,
+                                                      const std::string& variable) {
+    ast::StatementVector statements;
+
+    // starts with current initialized to 0
+    statements.emplace_back(visitor::create_statement("current = 0"));
+
+    // append compatible code statements from the breakpoint block
+    append_statements_from_block(statements, node.get_statement_block(), info);
+
+    // sum now all currents
+    for (auto& current: info.currents) {
+        statements.emplace_back(
+            visitor::create_statement("current = current + {}"_format(current)));
+    }
+
+    // assign computed current to the given variable
+    statements.emplace_back(visitor::create_statement("{} = current"_format(variable)));
+
+    // create StatementBlock for better readability of the generated code and add that to the main
+    // body statements
+    body_statements.emplace_back(new ast::ExpressionStatement(new ast::StatementBlock(statements)));
+}
+
+/**
+ * Print `nrn_cur` kernel without `CONDUCTANCE` statements in the BREAKPOINT block
+ * @param node Ast node representing BREAKPOINT block
+ * @param int_variables Vector of integer variables in the kernel being generated
+ * @param double_variables Vector of double variables in the kernel being generated
+ * @param index_statements Statements for loading indexes (typically for ions, rhs, d)
+ * @param body_statements Vector of statements representing loop body of the `nrn_cur` kernel
+ */
+void CodegenLLVMHelperVisitor::print_nrn_cur_non_conductance_kernel(
+    const ast::BreakpointBlock& node,
+    std::vector<std::string>& int_variables,
+    std::vector<std::string>& double_variables,
+    ast::StatementVector& index_statements,
+    ast::StatementVector& body_statements) {
+    // add double variables needed in the local scope
+    double_variables.emplace_back("g");
+    double_variables.emplace_back("rhs");
+    double_variables.emplace_back("v_org");
+    double_variables.emplace_back("current");
+
+    // store original voltage value as we are going to calculate current with v + 0.001
+    body_statements.emplace_back(visitor::create_statement("v_org = v"));
+
+    // first current calculation with v+0.001 and assign it to variable g
+    body_statements.emplace_back(visitor::create_statement("v = v + 0.001"));
+    print_nrn_current_body(node, body_statements, "g");
+
+    // now store all ionic currents to local variable
+    for (const auto& ion: info.ions) {
+        for (const auto& var: ion.writes) {
+            if (ion.is_ionic_current(var)) {
+                // also create local variable
+                std::string name{"di{}"_format(ion.name)};
+                double_variables.emplace_back(name);
+                body_statements.emplace_back(
+                    visitor::create_statement("{} = {}"_format(name, var)));
+            }
+        }
+    }
+
+    // now restore original v and calculate current and store it in rhs
+    body_statements.emplace_back(visitor::create_statement("v = v_org"));
+    print_nrn_current_body(node, body_statements, "rhs");
+
+    // calculate g
+    body_statements.emplace_back(visitor::create_statement("g = (g-rhs)/0.001"));
+
+    // in case of point process we need to load area from another vector.
+    if (info.point_process) {
+        // create integer variable for index and then load value from area_index vector
+        int_variables.emplace_back("{}_id"_format(naming::NODE_AREA_VARIABLE));
+        index_statements.emplace_back(visitor::create_statement(
+            " {0}_id = {0}_index[id]"_format(naming::NODE_AREA_VARIABLE)));
+    }
+
+    // update all ionic currents now
+    for (const auto& ion: info.ions) {
+        for (const auto& var: ion.writes) {
+            if (ion.is_ionic_current(var)) {
+                // variable on the lhs
+                std::string lhs{"{}di{}dv"_format(naming::ION_VARNAME_PREFIX, ion.name)};
+
+                // expression on the rhs
+                std::string rhs{"(di{}-{})/0.001"_format(ion.name, var)};
+                if (info.point_process) {
+                    rhs += "*1.e2/{0}[{0}_id]"_format(naming::NODE_AREA_VARIABLE);
+                }
+
+                // load the index for lhs variable
+                int_variables.emplace_back(lhs + "_id");
+                std::string index_statement{"{}_id = {}_index[id]"_format(lhs, lhs)};
+                index_statements.emplace_back(visitor::create_statement(index_statement));
+
+                // add statement that actually updates the
+                body_statements.emplace_back(
+                    visitor::create_statement("{0}[{0}_id] = {0}[{0}_id] + {1}"_format(lhs, rhs)));
+            }
+        }
+    }
+}
+
+/**
  * \brief Convert ast::BreakpointBlock to corresponding code generation function nrn_cur
  * @param node AST node representing ast::BreakpointBlock
  *
+ * The BREAKPOINT block from MOD file (ast::NrnStateBlock node in the AST) is converted
+ * to `nrn_cur` function in the generated CPP code via various transformations. Here we
+ * perform those transformations and create new codegen node in the AST.
  */
 void CodegenLLVMHelperVisitor::visit_breakpoint_block(ast::BreakpointBlock& node) {
+    // no-op in case there are no currents or breakpoint block doesn't exist
     if (!info.nrn_cur_required()) {
         return;
     }
 
-    /// statements for new function to be generated
-    ast::StatementVector function_statements;
-
-    /// create vectors of local variables that would be used in compute part
+    /// local variables in the function scope for integer and double variables
     std::vector<std::string> int_variables{"node_id"};
     std::vector<std::string> double_variables{"v"};
 
-    /// create now main compute part
-
-    /// compute body : initialization + solve blocks
-    ast::StatementVector def_statements;
+    /// statements to load indexes for gather/scatter like expressions
     ast::StatementVector index_statements;
+
+    /// statements for the rest of compute body
     ast::StatementVector body_statements;
+
+    /// prepare all function statements
     {
         /// access node index and corresponding voltage
         index_statements.push_back(
@@ -859,57 +1026,105 @@ void CodegenLLVMHelperVisitor::visit_breakpoint_block(ast::BreakpointBlock& node
                             index_statements,
                             body_statements);
 
-        /// main compute node : extract solution expressions from the derivative block
-        const auto& block = node.get_statement_block();
-        append_statements_from_block(body_statements, block);
+        /// print main current kernel based on conductance exist of not
+        if (info.conductances.empty()) {
+            print_nrn_cur_non_conductance_kernel(
+                node, int_variables, double_variables, index_statements, body_statements);
+        } else {
+            print_nrn_cur_conductance_kernel(
+                node, int_variables, double_variables, index_statements, body_statements);
+        }
 
-        /// write ion statements
+        /// add write ion statements
         ion_write_statements(BlockType::Equation,
                              int_variables,
                              double_variables,
                              index_statements,
                              body_statements);
 
-        // \todo handle nrn_current calls similar to C codegen backend
+        /// in case of point process, we have to scale values based on the area
+        if (info.point_process) {
+            double_variables.emplace_back("mfactor");
+            body_statements.emplace_back(visitor::create_statement(
+                "mfactor = 1.e2/{0}[{0}_id]"_format(naming::NODE_AREA_VARIABLE)));
+            body_statements.emplace_back(visitor::create_statement("g = g*mfactor"));
+            body_statements.emplace_back(visitor::create_statement("rhs = rhs*mfactor"));
+        }
+
+        /// as multiple point processes can exist at same node, with simd or gpu execution we have
+        /// to create atomic statements that will be handled by llvm ir generation
+        if (info.point_process && (platform.is_gpu() || platform.is_cpu_with_simd())) {
+            body_statements.emplace_back(create_atomic_statement(
+                naming::NTHREAD_RHS, "node_id", info.operator_for_rhs(), "rhs"));
+            body_statements.emplace_back(create_atomic_statement(
+                naming::NTHREAD_D, "node_id", info.operator_for_rhs(), "g"));
+        } else {
+            auto rhs_op(info.operator_for_rhs());
+            auto d_op(info.operator_for_d());
+
+            // convert a += b to a = a + b, see BlueBrain/nmodl/issues/851
+            // hence write update of rhs and de in the form of assignment statements
+            stringutils::remove_character(rhs_op, '=');
+            stringutils::remove_character(d_op, '=');
+
+            body_statements.emplace_back(visitor::create_statement(
+                "vec_rhs[node_id] = vec_rhs[node_id] {} rhs"_format(rhs_op)));
+            body_statements.emplace_back(
+                visitor::create_statement("vec_d[node_id] = vec_d[node_id] {} g"_format(d_op)));
+        }
     }
 
-    /// create target-specific compute body
-    ast::StatementVector compute_body;
-    compute_body.insert(compute_body.end(), def_statements.begin(), def_statements.end());
-    compute_body.insert(compute_body.end(), index_statements.begin(), index_statements.end());
-    compute_body.insert(compute_body.end(), body_statements.begin(), body_statements.end());
+    /// now create codegen function
+    {
+        /// compute body, index loading statements at the begining and then compute functions
+        ast::StatementVector compute_body;
+        compute_body.insert(compute_body.end(), index_statements.begin(), index_statements.end());
+        compute_body.insert(compute_body.end(), body_statements.begin(), body_statements.end());
 
-    std::vector<std::string> induction_variables{naming::INDUCTION_VAR};
-    function_statements.push_back(
-        create_local_variable_statement(induction_variables, INTEGER_TYPE));
+        /// statements for new function to be generated
+        ast::StatementVector function_statements;
 
-    if (platform.is_gpu()) {
-        create_gpu_compute_body(compute_body, function_statements, int_variables, double_variables);
-    } else {
-        create_cpu_compute_body(compute_body, function_statements, int_variables, double_variables);
+        std::vector<std::string> induction_variables{naming::INDUCTION_VAR};
+        function_statements.push_back(
+            create_local_variable_statement(induction_variables, INTEGER_TYPE));
+
+        if (platform.is_gpu()) {
+            create_gpu_compute_body(compute_body,
+                                    function_statements,
+                                    int_variables,
+                                    double_variables);
+        } else {
+            create_cpu_compute_body(compute_body,
+                                    function_statements,
+                                    int_variables,
+                                    double_variables);
+        }
+
+        /// new block for the function
+        auto function_block = new ast::StatementBlock(function_statements);
+
+        /// name of the function and it's return type
+        std::string function_name = "nrn_cur_" + stringutils::tolower(info.mod_suffix);
+        auto name = new ast::Name(new ast::String(function_name));
+        auto return_type = new ast::CodegenVarType(ast::AstNodeType::VOID);
+
+        /// only instance struct as an argument for now
+        ast::CodegenVarWithTypeVector code_arguments;
+        auto instance_var_type = new ast::CodegenVarType(ast::AstNodeType::INSTANCE_STRUCT);
+        auto instance_var_name = new ast::Name(new ast::String(naming::MECH_INSTANCE_VAR));
+        auto instance_var = new ast::CodegenVarWithType(instance_var_type, 1, instance_var_name);
+        code_arguments.emplace_back(instance_var);
+
+        /// finally, create new function
+        auto function = std::make_shared<ast::CodegenFunction>(return_type,
+                                                               name,
+                                                               code_arguments,
+                                                               function_block);
+        codegen_functions.push_back(function);
+
+        // todo: remove this, temporary
+        std::cout << nmodl::to_nmodl(*function) << std::endl;
     }
-
-    /// new block for the function
-    auto function_block = new ast::StatementBlock(function_statements);
-
-    /// name of the function and it's return type
-    std::string function_name = "nrn_cur_" + stringutils::tolower(info.mod_suffix);
-    auto name = new ast::Name(new ast::String(function_name));
-    auto return_type = new ast::CodegenVarType(ast::AstNodeType::VOID);
-
-    ast::CodegenVarWithTypeVector code_arguments;
-
-    auto instance_var_type = new ast::CodegenVarType(ast::AstNodeType::INSTANCE_STRUCT);
-    auto instance_var_name = new ast::Name(new ast::String(naming::MECH_INSTANCE_VAR));
-    auto instance_var = new ast::CodegenVarWithType(instance_var_type, 1, instance_var_name);
-    code_arguments.emplace_back(instance_var);
-
-    /// finally, create new function
-    auto function =
-        std::make_shared<ast::CodegenFunction>(return_type, name, code_arguments, function_block);
-    codegen_functions.push_back(function);
-
-    std::cout << nmodl::to_nmodl(function) << std::endl;
 }
 
 void CodegenLLVMHelperVisitor::visit_program(ast::Program& node) {

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -167,6 +167,7 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
     void visit_procedure_block(ast::ProcedureBlock& node) override;
     void visit_function_block(ast::FunctionBlock& node) override;
     void visit_nrn_state_block(ast::NrnStateBlock& node) override;
+    void visit_breakpoint_block(ast::BreakpointBlock& node) override;
     void visit_program(ast::Program& node) override;
 
   private:

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -167,7 +167,13 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
     void visit_procedure_block(ast::ProcedureBlock& node) override;
     void visit_function_block(ast::FunctionBlock& node) override;
     void visit_nrn_state_block(ast::NrnStateBlock& node) override;
+
+    /**
+     * \brief Convert ast::BreakpointBlock to corresponding code generation function nrn_cur
+     * @param node AST node representing ast::BreakpointBlock
+     */
     void visit_breakpoint_block(ast::BreakpointBlock& node) override;
+
     void visit_program(ast::Program& node) override;
 
   private:
@@ -196,6 +202,20 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
                                   std::vector<std::string>& int_variables,
                                   std::vector<std::string>& double_variables,
                                   bool is_remainder_loop = false);
+
+    void print_nrn_current_body(const ast::BreakpointBlock& node,
+                                ast::StatementVector& body_statements,
+                                const std::string& variable);
+    void print_nrn_cur_non_conductance_kernel(const ast::BreakpointBlock& node,
+                                              std::vector<std::string>& int_variables,
+                                              std::vector<std::string>& double_variables,
+                                              ast::StatementVector& index_statements,
+                                              ast::StatementVector& body_statements);
+    void print_nrn_cur_conductance_kernel(const ast::BreakpointBlock& node,
+                                          std::vector<std::string>& int_variables,
+                                          std::vector<std::string>& double_variables,
+                                          ast::StatementVector& index_statements,
+                                          ast::StatementVector& body_statements);
 };
 
 /** @} */  // end of llvm_codegen_details

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -1098,5 +1098,11 @@ void CodegenLLVMVisitor::visit_while_statement(const ast::WhileStatement& node) 
     ir_builder.set_insertion_point(exit);
 }
 
+// for the llvm backend we only support breakpoint and derivative blocks
+void CodegenLLVMVisitor::print_compute_functions() {
+    print_nrn_cur();
+    print_nrn_state();
+}
+
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -299,6 +299,9 @@ class CodegenLLVMVisitor: public CodegenCVisitor {
     /// the kernel.
     void wrap_kernel_functions();
 
+    /// print compute functions relevant for this backend
+    void print_compute_functions() override;
+
   private:
     // Annotates kernel function with NVVM metadata.
     void annotate_kernel_with_nvvm(llvm::Function* kernel);

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -59,9 +59,14 @@ llvm::Type* IRBuilder::get_void_type() {
 
 llvm::Type* IRBuilder::get_struct_ptr_type(const std::string& struct_type_name,
                                            TypeVector& member_types) {
-    llvm::StructType* llvm_struct_type = llvm::StructType::create(builder.getContext(),
-                                                                  struct_type_name);
-    llvm_struct_type->setBody(member_types);
+    llvm::StructType* llvm_struct_type = llvm::StructType::getTypeByName(builder.getContext(),
+                                                                         struct_type_name);
+
+    if (!llvm_struct_type) {
+        llvm_struct_type = llvm::StructType::create(builder.getContext(), struct_type_name);
+        llvm_struct_type->setBody(member_types);
+    }
+
     return llvm::PointerType::get(llvm_struct_type, /*AddressSpace=*/0);
 }
 

--- a/src/language/nmodl.yaml
+++ b/src/language/nmodl.yaml
@@ -1579,10 +1579,10 @@
                                 \sa nmodl::visitor::SympyConductanceVisitor
 
                   - ExpressionStatement:
-                      brief: "TODO"
+                      brief: "Represent statement created from an expression"
                       members:
                         - expression:
-                            brief: "TODO"
+                            brief: "An expression which represent statement in MOD file"
                             type: Expression
 
                   - ProtectStatement:

--- a/src/language/nmodl.yaml
+++ b/src/language/nmodl.yaml
@@ -1579,11 +1579,28 @@
                                 \sa nmodl::visitor::SympyConductanceVisitor
 
                   - ExpressionStatement:
-                      brief: "Represent statement created from an expression"
                       members:
                         - expression:
-                            brief: "An expression which represent statement in MOD file"
+                            brief: "An expression representing a construct in the mod file"
                             type: Expression
+                      brief: "Represent statement encpasulated by underlying expression of ast node typeExpression"
+                      description: |
+                                Certain statements defined in the NMODL are complex than typical "single line" statements.
+                                For example, often SOLVE block is written as:
+
+                                    SOLVE states METHOD cnexp
+
+                                but language allow it to be more complex as:
+
+                                    SOLVE states METHOD cnexp {
+                                        statement_1
+                                        statement_2
+                                    }
+
+                                So this type of construct is not really "single line" statement. There are other such cases
+                                where they are categorised as "statement" in the bison specification. Also, there are cases
+                                when a binary expression `a = b` is also a full statement..
+                                In all such cases we wrap underlying expression as statement using ExpressionStatement node.
 
                   - ProtectStatement:
                       brief: "TODO"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #ifdef NMODL_LLVM_BACKEND
 #include "codegen/llvm/codegen_llvm_visitor.hpp"
 #include "test/benchmark/llvm_benchmark.hpp"
+#include "visitors/inline_visitor.hpp"
 #endif
 
 #include "codegen/codegen_driver.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,6 @@
 #ifdef NMODL_LLVM_BACKEND
 #include "codegen/llvm/codegen_llvm_visitor.hpp"
 #include "test/benchmark/llvm_benchmark.hpp"
-#include "visitors/inline_visitor.hpp"
 #endif
 
 #include "codegen/codegen_driver.hpp"

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -287,6 +287,7 @@ SCENARIO("Simple scalar kernel", "[llvm][runner]") {
                 v
                 x0
                 x1
+                i (mA/cm2)
             }
 
             BREAKPOINT {
@@ -370,6 +371,7 @@ SCENARIO("Simple vectorised kernel", "[llvm][runner]") {
                 v
                 x0
                 x1
+                i (mA/cm2)
             }
 
             BREAKPOINT {

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -951,10 +951,16 @@ SCENARIO("Scalar state kernel", "[visitor][llvm]") {
                 m
             }
 
+            PARAMETER {
+                gl = .0003 (S/cm2)  <0,1e9>
+                el = -54.3 (mV)
+            }
+
             ASSIGNED {
                 v (mV)
                 minf
                 mtau (ms)
+                il (mA/cm2)
             }
 
             BREAKPOINT {
@@ -974,9 +980,10 @@ SCENARIO("Scalar state kernel", "[visitor][llvm]") {
             // Check the struct type with correct attributes and the kernel declaration.
             std::regex struct_type(
                 "%.*__instance_var__type = type \\{ double\\*, double\\*, double\\*, double\\*, "
-                "double\\*, double\\*, double\\*, i32\\*, double, double, double, i32, i32 \\}");
+                "double\\*, double\\*, double\\*, double\\*, double\\*, double\\*, i32\\*, double, "
+                "double, double, i32, i32 \\}");
             std::regex kernel_declaration(
-                R"(define void @nrn_state_hh\(%.*__instance_var__type\* noalias nocapture readonly .*\) #0)");
+                R"(define void @nrn_state_hh\(%.*__instance_var__type.0\* noalias nocapture readonly .*\) #0)");
             REQUIRE(std::regex_search(module_string, m, struct_type));
             REQUIRE(std::regex_search(module_string, m, kernel_declaration));
 
@@ -1063,6 +1070,7 @@ SCENARIO("Vectorised simple kernel", "[visitor][llvm]") {
 
             ASSIGNED {
                 v (mV)
+                i (mA/cm2)
             }
 
             BREAKPOINT {
@@ -1251,7 +1259,7 @@ SCENARIO("Scalar derivative block", "[visitor][llvm][derivative]") {
             }
         )";
 
-        std::string expected_loop = R"(
+        std::string expected_state_loop = R"(
             for(id = 0; id<mech->node_count; id = id+1) {
                 node_id = mech->node_index[id]
                 v = mech->voltage[node_id]
@@ -1263,10 +1271,10 @@ SCENARIO("Scalar derivative block", "[visitor][llvm][derivative]") {
             auto result = run_llvm_visitor_helper(nmodl_text,
                                                   default_platform,
                                                   {ast::AstNodeType::CODEGEN_FOR_STATEMENT});
-            REQUIRE(result.size() == 1);
+            REQUIRE(result.size() == 2);
 
-            auto main_loop = reindent_text(to_nmodl(result[0]));
-            REQUIRE(main_loop == reindent_text(expected_loop));
+            auto main_state_loop = reindent_text(to_nmodl(result[1]));
+            REQUIRE(main_state_loop == reindent_text(expected_state_loop));
         }
     }
 }
@@ -1276,39 +1284,63 @@ SCENARIO("Vectorised derivative block", "[visitor][llvm][derivative]") {
         std::string nmodl_text = R"(
             NEURON {
                 SUFFIX hh
+                USEION na READ ena WRITE ina
                 NONSPECIFIC_CURRENT il
-                RANGE minf, mtau
+                RANGE minf, mtau, gna, gnabar
             }
             STATE {
-                m
+                m h
+            }
+            PARAMETER {
+                gnabar = .12 (S/cm2) <0,1e9>
             }
             ASSIGNED {
                 v (mV)
                 minf
                 mtau (ms)
+                ena (mV)
+                ina (mA/cm2)
+                gna (S/cm2)
             }
             BREAKPOINT {
                 SOLVE states METHOD cnexp
-                il = 2
+                gna = gnabar*m*m*m*h
+                ina = gna*(v - ena)
             }
             DERIVATIVE states {
                 m = (minf-m)/mtau
             }
         )";
 
-        std::string expected_main_loop = R"(
+        std::string expected_state_main_loop = R"(
             for(id = 0; id<mech->node_count-7; id = id+8) {
                 node_id = mech->node_index[id]
+                ena_id = mech->ion_ena_index[id]
                 v = mech->voltage[node_id]
-                mech->m[id] = (mech->minf[id]-mech->m[id])/mech->mtau[id]
-            })";
-        std::string expected_epilogue_loop = R"(
-            for(; id<mech->node_count; id = id+1) {
-                epilogue_node_id = mech->node_index[id]
-                epilogue_v = mech->voltage[epilogue_node_id]
+                mech->ena[id] = mech->ion_ena[ena_id]
                 mech->m[id] = (mech->minf[id]-mech->m[id])/mech->mtau[id]
             })";
 
+        std::string expected_state_epilogue_loop = R"(
+            for(; id<mech->node_count; id = id+1) {
+                epilogue_node_id = mech->node_index[id]
+                epilogue_ena_id = mech->ion_ena_index[id]
+                epilogue_v = mech->voltage[epilogue_node_id]
+                mech->ena[id] = mech->ion_ena[epilogue_ena_id]
+                mech->m[id] = (mech->minf[id]-mech->m[id])/mech->mtau[id]
+            })";
+
+        std::string expected_cur_main_loop = R"(
+            for(id = 0; id<mech->node_count-7; id = id+8) {
+                node_id = mech->node_index[id]
+                ena_id = mech->ion_ena_index[id]
+                ion_ina_id = mech->ion_ina_index[id]
+                v = mech->voltage[node_id]
+                mech->ena[id] = mech->ion_ena[ena_id]
+                mech->gna[id] = mech->gnabar[id]*mech->m[id]*mech->m[id]*mech->m[id]*mech->h[id]
+                mech->ina[id] = mech->gna[id]*(v-mech->ena[id])
+                mech->ion_ina[ion_ina_id] = mech->ion_ina[ion_ina_id]+mech->ina[id]
+            })";
 
         THEN("vector and epilogue scalar loops are constructed") {
             codegen::Platform simd_platform(/*use_single_precision=*/false,
@@ -1316,13 +1348,16 @@ SCENARIO("Vectorised derivative block", "[visitor][llvm][derivative]") {
             auto result = run_llvm_visitor_helper(nmodl_text,
                                                   simd_platform,
                                                   {ast::AstNodeType::CODEGEN_FOR_STATEMENT});
-            REQUIRE(result.size() == 2);
+            REQUIRE(result.size() == 4);
 
-            auto main_loop = reindent_text(to_nmodl(result[0]));
-            REQUIRE(main_loop == reindent_text(expected_main_loop));
+            auto cur_main_loop = reindent_text(to_nmodl(result[0]));
+            REQUIRE(cur_main_loop == reindent_text(expected_cur_main_loop));
 
-            auto epilogue_loop = reindent_text(to_nmodl(result[1]));
-            REQUIRE(epilogue_loop == reindent_text(expected_epilogue_loop));
+            auto state_main_loop = reindent_text(to_nmodl(result[2]));
+            REQUIRE(state_main_loop == reindent_text(expected_state_main_loop));
+
+            auto state_epilogue_loop = reindent_text(to_nmodl(result[3]));
+            REQUIRE(state_epilogue_loop == reindent_text(expected_state_epilogue_loop));
         }
     }
 }
@@ -1343,6 +1378,7 @@ SCENARIO("Vector library calls", "[visitor][llvm][vector_lib]") {
             }
             ASSIGNED {
                 v (mV)
+                il (mA/cm2)
             }
             BREAKPOINT {
                 SOLVE states METHOD cnexp

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -983,7 +983,7 @@ SCENARIO("Scalar state kernel", "[visitor][llvm]") {
                 "double\\*, double\\*, double\\*, double\\*, double\\*, double\\*, i32\\*, double, "
                 "double, double, i32, i32, double\\*, double\\*, double\\*, double\\* \\}");
             std::regex kernel_declaration(
-                R"(define void @nrn_state_hh\(%.*__instance_var__type.0\* noalias nocapture readonly .*\) #0)");
+                R"(define void @nrn_state_hh\(%.*__instance_var__type\* noalias nocapture readonly .*\) #0)");
             REQUIRE(std::regex_search(module_string, m, struct_type));
             REQUIRE(std::regex_search(module_string, m, kernel_declaration));
 

--- a/test/unit/codegen/codegen_llvm_visitor.cpp
+++ b/test/unit/codegen/codegen_llvm_visitor.cpp
@@ -158,6 +158,10 @@ SCENARIO("Check instance struct declaration and setup in wrapper",
                 double celsius;
                 int secondorder;
                 int node_count;
+                double* __restrict__ vec_rhs;
+                double* __restrict__ vec_d;
+                double* __restrict__ _shadow_rhs;
+                double* __restrict__ _shadow_d;
             };
         )";
         std::string generated_instance_struct_setup = R"(

--- a/test/unit/codegen/codegen_llvm_visitor.cpp
+++ b/test/unit/codegen/codegen_llvm_visitor.cpp
@@ -13,6 +13,7 @@
 #include "config/config.h"
 #include "parser/nmodl_driver.hpp"
 #include "test/unit/utils/test_utils.hpp"
+#include "visitors/inline_visitor.hpp"
 #include "visitors/neuron_solve_visitor.hpp"
 #include "visitors/solve_block_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"
@@ -47,6 +48,23 @@ std::string get_wrapper_instance_struct(const std::string& nmodl_text) {
     llvm_visitor.print_mechanism_range_var_structure();
     llvm_visitor.print_instance_variable_setup();
     return strbuf.str();
+}
+
+// Run LLVM codegen helper visitor with given platform as target
+static std::vector<std::shared_ptr<ast::Ast>> run_llvm_visitor_helper(
+    const std::string& text,
+    codegen::Platform& platform,
+    const std::vector<ast::AstNodeType>& nodes_to_collect) {
+    NmodlDriver driver;
+    const auto& ast = driver.parse_string(text);
+
+    SymtabVisitor().visit_program(*ast);
+    InlineVisitor().visit_program(*ast);
+    NeuronSolveVisitor().visit_program(*ast);
+    SolveBlockVisitor().visit_program(*ast);
+    CodegenLLVMHelperVisitor(platform).visit_program(*ast);
+
+    return collect_nodes(*ast, nodes_to_collect);
 }
 
 SCENARIO("Check instance struct declaration and setup in wrapper",
@@ -217,10 +235,9 @@ SCENARIO("Check instance struct declaration and setup in wrapper",
             }
         )";
 
-        THEN("index and nt variables") {
+        THEN("index and nt variables created correctly") {
             auto result_instance_struct_declaration_setup = reindent_text(
                 get_wrapper_instance_struct(nmodl_text));
-            std::cout << "Result\n" << result_instance_struct_declaration_setup << std::endl;
 
             auto expected_instance_struct_declaration = reindent_text(
                 generated_instance_struct_declaration);
@@ -230,6 +247,385 @@ SCENARIO("Check instance struct declaration and setup in wrapper",
                         expected_instance_struct_declaration) != std::string::npos);
             REQUIRE(result_instance_struct_declaration_setup.find(expected_instance_struct_setup) !=
                     std::string::npos);
+        }
+    }
+}
+
+
+SCENARIO("Channel: Derivative and breakpoint block llvm transformations",
+         "[visitor][llvm_helper][channel]") {
+    GIVEN("A hh.mod file with derivative and breakpoint block") {
+        std::string nmodl_text = R"(
+            TITLE hh.mod   squid sodium, potassium, and leak channels
+
+            UNITS {
+                (mA) = (milliamp)
+                (mV) = (millivolt)
+                (S) = (siemens)
+            }
+
+            NEURON {
+                SUFFIX hh
+                USEION na READ ena WRITE ina
+                USEION k READ ek WRITE ik
+                NONSPECIFIC_CURRENT il
+                RANGE gnabar, gkbar, gl, el, gna, gk
+                RANGE minf, hinf, ninf, mtau, htau, ntau
+                THREADSAFE
+            }
+
+            PARAMETER {
+                gnabar = .12 (S/cm2) <0,1e9>
+                gkbar = .036 (S/cm2) <0,1e9>
+                gl = .0003 (S/cm2) <0,1e9>
+                el = -54.3 (mV)
+            }
+
+            STATE {
+                m
+                h
+                n
+            }
+
+            ASSIGNED {
+                v (mV)
+                celsius (degC)
+                ena (mV)
+                ek (mV)
+                gna (S/cm2)
+                gk (S/cm2)
+                ina (mA/cm2)
+                ik (mA/cm2)
+                il (mA/cm2)
+                minf
+                hinf
+                ninf
+                mtau (ms)
+                htau (ms)
+                ntau (ms)
+            }
+
+            BREAKPOINT {
+                SOLVE states METHOD cnexp
+                gna = gnabar*m*m*m*h
+                ina = gna*(v-ena)
+                gk = gkbar*n*n*n*n
+                ik = gk*(v-ek)
+                il = gl*(v-el)
+            }
+
+            DERIVATIVE states {
+                rates(v)
+                m' = (minf-m)/mtau
+                h' = (hinf-h)/htau
+                n' = (ninf-n)/ntau
+            }
+
+            PROCEDURE rates(v(mV)) {
+                LOCAL alpha, beta, sum, q10
+                UNITSOFF
+                q10 = 3^((celsius-6.3)/10)
+                alpha = .1*vtrap(-(v+40), 10)
+                beta = 4*exp(-(v+65)/18)
+                sum = alpha+beta
+                mtau = 1/(q10*sum)
+                minf = alpha/sum
+                alpha = .07*exp(-(v+65)/20)
+                beta = 1/(exp(-(v+35)/10)+1)
+                sum = alpha+beta
+                htau = 1/(q10*sum)
+                hinf = alpha/sum
+                alpha = .01*vtrap(-(v+55), 10)
+                beta = .125*exp(-(v+65)/80)
+                sum = alpha+beta
+                ntau = 1/(q10*sum)
+                ninf = alpha/sum
+            }
+
+            FUNCTION vtrap(x, y) {
+                IF (fabs(x/y)<1e-6) {
+                    vtrap = y*(1-x/y/2)
+                } ELSE {
+                    vtrap = x/(exp(x/y)-1)
+                }
+            }
+        )";
+
+        std::string expected_state_function = R"(
+            VOID nrn_state_hh(INSTANCE_STRUCT *mech){
+                INTEGER id
+                INTEGER node_id, ena_id, ek_id
+                DOUBLE v
+                for(id = 0; id<mech->node_count; id = id+1) {
+                    node_id = mech->node_index[id]
+                    ena_id = mech->ion_ena_index[id]
+                    ek_id = mech->ion_ek_index[id]
+                    v = mech->voltage[node_id]
+                    mech->ena[id] = mech->ion_ena[ena_id]
+                    mech->ek[id] = mech->ion_ek[ek_id]
+                    {
+                        DOUBLE alpha, beta, sum, q10, vtrap_in_0, vtrap_in_1, v_in_0
+                        v_in_0 = v
+                        UNITSOFF
+                        q10 = 3^((mech->celsius-6.3)/10)
+                        {
+                            DOUBLE x_in_0, y_in_0
+                            x_in_0 = -(v_in_0+40)
+                            y_in_0 = 10
+                            IF (fabs(x_in_0/y_in_0)<1e-6) {
+                                vtrap_in_0 = y_in_0*(1-x_in_0/y_in_0/2)
+                            } ELSE {
+                                vtrap_in_0 = x_in_0/(exp(x_in_0/y_in_0)-1)
+                            }
+                        }
+                        alpha = .1*vtrap_in_0
+                        beta = 4*exp(-(v_in_0+65)/18)
+                        sum = alpha+beta
+                        mech->mtau[id] = 1/(q10*sum)
+                        mech->minf[id] = alpha/sum
+                        alpha = .07*exp(-(v_in_0+65)/20)
+                        beta = 1/(exp(-(v_in_0+35)/10)+1)
+                        sum = alpha+beta
+                        mech->htau[id] = 1/(q10*sum)
+                        mech->hinf[id] = alpha/sum
+                        {
+                            DOUBLE x_in_1, y_in_1
+                            x_in_1 = -(v_in_0+55)
+                            y_in_1 = 10
+                            IF (fabs(x_in_1/y_in_1)<1e-6) {
+                                vtrap_in_1 = y_in_1*(1-x_in_1/y_in_1/2)
+                            } ELSE {
+                                vtrap_in_1 = x_in_1/(exp(x_in_1/y_in_1)-1)
+                            }
+                        }
+                        alpha = .01*vtrap_in_1
+                        beta = .125*exp(-(v_in_0+65)/80)
+                        sum = alpha+beta
+                        mech->ntau[id] = 1/(q10*sum)
+                        mech->ninf[id] = alpha/sum
+                    }
+                    mech->m[id] = mech->m[id]+(1.0-exp(mech->dt*((((-1.0)))/mech->mtau[id])))*(-(((mech->minf[id]))/mech->mtau[id])/((((-1.0)))/mech->mtau[id])-mech->m[id])
+                    mech->h[id] = mech->h[id]+(1.0-exp(mech->dt*((((-1.0)))/mech->htau[id])))*(-(((mech->hinf[id]))/mech->htau[id])/((((-1.0)))/mech->htau[id])-mech->h[id])
+                    mech->n[id] = mech->n[id]+(1.0-exp(mech->dt*((((-1.0)))/mech->ntau[id])))*(-(((mech->ninf[id]))/mech->ntau[id])/((((-1.0)))/mech->ntau[id])-mech->n[id])
+                }
+            })";
+
+        std::string expected_cur_function = R"(
+            VOID nrn_cur_hh(INSTANCE_STRUCT *mech){
+                INTEGER id
+                INTEGER node_id, ena_id, ek_id, ion_dinadv_id, ion_dikdv_id, ion_ina_id, ion_ik_id
+                DOUBLE v, g, rhs, v_org, current, dina, dik
+                for(id = 0; id<mech->node_count; id = id+1) {
+                    node_id = mech->node_index[id]
+                    ena_id = mech->ion_ena_index[id]
+                    ek_id = mech->ion_ek_index[id]
+                    ion_dinadv_id = mech->ion_dinadv_index[id]
+                    ion_dikdv_id = mech->ion_dikdv_index[id]
+                    ion_ina_id = mech->ion_ina_index[id]
+                    ion_ik_id = mech->ion_ik_index[id]
+                    v = mech->voltage[node_id]
+                    mech->ena[id] = mech->ion_ena[ena_id]
+                    mech->ek[id] = mech->ion_ek[ek_id]
+                    v_org = v
+                    v = v+0.001
+                    {
+                        current = 0
+                        mech->gna[id] = mech->gnabar[id]*mech->m[id]*mech->m[id]*mech->m[id]*mech->h[id]
+                        mech->ina[id] = mech->gna[id]*(v-mech->ena[id])
+                        mech->gk[id] = mech->gkbar[id]*mech->n[id]*mech->n[id]*mech->n[id]*mech->n[id]
+                        mech->ik[id] = mech->gk[id]*(v-mech->ek[id])
+                        mech->il[id] = mech->gl[id]*(v-mech->el[id])
+                        current = current+mech->il[id]
+                        current = current+mech->ina[id]
+                        current = current+mech->ik[id]
+                        g = current
+                    }
+                    dina = mech->ina[id]
+                    dik = mech->ik[id]
+                    v = v_org
+                    {
+                        current = 0
+                        mech->gna[id] = mech->gnabar[id]*mech->m[id]*mech->m[id]*mech->m[id]*mech->h[id]
+                        mech->ina[id] = mech->gna[id]*(v-mech->ena[id])
+                        mech->gk[id] = mech->gkbar[id]*mech->n[id]*mech->n[id]*mech->n[id]*mech->n[id]
+                        mech->ik[id] = mech->gk[id]*(v-mech->ek[id])
+                        mech->il[id] = mech->gl[id]*(v-mech->el[id])
+                        current = current+mech->il[id]
+                        current = current+mech->ina[id]
+                        current = current+mech->ik[id]
+                        rhs = current
+                    }
+                    g = (g-rhs)/0.001
+                    mech->ion_dinadv[ion_dinadv_id] = mech->ion_dinadv[ion_dinadv_id]+(dina-mech->ina[id])/0.001
+                    mech->ion_dikdv[ion_dikdv_id] = mech->ion_dikdv[ion_dikdv_id]+(dik-mech->ik[id])/0.001
+                    mech->ion_ina[ion_ina_id] = mech->ion_ina[ion_ina_id]+mech->ina[id]
+                    mech->ion_ik[ion_ik_id] = mech->ion_ik[ion_ik_id]+mech->ik[id]
+                    mech->vec_rhs[node_id] = mech->vec_rhs[node_id]-rhs
+                    mech->vec_d[node_id] = mech->vec_d[node_id]+g
+                }
+            })";
+
+        THEN("codegen functions are constructed correctly for density channel") {
+            codegen::Platform simd_platform(/*use_single_precision=*/false,
+                                            /*instruction_width=*/1);
+            auto result = run_llvm_visitor_helper(nmodl_text,
+                                                  simd_platform,
+                                                  {ast::AstNodeType::CODEGEN_FUNCTION});
+            REQUIRE(result.size() == 2);
+
+            auto cur_function = reindent_text(to_nmodl(result[0]));
+            REQUIRE(cur_function == reindent_text(expected_cur_function));
+
+            auto state_function = reindent_text(to_nmodl(result[1]));
+            REQUIRE(state_function == reindent_text(expected_state_function));
+        }
+    }
+}
+
+SCENARIO("Synapse: Derivative and breakpoint block llvm transformations",
+         "[visitor][llvm_helper][derivative]") {
+    GIVEN("A exp2syn.mod file with derivative and breakpoint block") {
+        // note that USEION statement is added just for better code coverage (ionic current)
+        std::string nmodl_text = R"(
+            NEURON {
+                POINT_PROCESS Exp2Syn
+                USEION na READ ena WRITE ina
+                RANGE tau1, tau2, e, i
+                NONSPECIFIC_CURRENT i
+                RANGE g, gna
+            }
+
+            UNITS {
+                (nA) = (nanoamp)
+                (mV) = (millivolt)
+                (uS) = (microsiemens)
+            }
+
+            PARAMETER {
+                tau1 = 0.1 (ms) <1e-9,1e9>
+                tau2 = 10 (ms) <1e-9,1e9>
+                e = 0 (mV)
+            }
+
+            ASSIGNED {
+                v (mV)
+                i (nA)
+                g (uS)
+                gna (S/cm2)
+                factor
+            }
+
+            STATE {
+                A (uS)
+                B (uS)
+            }
+
+            INITIAL {
+                LOCAL tp
+                IF (tau1/tau2>0.9999) {
+                    tau1 = 0.9999*tau2
+                }
+                IF (tau1/tau2<1e-9) {
+                    tau1 = tau2*1e-9
+                }
+                A = 0
+                B = 0
+                tp = (tau1*tau2)/(tau2-tau1)*log(tau2/tau1)
+                factor = -exp(-tp/tau1)+exp(-tp/tau2)
+                factor = 1/factor
+            }
+
+            BREAKPOINT {
+                SOLVE state METHOD cnexp
+                ina = gna*(v-ena)
+                g = B-A
+                i = g*(v-e)
+            }
+
+            DERIVATIVE state {
+                A' = -A/tau1
+                B' = -B/tau2
+            }
+
+            NET_RECEIVE (weight(uS)) {
+                A = A+weight*factor
+                B = B+weight*factor
+            })";
+
+        std::string expected_cur_function = R"(
+            VOID nrn_cur_exp2syn(INSTANCE_STRUCT *mech){
+                INTEGER id
+                INTEGER node_id, ena_id, node_area_id, ion_dinadv_id, ion_ina_id
+                DOUBLE v, g, rhs, v_org, current, dina, mfactor
+                for(id = 0; id<mech->node_count; id = id+1) {
+                    node_id = mech->node_index[id]
+                    ena_id = mech->ion_ena_index[id]
+                    node_area_id = mech->node_area_index[id]
+                    ion_dinadv_id = mech->ion_dinadv_index[id]
+                    ion_ina_id = mech->ion_ina_index[id]
+                    v = mech->voltage[node_id]
+                    mech->ena[id] = mech->ion_ena[ena_id]
+                    v_org = v
+                    v = v+0.001
+                    {
+                        current = 0
+                        mech->ina[id] = mech->gna[id]*(v-mech->ena[id])
+                        mech->g[id] = mech->B[id]-mech->A[id]
+                        mech->i[id] = mech->g[id]*(v-mech->e[id])
+                        current = current+mech->i[id]
+                        current = current+mech->ina[id]
+                        mech->g[id] = current
+                    }
+                    dina = mech->ina[id]
+                    v = v_org
+                    {
+                        current = 0
+                        mech->ina[id] = mech->gna[id]*(v-mech->ena[id])
+                        mech->g[id] = mech->B[id]-mech->A[id]
+                        mech->i[id] = mech->g[id]*(v-mech->e[id])
+                        current = current+mech->i[id]
+                        current = current+mech->ina[id]
+                        rhs = current
+                    }
+                    mech->g[id] = (mech->g[id]-rhs)/0.001
+                    mech->ion_dinadv[ion_dinadv_id] = mech->ion_dinadv[ion_dinadv_id]+(dina-mech->ina[id])/0.001*1.e2/mech->node_area[node_area_id]
+                    mech->ion_ina[ion_ina_id] = mech->ion_ina[ion_ina_id]+mech->ina[id]*(1.e2/mech->node_area[node_area_id])
+                    mfactor = 1.e2/mech->node_area[node_area_id]
+                    mech->g[id] = mech->g[id]*mfactor
+                    rhs = rhs*mfactor
+                    mech->vec_rhs[node_id] = mech->vec_rhs[node_id]-rhs
+                    mech->vec_d[node_id] = mech->vec_d[node_id]+mech->g[id]
+                }
+            })";
+
+        std::string expected_state_function = R"(
+            VOID nrn_state_exp2syn(INSTANCE_STRUCT *mech){
+                INTEGER id
+                INTEGER node_id, ena_id
+                DOUBLE v
+                for(id = 0; id<mech->node_count; id = id+1) {
+                    node_id = mech->node_index[id]
+                    ena_id = mech->ion_ena_index[id]
+                    v = mech->voltage[node_id]
+                    mech->ena[id] = mech->ion_ena[ena_id]
+                    mech->A[id] = mech->A[id]+(1.0-exp(mech->dt*((-1.0)/mech->tau1[id])))*(-(0.0)/((-1.0)/mech->tau1[id])-mech->A[id])
+                    mech->B[id] = mech->B[id]+(1.0-exp(mech->dt*((-1.0)/mech->tau2[id])))*(-(0.0)/((-1.0)/mech->tau2[id])-mech->B[id])
+                }
+            })";
+
+        THEN("codegen functions are constructed correctly for synapse") {
+            codegen::Platform simd_platform(/*use_single_precision=*/false,
+                                            /*instruction_width=*/1);
+            auto result = run_llvm_visitor_helper(nmodl_text,
+                                                  simd_platform,
+                                                  {ast::AstNodeType::CODEGEN_FUNCTION});
+            REQUIRE(result.size() == 2);
+
+            auto cur_function = reindent_text(to_nmodl(result[0]));
+            REQUIRE(cur_function == reindent_text(expected_cur_function));
+
+            auto state_function = reindent_text(to_nmodl(result[1]));
+            REQUIRE(state_function == reindent_text(expected_state_function));
         }
     }
 }


### PR DESCRIPTION
- [x]  similar to DERIVATIVE (nrn_state), handle BREAKPOINT (nrn_cur) blocks with AST level transformation
- [x] refactor nrn_state & nrn_cur to use common code to avoid
- [x] fix the llvm tests
- [x] implement nrn_current calls similar to C codeine backend
- [x] added tests

fixes #644