### PR TITLE
Code generation fixes for the legacy derivimplicit solver on the GPU

### DIFF
--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -231,7 +231,7 @@ void CodegenAccVisitor::print_newtonspace_transfer_to_device() const {
     int list_num = info.derivimplicit_list_num;
     printer->add_line("if (nt->compute_gpu) {");
     printer->add_line("    auto device_vec = static_cast<double*>(acc_copyin(vec, vec_size));");
-    printer->add_line("    auto device_ns = static_cast<NewtonSpace*>(acc_deviceptr(ns));");
+    printer->add_line("    auto device_ns = static_cast<NewtonSpace*>(acc_deviceptr(*ns));");
     printer->add_line("    auto device_thread = static_cast<ThreadDatum*>(acc_deviceptr(thread));");
     printer->add_line(
         "    acc_memcpy_to_device(&(device_thread[{}]._pvoid), &device_ns, sizeof(void*));"_format(
@@ -242,6 +242,18 @@ void CodegenAccVisitor::print_newtonspace_transfer_to_device() const {
     printer->add_line("}");
 }
 
+
+void CodegenAccVisitor::print_instance_variable_transfer_to_device() const {
+    printer->add_line("if (nt->compute_gpu) {");
+    printer->add_line("    auto dml = (Memb_list*) acc_deviceptr(ml);");
+    printer->add_line("    acc_memcpy_to_device(&(dml->instance), &inst, sizeof(void*));");
+    printer->add_line("}");
+}
+
+
+void CodegenAccVisitor::print_deriv_advance_flag_transfer_to_device() const {
+    printer->add_line("#pragma acc update device (deriv_advance_flag) if (nt->compute_gpu)");
+}
 
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -88,6 +88,12 @@ class CodegenAccVisitor: public CodegenCVisitor {
     /// transfer newtonspace structure to device
     void print_newtonspace_transfer_to_device() const override;
 
+    // update instance variable object pointer on the gpu device
+    void print_instance_variable_transfer_to_device() const override;
+
+    // update derivimplicit advance flag on the gpu device
+    void print_deriv_advance_flag_transfer_to_device() const override;
+
     std::string get_variable_device_pointer(const std::string& variable,
                                             const std::string& type) const override;
 

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1082,6 +1082,17 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
 
 
     /**
+     * Print the code to copy instance variable to device
+     */
+    virtual void print_instance_variable_transfer_to_device() const;
+
+    /**
+     * Print the code to copy derivative advance flag to device
+     */
+    virtual void print_deriv_advance_flag_transfer_to_device() const;
+
+
+    /**
      * Print byte arrays that register scalar and vector variables for hoc interface
      *
      */


### PR DESCRIPTION
 - NewtonSpace** was copied to GPU instead of NewtonSpace*
 - MechInstance variable pointer from the device was not setup
   in the membrane list structure
 - In case of derivimplicit solver, deriv1_advance flag was
   not updated on the GPU device
  - Integration test is now enabled via https://github.com/neuronsimulator/nrn/pull/1375

fixes #707