### PR TITLE
Fast math flags for LLVM backend

### DIFF
--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -113,14 +113,15 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
                        bool use_single_precision = false,
                        int vector_width = 1,
                        std::string vec_lib = "none",
-                       bool add_debug_information = false)
+                       bool add_debug_information = false,
+                       std::vector<std::string> fast_math_flags = {})
         : mod_filename(mod_filename)
         , output_dir(output_dir)
         , opt_passes(opt_passes)
         , vector_width(vector_width)
         , vector_library(veclib_map.at(vec_lib))
         , add_debug_information(add_debug_information)
-        , ir_builder(*context, use_single_precision, vector_width)
+        , ir_builder(*context, use_single_precision, vector_width, fast_math_flags)
         , debug_builder(*module)
         , codegen_pm(module.get())
         , opt_pm(module.get()) {}

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -79,7 +79,7 @@ class IRBuilder {
         , kernel_id("")
         , fast_math_flags(fast_math_flags) {}
 
-    /// Transforms the  fast math flags provided to the builder into LLVM's representation.
+    /// Transforms the fast math flags provided to the builder into LLVM's representation.
     llvm::FastMathFlags transform_to_fmf(std::vector<std::string>& flags) {
         static const std::map<std::string, void (llvm::FastMathFlags::*)(bool)> set_flag = {
             {"nnan", &llvm::FastMathFlags::setNoNaNs},

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -61,10 +61,14 @@ class IRBuilder {
     /// The name of induction variable used in kernel loops.
     std::string kernel_id;
 
+    /// Fast math flags for floating-point IR instructions.
+    std::vector<std::string> fast_math_flags;
+
   public:
     IRBuilder(llvm::LLVMContext& context,
               bool use_single_precision = false,
-              unsigned vector_width = 1)
+              unsigned vector_width = 1,
+              std::vector<std::string> fast_math_flags = {})
         : builder(context)
         , symbol_table(nullptr)
         , current_function(nullptr)
@@ -72,10 +76,30 @@ class IRBuilder {
         , fp_precision(use_single_precision ? single_precision : double_precision)
         , vector_width(vector_width)
         , mask(nullptr)
-        , kernel_id("") {}
+        , kernel_id("")
+        , fast_math_flags(fast_math_flags) {}
+
+    /// Transforms the  fast math flags provided to the builder into LLVM's representation.
+    llvm::FastMathFlags transform_to_fmf(std::vector<std::string>& flags) {
+        static const std::map<std::string, void (llvm::FastMathFlags::*)(bool)> set_flag = {
+                {"nnan", &llvm::FastMathFlags::setNoNaNs},
+                {"ninf", &llvm::FastMathFlags::setNoInfs},
+                {"nsz", &llvm::FastMathFlags::setNoSignedZeros},
+                {"contract", &llvm::FastMathFlags::setAllowContract},
+                {"afn", &llvm::FastMathFlags::setApproxFunc},
+                {"reassoc", &llvm::FastMathFlags::setAllowReassoc},
+                {"fast", &llvm::FastMathFlags::setFast}};
+        llvm::FastMathFlags fmf;
+        for (const auto& flag: flags) {
+            (fmf.*(set_flag.at(flag)))(true);
+        }
+        return fmf;
+    }
 
     /// Initializes the builder with the symbol table and the kernel induction variable id.
     void initialize(symtab::SymbolTable& symbol_table, std::string& kernel_id) {
+        if (!fast_math_flags.empty())
+            builder.setFastMathFlags(transform_to_fmf(fast_math_flags));
         this->symbol_table = &symbol_table;
         this->kernel_id = kernel_id;
     }

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -82,13 +82,13 @@ class IRBuilder {
     /// Transforms the  fast math flags provided to the builder into LLVM's representation.
     llvm::FastMathFlags transform_to_fmf(std::vector<std::string>& flags) {
         static const std::map<std::string, void (llvm::FastMathFlags::*)(bool)> set_flag = {
-                {"nnan", &llvm::FastMathFlags::setNoNaNs},
-                {"ninf", &llvm::FastMathFlags::setNoInfs},
-                {"nsz", &llvm::FastMathFlags::setNoSignedZeros},
-                {"contract", &llvm::FastMathFlags::setAllowContract},
-                {"afn", &llvm::FastMathFlags::setApproxFunc},
-                {"reassoc", &llvm::FastMathFlags::setAllowReassoc},
-                {"fast", &llvm::FastMathFlags::setFast}};
+            {"nnan", &llvm::FastMathFlags::setNoNaNs},
+            {"ninf", &llvm::FastMathFlags::setNoInfs},
+            {"nsz", &llvm::FastMathFlags::setNoSignedZeros},
+            {"contract", &llvm::FastMathFlags::setAllowContract},
+            {"afn", &llvm::FastMathFlags::setApproxFunc},
+            {"reassoc", &llvm::FastMathFlags::setAllowReassoc},
+            {"fast", &llvm::FastMathFlags::setFast}};
         llvm::FastMathFlags fmf;
         for (const auto& flag: flags) {
             (fmf.*(set_flag.at(flag)))(true);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -183,6 +183,9 @@ int main(int argc, const char* argv[]) {
     /// disable debug information generation for the IR
     bool disable_debug_information(false);
 
+    /// fast math flags for LLVM backend
+    std::vector<std::string> llvm_fast_math_flags;
+
     /// run llvm benchmark
     bool run_llvm_benchmark(false);
 
@@ -330,6 +333,9 @@ int main(int argc, const char* argv[]) {
     llvm_opt->add_option("--veclib",
                          vector_library,
                          "Vector library for maths functions ({})"_format(vector_library))->check(CLI::IsMember({"Accelerate", "libmvec", "MASSV", "SVML", "none"}));
+    llvm_opt->add_option("--fmf",
+                         llvm_fast_math_flags,
+                         "Fast math flags for floating-point optimizations (none)")->check(CLI::IsMember({"afn", "arcp", "contract", "ninf", "nnan", "nsz", "reassoc", "fast"}));
 
     // LLVM IR benchmark options.
     auto benchmark_opt = app.add_subcommand("benchmark", "LLVM benchmark option")->ignore_case();
@@ -659,7 +665,8 @@ int main(int argc, const char* argv[]) {
                                            llvm_float_type,
                                            llvm_vec_width,
                                            vector_library,
-                                           !disable_debug_information);
+                                           !disable_debug_information,
+                                           llvm_fast_math_flags);
                 visitor.visit_program(*ast);
                 ast_to_nmodl(*ast, filepath("llvm", "mod"));
                 ast_to_json(*ast, filepath("llvm", "json"));

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -37,7 +37,8 @@ std::string run_llvm_visitor(const std::string& text,
                              bool opt = false,
                              bool use_single_precision = false,
                              int vector_width = 1,
-                             std::string vec_lib = "none") {
+                             std::string vec_lib = "none",
+                             std::vector<std::string> fast_math_flags = {}) {
     NmodlDriver driver;
     const auto& ast = driver.parse_string(text);
 
@@ -50,7 +51,9 @@ std::string run_llvm_visitor(const std::string& text,
                                              opt,
                                              use_single_precision,
                                              vector_width,
-                                             vec_lib);
+                                             vec_lib,
+                                             /*add_debug_information=*/false,
+                                             fast_math_flags);
     llvm_visitor.visit_program(*ast);
     return llvm_visitor.dump_module();
 }
@@ -1279,6 +1282,37 @@ SCENARIO("Vector library calls", "[visitor][llvm][vector_lib]") {
             REQUIRE(std::regex_search(accelerate_library_module_str, m, accelerate_exp_call));
             REQUIRE(!std::regex_search(accelerate_library_module_str, m, fexp_call));
 #endif
+        }
+    }
+}
+
+//=============================================================================
+// Fast math flags
+//=============================================================================
+
+SCENARIO("Fast math flags", "[visitor][llvm]") {
+    GIVEN("A function to produce fma and specified math flags") {
+        std::string nmodl_text = R"(
+            FUNCTION foo(a, b, c) {
+                foo = (a * b) + c
+            }
+        )";
+
+        THEN("instructions are generated with the flags set") {
+            std::string module_string =
+                run_llvm_visitor(nmodl_text,
+                                 /*opt=*/true,
+                                 /*use_single_precision=*/false,
+                                 /*vector_width=*/1,
+                                 /*vec_lib=*/"none",
+                                 /*fast_math_flags=*/{"nnan", "contract", "afn"});
+            std::smatch m;
+
+            // Check flags for produced 'fmul' and 'fadd' instructions.
+            std::regex fmul(R"(fmul nnan contract afn double %.*, %.*)");
+            std::regex fadd(R"(fadd nnan contract afn double %.*, %.*)");
+            REQUIRE(std::regex_search(module_string, m, fmul));
+            REQUIRE(std::regex_search(module_string, m, fadd));
         }
     }
 }


### PR DESCRIPTION
This PR adds support for fast math flags in LLVM backend. Currently, the user can specify them via command-line (this approach was chosen for easier benchmarking). The specified flags are named exactly  the same as in LLVM. 

Example:
```c++
// fma.mod
FUNCTION fma(a, b, c) {
    fma = (a * b) + c
}
```
```bash
$ ./nmodl fma.mod --verbose debug llvm --ir --fmf nnan contract afn --opt
```
```llvm
define double @fma(double %a, double %b, double %c) {
  %1 = fmul nnan contract afn double %a, %b
  %2 = fadd nnan contract afn double %1, %c
  ret double %2
}
```

This is useful to enable previously unsafe FP-math optimizations. For example, fused-multiply-add instructions can now be generated when lowering LLVM IR to assembly/executing it via JIT.

For specification of FMF see LLVM LangRef: https://llvm.org/docs/LangRef.html#fastmath
