### PR TITLE
[LLVM] SLEEF and libsystem_m vector libraries support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -134,13 +134,13 @@ jobs:
     displayName: 'Install Dependencies'
   - script: |
       cd $HOME
-      git clone https://github.com/pramodk/llvm-nightly.git
+      git clone --depth 1 https://github.com/pramodk/llvm-nightly.git
     displayName: 'Setup LLVM v13'
   - script: |
       export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
       mkdir -p $(Build.Repository.LocalPath)/build
       cd $(Build.Repository.LocalPath)/build
-      cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DNMODL_ENABLE_PYTHON_BINDINGS=OFF -DLLVM_DIR=$HOME/llvm-nightly/0421/osx/lib/cmake/llvm -DNMODL_ENABLE_LLVM=ON
+      cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DNMODL_ENABLE_PYTHON_BINDINGS=OFF -DLLVM_DIR=$HOME/llvm-nightly/0621/osx/lib/cmake/llvm -DNMODL_ENABLE_LLVM=ON
       make -j 2
       if [ $? -ne 0 ]
       then

--- a/ci/bb5-pr.sh
+++ b/ci/bb5-pr.sh
@@ -42,7 +42,7 @@ function build_with() {
              -DNMODL_FORMATTING:BOOL=ON \
              -DClangFormat_EXECUTABLE=$clang_format_exe \
              -DNMODL_ENABLE_JIT_EVENT_LISTENERS=ON \
-             -DLLVM_DIR=/gpfs/bbp.cscs.ch/data/project/proj16/software/llvm/install/0521/lib/cmake/llvm
+             -DLLVM_DIR=/gpfs/bbp.cscs.ch/apps/hpc/llvm-install/0621/lib/cmake/llvm
     make -j6
     popd
 }

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -71,13 +71,15 @@ void CodegenLLVMVisitor::add_vectorizable_functions_from_vec_lib(llvm::TargetLib
     // Since LLVM does not support SLEEF as a vector library yet, process it separately.
     if (vector_library == "SLEEF") {
         // Populate function definitions for AArch64 architecture.
-#define FIXED(w) llvm::ElementCount::getFixed(w)
+#define FIXED(w)                        llvm::ElementCount::getFixed(w)
 #define DISPATCH(func, vec_func, width) {func, vec_func, width},
         const llvm::VecDesc functions[] = {
+            // clang-format off
             DISPATCH("llvm.exp.f32", "_ZGVnN4v_expf", FIXED(4))
             DISPATCH("llvm.exp.f64", "_ZGVnN2v_exp", FIXED(2))
             DISPATCH("llvm.pow.f32", "_ZGVnN4vv_powf", FIXED(4))
             DISPATCH("llvm.pow.f64", "_ZGVnN2vv_pow", FIXED(2))
+            // clang-format on
         };
 #undef DISPATCH
         tli.addVectorizableFunctions(functions);

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -48,15 +48,6 @@ namespace codegen {
  * @{
  */
 
-/// A map to query vector library by its string value.
-static const std::map<std::string, llvm::TargetLibraryInfoImpl::VectorLibrary> veclib_map = {
-    {"Accelerate", llvm::TargetLibraryInfoImpl::Accelerate},
-#if LLVM_VERSION_MAJOR >= 13
-    {"libmvec", llvm::TargetLibraryInfoImpl::LIBMVEC_X86},
-#endif
-    {"MASSV", llvm::TargetLibraryInfoImpl::MASSV},
-    {"SVML", llvm::TargetLibraryInfoImpl::SVML},
-    {"none", llvm::TargetLibraryInfoImpl::NoLibrary}};
 
 /**
  * \class CodegenLLVMVisitor
@@ -100,8 +91,8 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     /// Pass manager for optimisation passes that are used for target code generation.
     llvm::legacy::FunctionPassManager codegen_pm;
 
-    /// Vector library used for maths functions.
-    llvm::TargetLibraryInfoImpl::VectorLibrary vector_library;
+    /// Vector library used for math functions.
+    std::string vector_library;
 
     /// Explicit vectorisation width.
     int vector_width;
@@ -119,7 +110,7 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
         , output_dir(output_dir)
         , opt_passes(opt_passes)
         , vector_width(vector_width)
-        , vector_library(veclib_map.at(vec_lib))
+        , vector_library(vec_lib)
         , add_debug_information(add_debug_information)
         , ir_builder(*context, use_single_precision, vector_width, fast_math_flags)
         , debug_builder(*module)
@@ -183,6 +174,11 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     void wrap_kernel_functions();
 
   private:
+#if LLVM_VERSION_MAJOR >= 13
+    /// Populates target library info with the vector library definitions.
+    void add_vectorizable_functions_from_vec_lib(llvm::TargetLibraryInfoImpl& tli, llvm::Triple& triple);
+#endif
+
     /// Accepts the given AST node and returns the processed value.
     llvm::Value* accept_and_get(const std::shared_ptr<ast::Node>& node);
 

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -176,7 +176,8 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
   private:
 #if LLVM_VERSION_MAJOR >= 13
     /// Populates target library info with the vector library definitions.
-    void add_vectorizable_functions_from_vec_lib(llvm::TargetLibraryInfoImpl& tli, llvm::Triple& triple);
+    void add_vectorizable_functions_from_vec_lib(llvm::TargetLibraryInfoImpl& tli,
+                                                 llvm::Triple& triple);
 #endif
 
     /// Accepts the given AST node and returns the processed value.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -332,7 +332,7 @@ int main(int argc, const char* argv[]) {
         "LLVM explicit vectorisation width ({})"_format(llvm_vec_width))->ignore_case();
     llvm_opt->add_option("--veclib",
                          vector_library,
-                         "Vector library for maths functions ({})"_format(vector_library))->check(CLI::IsMember({"Accelerate", "libmvec", "MASSV", "SVML", "none"}));
+                         "Vector library for maths functions ({})"_format(vector_library))->check(CLI::IsMember({"Accelerate", "libsystem_m", "libmvec", "MASSV", "SLEEF", "SVML", "none"}));
     llvm_opt->add_option("--fmf",
                          llvm_fast_math_flags,
                          "Fast math flags for floating-point optimizations (none)")->check(CLI::IsMember({"afn", "arcp", "contract", "ninf", "nnan", "nsz", "reassoc", "fast"}));

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -1383,14 +1383,19 @@ SCENARIO("Vector library calls", "[visitor][llvm][vector_lib]") {
             REQUIRE(std::regex_search(accelerate_library_module_str, m, accelerate_exp_call));
             REQUIRE(!std::regex_search(accelerate_library_module_str, m, fexp_call));
 
-            // Check correct replacement of @llvm.exp.v4f32 into @_ZGVnN4v_expf when using SLEEF.
+            // Check correct replacement of @llvm.exp.v2f64 into @_ZGV?N?v_exp when using SLEEF.
             std::string sleef_library_module_str = run_llvm_visitor(nmodl_text,
                                                                     /*opt=*/false,
-                                                                    /*use_single_precision=*/true,
-                                                                    /*vector_width=*/4,
+                                                                    /*use_single_precision=*/false,
+                                                                    /*vector_width=*/2,
                                                                     /*vec_lib=*/"SLEEF");
-            std::regex sleef_exp_decl(R"(declare <4 x float> @_ZGVnN4v_expf\(<4 x float>\))");
-            std::regex sleef_exp_call(R"(call <4 x float> @_ZGVnN4v_expf\(<4 x float> .*\))");
+#if defined(__arm64__) || defined(__aarch64__)
+            std::regex sleef_exp_decl(R"(declare <2 x double> @_ZGVnN2v_exp\(<2 x double>\))");
+            std::regex sleef_exp_call(R"(call <2 x double> @_ZGVnN2v_exp\(<2 x double> .*\))");
+#else
+            std::regex sleef_exp_decl(R"(declare <2 x double> @_ZGVbN2v_exp\(<2 x double>\))");
+            std::regex sleef_exp_call(R"(call <2 x double> @_ZGVbN2v_exp\(<2 x double> .*\))");
+#endif
             REQUIRE(std::regex_search(sleef_library_module_str, m, sleef_exp_decl));
             REQUIRE(std::regex_search(sleef_library_module_str, m, sleef_exp_call));
             REQUIRE(!std::regex_search(sleef_library_module_str, m, fexp_call));


### PR DESCRIPTION
This PR adds support for `libsystem_m` and `SLEEF` vector libraries. The first is supported by LLVM internally, so it comes for free with LLVM 13. For `SLEEF`, basic support was added for AArch64 architecture. We currently support only fixed type vectors and exponential/power functions.

Also, corresponding IR checks were added.