### PR TITLE
Fix the issue with ION ordering

### DIFF
--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1050,12 +1050,6 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
 
 
     /**
-     * Print the structure that wraps all range and int variables required for the NMODL
-     */
-    void print_mechanism_range_var_structure();
-
-
-    /**
      * Print structure of ion variables used for local copies
      */
     void print_ion_var_structure();
@@ -1085,13 +1079,6 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      * Print the function that initialize range variable with different data type
      */
     void print_setup_range_variable();
-
-
-    /**
-     * Print the function that initialize instance structure
-     *
-     */
-    void print_instance_variable_setup();
 
 
     /**
@@ -1837,6 +1824,16 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      * @return std::string Unique name produced as [original_name]_[random_string]
      */
     std::string find_var_unique_name(const std::string& original_name) const;
+
+    /**
+     * Print the structure that wraps all range and int variables required for the NMODL
+     */
+    void print_mechanism_range_var_structure();
+
+    /**
+     * Print the function that initialize instance structure
+     */
+    void print_instance_variable_setup();
 
     void visit_binary_expression(const ast::BinaryExpression& node) override;
     void visit_binary_operator(const ast::BinaryOperator& node) override;

--- a/src/codegen/codegen_helper_visitor.hpp
+++ b/src/codegen/codegen_helper_visitor.hpp
@@ -69,7 +69,7 @@ class CodegenHelperVisitor: public visitor::ConstAstVisitor {
     /// lhs of assignment in derivative block
     std::shared_ptr<ast::Expression> assign_lhs;
 
-    void find_ion_variables();
+    void find_ion_variables(const ast::Program& node);
     void find_table_variables();
     void find_range_variables();
     void find_non_range_variables();

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -56,7 +56,7 @@ add_executable(testfast_math fast_math/fast_math.cpp ${SOLVER_SOURCE_FILES})
 add_executable(testunitlexer units/lexer.cpp)
 add_executable(testunitparser units/parser.cpp)
 add_executable(testcodegen codegen/main.cpp codegen/codegen_ispc.cpp codegen/codegen_helper.cpp
-                           codegen/codegen_utils.cpp)
+                           codegen/codegen_utils.cpp codegen/codegen_c_visitor.cpp)
 
 target_link_libraries(testmodtoken lexer util)
 target_link_libraries(testlexer lexer util)

