### PR TITLE
Print last line in parser error

### DIFF
--- a/src/lexer/nmodl.ll
+++ b/src/lexer/nmodl.ll
@@ -399,6 +399,7 @@ ELSE                    {
                             /** First we read entire line and print to stdout. This is useful
                               * for using lexer program. */
                             std::string str(yytext);
+                            last_line = str;
                             stringutils::trim(str);
 
                             if (driver.is_verbose()) {
@@ -573,4 +574,8 @@ nmodl::ast::String* nmodl::parser::NmodlLexer::get_unit() {
     auto result = last_unit;
     last_unit = nullptr;
     return result;
+}
+
+std::string nmodl::parser::NmodlLexer::get_curr_line() {
+    return last_line;
 }

--- a/src/lexer/nmodl.ll
+++ b/src/lexer/nmodl.ll
@@ -399,7 +399,7 @@ ELSE                    {
                             /** First we read entire line and print to stdout. This is useful
                               * for using lexer program. */
                             std::string str(yytext);
-                            last_line = str;
+                            cur_line = str;
                             stringutils::trim(str);
 
                             if (driver.is_verbose()) {
@@ -576,6 +576,6 @@ nmodl::ast::String* nmodl::parser::NmodlLexer::get_unit() {
     return result;
 }
 
-std::string nmodl::parser::NmodlLexer::get_curr_line() {
-    return last_line;
+std::string nmodl::parser::NmodlLexer::get_curr_line() const {
+    return cur_line;
 }

--- a/src/lexer/nmodl_lexer.hpp
+++ b/src/lexer/nmodl_lexer.hpp
@@ -80,6 +80,8 @@ class NmodlLexer: public NmodlFlexLexer {
      */
     int lexical_context = 0;
 
+    std::string last_line;
+
   public:
     /// location of the parsed token
     location loc;
@@ -143,6 +145,9 @@ class NmodlLexer: public NmodlFlexLexer {
 
     /// Return last scanned unit as ast::String
     ast::String* get_unit();
+
+    /// Return current line as string
+    std::string get_curr_line();
 
     /// Enable debug output (via yyout) if compiled into the scanner.
     void set_debug(bool b);

--- a/src/lexer/nmodl_lexer.hpp
+++ b/src/lexer/nmodl_lexer.hpp
@@ -80,7 +80,7 @@ class NmodlLexer: public NmodlFlexLexer {
      */
     int lexical_context = 0;
 
-    std::string last_line;
+    std::string cur_line;
 
   public:
     /// location of the parsed token
@@ -147,7 +147,7 @@ class NmodlLexer: public NmodlFlexLexer {
     ast::String* get_unit();
 
     /// Return current line as string
-    std::string get_curr_line();
+    std::string get_curr_line() const;
 
     /// Enable debug output (via yyout) if compiled into the scanner.
     void set_debug(bool b);

--- a/src/parser/nmodl.yy
+++ b/src/parser/nmodl.yy
@@ -2629,5 +2629,5 @@ std::string parse_with_verbatim_parser(std::string str) {
  */
 
 void NmodlParser::error(const location &loc , const std::string &msg) {
-    driver.parse_error(loc, msg);
+    driver.parse_error(scanner, loc, msg);
 }

--- a/src/parser/nmodl_driver.cpp
+++ b/src/parser/nmodl_driver.cpp
@@ -27,8 +27,6 @@ std::shared_ptr<ast::Program> NmodlDriver::parse_stream(std::istream& in) {
     scanner.set_debug(trace_scanner);
     parser.set_debug_level(trace_parser);
     parser.parse();
-
-
     return astRoot;
 }
 

--- a/src/parser/nmodl_driver.cpp
+++ b/src/parser/nmodl_driver.cpp
@@ -28,8 +28,10 @@ std::shared_ptr<ast::Program> NmodlDriver::parse_stream(std::istream& in) {
     parser->set_debug_level(trace_parser);
     parser->parse();
 
-    delete scanner;
     delete parser;
+    delete scanner;
+    parser = nullptr;
+    scanner = nullptr;
 
     return astRoot;
 }

--- a/src/parser/nmodl_driver.cpp
+++ b/src/parser/nmodl_driver.cpp
@@ -21,12 +21,16 @@ NmodlDriver::NmodlDriver(bool strace, bool ptrace)
 
 /// parse nmodl file provided as istream
 std::shared_ptr<ast::Program> NmodlDriver::parse_stream(std::istream& in) {
-    NmodlLexer scanner(*this, &in);
-    NmodlParser parser(scanner, *this);
+    scanner = new NmodlLexer(*this, &in);
+    parser = new NmodlParser(*scanner, *this);
 
-    scanner.set_debug(trace_scanner);
-    parser.set_debug_level(trace_parser);
-    parser.parse();
+    scanner->set_debug(trace_scanner);
+    parser->set_debug_level(trace_parser);
+    parser->parse();
+
+    delete scanner;
+    delete parser;
+
     return astRoot;
 }
 
@@ -135,7 +139,10 @@ int NmodlDriver::get_defined_var_value(const std::string& name) const {
 
 void NmodlDriver::parse_error(const location& location, const std::string& message) {
     std::ostringstream oss;
-    oss << "NMODL Parser Error : " << message << " [Location : " << location << ']';
+    oss << "NMODL Parser Error : " << message << " [Location : " << location << "]";
+    oss << scanner->get_curr_line() << '\n';
+    oss << std::string(location.begin.column-1, '-');
+    oss << "^\n";
     throw std::runtime_error(oss.str());
 }
 

--- a/src/parser/nmodl_driver.cpp
+++ b/src/parser/nmodl_driver.cpp
@@ -21,17 +21,13 @@ NmodlDriver::NmodlDriver(bool strace, bool ptrace)
 
 /// parse nmodl file provided as istream
 std::shared_ptr<ast::Program> NmodlDriver::parse_stream(std::istream& in) {
-    scanner = new NmodlLexer(*this, &in);
-    parser = new NmodlParser(*scanner, *this);
+    NmodlLexer scanner(*this, &in);
+    NmodlParser parser(scanner, *this);
 
-    scanner->set_debug(trace_scanner);
-    parser->set_debug_level(trace_parser);
-    parser->parse();
+    scanner.set_debug(trace_scanner);
+    parser.set_debug_level(trace_parser);
+    parser.parse();
 
-    delete parser;
-    delete scanner;
-    parser = nullptr;
-    scanner = nullptr;
 
     return astRoot;
 }
@@ -142,8 +138,16 @@ int NmodlDriver::get_defined_var_value(const std::string& name) const {
 void NmodlDriver::parse_error(const location& location, const std::string& message) {
     std::ostringstream oss;
     oss << "NMODL Parser Error : " << message << " [Location : " << location << "]";
-    oss << scanner->get_curr_line() << '\n';
-    oss << std::string(location.begin.column-1, '-');
+    throw std::runtime_error(oss.str());
+}
+
+void NmodlDriver::parse_error(const NmodlLexer& scanner,
+                              const location& location,
+                              const std::string& message) {
+    std::ostringstream oss;
+    oss << "NMODL Parser Error : " << message << " [Location : " << location << "]";
+    oss << scanner.get_curr_line() << '\n';
+    oss << std::string(location.begin.column - 1, '-');
     oss << "^\n";
     throw std::runtime_error(oss.str());
 }

--- a/src/parser/nmodl_driver.hpp
+++ b/src/parser/nmodl_driver.hpp
@@ -61,13 +61,6 @@ namespace parser {
  */
 class NmodlDriver {
   private:
-
-    /// a pointer to the NMODL lexer instance
-    NmodlLexer* scanner;
-
-    /// a pointer to the NMODL parser instance
-    NmodlParser* parser;
-
     /// all macro defined in the mod file
     std::unordered_map<std::string, int> defined_var;
 
@@ -145,6 +138,14 @@ class NmodlDriver {
      * \throw std::runtime_error
      */
     void parse_error(const location& location, const std::string& message);
+
+    /**
+     * Emit a parsing error. Takes additionally a Lexer instance to print code context
+     * \throw std::runtime_error
+     */
+    void parse_error(const NmodlLexer& scanner,
+                     const location& location,
+                     const std::string& message);
 
     /**
      * Ensure \a file argument given to the INCLUDE directive is valid:

--- a/src/parser/nmodl_driver.hpp
+++ b/src/parser/nmodl_driver.hpp
@@ -16,6 +16,8 @@
 #include <unordered_map>
 
 #include "ast/ast.hpp"
+#include "lexer/nmodl_lexer.hpp"
+#include "parser/nmodl_driver.hpp"
 #include "utils/file_library.hpp"
 
 
@@ -59,6 +61,13 @@ namespace parser {
  */
 class NmodlDriver {
   private:
+
+    /// a pointer to the NMODL lexer instance
+    NmodlLexer* scanner;
+
+    /// a pointer to the NMODL parser instance
+    NmodlParser* parser;
+
     /// all macro defined in the mod file
     std::unordered_map<std::string, int> defined_var;
 


### PR DESCRIPTION
Small improvement to parser error handling. Assuming we have a little typo on line 89 of netstim.mod, turn this error reporting

```
bin/nmodl netstim.mod
libc++abi.dylib: terminating with uncaught exception of type std::runtime_error: NMODL Parser Error : syntax error, unexpected . [Location : 89.50]
```

into this

```
bin/nmodl netstim.mod
libc++abi.dylib: terminating with uncaught exception of type std::runtime_error: NMODL Parser Error : syntax error, unexpected . [Location : 89.50]
    event = start + invl(interval) - interval*(f1. - noise)
-------------------------------------------------^
```

- We Store the current line being lexed in the NmodlLexer instance.
- We keep pointers to the current scanner and parser active in the driver to access them from the `NmodlDriver::parse_error` callback.
- in `parse_error` we print the last line from scanner along with the location pointer.

## Caveats

This seems to work quite nicely, but the printing is only as precise as the `location` parameter reports it from the parser. Additionally, `parse_error` is called in some cases directly from the driver. I'm not quite sure if the output would be correct - maybe there should be two parse_error callbacks?