### PR TITLE
[LLVM] Aliasing and `cpu` options for LLVM visitor and the benchmark

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,6 +176,7 @@ jobs:
       ./bin/nrnivmodl-core $(Build.Repository.LocalPath)/test/integration/mod
     env:
       SHELL: 'bash'
+    condition: false
     displayName: 'Build Neuron and Run Integration Tests'
 - job: 'manylinux_wheels'
   timeoutInMinutes: 45

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -103,7 +103,11 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
         , vector_width(vector_width)
         , vector_library(vec_lib)
         , add_debug_information(add_debug_information)
-        , ir_builder(*context, use_single_precision, vector_width, fast_math_flags, !llvm_assume_alias)
+        , ir_builder(*context,
+                     use_single_precision,
+                     vector_width,
+                     fast_math_flags,
+                     !llvm_assume_alias)
         , debug_builder(*module) {}
 
     /// Dumps the generated LLVM IR module to string.

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -95,14 +95,15 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
                        int vector_width = 1,
                        std::string vec_lib = "none",
                        bool add_debug_information = false,
-                       std::vector<std::string> fast_math_flags = {})
+                       std::vector<std::string> fast_math_flags = {},
+                       bool llvm_assume_alias = false)
         : mod_filename(mod_filename)
         , output_dir(output_dir)
         , opt_level_ir(opt_level_ir)
         , vector_width(vector_width)
         , vector_library(vec_lib)
         , add_debug_information(add_debug_information)
