### PR TITLE
Fixing pyvisitor template so that no node copies are done

### DIFF
--- a/src/language/templates/pybind/pyvisitor.cpp
+++ b/src/language/templates/pybind/pyvisitor.cpp
@@ -103,25 +103,25 @@ namespace py = pybind11;
 
 {% for node in nodes %}
 void PyVisitor::visit_{{ node.class_name|snake_case }}(ast::{{ node.class_name }}& node) {
-    PYBIND11_OVERLOAD_PURE(void, Visitor, visit_{{ node.class_name|snake_case }}, node);
+    PYBIND11_OVERLOAD_PURE(void, Visitor, visit_{{ node.class_name|snake_case }}, std::ref(node));
 }
 {% endfor %}
 
 {% for node in nodes %}
 void PyAstVisitor::visit_{{ node.class_name|snake_case }}(ast::{{ node.class_name }}& node) {
-    PYBIND11_OVERLOAD(void, AstVisitor, visit_{{ node.class_name|snake_case }}, node);
+    PYBIND11_OVERLOAD(void, AstVisitor, visit_{{ node.class_name|snake_case }}, std::ref(node));
 }
 {% endfor %}
 
 {% for node in nodes %}
 void PyConstVisitor::visit_{{ node.class_name|snake_case }}(const ast::{{ node.class_name }}& node) {
-PYBIND11_OVERLOAD_PURE(void, ConstVisitor, visit_{{ node.class_name|snake_case }}, node);
+    PYBIND11_OVERLOAD_PURE(void, ConstVisitor, visit_{{ node.class_name|snake_case }}, std::cref(node));
 }
 {% endfor %}
 
 {% for node in nodes %}
 void PyConstAstVisitor::visit_{{ node.class_name|snake_case }}(const ast::{{ node.class_name }}& node) {
-PYBIND11_OVERLOAD(void, ConstAstVisitor, visit_{{ node.class_name|snake_case }}, node);
+    PYBIND11_OVERLOAD(void, ConstAstVisitor, visit_{{ node.class_name|snake_case }}, std::cref(node));
 }
 {% endfor %}
 // clang-format on

--- a/src/language/templates/visitors/ast_visitor.cpp
+++ b/src/language/templates/visitors/ast_visitor.cpp
@@ -12,7 +12,6 @@
 #include "visitors/ast_visitor.hpp"
 
 #include "ast/all.hpp"
-#include "visitors/json_visitor.hpp"
 
 
 namespace nmodl {
@@ -22,22 +21,7 @@ using namespace ast;
 
 {% for node in nodes %}
 void AstVisitor::visit_{{ node.class_name|snake_case }}({{ node.class_name }}& node) {
-    std::cerr << "visiting {{node.class_name}}"  << std::endl;
-    std::stringstream ssb;
-    nmodl::visitor::JSONVisitor vb(ssb);
-    vb.compact_json(true);
-    node.accept(vb);
-    vb.flush();
-    std::cerr << ssb.str() << std::endl;
-    std::cerr << "node: " << *node << " node parent:" << node.get_parent() << std::endl;
     node.visit_children(*this);
-    std::cerr << "back into {{node.class_name}}"  << std::endl;
-    std::stringstream ssa;
-    nmodl::visitor::JSONVisitor va(ssa);
-    va.compact_json(true);
-    node.accept(va);
-    va.flush();
-    std::cerr << ssa.str() << std::endl;
 }
 {% endfor %}
 

--- a/src/language/templates/visitors/ast_visitor.cpp
+++ b/src/language/templates/visitors/ast_visitor.cpp
@@ -12,6 +12,7 @@
 #include "visitors/ast_visitor.hpp"
 
 #include "ast/all.hpp"
+#include "visitors/json_visitor.hpp"
 
 
 namespace nmodl {
@@ -21,7 +22,22 @@ using namespace ast;
 
 {% for node in nodes %}
 void AstVisitor::visit_{{ node.class_name|snake_case }}({{ node.class_name }}& node) {
+    std::cerr << "visiting {{node.class_name}}"  << std::endl;
+    std::stringstream ssb;
+    nmodl::visitor::JSONVisitor vb(ssb);
+    vb.compact_json(true);
+    node.accept(vb);
+    vb.flush();
+    std::cerr << ssb.str() << std::endl;
+    std::cerr << "node: " << *node << " node parent:" << node.get_parent() << std::endl;
     node.visit_children(*this);
+    std::cerr << "back into {{node.class_name}}"  << std::endl;
+    std::stringstream ssa;
+    nmodl::visitor::JSONVisitor va(ssa);
+    va.compact_json(true);
+    node.accept(va);
+    va.flush();
+    std::cerr << ssa.str() << std::endl;
 }
 {% endfor %}
 

--- a/test/unit/pybind/test_visitor.py
+++ b/test/unit/pybind/test_visitor.py
@@ -8,6 +8,7 @@
 import nmodl
 from nmodl.dsl import ast, visitor
 import pytest
+import sys
 
 
 def test_lookup_visitor(ch_ast):
@@ -82,3 +83,35 @@ def test_custom_visitor(ch_ast):
     assert len(myvisitor.states) is 2
     assert myvisitor.states[0] == "m"
     assert myvisitor.states[1] == "h"
+
+
+def test_modify_ast():
+    one_var = """NEURON {
+    SUFFIX test
+    RANGE x
+}
+    """
+    class ModifyVisitor(visitor.AstVisitor):
+        def __init__(self, old_name, new_name):
+            visitor.AstVisitor.__init__(self)
+            self.old_name = old_name
+            self.new_name = new_name
+
+        def visit_program(self, node):
+            node.visit_children(self)
+
+        def visit_range_var(self, node):
+            if nmodl.to_nmodl(node.name) == self.old_name:
+                node.name = ast.Name(ast.String(self.new_name))
+            node.visit_children(self)
+
+    driver = nmodl.NmodlDriver()
+    modast = driver.parse_string(one_var)
+    mod_visitor = ModifyVisitor("x", "y")
+    mod_visitor.visit_program(modast)
+    one_var_after = """NEURON {
+    SUFFIX test
+    RANGE y
+}
+    """
+    assert str(modast) == one_var_after

--- a/test/unit/pybind/test_visitor.py
+++ b/test/unit/pybind/test_visitor.py
@@ -8,7 +8,6 @@
 import nmodl
 from nmodl.dsl import ast, visitor
 import pytest
-import sys
 
 
 def test_lookup_visitor(ch_ast):

--- a/test/unit/pybind/test_visitor.py
+++ b/test/unit/pybind/test_visitor.py
@@ -97,12 +97,9 @@ def test_modify_ast():
             self.old_name = old_name
             self.new_name = new_name
 
-        def visit_program(self, node):
-            node.visit_children(self)
-
         def visit_range_var(self, node):
             if nmodl.to_nmodl(node.name) == self.old_name:
-                node.name = ast.Name(ast.String(self.new_name))
+                node.name.value = ast.String(self.new_name)
             node.visit_children(self)
 
     driver = nmodl.NmodlDriver()
@@ -113,5 +110,5 @@ def test_modify_ast():
     SUFFIX test
     RANGE y
 }
-    """
+"""
     assert str(modast) == one_var_after


### PR DESCRIPTION
This will fix the Python visitor modifier which didn't modify the underlying AST, only a copy.

Tech detail:
We need to provide Pybind11 a reference wrapper object so it understands it's a reference and not a new object.