### PR TITLE
Fix azure yaml pipeline from merge

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,7 +174,6 @@ jobs:
         exit 1
       fi
       ./bin/nrnivmodl-core $(Build.Repository.LocalPath)/test/integration/mod
-    condition: false
     env:
       SHELL: 'bash'
     condition: false


### PR DESCRIPTION
#685 and #686 introduced `condition` twice in the YAML file