### PR TITLE
Remove only inlined blocks from AST based on symtab properties

### DIFF
--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -103,9 +103,6 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
     /// explicit vectorisation width
     int vector_width;
 
-    /// variable to check whether Function and Procedures blocks are inline by NMODL passes
-    bool nmodl_inline;
-
     /// newly generated code generation specific functions
     CodegenFunctionVector codegen_functions;
 
@@ -137,9 +134,8 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
     static const std::string VOLTAGE_VAR;
     static const std::string NODE_INDEX_VAR;
 
-    CodegenLLVMHelperVisitor(int vector_width, bool nmodl_inline)
-        : vector_width(vector_width)
-        , nmodl_inline(nmodl_inline) {}
+    CodegenLLVMHelperVisitor(int vector_width)
+        : vector_width(vector_width) {}
 
     const InstanceVarHelper& get_instance_var_helper() {
         return instance_var_helper;
@@ -168,6 +164,9 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
 
     void convert_local_statement(ast::StatementBlock& node);
     void rename_local_variables(ast::StatementBlock& node);
+
+    /// Remove Function and Procedure blocks from the node since they are already inlined
+    void remove_inlined_nodes(ast::Program& node);
 
     void visit_procedure_block(ast::ProcedureBlock& node) override;
     void visit_function_block(ast::FunctionBlock& node) override;

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -770,7 +770,7 @@ void CodegenLLVMVisitor::visit_program(const ast::Program& node) {
     //   - convert function and procedure blocks into CodegenFunctions
     //   - gather information about AST. For now, information about functions
     //     and procedures is used only.
-    CodegenLLVMHelperVisitor v{vector_width, nmodl_inline};
+    CodegenLLVMHelperVisitor v{vector_width};
     const auto& functions = v.get_codegen_functions(node);
     instance_var_helper = v.get_instance_var_helper();
     sym_tab = node.get_symbol_table();

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -69,9 +69,6 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     /// Output directory for code generation.
     std::string output_dir;
 
-    /// Variable to check if Functions and Procedures are inlined by NMODL passes
-    bool nmodl_inline;
-
   private:
     /// Underlying LLVM context.
     std::unique_ptr<llvm::LLVMContext> context = std::make_unique<llvm::LLVMContext>();
@@ -117,11 +114,9 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
                        int vector_width = 1,
                        std::string vec_lib = "none",
                        bool add_debug_information = false,
-                       std::vector<std::string> fast_math_flags = {},
-                       bool nmodl_inline = false)
+                       std::vector<std::string> fast_math_flags = {})
         : mod_filename(mod_filename)
         , output_dir(output_dir)
-        , nmodl_inline(nmodl_inline)
         , opt_passes(opt_passes)
         , vector_width(vector_width)
         , vector_library(veclib_map.at(vec_lib))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -666,8 +666,7 @@ int main(int argc, const char* argv[]) {
                                            llvm_vec_width,
                                            vector_library,
                                            !disable_debug_information,
-                                           llvm_fast_math_flags,
-                                           nmodl_inline);
+                                           llvm_fast_math_flags);
                 visitor.visit_program(*ast);
                 ast_to_nmodl(*ast, filepath("llvm", "mod"));
                 ast_to_json(*ast, filepath("llvm", "json"));

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -58,8 +58,7 @@ std::string run_llvm_visitor(const std::string& text,
                                              vector_width,
                                              vec_lib,
                                              /*add_debug_information=*/false,
-                                             fast_math_flags,
-                                             nmodl_inline);
+                                             fast_math_flags);
 
     llvm_visitor.visit_program(*ast);
     return llvm_visitor.dump_module();
@@ -78,7 +77,7 @@ std::vector<std::shared_ptr<ast::Ast>> run_llvm_visitor_helper(
 
     SymtabVisitor().visit_program(*ast);
     SolveBlockVisitor().visit_program(*ast);
-    CodegenLLVMHelperVisitor(vector_width, /*nmodl_inline=*/false).visit_program(*ast);
+    CodegenLLVMHelperVisitor(vector_width).visit_program(*ast);
 
     const auto& nodes = collect_nodes(*ast, nodes_to_collect);
 


### PR DESCRIPTION
For example the following mod file
```
PROCEDURE loop(a, b) {
    LOCAL x
    x = 7
    IF (a > 0) {
        x = bar(b)
    }
}
FUNCTION bar(i) {
    bar = 2 * i
}
```
gets translated to:
```
; ModuleID = 'test'
source_filename = "test"

define i32 @loop(double %a1, double %b2) !dbg !4 {
  %a = alloca double, align 8
  %b = alloca double, align 8
  %ret_loop = alloca i32, align 4
  %x = alloca double, align 8
  %bar_in_0 = alloca double, align 8
  %i_in_0 = alloca double, align 8
  store double %a1, double* %a, align 8
  store double %b2, double* %b, align 8
  store i32 0, i32* %ret_loop, align 4
  store double 7.000000e+00, double* %x, align 8
  %1 = load double, double* %a, align 8
  %2 = fcmp ogt double %1, 0.000000e+00
  br i1 %2, label %3, label %7

3:                                                ; preds = %0
  %4 = load double, double* %b, align 8
  store double %4, double* %i_in_0, align 8
  %5 = load double, double* %i_in_0, align 8
  %6 = fmul double 2.000000e+00, %5
  store double %6, double* %bar_in_0, align 8
  store double %5, double* %x, align 8
  br label %7

7:                                                ; preds = %0, %3
  %8 = load i32, i32* %ret_loop, align 4
  ret i32 %8
}
```