### PR TITLE
Do not open data presence block in destructors

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3230,7 +3230,11 @@ void CodegenCVisitor::print_global_function_common_code(BlockType type) {
 
     print_global_method_annotation();
     printer->start_block("void {}({})"_format(method, args));
-    print_kernel_data_present_annotation_block_begin();
+    if (type != BlockType::Destructor) {
+        // We do not (currently) support DESTRUCTOR (and, eventually,
+        // CONSTRUCTOR) blocks running anything on the GPU.
+        print_kernel_data_present_annotation_block_begin();
+    }
     printer->add_line("int nodecount = ml->nodecount;");
     printer->add_line("int pnodecount = ml->_nodecount_padded;");
     printer->add_line(


### PR DESCRIPTION
Without this change then with the OpenACC backend a closing brace is omitted:
```c++
void nrn_destructor_hh(NrnThread* nt, Memb_list* ml, int type) {
  #pragma acc data present(nt, ml, hh_global)
  {
    int nodecount = ml->nodecount;
    // ...
  } // this one was not printed
}
```
This breaks compilation of NEURON + CoreNEURON + NMODL with GPU support enabled. This change stops the `#pragma acc ...` block being opened.