### PR TITLE
Fix Newton solver code generation

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3243,6 +3243,8 @@ void CodegenCVisitor::print_global_function_common_code(BlockType type) {
         // running anything on the GPU.
         print_kernel_data_present_annotation_block_begin();
     } else {
+        /// TODO: Remove this when the code generation is propery done
+        /// Related to https://github.com/BlueBrain/nmodl/issues/692
         printer->add_line("#ifndef CORENEURON_BUILD");
     }
     printer->add_line("int nodecount = ml->nodecount;");

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3242,6 +3242,8 @@ void CodegenCVisitor::print_global_function_common_code(BlockType type) {
         // We do not (currently) support DESTRUCTOR and CONSTRUCTOR blocks
         // running anything on the GPU.
         print_kernel_data_present_annotation_block_begin();
+    } else {
+        printer->add_line("#ifndef CORENEURON_BUILD");
     }
     printer->add_line("int nodecount = ml->nodecount;");
     printer->add_line("int pnodecount = ml->_nodecount_padded;");
@@ -3330,6 +3332,7 @@ void CodegenCVisitor::print_nrn_constructor() {
         const auto& block = info.constructor_node->get_statement_block();
         print_statement_block(*block.get(), false, false);
     }
+    printer->add_line("#endif");
     printer->end_block(1);
 }
 
@@ -3341,6 +3344,7 @@ void CodegenCVisitor::print_nrn_destructor() {
         const auto& block = info.destructor_node->get_statement_block();
         print_statement_block(*block.get(), false, false);
     }
+    printer->add_line("#endif");
     printer->end_block(1);
 }
 

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1739,7 +1739,7 @@ void CodegenCVisitor::visit_eigen_newton_solver_block(const ast::EigenNewtonSolv
     printer->add_text(
         "void operator()(const Eigen::Matrix<{0}, {1}, 1>& {2}, Eigen::Matrix<{0}, {1}, "
         "1>& {3}, "
-        "Eigen::Matrix<{0}, {1}, {1}>& {4}) const"_format(float_type, N, X, F, Jm));
+        "Eigen::Matrix<{0}, {1}, {1}>& {4}) "_format(float_type, N, X, F, Jm));
     printer->start_block();
     printer->add_line("{}* {} = {}.data();"_format(float_type, J, Jm));
     print_statement_block(*node.get_functor_block(), false, false);

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1739,7 +1739,7 @@ void CodegenCVisitor::visit_eigen_newton_solver_block(const ast::EigenNewtonSolv
     printer->add_text(
         "void operator()(const Eigen::Matrix<{0}, {1}, 1>& {2}, Eigen::Matrix<{0}, {1}, "
         "1>& {3}, "
-        "Eigen::Matrix<{0}, {1}, {1}>& {4}) "_format(float_type, N, X, F, Jm));
+        "Eigen::Matrix<{0}, {1}, {1}>& {4}) const "_format(float_type, N, X, F, Jm));
     printer->start_block();
     printer->add_line("{}* {} = {}.data();"_format(float_type, J, Jm));
     print_statement_block(*node.get_functor_block(), false, false);

--- a/test/unit/visitor/sympy_solver.cpp
+++ b/test/unit/visitor/sympy_solver.cpp
@@ -1046,7 +1046,7 @@ SCENARIO("Solve ODEs with derivimplicit method using SympySolverVisitor",
         std::string expected_result = R"(
             DERIVATIVE ihkin {
                 EIGEN_LINEAR_SOLVE[5]{
-                    LOCAL alpha, beta, k3p, k4, k1ca, k2, old_c1, old_o1, old_p0
+                    LOCAL old_c1, old_o1, old_p0
                 }{
                     evaluate_fct(v, cai)
                     old_c1 = c1
@@ -1058,6 +1058,7 @@ SCENARIO("Solve ODEs with derivimplicit method using SympySolverVisitor",
                     X[2] = o2
                     X[3] = p0
                     X[4] = p1
+                    LOCAL alpha, beta, k3p, k4, k1ca, k2
                     F[0] = -old_c1
                     F[1] = -old_o1
                     F[2] = -1.0


### PR DESCRIPTION
- Fixes #691 
- Add only `old_*` variables as member variables of `struct functor` of `Newton solver` and add the rest of them as local variables in the `operator()` of the `functor`
- Temprorary fix for #692 by adding `#ifdef CORENEURON_BUILD` in the code generated for `CONSTRUCTOR` and `DESTRUCTOR`