### PR TITLE
Set the project version using git describe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,7 @@
 
 cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
-
-project(
-  NMODL
-  LANGUAGES CXX)
+project(NMODL LANGUAGES CXX)
 
 # =============================================================================
 # CMake common project settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,10 @@
 # =============================================================================
 
 cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
+
+
 project(
   NMODL
-  VERSION 0.2
   LANGUAGES CXX)
 
 # =============================================================================
@@ -67,6 +68,14 @@ include(GitRevision)
 include(PythonLinkHelper)
 include(RpathHelper)
 include(ExternalProjectHelper)
+
+# =============================================================================
+# Set the project version now using git
+# =============================================================================
+project(
+  NMODL
+  VERSION ${GIT_LAST_TAG}
+  LANGUAGES CXX)
 
 # =============================================================================
 # Initialize external libraries as submodule

--- a/cmake/GitRevision.cmake
+++ b/cmake/GitRevision.cmake
@@ -23,8 +23,16 @@ if(GIT_FOUND)
   string(REGEX REPLACE "\"" "" GIT_REVISION_DATE "${GIT_REVISION_DATE}")
   set(GIT_REVISION "${GIT_REVISION_SHA1} ${GIT_REVISION_DATE}")
 
+  # get the last version tag from git
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --abbrev=0 --tags
+    WORKING_DIRECTORY ${NMODL_PROJECT_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_LAST_TAG
+    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 else()
 
   set(GIT_REVISION "unknown")
+  set(GIT_LAST_TAG "unknown")
 
 endif()


### PR DESCRIPTION
We extend GitRevision.cmake a little to look up the last git tag. We
then call `project()` again in the main CMakeLists.txt to set the
version.

This fixes #694