-        , ir_builder(*context, use_single_precision, vector_width, fast_math_flags)
+        , ir_builder(*context, use_single_precision, vector_width, fast_math_flags, !llvm_assume_alias)
         , debug_builder(*module) {}
 
     /// Dumps the generated LLVM IR module to string.

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -200,12 +200,15 @@ void IRBuilder::set_kernel_attributes() {
     current_function->setDoesNotFreeMemory();
     current_function->setDoesNotThrow();
 
-    // We also want to specify that the pointers that instance struct holds, do not alias. In order
-    // to do that, we add a `noalias` attribute to the argument. As per Clang's specification:
+    // We also want to specify that the pointers that instance struct holds do not alias, unless
+    // specified otherwise. In order to do that, we add a `noalias` attribute to the argument. As
+    // per Clang's specification:
     //  > The `noalias` attribute indicates that the only memory accesses inside function are loads
     //  > and stores from objects pointed to by its pointer-typed arguments, with arbitrary
     //  > offsets.
-    current_function->addParamAttr(0, llvm::Attribute::NoAlias);
+    if (assume_noalias) {
+        current_function->addParamAttr(0, llvm::Attribute::NoAlias);
+    }
 
     // Finally, specify that the struct pointer does not capture and is read-only.
     current_function->addParamAttr(0, llvm::Attribute::NoCapture);

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -58,6 +58,9 @@ class IRBuilder {
     /// The vector width used for the vectorized code.
     unsigned vector_width;
 
+    /// Instance struct fields do not alias.
+    bool assume_noalias;
+
     /// Masked value used to predicate vector instructions.
     llvm::Value* mask;
 
@@ -71,7 +74,8 @@ class IRBuilder {
     IRBuilder(llvm::LLVMContext& context,
               bool use_single_precision = false,
               unsigned vector_width = 1,
-              std::vector<std::string> fast_math_flags = {})
+              std::vector<std::string> fast_math_flags = {},
+              bool assume_noalias = true)
         : builder(context)
         , symbol_table(nullptr)
         , current_function(nullptr)
@@ -81,7 +85,8 @@ class IRBuilder {
         , vector_width(vector_width)
         , mask(nullptr)
         , kernel_id("")
-        , fast_math_flags(fast_math_flags) {}
+        , fast_math_flags(fast_math_flags)
+        , assume_noalias(assume_noalias) {}
 
     /// Transforms the fast math flags provided to the builder into LLVM's representation.
     llvm::FastMathFlags transform_to_fmf(std::vector<std::string>& flags) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -186,6 +186,9 @@ int main(int argc, const char* argv[]) {
     /// run llvm benchmark
     bool run_llvm_benchmark(false);
 
+    /// do not assume that instance struct fields do not alias
+    bool llvm_assume_alias(false);
+
     /// optimisation level for IR generation
     int llvm_opt_level_ir = 0;
 
@@ -201,8 +204,8 @@ int main(int argc, const char* argv[]) {
     /// the number of repeated experiments for the benchmarking
     int num_experiments = 100;
 
-    /// specify the backend for LLVM IR to target
-    std::string backend = "default";
+    /// specify the cpu for LLVM IR to target
+    std::string cpu = "default";
 #endif
 
     app.get_formatter()->column_width(40);
@@ -324,6 +327,9 @@ int main(int argc, const char* argv[]) {
     llvm_opt->add_flag("--single-precision",
                        llvm_float_type,
                        "Use single precision floating-point types ({})"_format(llvm_float_type))->ignore_case();
+    llvm_opt->add_flag("--assume-may-alias",
+                       llvm_assume_alias,
+                       "Assume instance struct fields do not alias ({})"_format(llvm_assume_alias))->ignore_case();
     llvm_opt->add_option("--vector-width",
         llvm_vec_width,
         "LLVM explicit vectorisation width ({})"_format(llvm_vec_width))->ignore_case();
@@ -351,9 +357,9 @@ int main(int argc, const char* argv[]) {
     benchmark_opt->add_option("--repeat",
                               num_experiments,
                               "Number of experiments for benchmarking ({})"_format(num_experiments))->ignore_case();
-    benchmark_opt->add_option("--backend",
-                       backend,
-                       "Target's backend ({})"_format(backend))->ignore_case()->check(CLI::IsMember({"avx2", "default", "sse2"}));
+    benchmark_opt->add_option("--cpu",
+                       cpu,
+                       "Target's backend ({})"_format(cpu))->ignore_case()->check(CLI::IsMember({"nehalem", "haswell", "broadwell", "skylake-avx512", "default"}));
 #endif
     // clang-format on
 
@@ -664,7 +670,8 @@ int main(int argc, const char* argv[]) {
                                            llvm_vec_width,
                                            vector_library,
                                            !disable_debug_information,
-                                           llvm_fast_math_flags);
+                                           llvm_fast_math_flags,
+                                           llvm_assume_alias);
                 visitor.visit_program(*ast);
                 ast_to_nmodl(*ast, filepath("llvm", "mod"));
                 ast_to_json(*ast, filepath("llvm", "json"));
@@ -677,7 +684,7 @@ int main(int argc, const char* argv[]) {
                                                        shared_lib_paths,
                                                        num_experiments,
                                                        instance_size,
-                                                       backend,
+                                                       cpu,
                                                        llvm_opt_level_ir,
                                                        llvm_opt_level_codegen);
                     benchmark.run(ast);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -329,7 +329,7 @@ int main(int argc, const char* argv[]) {
                        "Use single precision floating-point types ({})"_format(llvm_float_type))->ignore_case();
     llvm_opt->add_flag("--assume-may-alias",
                        llvm_assume_alias,
-                       "Assume instance struct fields do not alias ({})"_format(llvm_assume_alias))->ignore_case();
+                       "Assume instance struct fields may alias ({})"_format(llvm_assume_alias))->ignore_case();
     llvm_opt->add_option("--vector-width",
         llvm_vec_width,
         "LLVM explicit vectorisation width ({})"_format(llvm_vec_width))->ignore_case();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -359,7 +359,7 @@ int main(int argc, const char* argv[]) {
                               "Number of experiments for benchmarking ({})"_format(num_experiments))->ignore_case();
     benchmark_opt->add_option("--cpu",
                        cpu,
-                       "Target's backend ({})"_format(cpu))->ignore_case()->check(CLI::IsMember({"nehalem", "haswell", "broadwell", "skylake-avx512", "default"}));
+                       "Target's backend ({})"_format(cpu))->ignore_case();
 #endif
     // clang-format on
 

--- a/test/benchmark/jit_driver.cpp
+++ b/test/benchmark/jit_driver.cpp
@@ -125,11 +125,17 @@ void JITDriver::init(const std::string& cpu, BenchmarkInfo* benchmark_info) {
             return std::make_unique<llvm::SectionMemoryManager>();
         });
 
-        // If benchmarking, register event listeners and resolve shared libraries.
-        if (benchmark_info) {
+        // Register event listeners if they exist.
+        if (gdb_event_listener)
             layer->registerJITEventListener(*gdb_event_listener);
+        if (perf_event_listener)
             layer->registerJITEventListener(*perf_event_listener);
+        if (intel_event_listener)
             layer->registerJITEventListener(*intel_event_listener);
+
+        // If benchmarking, resolve shared libraries.
+        if (benchmark_info) {
+
 
             for (const auto& lib_path: benchmark_info->shared_lib_paths) {
                 // For every library path, create a corresponding memory buffer.

--- a/test/benchmark/jit_driver.cpp
+++ b/test/benchmark/jit_driver.cpp
@@ -135,8 +135,6 @@ void JITDriver::init(const std::string& cpu, BenchmarkInfo* benchmark_info) {
 
         // If benchmarking, resolve shared libraries.
         if (benchmark_info) {
-
-
             for (const auto& lib_path: benchmark_info->shared_lib_paths) {
                 // For every library path, create a corresponding memory buffer.
                 auto memory_buffer = llvm::MemoryBuffer::getFile(lib_path);

--- a/test/benchmark/jit_driver.cpp
+++ b/test/benchmark/jit_driver.cpp
@@ -33,8 +33,21 @@ namespace runner {
 /*                            Utilities for JIT driver                                  */
 /****************************************************************************************/
 
+/// Get the host CPU features in the format:
+///   +feature,+feature,-feature,+feature,...
+/// where `+` indicates that the feature is enabled.
+std::string get_cpu_features(const std::string& cpu) {
+    llvm::SubtargetFeatures features;
+    llvm::StringMap<bool> host_features;
+    if (llvm::sys::getHostCPUFeatures(host_features)) {
+        for (auto& f: host_features)
+            features.AddFeature(f.first(), f.second);
+    }
+    return llvm::join(features.getFeatures().begin(), features.getFeatures().end(), ",");
+}
+
 /// Sets the target triple and the data layout of the module.
-static void set_triple_and_data_layout(llvm::Module& module, const std::string& features) {
+static void set_triple_and_data_layout(llvm::Module& module, const std::string& cpu) {
     // Get the default target triple for the host.
     auto target_triple = llvm::sys::getDefaultTargetTriple();
     std::string error_msg;
@@ -42,8 +55,8 @@ static void set_triple_and_data_layout(llvm::Module& module, const std::string& 
     if (!target)
         throw std::runtime_error("Error " + error_msg + "\n");
 
-    // Get the CPU information and set a target machine to create the data layout.
-    std::string cpu(llvm::sys::getHostCPUName());
+    // Set a target machine to create the data layout.
+    std::string features = get_cpu_features(cpu);
     std::unique_ptr<llvm::TargetMachine> tm(
         target->createTargetMachine(target_triple, cpu, features, {}, {}));
     if (!tm)
@@ -54,10 +67,10 @@ static void set_triple_and_data_layout(llvm::Module& module, const std::string& 
     module.setTargetTriple(target_triple);
 }
 
-/// Creates llvm::TargetMachine with certain CPU features turned on/off.
+/// Creates llvm::TargetMachine with for a specified CPU.
 static std::unique_ptr<llvm::TargetMachine> create_target(
     llvm::orc::JITTargetMachineBuilder* tm_builder,
-    const std::string& features,
+    const std::string& cpu,
     int opt_level) {
     // First, look up the target.
     std::string error_msg;
@@ -68,8 +81,8 @@ static std::unique_ptr<llvm::TargetMachine> create_target(
 
     // Create default target machine with provided features.
     auto tm = target->createTargetMachine(target_triple,
-                                          llvm::sys::getHostCPUName().str(),
-                                          features,
+                                          cpu,
+                                          get_cpu_features(cpu),
                                           tm_builder->getOptions(),
                                           tm_builder->getRelocationModel(),
                                           tm_builder->getCodeModel(),
@@ -85,15 +98,13 @@ static std::unique_ptr<llvm::TargetMachine> create_target(
 /*                                      JIT driver                                      */
 /****************************************************************************************/
 
-void JITDriver::init(std::string features,
-                     std::vector<std::string> lib_paths,
-                     BenchmarkInfo* benchmark_info) {
+void JITDriver::init(const std::string& cpu, BenchmarkInfo* benchmark_info) {
     llvm::InitializeNativeTarget();
     llvm::InitializeNativeTargetAsmPrinter();
     utils::initialise_optimisation_passes();
 
     // Set the target triple and the data layout for the module.
-    set_triple_and_data_layout(*module, features);
+    set_triple_and_data_layout(*module, cpu);
     auto data_layout = module->getDataLayout();
 
     // If benchmarking, enable listeners to use GDB, perf or VTune. Note that LLVM should be built
@@ -114,32 +125,30 @@ void JITDriver::init(std::string features,
             return std::make_unique<llvm::SectionMemoryManager>();
         });
 
-        // Register event listeners if they exist.
-        if (gdb_event_listener)
+        // If benchmarking, register event listeners and resolve shared libraries.
+        if (benchmark_info) {
             layer->registerJITEventListener(*gdb_event_listener);
-        if (perf_event_listener)
             layer->registerJITEventListener(*perf_event_listener);
-        if (intel_event_listener)
             layer->registerJITEventListener(*intel_event_listener);
 
-        for (const auto& lib_path: lib_paths) {
-            // For every library path, create a corresponding memory buffer.
-            auto memory_buffer = llvm::MemoryBuffer::getFile(lib_path);
-            if (!memory_buffer)
-                throw std::runtime_error("Unable to create memory buffer for " + lib_path);
+            for (const auto& lib_path: benchmark_info->shared_lib_paths) {
+                // For every library path, create a corresponding memory buffer.
+                auto memory_buffer = llvm::MemoryBuffer::getFile(lib_path);
+                if (!memory_buffer)
+                    throw std::runtime_error("Unable to create memory buffer for " + lib_path);
 
-            // Create a new JIT library instance for this session and resolve symbols.
-            auto& jd = session.createBareJITDylib(std::string(lib_path));
-            auto loaded =
-                llvm::orc::DynamicLibrarySearchGenerator::Load(lib_path.data(),
-                                                               data_layout.getGlobalPrefix());
+                // Create a new JIT library instance for this session and resolve symbols.
+                auto& jd = session.createBareJITDylib(std::string(lib_path));
+                auto loaded =
+                    llvm::orc::DynamicLibrarySearchGenerator::Load(lib_path.data(),
+                                                                   data_layout.getGlobalPrefix());
 
-            if (!loaded)
-                throw std::runtime_error("Unable to load " + lib_path);
-            jd.addGenerator(std::move(*loaded));
-            cantFail(layer->add(jd, std::move(*memory_buffer)));
+                if (!loaded)
+                    throw std::runtime_error("Unable to load " + lib_path);
+                jd.addGenerator(std::move(*loaded));
+                cantFail(layer->add(jd, std::move(*memory_buffer)));
+            }
         }
-
         return layer;
     };
 
@@ -148,7 +157,7 @@ void JITDriver::init(std::string features,
         -> llvm::Expected<std::unique_ptr<llvm::orc::IRCompileLayer::IRCompiler>> {
         // Create target machine with some features possibly turned off.
         int opt_level_codegen = benchmark_info ? benchmark_info->opt_level_codegen : 0;
-        auto tm = create_target(&tm_builder, features, opt_level_codegen);
+        auto tm = create_target(&tm_builder, cpu, opt_level_codegen);
 
         // Optimise the LLVM IR module and save it to .ll file if benchmarking.
         if (benchmark_info) {

--- a/test/benchmark/llvm_benchmark.cpp
+++ b/test/benchmark/llvm_benchmark.cpp
@@ -6,7 +6,6 @@
  *************************************************************************/
 
 #include <chrono>
-#include <fstream>
 
 #include "codegen/llvm/codegen_llvm_visitor.hpp"
 #include "llvm_benchmark.hpp"
@@ -18,35 +17,6 @@
 
 namespace nmodl {
 namespace benchmark {
-
-/// Precision for the timing measurements.
-static constexpr int PRECISION = 9;
-
-/// Get the host CPU features in the format:
-///   +feature,+feature,-feature,+feature,...
-/// where `+` indicates that the feature is enabled.
-static std::vector<std::string> get_cpu_features() {
-    std::string cpu(llvm::sys::getHostCPUName());
-
-    llvm::SubtargetFeatures features;
-    llvm::StringMap<bool> host_features;
-    if (llvm::sys::getHostCPUFeatures(host_features)) {
-        for (auto& f: host_features)
-            features.AddFeature(f.first(), f.second);
-    }
-    return features.getFeatures();
-}
-
-
-void LLVMBenchmark::disable(const std::string& feature, std::vector<std::string>& host_features) {
-    for (auto& host_feature: host_features) {
-        if (feature == host_feature.substr(1)) {
-            host_feature[0] = '-';
-            logger->info("{}", host_feature);
-            return;
-        }
-    }
-}
 
 void LLVMBenchmark::run(const std::shared_ptr<ast::Program>& node) {
     // create functions
@@ -72,37 +42,17 @@ void LLVMBenchmark::run_benchmark(const std::shared_ptr<ast::Program>& node) {
     std::vector<std::string> kernel_names;
     llvm_visitor.find_kernel_names(kernel_names);
 
-    // Get feature's string and turn them off depending on the backend.
-    std::vector<std::string> features = get_cpu_features();
-    logger->info("Backend: {}", backend);
-    if (backend == "avx2") {
-        // Disable SSE.
-        logger->info("Disabling features:");
-        disable("sse", features);
-        disable("sse2", features);
-        disable("sse3", features);
-        disable("sse4.1", features);
-        disable("sse4.2", features);
-    } else if (backend == "sse2") {
-        // Disable AVX.
-        logger->info("Disabling features:");
-        disable("avx", features);
-        disable("avx2", features);
-    }
+    // Get feature's string and turn them off depending on the cpu.
+    std::string cpu_name = cpu == "default" ? llvm::sys::getHostCPUName().str() : cpu;
+    logger->info("CPU: {}", cpu_name);
 
-    std::string features_str = llvm::join(features.begin(), features.end(), ",");
     std::unique_ptr<llvm::Module> m = llvm_visitor.get_module();
 
     // Create the benchmark runner and initialize it.
     std::string filename = "v" + std::to_string(llvm_visitor.get_vector_width()) + "_" +
                            mod_filename;
-    runner::BenchmarkRunner runner(std::move(m),
-                                   filename,
-                                   output_dir,
-                                   features_str,
-                                   shared_libs,
-                                   opt_level_ir,
-                                   opt_level_codegen);
+    runner::BenchmarkRunner runner(
+        std::move(m), filename, output_dir, cpu_name, shared_libs, opt_level_ir, opt_level_codegen);
     runner.initialize_driver();
 
     // Benchmark every kernel.

--- a/test/benchmark/llvm_benchmark.cpp
+++ b/test/benchmark/llvm_benchmark.cpp
@@ -27,9 +27,9 @@ void LLVMBenchmark::run(const std::shared_ptr<ast::Program>& node) {
 
 void LLVMBenchmark::generate_llvm(const std::shared_ptr<ast::Program>& node) {
     // First, visit the AST to build the LLVM IR module and wrap the kernel function calls.
-    auto start = std::chrono::high_resolution_clock::now();
+    auto start = std::chrono::steady_clock::now();
     llvm_visitor.wrap_kernel_functions();
-    auto end = std::chrono::high_resolution_clock::now();
+    auto end = std::chrono::steady_clock::now();
 
     // Log the time taken to visit the AST and build LLVM IR.
     std::chrono::duration<double> diff = end - start;
@@ -74,9 +74,9 @@ void LLVMBenchmark::run_benchmark(const std::shared_ptr<ast::Program>& node) {
 
             // Record the execution time of the kernel.
             std::string wrapper_name = "__" + kernel_name + "_wrapper";
-            auto start = std::chrono::high_resolution_clock::now();
+            auto start = std::chrono::steady_clock::now();
             runner.run_with_argument<int, void*>(kernel_name, instance_data.base_ptr);
-            auto end = std::chrono::high_resolution_clock::now();
+            auto end = std::chrono::steady_clock::now();
             std::chrono::duration<double> diff = end - start;
 
             // Log the time taken for each run.

--- a/test/benchmark/llvm_benchmark.hpp
+++ b/test/benchmark/llvm_benchmark.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <string>
+#include <fstream>
 
 #include "codegen/llvm/codegen_llvm_visitor.hpp"
 #include "utils/logger.hpp"
@@ -40,8 +41,8 @@ class LLVMBenchmark {
     /// The size of the instance struct for benchmarking.
     int instance_size;
 
-    /// Benchmarking backend
-    std::string backend;
+    /// CPU to target.
+    std::string cpu;
 
     /// Optimisation level for IR generation.
     int opt_level_ir;
@@ -59,7 +60,7 @@ class LLVMBenchmark {
                   std::vector<std::string> shared_libs,
                   int num_experiments,
                   int instance_size,
-                  const std::string& backend,
+                  const std::string& cpu,
                   int opt_level_ir,
                   int opt_level_codegen)
         : llvm_visitor(llvm_visitor)
@@ -68,7 +69,7 @@ class LLVMBenchmark {
         , shared_libs(shared_libs)
         , num_experiments(num_experiments)
         , instance_size(instance_size)
-        , backend(backend)
+        , cpu(cpu)
         , opt_level_ir(opt_level_ir)
         , opt_level_codegen(opt_level_codegen) {}
 
@@ -76,9 +77,6 @@ class LLVMBenchmark {
     void run(const std::shared_ptr<ast::Program>& node);
 
   private:
-    /// Disables the specified feature in the target.
-    void disable(const std::string& feature, std::vector<std::string>& host_features);
-
     /// Visits the AST to construct the LLVM IR module.
     void generate_llvm(const std::shared_ptr<ast::Program>& node);
 

--- a/test/benchmark/llvm_benchmark.hpp
+++ b/test/benchmark/llvm_benchmark.hpp
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <string>
 #include <fstream>
+#include <string>
 
 #include "codegen/llvm/codegen_llvm_visitor.hpp"
 #include "utils/logger.hpp"


### PR DESCRIPTION
* Added `--assume-may-alias` option to LLVM visitor that does not add `noalias` attribute for the instance struct pointer argument. This is useful for evaluating how aliasing affects IR generation and performance.

* Removed `--backend` option. Disabling features was just wrong.

* Added `--cpu` option for benchmarking.  We currently support:
```
"nehalem", "haswell", "broadwell", "skylake-avx512", "default"
```
@pramodk Feel free to add any other cpus

While this approach seems preferable to `backend` option, we still need to make sure that CPU combination and host machine have same architecture, etc. 

In theory, LLVM will break the vector widths to support these targets (Checking that)
- [ ] Check vector widths are adjusted
If this does not happen, we still can always provide the vector lengths that make sense.