### PR TITLE
Improvements for LLVM code generation and benchmarking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,9 +150,6 @@ if(NMODL_ENABLE_LLVM)
   include(LLVMHelper)
   include_directories(${LLVM_INCLUDE_DIRS})
   add_definitions(-DNMODL_LLVM_BACKEND)
-  if(LLVM_VERSION VERSION_LESS_EQUAL 12)
-    add_definitions(-DLLVM_VERSION_LESS_THAN_13)
-  endif()
 endif()
 
 # =============================================================================

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -20,7 +20,7 @@
 #include "llvm/Support/Host.h"
 #include "llvm/Support/ToolOutputFile.h"
 
-#ifndef LLVM_VERSION_LESS_THAN_13
+#if LLVM_VERSION_MAJOR >= 13
 #include "llvm/CodeGen/ReplaceWithVeclib.h"
 #endif
 
@@ -819,7 +819,7 @@ void CodegenLLVMVisitor::visit_program(const ast::Program& node) {
 
     // Optionally, replace LLVM's maths intrinsics with vector library calls.
     if (vector_width > 1 && vector_library != llvm::TargetLibraryInfoImpl::NoLibrary) {
-#ifdef LLVM_VERSION_LESS_THAN_13
+#if LLVM_VERSION_MAJOR < 13
         logger->warn(
             "This version of LLVM does not support replacement of LLVM intrinsics with vector "
             "library calls");

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -51,7 +51,7 @@ namespace codegen {
 /// A map to query vector library by its string value.
 static const std::map<std::string, llvm::TargetLibraryInfoImpl::VectorLibrary> veclib_map = {
     {"Accelerate", llvm::TargetLibraryInfoImpl::Accelerate},
-#ifndef LLVM_VERSION_LESS_THAN_13
+#if LLVM_VERSION_MAJOR >= 13
     {"libmvec", llvm::TargetLibraryInfoImpl::LIBMVEC_X86},
 #endif
     {"MASSV", llvm::TargetLibraryInfoImpl::MASSV},

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -165,9 +165,26 @@ void IRBuilder::create_function_call(llvm::Function* callee,
 void IRBuilder::create_intrinsic(const std::string& name,
                                  ValueVector& argument_values,
                                  TypeVector& argument_types) {
+    // Process 'pow' call separately.
+    if (name == "pow") {
+        llvm::Value* pow_intrinsic = builder.CreateIntrinsic(llvm::Intrinsic::pow,
+                                                             {argument_types.front()},
+                                                             argument_values);
+        value_stack.push_back(pow_intrinsic);
+        return;
+    }
+
+    // Create other intrinsics.
     unsigned intrinsic_id = llvm::StringSwitch<llvm::Intrinsic::ID>(name)
+                                .Case("ceil", llvm::Intrinsic::ceil)
+                                .Case("cos", llvm::Intrinsic::cos)
                                 .Case("exp", llvm::Intrinsic::exp)
-                                .Case("pow", llvm::Intrinsic::pow)
+                                .Case("fabs", llvm::Intrinsic::fabs)
+                                .Case("floor", llvm::Intrinsic::floor)
+                                .Case("log", llvm::Intrinsic::log)
+                                .Case("log10", llvm::Intrinsic::log10)
+                                .Case("sin", llvm::Intrinsic::sin)
+                                .Case("sqrt", llvm::Intrinsic::sqrt)
                                 .Default(llvm::Intrinsic::not_intrinsic);
     if (intrinsic_id) {
         llvm::Value* intrinsic =

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -267,6 +267,11 @@ void IRBuilder::create_binary_op(llvm::Value* lhs, llvm::Value* rhs, ast::Binary
 
 #undef DISPATCH
 
+    // Separately replace ^ with the `pow` intrinsic.
+    case ast::BinaryOp::BOP_POWER:
+        result = builder.CreateIntrinsic(llvm::Intrinsic::pow, {lhs->getType()}, {lhs, rhs});
+        break;
+
     // Logical instructions.
     case ast::BinaryOp::BOP_AND:
         result = builder.CreateAnd(lhs, rhs);

--- a/test/benchmark/llvm_benchmark.cpp
+++ b/test/benchmark/llvm_benchmark.cpp
@@ -141,7 +141,7 @@ void LLVMBenchmark::run_benchmark(const std::shared_ptr<ast::Program>& node) {
         // Log the average time taken for the kernel.
         double time_mean = time_sum / num_experiments;
         logger->info("Average compute time = {:.6f}", time_mean);
-        logger->info("Compute time variance = {:.6f}",
+        logger->info("Compute time variance = {:g}",
                      time_squared_sum / num_experiments - time_mean * time_mean);
         logger->info("Minimum compute time = {:.6f}", time_min);
         logger->info("Minimum compute time = {:.6f}\n", time_max);

--- a/test/benchmark/llvm_benchmark.cpp
+++ b/test/benchmark/llvm_benchmark.cpp
@@ -107,15 +107,21 @@ void LLVMBenchmark::run_benchmark(const std::shared_ptr<ast::Program>& node) {
 
     // Benchmark every kernel.
     for (const auto& kernel_name: kernel_names) {
-        // Initialise the data.
-        auto instance_data = codegen_data.create_data(instance_size, /*seed=*/1);
-
-        double size_mbs = instance_data.num_bytes / (1024.0 * 1024.0);
-        logger->info("Benchmarking kernel '{}' with {} MBs dataset", kernel_name, size_mbs);
-
         // For every kernel run the benchmark `num_experiments` times.
+        double time_min = std::numeric_limits<double>::max();
+        double time_max = 0.0;
         double time_sum = 0.0;
+        double time_squared_sum = 0.0;
         for (int i = 0; i < num_experiments; ++i) {
+            // Initialise the data.
+            auto instance_data = codegen_data.create_data(instance_size, /*seed=*/1);
+
+            // Log instance size once.
+            if (i == 0) {
+                double size_mbs = instance_data.num_bytes / (1024.0 * 1024.0);
+                logger->info("Benchmarking kernel '{}' with {} MBs dataset", kernel_name, size_mbs);
+            }
+
             // Record the execution time of the kernel.
             std::string wrapper_name = "__" + kernel_name + "_wrapper";
             auto start = std::chrono::high_resolution_clock::now();
@@ -126,10 +132,19 @@ void LLVMBenchmark::run_benchmark(const std::shared_ptr<ast::Program>& node) {
             // Log the time taken for each run.
             logger->info("Experiment {} compute time = {:.6f} sec", i, diff.count());
 
+            // Update statistics.
             time_sum += diff.count();
+            time_squared_sum += diff.count() * diff.count();
+            time_min = std::min(time_min, diff.count());
+            time_max = std::max(time_max, diff.count());
         }
         // Log the average time taken for the kernel.
-        logger->info("Average compute time = {:.6f} \n", time_sum / num_experiments);
+        double time_mean = time_sum / num_experiments;
+        logger->info("Average compute time = {:.6f}", time_mean);
+        logger->info("Compute time variance = {:.6f}",
+                     time_squared_sum / num_experiments - time_mean * time_mean);
+        logger->info("Minimum compute time = {:.6f}", time_min);
+        logger->info("Minimum compute time = {:.6f}\n", time_max);
     }
 }
 

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -1230,7 +1230,7 @@ SCENARIO("Vector library calls", "[visitor][llvm][vector_lib]") {
             REQUIRE(std::regex_search(no_library_module_str, m, exp_decl));
             REQUIRE(std::regex_search(no_library_module_str, m, exp_call));
 
-#ifndef LLVM_VERSION_LESS_THAN_13
+#if LLVM_VERSION_MAJOR >= 13
             // Check exponential calls are replaced with calls to SVML library.
             std::string svml_library_module_str = run_llvm_visitor(nmodl_text,
                                                                    /*opt=*/false,

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -515,8 +515,44 @@ SCENARIO("Function call", "[visitor][llvm]") {
 
     GIVEN("A call to external method") {
         std::string nmodl_text = R"(
-            FUNCTION bar(i) {
-                bar = exp(i)
+            FUNCTION nmodl_ceil(x) {
+                nmodl_ceil = ceil(x)
+            }
+
+            FUNCTION nmodl_cos(x) {
+                nmodl_cos = cos(x)
+            }
+
+            FUNCTION nmodl_exp(x) {
+                nmodl_exp = exp(x)
+            }
+
+            FUNCTION nmodl_fabs(x) {
+                nmodl_fabs = fabs(x)
+            }
+
+            FUNCTION nmodl_floor(x) {
+                nmodl_floor = floor(x)
+            }
+
+            FUNCTION nmodl_log(x) {
+                nmodl_log = log(x)
+            }
+
+            FUNCTION nmodl_log10(x) {
+                nmodl_log10 = log10(x)
+            }
+
+            FUNCTION nmodl_pow(x, y) {
+                nmodl_pow = pow(x, y)
+            }
+
+            FUNCTION nmodl_sin(x) {
+                nmodl_sin = sin(x)
+            }
+
+            FUNCTION nmodl_sqrt(x) {
+                nmodl_sqrt = sqrt(x)
             }
         )";
 
@@ -524,13 +560,49 @@ SCENARIO("Function call", "[visitor][llvm]") {
             std::string module_string = run_llvm_visitor(nmodl_text);
             std::smatch m;
 
-            // Check for intrinsic declaration.
+            // Check for intrinsic declarations.
+            std::regex ceil(R"(declare double @llvm\.ceil\.f64\(double\))");
+            std::regex cos(R"(declare double @llvm\.cos\.f64\(double\))");
             std::regex exp(R"(declare double @llvm\.exp\.f64\(double\))");
+            std::regex fabs(R"(declare double @llvm\.fabs\.f64\(double\))");
+            std::regex floor(R"(declare double @llvm\.floor\.f64\(double\))");
+            std::regex log(R"(declare double @llvm\.log\.f64\(double\))");
+            std::regex log10(R"(declare double @llvm\.log10\.f64\(double\))");
+            std::regex pow(R"(declare double @llvm\.pow\.f64\(double, double\))");
+            std::regex sin(R"(declare double @llvm\.sin\.f64\(double\))");
+            std::regex sqrt(R"(declare double @llvm\.sqrt\.f64\(double\))");
+            REQUIRE(std::regex_search(module_string, m, ceil));
+            REQUIRE(std::regex_search(module_string, m, cos));
             REQUIRE(std::regex_search(module_string, m, exp));
+            REQUIRE(std::regex_search(module_string, m, fabs));
+            REQUIRE(std::regex_search(module_string, m, floor));
+            REQUIRE(std::regex_search(module_string, m, log));
+            REQUIRE(std::regex_search(module_string, m, log10));
+            REQUIRE(std::regex_search(module_string, m, pow));
+            REQUIRE(std::regex_search(module_string, m, sin));
+            REQUIRE(std::regex_search(module_string, m, sqrt));
 
             // Check the correct call is made.
-            std::regex call(R"(call double @llvm\.exp\.f64\(double %[0-9]+\))");
-            REQUIRE(std::regex_search(module_string, m, call));
+            std::regex ceil_call(R"(call double @llvm\.ceil\.f64\(double %[0-9]+\))");
+            std::regex cos_call(R"(call double @llvm\.cos\.f64\(double %[0-9]+\))");
+            std::regex exp_call(R"(call double @llvm\.exp\.f64\(double %[0-9]+\))");
+            std::regex fabs_call(R"(call double @llvm\.fabs\.f64\(double %[0-9]+\))");
+            std::regex floor_call(R"(call double @llvm\.floor\.f64\(double %[0-9]+\))");
+            std::regex log_call(R"(call double @llvm\.log\.f64\(double %[0-9]+\))");
+            std::regex log10_call(R"(call double @llvm\.log10\.f64\(double %[0-9]+\))");
+            std::regex pow_call(R"(call double @llvm\.pow\.f64\(double %[0-9]+, double %[0-9]+\))");
+            std::regex sin_call(R"(call double @llvm\.sin\.f64\(double %[0-9]+\))");
+            std::regex sqrt_call(R"(call double @llvm\.sqrt\.f64\(double %[0-9]+\))");
+            REQUIRE(std::regex_search(module_string, m, ceil_call));
+            REQUIRE(std::regex_search(module_string, m, cos_call));
+            REQUIRE(std::regex_search(module_string, m, exp_call));
+            REQUIRE(std::regex_search(module_string, m, fabs_call));
+            REQUIRE(std::regex_search(module_string, m, floor_call));
+            REQUIRE(std::regex_search(module_string, m, log_call));
+            REQUIRE(std::regex_search(module_string, m, log10_call));
+            REQUIRE(std::regex_search(module_string, m, pow_call));
+            REQUIRE(std::regex_search(module_string, m, sin_call));
+            REQUIRE(std::regex_search(module_string, m, sqrt_call));
         }
     }
 

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -97,7 +97,7 @@ SCENARIO("Binary expression", "[visitor][llvm]") {
             std::regex lhs(R"(%2 = load float, float\* %a)");
             std::regex res(R"(%3 = fadd float %2, %1)");
 
-            // Check the float values are loaded correctly and added
+            // Check the float values are loaded correctly and added.
             REQUIRE(std::regex_search(module_string, m, rhs));
             REQUIRE(std::regex_search(module_string, m, lhs));
             REQUIRE(std::regex_search(module_string, m, res));
@@ -116,7 +116,7 @@ SCENARIO("Binary expression", "[visitor][llvm]") {
             std::string module_string = run_llvm_visitor(nmodl_text);
             std::smatch m;
 
-            // Check rhs
+            // Check rhs.
             std::regex rr(R"(%1 = load double, double\* %b)");
             std::regex rl(R"(%2 = load double, double\* %a)");
             std::regex x(R"(%3 = fadd double %2, %1)");
@@ -124,7 +124,7 @@ SCENARIO("Binary expression", "[visitor][llvm]") {
             REQUIRE(std::regex_search(module_string, m, rl));
             REQUIRE(std::regex_search(module_string, m, x));
 
-            // Check lhs
+            // Check lhs.
             std::regex lr(R"(%4 = load double, double\* %b)");
             std::regex ll(R"(%5 = load double, double\* %a)");
             std::regex y(R"(%6 = fsub double %5, %4)");
@@ -132,7 +132,7 @@ SCENARIO("Binary expression", "[visitor][llvm]") {
             REQUIRE(std::regex_search(module_string, m, ll));
             REQUIRE(std::regex_search(module_string, m, y));
 
-            // Check result
+            // Check result.
             std::regex res(R"(%7 = fdiv double %6, %3)");
             REQUIRE(std::regex_search(module_string, m, res));
         }
@@ -150,11 +150,34 @@ SCENARIO("Binary expression", "[visitor][llvm]") {
             std::string module_string = run_llvm_visitor(nmodl_text);
             std::smatch m;
 
-            // Check store immediate is created
+            // Check store immediate is created.
             std::regex allocation(R"(%i = alloca double)");
             std::regex assignment(R"(store double 2.0*e\+00, double\* %i)");
             REQUIRE(std::regex_search(module_string, m, allocation));
             REQUIRE(std::regex_search(module_string, m, assignment));
+        }
+    }
+
+    GIVEN("Function with power operator") {
+        std::string nmodl_text = R"(
+            FUNCTION power() {
+                LOCAL i, j
+                i = 2
+                j = 4
+                power = i ^ j
+            }
+        )";
+
+        THEN("'pow' intrinsic is created") {
+            std::string module_string =
+                run_llvm_visitor(nmodl_text, /*opt=*/false, /*use_single_precision=*/true);
+            std::smatch m;
+
+            // Check 'pow' intrinsic.
+            std::regex declaration(R"(declare float @llvm\.pow\.f32\(float, float\))");
+            std::regex pow(R"(call float @llvm\.pow\.f32\(float %.*, float %.*\))");
+            REQUIRE(std::regex_search(module_string, m, declaration));
+            REQUIRE(std::regex_search(module_string, m, pow));
         }
     }
 }


### PR DESCRIPTION
This PR has several improvements for the current LLVM infrastructure.

1. A nicer (I guess) approach is used to check the LLVM version in `.cpp` files: instead of defining a variable, we directly check `LLVM_VERSION MAJOR`.

2. More external methods are supported now, particularly: `ceil`, `cos`, `fabs`, `floor`, `log`, `log10`, `sin`, `sqrt`. Code generation for `pow` was also fixed, and corresponding IR  tests were added. Moreover, `^` is also now supported and transformed into `pow` intrinsic.

3. Benchmarking has been also improved. Firstly, the data is initialised for every experiment (based on the Slack discussion this is the preferred way to avoid traps, unexpected timings for large number of experiments). Secondly, minimum and maximum compute times, as well as compute time variance were added to benchmarking metrics.