### PR TITLE
Predication support for LLVM backend

### DIFF
--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -251,7 +251,8 @@ static void append_statements_from_block(ast::StatementVector& statements,
     for (const auto& statement: block_statements) {
         const auto& expression_statement = std::dynamic_pointer_cast<ast::ExpressionStatement>(
             statement);
-        if (!expression_statement->get_expression()->is_solve_block())
+        if (!expression_statement ||
+            expression_statement && !expression_statement->get_expression()->is_solve_block())
             statements.push_back(statement);
     }
 }

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -251,8 +251,7 @@ static void append_statements_from_block(ast::StatementVector& statements,
     for (const auto& statement: block_statements) {
         const auto& expression_statement = std::dynamic_pointer_cast<ast::ExpressionStatement>(
             statement);
-        if (!expression_statement ||
-            expression_statement && !expression_statement->get_expression()->is_solve_block())
+        if (!expression_statement || !expression_statement->get_expression()->is_solve_block())
             statements.push_back(statement);
     }
 }

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -204,6 +204,9 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     /// Creates a call to `printf` function.
     void create_printf_call(const ast::ExpressionVector& arguments);
 
+    /// Creates a vectorized version of the LLVM IR for the simple control flow statement.
+    void create_vectorized_control_flow_block(const ast::IfStatement& node);
+
     /// Returns LLVM type for the given CodegenVarType AST node.
     llvm::Type* get_codegen_var_type(const ast::CodegenVarType& node);
 

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -52,10 +52,6 @@ class IRBuilder {
     /// Precision of the floating-point numbers (32 or 64 bit).
     unsigned fp_precision;
 
-    /// If 1, indicates that the scalar code is generated. Otherwise, the current vectorization
-    /// width.
-    unsigned instruction_width;
-
     /// The vector width used for the vectorized code.
     unsigned vector_width;
 
@@ -75,7 +71,6 @@ class IRBuilder {
         , vectorize(false)
         , fp_precision(use_single_precision ? single_precision : double_precision)
         , vector_width(vector_width)
-        , instruction_width(vector_width)
         , mask(nullptr)
         , kernel_id("") {}
 
@@ -85,24 +80,14 @@ class IRBuilder {
         this->kernel_id = kernel_id;
     }
 
-    /// Explicitly sets the builder to produce scalar code (even during vectorization).
-    void generate_scalar_code() {
-        instruction_width = 1;
-    }
-
-    /// Explicitly sets the builder to produce vectorized code.
-    void generate_vectorized_code() {
-        instruction_width = vector_width;
-    }
-
-    /// Turns on vectorization mode.
-    void start_vectorization() {
-        vectorize = true;
-    }
-
-    /// Turns off vectorization mode.
-    void stop_vectorization() {
+    /// Explicitly sets the builder to produce scalar IR.
+    void generate_scalar_ir() {
         vectorize = false;
+    }
+
+    /// Explicitly sets the builder to produce vectorized IR.
+    void generate_vector_ir() {
+        vectorize = true;
     }
 
     /// Sets the current function for which LLVM IR is generated.

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -59,6 +59,9 @@ class IRBuilder {
     /// The vector width used for the vectorized code.
     unsigned vector_width;
 
+    /// Masked value used to predicate vector instructions.
+    llvm::Value* mask;
+
     /// The name of induction variable used in kernel loops.
     std::string kernel_id;
 
@@ -73,6 +76,7 @@ class IRBuilder {
         , fp_precision(use_single_precision ? single_precision : double_precision)
         , vector_width(vector_width)
         , instruction_width(vector_width)
+        , mask(nullptr)
         , kernel_id("") {}
 
     /// Initializes the builder with the symbol table and the kernel induction variable id.
@@ -110,6 +114,16 @@ class IRBuilder {
     void clear_function() {
         value_stack.clear();
         current_function = nullptr;
+    }
+
+    /// Sets the value to be the mask for vector code generation.
+    void set_mask(llvm::Value* value) {
+        mask = value;
+    }
+
+    /// Clears the mask for vector code generation.
+    void clear_mask() {
+        mask = nullptr;
     }
 
     /// Generates LLVM IR to allocate the arguments of the function on the stack.
@@ -168,20 +182,20 @@ class IRBuilder {
     void create_i32_constant(int value);
 
     /// Generates LLVM IR to load the value specified by its name and returns it.
-    llvm::Value* create_load(const std::string& name);
+    llvm::Value* create_load(const std::string& name, bool masked = false);
 
     /// Generates LLVM IR to load the value from the pointer and returns it.
-    llvm::Value* create_load(llvm::Value* ptr);
+    llvm::Value* create_load(llvm::Value* ptr, bool masked = false);
 
     /// Generates LLVM IR to load the element at the specified index from the given array name and
     /// returns it.
     llvm::Value* create_load_from_array(const std::string& name, llvm::Value* index);
 
     /// Generates LLVM IR to store the value to the location specified by the name.
-    void create_store(const std::string& name, llvm::Value* value);
+    void create_store(const std::string& name, llvm::Value* value, bool masked = false);
 
     /// Generates LLVM IR to store the value to the location specified by the pointer.
-    void create_store(llvm::Value* ptr, llvm::Value* value);
+    void create_store(llvm::Value* ptr, llvm::Value* value, bool masked = false);
 
     /// Generates LLVM IR to store the value to the array element, where array is specified by the
     /// name.
@@ -233,6 +247,9 @@ class IRBuilder {
 
     /// Creates a pointer to struct type with the given name and given members.
     llvm::Type* get_struct_ptr_type(const std::string& struct_type_name, TypeVector& member_types);
+
+    /// Inverts the mask for vector code generation by xoring it.
+    void invert_mask();
 
     /// Generates IR that loads the elements of the array even during vectorization. If the value is
     /// specified, then it is stored to the array at the given index.

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -85,6 +85,11 @@ class IRBuilder {
         vectorize = false;
     }
 
+    /// Indicates whether the builder generates vectorized IR.
+    bool vectorizing() {
+        return vectorize;
+    }
+
     /// Explicitly sets the builder to produce vectorized IR.
     void generate_vector_ir() {
         vectorize = true;
@@ -109,6 +114,11 @@ class IRBuilder {
     /// Clears the mask for vector code generation.
     void clear_mask() {
         mask = nullptr;
+    }
+
+    /// Indicates whether the vectorized IR is predicated.
+    bool generates_predicated_ir() {
+        return vectorize && mask;
     }
 
     /// Generates LLVM IR to allocate the arguments of the function on the stack.

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -508,3 +508,104 @@ SCENARIO("Vectorised kernel with scatter instruction", "[llvm][runner]") {
         }
     }
 }
+
+//=============================================================================
+// Vectorised kernel with control flow.
+//=============================================================================
+
+SCENARIO("Vectorised kernel with simple control flow", "[llvm][runner]") {
+    GIVEN("Simple MOD file with if statement") {
+        std::string nmodl_text = R"(
+            NEURON {
+                SUFFIX test
+            }
+
+            STATE {
+                w x y z
+            }
+
+            BREAKPOINT {
+                SOLVE states METHOD cnexp
+            }
+
+            DERIVATIVE states {
+                IF (v > 0) {
+                    w = v * w
+                }
+
+                IF (x < 0) {
+                    x = 7
+                }
+
+                IF (0 <= y && y < 10 || z == 0) {
+                    y = 2 * y
+                } ELSE {
+                    z = z - y
+                }
+
+            }
+        )";
+
+
+        NmodlDriver driver;
+        const auto& ast = driver.parse_string(nmodl_text);
+
+        // Run passes on the AST to generate LLVM.
+        SymtabVisitor().visit_program(*ast);
+        NeuronSolveVisitor().visit_program(*ast);
+        SolveBlockVisitor().visit_program(*ast);
+        codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
+                                                 /*output_dir=*/".",
+                                                 /*opt_passes=*/false,
+                                                 /*use_single_precision=*/false,
+                                                 /*vector_width=*/2);
+        llvm_visitor.visit_program(*ast);
+        llvm_visitor.wrap_kernel_functions();
+
+        // Create the instance struct data.
+        int num_elements = 5;
+        const auto& generated_instance_struct = llvm_visitor.get_instance_struct_ptr();
+        auto codegen_data = codegen::CodegenDataHelper(ast, generated_instance_struct);
+        auto instance_data = codegen_data.create_data(num_elements, /*seed=*/1);
+
+        // Fill the instance struct data with some values.
+        std::vector<double> x = {-1.0, 2.0, -3.0, 4.0, -5.0};
+        std::vector<double> y = {11.0, 2.0, -3.0, 4.0, 100.0};
+        std::vector<double> z = {0.0, 1.0, 20.0, 0.0, 40.0};
+
+        std::vector<double> w = {10.0, 20.0, 30.0, 40.0, 50.0};
+        std::vector<double> voltage = {-1.0, 2.0, -1.0, 2.0, -1.0};
+        std::vector<int> node_index = {1, 2, 3, 4, 0};
+
+        InstanceTestInfo instance_info{&instance_data,
+                                       llvm_visitor.get_instance_var_helper(),
+                                       num_elements};
+        initialise_instance_variable(instance_info, w, "w");
+        initialise_instance_variable(instance_info, voltage, "voltage");
+        initialise_instance_variable(instance_info, node_index, "node_index");
+
+        initialise_instance_variable(instance_info, x, "x");
+        initialise_instance_variable(instance_info, y, "y");
+        initialise_instance_variable(instance_info, z, "z");
+
+        // Set up the JIT runner.
+        std::unique_ptr<llvm::Module> module = llvm_visitor.get_module();
+        TestRunner runner(std::move(module));
+        runner.initialize_driver();
+
+        THEN("Masked instructions are generated") {
+            runner.run_with_argument<int, void*>("__nrn_state_test_wrapper",
+                                                 instance_data.base_ptr);
+            std::vector<double> w_expected = {20.0, 20.0, 60.0, 40.0, 50.0};
+            REQUIRE(check_instance_variable(instance_info, w_expected, "w"));
+
+            std::vector<double> x_expected = {7.0, 2.0, 7.0, 4.0, 7.0};
+            REQUIRE(check_instance_variable(instance_info, x_expected, "x"));
+
+            std::vector<double> y_expected = {22.0, 4.0, -3.0, 8.0, 100.0};
+            std::vector<double> z_expected = {0.0, 1.0, 23.0, 0.0, -60.0};
+            REQUIRE(check_instance_variable(instance_info, y_expected, "y"));
+            REQUIRE(check_instance_variable(instance_info, z_expected, "z"));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for vector predication. Currently, we support a very basic predication:
```c++
IF (/*condition*/) {
  // code here
} ELSE {
  // code here
} 
```
**What has been changed and added**

1. Removed vectorization check

Before, in the `FOR` statement visitor we were checking whether the code can be vectorized. After refactoring `llvm::IRBuilder<>` into a separate class, there is no interface to reset the builder's vector width. Hence, this check leads to visitor having scalar vector width of 1, and builder having the same vector width.
```c++
if (!can_vectorize(node, sym_tab)) {
    vector_width = 1;
     ir_builder.generate_scalar_code();
}
```
In order to avoid any issues, this check is simply removed and will be added in the separate PR.

2. Predication support

- `can_vectorize` has been changed to support a single `IF` or `IF/ELSE` pair.
- A special vectorized `IF` AST node visitor has been added.
- If generating code within `IF` AST node, instructions are masked.

Example:
```c++
VOID nrn_state_test(INSTANCE_STRUCT *mech){
    INTEGER id
    INTEGER node_id
    DOUBLE v
    for(id = 0; id<mech->node_count-7; id = id+8) {
        node_id = mech->node_index[id]
        v = mech->voltage[node_id]
        IF (mech->y[id]<0) {
            mech->y[id] = mech->y[id]+7
        } ELSE {
            mech->y[id] = v
        }
    }
    INTEGER epilogue_node_id
    DOUBLE epilogue_v
    for(; id<mech->node_count; id = id+1) {
        epilogue_node_id = mech->node_index[id]
        epilogue_v = mech->voltage[epilogue_node_id]
        IF (mech->y[id]<0) {
            mech->y[id] = mech->y[id]+7
        } ELSE {
            mech->y[id] = epilogue_v
        }
    }
}
```
is converted to
```llvm
define void @nrn_state_test(%test__instance_var__type* noalias nocapture readonly %mech1) #0 !dbg !4 {
  %mech = alloca %test__instance_var__type*, align 8
  store %test__instance_var__type* %mech1, %test__instance_var__type** %mech, align 8
  %id = alloca i32, align 4
  %node_id = alloca <8 x i32>, align 32
  %v = alloca <8 x float>, align 32
  store i32 0, i32* %id, align 4
  br label %for.cond

for.cond:                                         ; preds = %for.inc, %0
  %1 = load %test__instance_var__type*, %test__instance_var__type** %mech, align 8
  %2 = getelementptr inbounds %test__instance_var__type, %test__instance_var__type* %1, i32 0, i32 10
  %3 = load i32, i32* %2, align 4
  %4 = sub i32 %3, 7
  %5 = load i32, i32* %id, align 4
  %6 = icmp slt i32 %5, %4
  br i1 %6, label %for.body, label %for.exit

for.body:                                         ; preds = %for.cond
  %7 = load %test__instance_var__type*, %test__instance_var__type** %mech, align 8
  %8 = getelementptr inbounds %test__instance_var__type, %test__instance_var__type* %7, i32 0, i32 5
  %9 = load i32, i32* %id, align 4
  %10 = sext i32 %9 to i64
  %11 = load i32*, i32** %8, align 8
  %12 = getelementptr inbounds i32, i32* %11, i64 %10
  %13 = bitcast i32* %12 to <8 x i32>*
  %14 = load <8 x i32>, <8 x i32>* %13, align 32
  store <8 x i32> %14, <8 x i32>* %node_id, align 32
  %15 = load %test__instance_var__type*, %test__instance_var__type** %mech, align 8
  %16 = getelementptr inbounds %test__instance_var__type, %test__instance_var__type* %15, i32 0, i32 4
  %17 = load <8 x i32>, <8 x i32>* %node_id, align 32
  %18 = sext <8 x i32> %17 to <8 x i64>
  %19 = load float*, float** %16, align 8
  %20 = getelementptr inbounds float, float* %19, <8 x i64> %18
  %21 = call <8 x float> @llvm.masked.gather.v8f32.v8p0f32(<8 x float*> %20, i32 1, <8 x i1> <i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true>, <8 x float> undef)
  store <8 x float> %21, <8 x float>* %v, align 32
  %22 = load %test__instance_var__type*, %test__instance_var__type** %mech, align 8
  %23 = getelementptr inbounds %test__instance_var__type, %test__instance_var__type* %22, i32 0, i32 0
  %24 = load i32, i32* %id, align 4
  %25 = sext i32 %24 to i64
  %26 = load float*, float** %23, align 8
  %27 = getelementptr inbounds float, float* %26, i64 %25
  %28 = bitcast float* %27 to <8 x float>*
  %29 = load <8 x float>, <8 x float>* %28, align 32
  %30 = fcmp olt <8 x float> %29, zeroinitializer
  %31 = load %test__instance_var__type*, %test__instance_var__type** %mech, align 8
  %32 = getelementptr inbounds %test__instance_var__type, %test__instance_var__type* %31, i32 0, i32 0
  %33 = load i32, i32* %id, align 4
  %34 = sext i32 %33 to i64
  %35 = load float*, float** %32, align 8
  %36 = getelementptr inbounds float, float* %35, i64 %34
  %37 = bitcast float* %36 to <8 x float>*
  %38 = call <8 x float> @llvm.masked.load.v8f32.p0v8f32(<8 x float>* %37, i32 1, <8 x i1> %30, <8 x float> undef)
  %39 = fadd <8 x float> %38, <float 7.000000e+00, float 7.000000e+00, float 7.000000e+00, float 7.000000e+00, float 7.000000e+00, float 7.000000e+00, float 7.000000e+00, float 7.000000e+00>
  %40 = load %test__instance_var__type*, %test__instance_var__type** %mech, align 8
  %41 = getelementptr inbounds %test__instance_var__type, %test__instance_var__type* %40, i32 0, i32 0
  %42 = load i32, i32* %id, align 4
  %43 = sext i32 %42 to i64
  %44 = load float*, float** %41, align 8
  %45 = getelementptr inbounds float, float* %44, i64 %43
  %46 = bitcast float* %45 to <8 x float>*
  call void @llvm.masked.store.v8f32.p0v8f32(<8 x float> %39, <8 x float>* %46, i32 1, <8 x i1> %30)
  %47 = xor <8 x i1> %30, <i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true, i1 true>
  %48 = call <8 x float> @llvm.masked.load.v8f32.p0v8f32(<8 x float>* %v, i32 1, <8 x i1> %47, <8 x float> undef)
  %49 = load %test__instance_var__type*, %test__instance_var__type** %mech, align 8
  %50 = getelementptr inbounds %test__instance_var__type, %test__instance_var__type* %49, i32 0, i32 0
  %51 = load i32, i32* %id, align 4
  %52 = sext i32 %51 to i64
  %53 = load float*, float** %50, align 8
  %54 = getelementptr inbounds float, float* %53, i64 %52
  %55 = bitcast float* %54 to <8 x float>*
  call void @llvm.masked.store.v8f32.p0v8f32(<8 x float> %48, <8 x float>* %55, i32 1, <8 x i1> %47)
  br label %for.inc

; ... rest of the kernel
```

3. Added execution and IR tests

fixes #539 