### PR TITLE
Fix repr() and str() for AST python wrappers

### DIFF
--- a/docs/contents/visitors.rst
+++ b/docs/contents/visitors.rst
@@ -54,11 +54,20 @@ First, we have to create nmodl parser object using :class:`nmodl.NmodlDriver` an
     >>> modast = driver.parse_string(channel)
 
 The :func:`nmodl.NmodlDriver.parse_string` method will throw an exception with parsing error if the input is invalid.
-Otherwise it return :class:`nmodl.ast.AST` object.
+Otherwise it returns :class:`nmodl.ast.AST` object.
 
-If we simply print AST object, we can see JSON representation:
+If we simply print the AST object, we can see the NMODL code:
 
-    >>> print ('%.100s' % modast)  # only first 100 characters
+    >>> print ('%.103s' % modast)  # only first 103 characters
+    NEURON {
+        SUFFIX CaDynamics
+        USEION ca READ ica WRITE cai
+        RANGE decay, gamma, minCai, depth
+    }
+
+If we would like to see the AST tree, we can simply print the python representation `repr` of the AST object:
+
+    >>> print ('%.100s' % repr(modast))  # only first 100 characters
     {"Program":[{"NeuronBlock":[{"StatementBlock":[{"Suffix":[{"Name":[{"String":[{"name":"SUFFIX"}]}]},
 
 

--- a/src/language/templates/pybind/pyast.cpp
+++ b/src/language/templates/pybind/pyast.cpp
@@ -15,6 +15,7 @@
 #include <pybind11/stl.h>
 
 #include "visitors/json_visitor.hpp"
+#include "visitors/nmodl_visitor.hpp"
 
 
 /**
@@ -166,6 +167,7 @@ static const char* eval_method = R"(
 namespace py = pybind11;
 using namespace nmodl::ast;
 using nmodl::visitor::JSONVisitor;
+using nmodl::visitor::NmodlPrintVisitor;
 using namespace pybind11::literals;
 
 
@@ -240,6 +242,15 @@ void init_ast_module(py::module& m) {
             std::stringstream ss;
             JSONVisitor v(ss);
             v.compact_json(true);
+            n.accept(v);
+            v.flush();
+            return ss.str();
+        });
+
+    {{var(node)}}
+        .def("__str__", []({{node.class_name}} & n) {
+            std::stringstream ss;
+            NmodlPrintVisitor v(ss);
             n.accept(v);
             return ss.str();
         });

--- a/test/unit/pybind/test_ast.py
+++ b/test/unit/pybind/test_ast.py
@@ -12,7 +12,7 @@ import pytest
 class TestAst(object):
     def test_empty_program(self):
         pnode = ast.Program()
-        assert str(pnode) == '{"Program":[]}'
+        assert str(pnode) == ''
 
     def test_ast_construction(self):
         string = ast.String("tau")
@@ -26,3 +26,13 @@ class TestAst(object):
         block = ast.StatementBlock(statements)
         neuron_block = ast.NeuronBlock(block)
         assert nmodl.to_nmodl(neuron_block) == 'NEURON {\n}'
+
+    def test_ast_node_repr(self):
+        string = ast.String("tau")
+        name = ast.Name(string)
+        assert repr(name) == nmodl.to_json(name, compact=True)
+
+    def test_ast_node_str(self):
+        string = ast.String("tau")
+        name = ast.Name(string)
+        assert str(name) == nmodl.to_nmodl(name)


### PR DESCRIPTION
The python bindings for AST classes were fixed to now properly print a
compact json representation of the node (and its children) when the repr
is called (implicitly or explictely). Additionally I added a `__str__`
to each AST node binding that will be used for string conversions (as in
print). This function returns the NMODL representation of the node (and
its children).

Added also two unit tests for this.