### PR TITLE
Added attributes and metadata to LLVM IR compute kernels

### DIFF
--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -549,7 +549,8 @@ void CodegenLLVMVisitor::visit_codegen_for_statement(const ast::CodegenForStatem
 
     // Extract the condition to decide whether to branch to the loop body or loop exit.
     llvm::Value* cond = accept_and_get(node.get_condition());
-    ir_builder.create_cond_br(cond, for_body, exit);
+    llvm::BranchInst* loop_br = ir_builder.create_cond_br(cond, for_body, exit);
+    ir_builder.set_loop_metadata(loop_br);
 
     // Generate code for the loop body and create the basic block for the increment.
     ir_builder.set_insertion_point(for_body);

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -237,6 +237,16 @@ int CodegenLLVMVisitor::get_num_elements(const ast::IndexedName& node) {
     return static_cast<int>(*macro->get_value());
 }
 
+/**
+ * Currently, functions are identified as compute kernels if they satisfy the following:
+ *   1. They have a void return type
+ *   2. They have a single argument
+ *   3. The argument is a struct type pointer
+ * This is not robust, and hence it would be better to find what functions are kernels on the NMODL
+ * AST side (e.g. via a flag, or via names list).
+ *
+ * \todo identify kernels on NMODL AST side.
+ */
 bool CodegenLLVMVisitor::is_kernel_function(const std::string& function_name) {
     llvm::Function* function = module->getFunction(function_name);
     if (!function)

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -211,6 +211,9 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     /// Returns the number of elements in the array specified by the IndexedName AST node.
     int get_num_elements(const ast::IndexedName& node);
 
+    /// Returns whether the function is an NMODL compute kernel.
+    bool is_kernel_function(const std::string& function_name);
+
     /// If the value to store is specified, writes it to the instance. Otherwise, returns the
     /// instance variable.
     llvm::Value* read_from_or_write_to_instance(const ast::CodegenInstanceVar& node,

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -182,8 +182,13 @@ void IRBuilder::set_kernel_attributes() {
     // We also want to specify that the pointers that instance struct holds, do not alias. In order
     // to do that, we add a `noalias` attribute to the argument. As per Clang's specification:
     //  > The `noalias` attribute indicates that the only memory accesses inside function are loads
-    //  and stores from objects pointed to by its pointer-typed arguments, with arbitrary offsets.
+    //  > and stores from objects pointed to by its pointer-typed arguments, with arbitrary
+    //  > offsets.
     current_function->addParamAttr(0, llvm::Attribute::NoAlias);
+
+    // Finally, specify that the struct pointer does not capture and is read-only.
+    current_function->addParamAttr(0, llvm::Attribute::NoCapture);
+    current_function->addParamAttr(0, llvm::Attribute::ReadOnly);
 }
 
 /****************************************************************************************/

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -199,7 +199,7 @@ void IRBuilder::set_loop_metadata(llvm::BranchInst* branch) {
     llvm::LLVMContext& context = builder.getContext();
     MetadataVector loop_metadata;
 
-    // Add nullptr for loop's metadata self-reference.
+    // Add nullptr to reserve the first place for loop's metadata self-reference.
     loop_metadata.push_back(nullptr);
 
     // If `vector_width` is 1, explicitly disable vectorization for benchmarking purposes.
@@ -214,7 +214,7 @@ void IRBuilder::set_loop_metadata(llvm::BranchInst* branch) {
     if (loop_metadata.size() <= 1)
         return;
 
-    // Add metadata to the branch.
+    // Add loop's metadata self-reference and attach it to the branch.
     llvm::MDNode* metadata = llvm::MDNode::get(context, loop_metadata);
     metadata->replaceOperandWith(0, metadata);
     branch->setMetadata(llvm::LLVMContext::MD_loop, metadata);

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -174,6 +174,18 @@ void IRBuilder::create_intrinsic(const std::string& name,
     }
 }
 
+void IRBuilder::set_kernel_attributes() {
+    // By convention, the compute kernel does not free memory and does not throw exceptions.
+    current_function->setDoesNotFreeMemory();
+    current_function->setDoesNotThrow();
+
+    // We also want to specify that the pointers that instance struct holds, do not alias. In order
+    // to do that, we add a `noalias` attribute to the argument. As per Clang's specification:
+    //  > The `noalias` attribute indicates that the only memory accesses inside function are loads
+    //  and stores from objects pointed to by its pointer-typed arguments, with arbitrary offsets.
+    current_function->addParamAttr(0, llvm::Attribute::NoAlias);
+}
+
 /****************************************************************************************/
 /*                             LLVM instruction utilities                               */
 /****************************************************************************************/

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -24,6 +24,7 @@ static constexpr const unsigned double_precision = 64;
 
 /// Some typedefs.
 using ConstantVector = std::vector<llvm::Constant*>;
+using MetadataVector = std::vector<llvm::Metadata*>;
 using TypeVector = std::vector<llvm::Type*>;
 using ValueVector = std::vector<llvm::Value*>;
 
@@ -137,9 +138,9 @@ class IRBuilder {
     void create_br_and_set_insertion_point(llvm::BasicBlock* block);
 
     /// Generates LLVM IR for conditional branch.
-    void create_cond_br(llvm::Value* condition,
-                        llvm::BasicBlock* true_block,
-                        llvm::BasicBlock* false_block);
+    llvm::BranchInst* create_cond_br(llvm::Value* condition,
+                                     llvm::BasicBlock* true_block,
+                                     llvm::BasicBlock* false_block);
 
     /// Generates LLVM IR for the boolean constant.
     void create_boolean_constant(int value);
@@ -251,6 +252,9 @@ class IRBuilder {
 
     /// Sets the necessary attributes for the kernel and its arguments.
     void set_kernel_attributes();
+
+    /// Sets the loop metadata for the given branch from the loop.
+    void set_loop_metadata(llvm::BranchInst* branch);
 
     /// Pops the last visited value from the value stack.
     llvm::Value* pop_last_value();

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -249,6 +249,9 @@ class IRBuilder {
     /// Sets builder's insertion point to the given block.
     void set_insertion_point(llvm::BasicBlock* block);
 
+    /// Sets the necessary attributes for the kernel and its arguments.
+    void set_kernel_attributes();
+
     /// Pops the last visited value from the value stack.
     llvm::Value* pop_last_value();
 


### PR DESCRIPTION
Previously, there was no metadata and attributes associated with the instance struct pointer, compute kernels or loops. This patch fixes this.

**Instance struct attributes**

Since all pointers contained in the instance struct do not alias, we add a `noalias` (LLVM's `__restrict` alternative) attribute to it. In addition, we add `nocapture` (No capturing occurs in the function) and `readonly` (Struct pointer is not written to) attributes.

This means that some load instructions can be moved out from the loop body! Example:
```llvm
; BEFORE
for.body.lr.ph:                                   ; preds = %0
  %5 = getelementptr inbounds %avx__instance_var__type, %avx__instance_var__type* %mech1, i64 0, i32 1
  %6 = getelementptr inbounds %avx__instance_var__type, %avx__instance_var__type* %mech1, i64 0, i32 3
  %7 = getelementptr inbounds %avx__instance_var__type, %avx__instance_var__type* %mech1, i64 0, i32 2
  br label %for.body

for.body:                                         ; preds = %for.body.lr.ph, %for.body
  ; ...
  %15 = load double*, double** %5, align 8
  ; ...
  %19 = load double*, double** %6, align 8

; AFTER
for.body.lr.ph:                                   ; preds = %0
  %5 = getelementptr inbounds %avx__instance_var__type, %avx__instance_var__type* %mech1, i64 0, i32 1
  %6 = load double*, double** %5, align 8
  %7 = getelementptr inbounds %avx__instance_var__type, %avx__instance_var__type* %mech1, i64 0, i32 3
  %8 = load double*, double** %7, align 8
  %9 = getelementptr inbounds %avx__instance_var__type, %avx__instance_var__type* %mech1, i64 0, i32 2
  %10 = load double*, double** %9, align 8
  br label %for.body
```

**Loop metadata**

Also, loop metadata is added to scalar kernels, specifying that no vectorization is needed. The reason for this is because we want to benchmark truly scalar kernels, and disable LLVM's vectorization if necessary.

Note that for vector loop epilogue there is no metadata that disables vectorization.

fixes #607 