### PR TITLE
Use VarName on the RHS of assignment expression

### DIFF
--- a/src/visitors/inline_visitor.cpp
+++ b/src/visitors/inline_visitor.cpp
@@ -298,6 +298,8 @@ void InlineVisitor::visit_statement_block(StatementBlock& node) {
 /** Visit all wrapped expressions which can contain function calls.
  *  If a function call is replaced then the wrapped expression is
  *  also replaced with new variable node from the inlining result.
+ *  Note that we use `VarName` so that LHS of assignment expression
+ *  is `VarName`, similar to parser.
  */
 void InlineVisitor::visit_wrapped_expression(WrappedExpression& node) {
     node.visit_children(*this);
@@ -306,7 +308,7 @@ void InlineVisitor::visit_wrapped_expression(WrappedExpression& node) {
         auto expression = dynamic_cast<FunctionCall*>(e.get());
         if (replaced_fun_calls.find(expression) != replaced_fun_calls.end()) {
             auto var = replaced_fun_calls[expression];
-            node.set_expression(std::make_shared<Name>(new String(var)));
+            node.set_expression(std::make_shared<VarName>(new Name(new String(var)), nullptr, nullptr));
         }
     }
 }

--- a/src/visitors/inline_visitor.cpp
+++ b/src/visitors/inline_visitor.cpp
@@ -308,7 +308,8 @@ void InlineVisitor::visit_wrapped_expression(WrappedExpression& node) {
         auto expression = dynamic_cast<FunctionCall*>(e.get());
         if (replaced_fun_calls.find(expression) != replaced_fun_calls.end()) {
             auto var = replaced_fun_calls[expression];
-            node.set_expression(std::make_shared<VarName>(new Name(new String(var)), nullptr, nullptr));
+            node.set_expression(
+                std::make_shared<VarName>(new Name(new String(var)), nullptr, nullptr));
         }
     }
 }

--- a/src/visitors/inline_visitor.cpp
+++ b/src/visitors/inline_visitor.cpp
@@ -308,8 +308,9 @@ void InlineVisitor::visit_wrapped_expression(WrappedExpression& node) {
         auto expression = dynamic_cast<FunctionCall*>(e.get());
         if (replaced_fun_calls.find(expression) != replaced_fun_calls.end()) {
             auto var = replaced_fun_calls[expression];
-            node.set_expression(
-                std::make_shared<VarName>(new Name(new String(var)), nullptr, nullptr));
+            node.set_expression(std::make_shared<VarName>(new Name(new String(var)),
+                                                          /*at=*/nullptr,
+                                                          /*index=*/nullptr));
         }
     }
 }


### PR DESCRIPTION
 - NMODL parser uses VarName on the LHS of assignment expression
 - Inline visitor was using Name on the LHS of assignment expression

Related to #667

With this, original `hh.mod` can be run without any modifications:

```
DYLD_LIBRARY_PATH=/opt/intel/oneapi//compiler/2021.1.1/mac/compiler/lib \
   ./bin/nmodl ~/Downloads/CoreNeuron/coreneuron/mechanism/mech/modfile/hh.mod \
    passes --inline llvm --ir --vector-width 4 --veclib SVML --opt \
   benchmark --run --instance-size 100000 --repeat 4  \
   --libs /opt/intel/oneapi//compiler/2021.1.1/mac/compiler/lib/libsvml.dylib
```