--- a/test/unit/codegen/codegen_c_visitor.cpp
+++ b/test/unit/codegen/codegen_c_visitor.cpp
@@ -1,0 +1,225 @@
+/*************************************************************************
+ * Copyright (C) 2019-2021 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#include <catch/catch.hpp>
+
+#include "ast/program.hpp"
+#include "codegen/codegen_c_visitor.hpp"
+#include "parser/nmodl_driver.hpp"
+#include "test/unit/utils/test_utils.hpp"
+#include "visitors/symtab_visitor.hpp"
+
+using namespace nmodl;
+using namespace visitor;
+using namespace codegen;
+
+using nmodl::parser::NmodlDriver;
+using nmodl::test_utils::reindent_text;
+
+/// Helper for creating C codegen visitor
+std::shared_ptr<CodegenCVisitor> create_c_visitor(const std::string& text, std::stringstream& ss) {
+    /// parse mod file and create AST
+    NmodlDriver driver;
+    const auto& ast = driver.parse_string(text);
+
+    /// construct symbol table
+    SymtabVisitor().visit_program(*ast);
+
+    /// create C code generation visitor
+    auto cv = std::make_shared<CodegenCVisitor>("temp.mod", ss, "double", false);
+    cv->setup(*ast);
+    return cv;
+}
+
+/// print instance structure for testing purpose
+std::string get_instance_var_setup_function(std::string& nmodl_text) {
+    std::stringstream ss;
+    auto cvisitor = create_c_visitor(nmodl_text, ss);
+    cvisitor->print_instance_variable_setup();
+    return reindent_text(ss.str());
+}
+
+SCENARIO("Check instance variable definition order", "[codegen][var_order]") {
+    GIVEN("cal_mig.mod: USEION variables declared as RANGE") {
+
+        // In the below mod file, the ion variables cai and cao are also
+        // declared as RANGE variables. The ordering issue was fixed in #443.
+        std::string nmodl_text = R"(
+            PARAMETER {
+              gcalbar=.003 (mho/cm2)
+              ki=.001 (mM)
+              cai = 50.e-6 (mM)
+              cao = 2 (mM)
+            }
+            NEURON {
+              SUFFIX cal
+              USEION ca READ cai,cao WRITE ica
+              RANGE gcalbar, cai, ica, gcal, ggk
+              RANGE minf, tau
+            }
+            STATE {
+              m
+            }
+            ASSIGNED {
+              ica (mA/cm2)
+              gcal (mho/cm2)
+              minf
+              tau   (ms)
+              ggk
+            }
+        )";
+
+        THEN("ionic current variable declared as RANGE appears first") {
+            std::string generated_code = R"(
+                static inline void setup_instance(NrnThread* nt, Memb_list* ml)  {
+                    cal_Instance* inst = (cal_Instance*) mem_alloc(1, sizeof(cal_Instance));
+                    int pnodecount = ml->_nodecount_padded;
+                    Datum* indexes = ml->pdata;
+                    inst->gcalbar = ml->data+0*pnodecount;
+                    inst->ica = ml->data+1*pnodecount;
+                    inst->gcal = ml->data+2*pnodecount;
+                    inst->minf = ml->data+3*pnodecount;
+                    inst->tau = ml->data+4*pnodecount;
+                    inst->ggk = ml->data+5*pnodecount;
+                    inst->m = ml->data+6*pnodecount;
+                    inst->cai = ml->data+7*pnodecount;
+                    inst->cao = ml->data+8*pnodecount;
+                    inst->Dm = ml->data+9*pnodecount;
+                    inst->v_unused = ml->data+10*pnodecount;
+                    inst->ion_cai = nt->_data;
+                    inst->ion_cao = nt->_data;
+                    inst->ion_ica = nt->_data;
+                    inst->ion_dicadv = nt->_data;
+                    ml->instance = (void*) inst;
+                }
+            )";
+            auto expected = reindent_text(generated_code);
+            auto result = get_instance_var_setup_function(nmodl_text);
+            REQUIRE(result.find(expected) != std::string::npos);
+        }
+    }
+
+    // In the below mod file, the `cao` is defined first in the PARAMETER
+    // block but it appears after cai in the USEION statement. As per NEURON
+    // implementation, variables should appear in the order of USEION
+    // statements i.e. ion_cai should come before ion_cao. This was a bug
+    // and it has been fixed in #697.
+    GIVEN("LcaMig.mod: mod file from reduced_dentate model") {
+        std::string nmodl_text = R"(
+            PARAMETER {
+              ki = .001(mM)
+              cao(mM)
+              tfa = 1
+            }
+            NEURON {
+              SUFFIX lca
+              USEION ca READ cai, cao VALENCE 2
+              RANGE cai, ilca, elca
+            }
+            STATE {
+              m
+            }
+        )";
+
+        THEN("Ion variables are defined in the order of USEION") {
+            std::string generated_code = R"(
+                static inline void setup_instance(NrnThread* nt, Memb_list* ml)  {
+                    lca_Instance* inst = (lca_Instance*) mem_alloc(1, sizeof(lca_Instance));
+                    int pnodecount = ml->_nodecount_padded;
+                    Datum* indexes = ml->pdata;
+                    inst->m = ml->data+0*pnodecount;
+                    inst->cai = ml->data+1*pnodecount;
+                    inst->cao = ml->data+2*pnodecount;
+                    inst->Dm = ml->data+3*pnodecount;
+                    inst->v_unused = ml->data+4*pnodecount;
+                    inst->ion_cai = nt->_data;
+                    inst->ion_cao = nt->_data;
+                    ml->instance = (void*) inst;
+                }
+            )";
+
+            auto expected = reindent_text(generated_code);
+            auto result = get_instance_var_setup_function(nmodl_text);
+            REQUIRE(result.find(expected) != std::string::npos);
+        }
+    }
+
+    // In the below mod file, ion variables ncai and lcai are declared
+    // as state variables as well as range variables. The issue about
+    // this mod file ordering was fixed in #443.
+    GIVEN("ccanl.mod: mod file from reduced_dentate model") {
+        std::string nmodl_text = R"(
+            NEURON {
+              SUFFIX ccanl
+              USEION nca READ ncai, inca, enca WRITE enca, ncai VALENCE 2
+              USEION lca READ lcai, ilca, elca WRITE elca, lcai VALENCE 2
+              RANGE caiinf, catau, cai, ncai, lcai, eca, elca, enca
+            }
+            UNITS {
+              FARADAY = 96520(coul)
+              R = 8.3134(joule / degC)
+            }
+            PARAMETER {
+              depth = 200(nm): assume volume = area * depth
+              catau = 9(ms)
+              caiinf = 50.e-6(mM)
+              cao = 2(mM)
+            }
+            ASSIGNED {
+              celsius(degC)
+              ica(mA / cm2)
+              inca(mA / cm2)
+              ilca(mA / cm2)
+              cai(mM)
+              enca(mV)
+              elca(mV)
+              eca(mV)
+            }
+            STATE {
+              ncai(mM)
+              lcai(mM)
+            }
+        )";
+
+        THEN("Ion variables are defined in the order of USEION") {
+            std::string generated_code = R"(
+                static inline void setup_instance(NrnThread* nt, Memb_list* ml)  {
+                    ccanl_Instance* inst = (ccanl_Instance*) mem_alloc(1, sizeof(ccanl_Instance));
+                    int pnodecount = ml->_nodecount_padded;
+                    Datum* indexes = ml->pdata;
+                    inst->catau = ml->data+0*pnodecount;
+                    inst->caiinf = ml->data+1*pnodecount;
+                    inst->cai = ml->data+2*pnodecount;
+                    inst->eca = ml->data+3*pnodecount;
+                    inst->ica = ml->data+4*pnodecount;
+                    inst->inca = ml->data+5*pnodecount;
+                    inst->ilca = ml->data+6*pnodecount;
+                    inst->enca = ml->data+7*pnodecount;
+                    inst->elca = ml->data+8*pnodecount;
+                    inst->ncai = ml->data+9*pnodecount;
+                    inst->Dncai = ml->data+10*pnodecount;
+                    inst->lcai = ml->data+11*pnodecount;
+                    inst->Dlcai = ml->data+12*pnodecount;
+                    inst->v_unused = ml->data+13*pnodecount;
+                    inst->ion_ncai = nt->_data;
+                    inst->ion_inca = nt->_data;
+                    inst->ion_enca = nt->_data;
+                    inst->style_nca = ml->pdata;
+                    inst->ion_lcai = nt->_data;
+                    inst->ion_ilca = nt->_data;
+                    inst->ion_elca = nt->_data;
+                    inst->style_lca = ml->pdata;
+                    ml->instance = (void*) inst;
+                }
+            )";
+
+            auto expected = reindent_text(generated_code);
+            auto result = get_instance_var_setup_function(nmodl_text);
+            REQUIRE(result.find(expected) != std::string::npos);
+        }
+    }
+}

--- a/test/unit/codegen/codegen_c_visitor.cpp
+++ b/test/unit/codegen/codegen_c_visitor.cpp
@@ -45,7 +45,6 @@ std::string get_instance_var_setup_function(std::string& nmodl_text) {
 
 SCENARIO("Check instance variable definition order", "[codegen][var_order]") {
     GIVEN("cal_mig.mod: USEION variables declared as RANGE") {
-
         // In the below mod file, the ion variables cai and cao are also
         // declared as RANGE variables. The ordering issue was fixed in #443.
         std::string nmodl_text = R"(

--- a/test/unit/codegen/codegen_helper.cpp
+++ b/test/unit/codegen/codegen_helper.cpp
@@ -19,9 +19,9 @@ using namespace codegen;
 using nmodl::parser::NmodlDriver;
 
 //=============================================================================
-// Helper for codege related visitor
+// Helper for codegen related visitor
 //=============================================================================
-std::string run_inline_visitor(const std::string& text) {
+std::string run_codegen_helper_visitor(const std::string& text) {
     NmodlDriver driver;
     const auto& ast = driver.parse_string(text);
 
@@ -88,7 +88,7 @@ SCENARIO("unusual / failing mod files", "[codegen][var_order]") {
 
         THEN("ionic current variable declared as RANGE appears first") {
             std::string expected = "gcalbar;ica;gcal;minf;tau;ggk;m;cai;cao;";
-            auto result = run_inline_visitor(nmodl_text);
+            auto result = run_codegen_helper_visitor(nmodl_text);
             REQUIRE(result == expected);
         }
     }
@@ -121,7 +121,7 @@ SCENARIO("unusual / failing mod files", "[codegen][var_order]") {
 
         THEN("ion state variable is ordered after parameter and assigned ionic current") {
             std::string expected = "gamma;decay;depth;minCai;ica;cai;";
-            auto result = run_inline_visitor(nmodl_text);
+            auto result = run_codegen_helper_visitor(nmodl_text);
             REQUIRE(result == expected);
         }
     }
@@ -163,7 +163,7 @@ SCENARIO("unusual / failing mod files", "[codegen][var_order]") {
 
         THEN("ion variables are ordered correctly") {
             std::string expected = "ca;cai;ica;drive_channel;";
-            auto result = run_inline_visitor(nmodl_text);
+            auto result = run_codegen_helper_visitor(nmodl_text);
             REQUIRE(result == expected);
         }
     }

--- a/test/unit/visitor/inline.cpp
+++ b/test/unit/visitor/inline.cpp
@@ -27,7 +27,7 @@ using nmodl::parser::NmodlDriver;
 // Procedure/Function inlining tests
 //=============================================================================
 
-std::string run_codegen_helper_visitor(const std::string& text) {
+std::string run_inline_visitor(const std::string& text) {
     NmodlDriver driver;
     const auto& ast = driver.parse_string(text);
 
@@ -57,7 +57,7 @@ SCENARIO("Inlining of external procedure calls", "[visitor][inline]") {
 
         THEN("nothing gets inlinine") {
             std::string input = reindent_text(nmodl_text);
-            auto result = run_codegen_helper_visitor(input);
+            auto result = run_inline_visitor(input);
             REQUIRE(result == input);
         }
     }
@@ -91,7 +91,7 @@ SCENARIO("Inlining of function call as argument in external function", "[visitor
         THEN("External function doesn't get inlined") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_codegen_helper_visitor(input);
+            auto result = run_inline_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -129,7 +129,7 @@ SCENARIO("Inlining of simple, one level procedure call", "[visitor][inline]") {
         THEN("Procedure body gets inlined") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_codegen_helper_visitor(input);
+            auto result = run_inline_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -197,7 +197,7 @@ SCENARIO("Inlining of nested procedure call", "[visitor][inline]") {
         THEN("Nested procedure gets inlined with variables renaming") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_codegen_helper_visitor(input);
+            auto result = run_inline_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -238,7 +238,7 @@ SCENARIO("Inline function call in procedure", "[visitor][inline]") {
         THEN("Procedure body gets inlined") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_codegen_helper_visitor(input);
+            auto result = run_inline_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -281,7 +281,7 @@ SCENARIO("Inling function call within conditional statement", "[visitor][inline]
         THEN("Procedure body gets inlined and return value is used in if condition") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_codegen_helper_visitor(input);
+            auto result = run_inline_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -323,7 +323,7 @@ SCENARIO("Inline multiple function calls in same statement", "[visitor][inline]"
         THEN("Procedure body gets inlined") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_codegen_helper_visitor(input);
+            auto result = run_inline_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -363,7 +363,7 @@ SCENARIO("Inline multiple function calls in same statement", "[visitor][inline]"
         THEN("Procedure body gets inlined and return values are used in an expression") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_codegen_helper_visitor(input);
+            auto result = run_inline_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -441,7 +441,7 @@ SCENARIO("Inline nested function calls withing arguments", "[visitor][inline]") 
         THEN("Procedure body gets inlined") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_codegen_helper_visitor(input);
+            auto result = run_inline_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -478,7 +478,7 @@ SCENARIO("Inline function call in non-binary expression", "[visitor][inline]") {
         THEN("Function gets inlined in the unary expression") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_codegen_helper_visitor(input);
+            auto result = run_inline_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -517,7 +517,7 @@ SCENARIO("Inline function call in non-binary expression", "[visitor][inline]") {
         THEN("Function and it's arguments gets inlined recursively") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_codegen_helper_visitor(input);
+            auto result = run_inline_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -554,7 +554,7 @@ SCENARIO("Inline function call as standalone expression", "[visitor][inline]") {
         THEN("Function gets inlined but it's value is not used") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_codegen_helper_visitor(input);
+            auto result = run_inline_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -591,7 +591,7 @@ SCENARIO("Inline procedure call as standalone statement as well as part of expre
         THEN("Return statement from procedure (with zero value) is used") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_codegen_helper_visitor(input);
+            auto result = run_inline_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -641,7 +641,7 @@ SCENARIO("Inlining pass handles local-global name conflict", "[visitor][inline]"
         THEN("Caller variables get renamed first and then inlining is done") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_codegen_helper_visitor(input);
+            auto result = run_inline_visitor(input);
             REQUIRE(result == expected_result);
         }
     }

--- a/test/unit/visitor/inline.cpp
+++ b/test/unit/visitor/inline.cpp
@@ -27,7 +27,7 @@ using nmodl::parser::NmodlDriver;
 // Procedure/Function inlining tests
 //=============================================================================
 
-std::string run_inline_visitor(const std::string& text) {
+std::string run_codegen_helper_visitor(const std::string& text) {
     NmodlDriver driver;
     const auto& ast = driver.parse_string(text);
 
@@ -57,7 +57,7 @@ SCENARIO("Inlining of external procedure calls", "[visitor][inline]") {
 
         THEN("nothing gets inlinine") {
             std::string input = reindent_text(nmodl_text);
-            auto result = run_inline_visitor(input);
+            auto result = run_codegen_helper_visitor(input);
             REQUIRE(result == input);
         }
     }
@@ -91,7 +91,7 @@ SCENARIO("Inlining of function call as argument in external function", "[visitor
         THEN("External function doesn't get inlined") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_inline_visitor(input);
+            auto result = run_codegen_helper_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -129,7 +129,7 @@ SCENARIO("Inlining of simple, one level procedure call", "[visitor][inline]") {
         THEN("Procedure body gets inlined") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_inline_visitor(input);
+            auto result = run_codegen_helper_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -197,7 +197,7 @@ SCENARIO("Inlining of nested procedure call", "[visitor][inline]") {
         THEN("Nested procedure gets inlined with variables renaming") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_inline_visitor(input);
+            auto result = run_codegen_helper_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -238,7 +238,7 @@ SCENARIO("Inline function call in procedure", "[visitor][inline]") {
         THEN("Procedure body gets inlined") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_inline_visitor(input);
+            auto result = run_codegen_helper_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -281,7 +281,7 @@ SCENARIO("Inling function call within conditional statement", "[visitor][inline]
         THEN("Procedure body gets inlined and return value is used in if condition") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_inline_visitor(input);
+            auto result = run_codegen_helper_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -323,7 +323,7 @@ SCENARIO("Inline multiple function calls in same statement", "[visitor][inline]"
         THEN("Procedure body gets inlined") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_inline_visitor(input);
+            auto result = run_codegen_helper_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -363,7 +363,7 @@ SCENARIO("Inline multiple function calls in same statement", "[visitor][inline]"
         THEN("Procedure body gets inlined and return values are used in an expression") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_inline_visitor(input);
+            auto result = run_codegen_helper_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -441,7 +441,7 @@ SCENARIO("Inline nested function calls withing arguments", "[visitor][inline]") 
         THEN("Procedure body gets inlined") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_inline_visitor(input);
+            auto result = run_codegen_helper_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -478,7 +478,7 @@ SCENARIO("Inline function call in non-binary expression", "[visitor][inline]") {
         THEN("Function gets inlined in the unary expression") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_inline_visitor(input);
+            auto result = run_codegen_helper_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -517,7 +517,7 @@ SCENARIO("Inline function call in non-binary expression", "[visitor][inline]") {
         THEN("Function and it's arguments gets inlined recursively") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_inline_visitor(input);
+            auto result = run_codegen_helper_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -554,7 +554,7 @@ SCENARIO("Inline function call as standalone expression", "[visitor][inline]") {
         THEN("Function gets inlined but it's value is not used") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_inline_visitor(input);
+            auto result = run_codegen_helper_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -591,7 +591,7 @@ SCENARIO("Inline procedure call as standalone statement as well as part of expre
         THEN("Return statement from procedure (with zero value) is used") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_inline_visitor(input);
+            auto result = run_codegen_helper_visitor(input);
             REQUIRE(result == expected_result);
         }
     }
@@ -641,7 +641,7 @@ SCENARIO("Inlining pass handles local-global name conflict", "[visitor][inline]"
         THEN("Caller variables get renamed first and then inlining is done") {
             std::string input = reindent_text(input_nmodl);
             auto expected_result = reindent_text(output_nmodl);
-            auto result = run_inline_visitor(input);
+            auto result = run_codegen_helper_visitor(input);
             REQUIRE(result == expected_result);
         }
     }


### PR DESCRIPTION
* NMODL was ordering ION variables based on symbol
  table i.e. the order in which variables appear
  in MOD file
* MOD2C orders ION variables based on the order
  of USEION statements in MOD file.
* If other blocks like PARAMETER appear first in
  MOD file with ION variables, the NMODL will end
  up with different order than MOD2C.
* In order to avoid this issue, use USEION statement
  from AST.

fixes #150

- [x] Add unit test for ION and other variables ordering