### PR TITLE
Fixed `alloca`s insertion point for LLVM backend

### DIFF
--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -601,12 +601,12 @@ void CodegenLLVMVisitor::visit_codegen_for_statement(const ast::CodegenForStatem
 void CodegenLLVMVisitor::visit_codegen_function(const ast::CodegenFunction& node) {
     const auto& name = node.get_node_name();
     const auto& arguments = node.get_arguments();
-    llvm::Function* func = module->getFunction(name);
-    ir_builder.set_function(func);
 
     // Create the entry basic block of the function/procedure and point the local named values table
     // to the symbol table.
+    llvm::Function* func = module->getFunction(name);
     ir_builder.create_block_and_set_insertion_point(func);
+    ir_builder.set_function(func);
 
     // When processing a function, it returns a value named <function_name> in NMODL. Therefore, we
     // first run RenameVisitor to rename it into ret_<function_name>. This will aid in avoiding

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -229,11 +229,19 @@ void IRBuilder::set_loop_metadata(llvm::BranchInst* branch) {
 /****************************************************************************************/
 
 llvm::Value* IRBuilder::create_alloca(const std::string& name, llvm::Type* type) {
-    // If insertion point for `alloca` instructions is not set, then set the first processed
-    // instruction to be the insertion point.
+    // If insertion point for `alloca` instructions is not set, then create the instruction in the
+    // entry block and set it to be the insertion point.
     if (!alloca_ip) {
+        // Get the entry block and insert the `alloca` instruction there.
+        llvm::BasicBlock* current_block = builder.GetInsertBlock();
+        llvm::BasicBlock& entry_block = current_block->getParent()->getEntryBlock();
+        builder.SetInsertPoint(&entry_block);
         llvm::Value* alloca = builder.CreateAlloca(type, /*ArraySize=*/nullptr, name);
+
+        // Set the `alloca` instruction insertion point and restore the insertion point for the next
+        // set of instructions.
         alloca_ip = llvm::cast<llvm::AllocaInst>(alloca);
+        builder.SetInsertPoint(current_block);
         return alloca;
     }
 

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -46,6 +46,9 @@ class IRBuilder {
     /// Symbol table of the NMODL AST.
     symtab::SymbolTable* symbol_table;
 
+    /// Insertion point for `alloca` instructions.
+    llvm::Instruction* alloca_ip;
+
     /// Flag to indicate that the generated IR should be vectorized.
     bool vectorize;
 
@@ -69,6 +72,7 @@ class IRBuilder {
         , symbol_table(nullptr)
         , current_function(nullptr)
         , vectorize(false)
+        , alloca_ip(nullptr)
         , fp_precision(use_single_precision ? single_precision : double_precision)
         , vector_width(vector_width)
         , mask(nullptr)
@@ -104,6 +108,7 @@ class IRBuilder {
     void clear_function() {
         value_stack.clear();
         current_function = nullptr;
+        alloca_ip = nullptr;
     }
 
     /// Sets the value to be the mask for vector code generation.
@@ -124,6 +129,8 @@ class IRBuilder {
     /// Generates LLVM IR to allocate the arguments of the function on the stack.
     void allocate_function_arguments(llvm::Function* function,
                                      const ast::CodegenVarWithTypeVector& nmodl_arguments);
+
+    llvm::Value* create_alloca(const std::string& name, llvm::Type* type);
 
     /// Generates IR for allocating an array.
     void create_array_alloca(const std::string& name, llvm::Type* element_type, int num_elements);


### PR DESCRIPTION
With this PR `alloca` instructions are always inserted in the beginning of the function entry block. This is done to avoid them in the while or for loops, where allocations per iteration cause stack overflow (if the IR is not optimized). 

Example:
```c++
/// loop.mod
PROCEDURE loop(a, b) {
    WHILE (a > 0) {
        LOCAL x 
        x = b
    }
}
```
Before, this code would produce the following LLVM IR:
```llvm
define i32 @loop(double %a1, double %b2) {
  %a = alloca double, align 8
  store double %a1, double* %a, align 8
  %b = alloca double, align 8
  store double %b2, double* %b, align 8
  %ret_loop = alloca i32, align 4
  store i32 0, i32* %ret_loop, align 4
  br label %1

1:                                                ; preds = %4, %0
  %2 = load double, double* %a, align 8
  %3 = fcmp ogt double %2, 0.000000e+00
  br i1 %3, label %4, label %6

4:                                                ; preds = %1
  ; x is allocated inside the loop body - this is bad!
  %x = alloca double, align 8
  %5 = load double, double* %b, align 8
  store double %5, double* %x, align 8
  br label %1

6:                                                ; preds = %1
  %7 = load i32, i32* %ret_loop, align 4
  ret i32 %7
}
```
Now, the result is:
```llvm
define i32 @loop(double %a1, double %b2) {
  %a = alloca double, align 8
  %b = alloca double, align 8
  %ret_loop = alloca i32, align 4
  ; x is not allocated inside the loop body!
  %x = alloca double, align 8
  store double %a1, double* %a, align 8
  store double %b2, double* %b, align 8
  store i32 0, i32* %ret_loop, align 4
  br label %1

1:                                                ; preds = %4, %0
  %2 = load double, double* %a, align 8
  %3 = fcmp ogt double %2, 0.000000e+00
  br i1 %3, label %4, label %6

4:                                                ; preds = %1
  %5 = load double, double* %b, align 8
  store double %5, double* %x, align 8
  br label %1

6:                                                ; preds = %1
  %7 = load i32, i32* %ret_loop, align 4
  ret i32 %7
}
```