### PR TITLE
Fixed for watch statements codegen, global and NetSendBuffer_t variables  update on CPU/GPU

### DIFF
--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -255,5 +255,10 @@ void CodegenAccVisitor::print_deriv_advance_flag_transfer_to_device() const {
     printer->add_line("#pragma acc update device (deriv_advance_flag) if (nt->compute_gpu)");
 }
 
+
+void CodegenAccVisitor::print_device_atomic_capture_annotation() const {
+    printer->add_line("#pragma acc atomic capture");
+}
+
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -260,5 +260,21 @@ void CodegenAccVisitor::print_device_atomic_capture_annotation() const {
     printer->add_line("#pragma acc atomic capture");
 }
 
+
+void CodegenAccVisitor::print_device_stream_wait() const {
+    printer->add_line("#pragma acc wait(nt->stream_id)");
+}
+
+
+void CodegenAccVisitor::print_net_send_buf_count_update_to_host() const {
+    print_device_stream_wait();
+    printer->add_line("#pragma acc update self(nsb->_cnt) if(nt->compute_gpu)");
+}
+
+
+void CodegenAccVisitor::print_net_send_buf_count_update_to_device() const {
+    printer->add_line("#pragma acc update device(nsb->_cnt) if (nt->compute_gpu)");
+}
+
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -103,7 +103,7 @@ class CodegenAccVisitor: public CodegenCVisitor {
     // synchronise/wait on stream specific to NrnThread
     virtual void print_device_stream_wait() const override;
 
-    // print aotmic capture pragma
+    // print atomic capture pragma
     void print_device_atomic_capture_annotation() const override;
 
     std::string get_variable_device_pointer(const std::string& variable,

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -94,6 +94,15 @@ class CodegenAccVisitor: public CodegenCVisitor {
     // update derivimplicit advance flag on the gpu device
     void print_deriv_advance_flag_transfer_to_device() const override;
 
+    // update NetSendBuffer_t count from device to host
+    void print_net_send_buf_count_update_to_host() const override;
+
+    // update NetSendBuffer_t count from host to device
+    virtual void print_net_send_buf_count_update_to_device() const override;
+
+    // synchronise/wait on stream specific to NrnThread
+    virtual void print_device_stream_wait() const override;
+
     // print aotmic capture pragma
     void print_device_atomic_capture_annotation() const override;
 

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -94,6 +94,9 @@ class CodegenAccVisitor: public CodegenCVisitor {
     // update derivimplicit advance flag on the gpu device
     void print_deriv_advance_flag_transfer_to_device() const override;
 
+    // print aotmic capture pragma
+    void print_device_atomic_capture_annotation() const override;
+
     std::string get_variable_device_pointer(const std::string& variable,
                                             const std::string& type) const override;
 

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1042,6 +1042,18 @@ void CodegenCVisitor::print_device_atomic_capture_annotation() const {
     // backend specific, do nothing
 }
 
+void CodegenCVisitor::print_net_send_buf_count_update_to_host() const {
+    // backend specific, do nothing
+}
+
+void CodegenCVisitor::print_net_send_buf_count_update_to_device() const {
+    // backend specific, do nothing
+}
+
+void CodegenCVisitor::print_device_stream_wait() const {
+    // backend specific, do nothing
+}
+
 /**
  * \details Each kernel such as \c nrn\_init, \c nrn\_state and \c nrn\_cur could be offloaded
  * to accelerator. In this case, at very top level, we print pragma
@@ -3679,9 +3691,7 @@ void CodegenCVisitor::print_net_init() {
 void CodegenCVisitor::print_send_event_move() {
     printer->add_newline();
     printer->add_line("NetSendBuffer_t* nsb = ml->_net_send_buffer;");
-    /// \todo Update net send buffer on host
-    printer->add_line("#pragma aacc wait(nt->stream_id)");
-    printer->add_line("#pragma acc update self(nsb->_cnt) if(nt->compute_gpu)");
+    print_net_send_buf_count_update_to_host();
     printer->add_line("update_net_send_buffer_on_host(nt, nsb);");
     printer->add_line("for (int i=0; i < nsb->_cnt; i++) {");
     printer->add_line("    int type = nsb->_sendtype[i];");
@@ -3696,8 +3706,7 @@ void CodegenCVisitor::print_send_event_move() {
     // clang-format on
     printer->add_line("}");
     printer->add_line("nsb->_cnt = 0;");
-    printer->add_line("#pragma acc update device(nsb->_cnt) if (nt->compute_gpu)");
-    /// \todo Update net send buffer count on device
+    print_net_send_buf_count_update_to_device();
 }
 
 
@@ -3760,7 +3769,7 @@ void CodegenCVisitor::print_net_receive_buffering(bool need_mech_inst) {
     printer->end_block(1);
     print_net_receive_loop_end();
 
-    printer->add_line("#pragma aacc wait(nt->stream_id)");
+    print_device_stream_wait();
     printer->add_line("nrb->_displ_cnt = 0;");
     printer->add_line("nrb->_cnt = 0;");
 

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3560,10 +3560,9 @@ void CodegenCVisitor::print_net_send_call(const FunctionCall& node) {
     std::string weight_index = "weight_index";
     std::string pnt = "pnt";
 
-    // for non-net-receieve functions there is no weight index argument
-    // and artificial cell is in vdata which is void**
+    // for non-net_receieve functions i.e. initial block, the weight_index argument is 0.
     if (!printing_net_receive) {
-        weight_index = "-1";
+        weight_index = "0";
         auto var = get_variable_name("point_process");
         if (info.artificial_cell) {
             pnt = "(Point_process*)" + var;

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3346,8 +3346,8 @@ void CodegenCVisitor::print_nrn_init(bool skip_init_check) {
         print_deriv_advance_flag_transfer_to_device();
     }
 
-    if(info.net_send_used && !info.artificial_cell) {
-       print_send_event_move();
+    if (info.net_send_used && !info.artificial_cell) {
+        print_send_event_move();
     }
 
     print_kernel_data_present_annotation_block_end();

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3457,13 +3457,16 @@ void CodegenCVisitor::print_watch_check() {
         printer->add_line("double v = voltage[node_id];");
     }
 
+    // flat to make sure only one WATCH statement can be triggered at a time
+    printer->add_line("bool watch_untriggered = true;");
+
     for (int i = 0; i < info.watch_statements.size(); i++) {
         auto statement = info.watch_statements[i];
         auto watch = statement->get_statements().front();
         auto varname = get_variable_name("watch{}"_format(i + 1));
 
         // start block 1
-        printer->start_block("if ({}&2)"_format(varname));
+        printer->start_block("if ({}&2 && watch_untriggered)"_format(varname));
 
         // start block 2
         printer->add_indent();
@@ -3475,6 +3478,8 @@ void CodegenCVisitor::print_watch_check() {
 
         // start block 3
         printer->start_block("if (({}&1) == 0)"_format(varname));
+
+        printer->add_line("watch_untriggered = false;");
 
         auto tqitem = get_variable_name("tqitem");
         auto point_process = get_variable_name("point_process");

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1086,10 +1086,29 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      */
     virtual void print_instance_variable_transfer_to_device() const;
 
+
     /**
      * Print the code to copy derivative advance flag to device
      */
     virtual void print_deriv_advance_flag_transfer_to_device() const;
+
+
+    /**
+     * Print the code to update NetSendBuffer_t count from device to host
+     */
+    virtual void print_net_send_buf_count_update_to_host() const;
+
+
+    /**
+     * Print the code to update NetSendBuffer_t count from host to device
+     */
+    virtual void print_net_send_buf_count_update_to_device() const;
+
+
+    /**
+     * Print the code to synchronise/wait on stream specific to NrnThread
+     */
+    virtual void print_device_stream_wait() const;
 
 
     /**

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1434,6 +1434,11 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
 
 
     /**
+     * Print pragma annotation for increase and capture of variable in automatic way
+     */
+    virtual void print_device_atomic_capture_annotation() const;
+
+    /**
      * Print block / loop for statement requiring reduction
      *
      */

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -611,7 +611,8 @@ bool CodegenIspcVisitor::check_incompatibilities() {
     if (info.initial_node) {
         emit_fallback[BlockType::Initial] =
             emit_fallback[BlockType::Initial] || has_incompatible_nodes(*info.initial_node) ||
-            visitor::calls_function(*info.initial_node, "net_send") || info.require_wrote_conc;
+            visitor::calls_function(*info.initial_node, "net_send") || info.require_wrote_conc ||
+            info.net_send_used || info.net_event_used;
     } else {
         emit_fallback[BlockType::Initial] = emit_fallback[BlockType::Initial] ||
                                             info.net_receive_initial_node ||


### PR DESCRIPTION
* fix watch statement code generation as described in #679
* fix global variable update to gpu descrbed in #678
* atomic capture for net_send buffer
* Initial block was missing net_send_buffering related codegen
   when net_send was used
* fix indentation with watch if-else statements
* net_buf_receive related code was out of place

Integration test from testcorenrn/hhwatch will be enabled in NEURON.

### todos 
- [x] changes from PR BlueBrain/mod2c#63 mentioned in 679
- [x] review/fix index argument passed to `net_send_buffering`
- [x] fix CVF CI: ISPC backend shouldn't have code for host/device update for net_send/receieve_buffering

Closes #679, closes #678, closes #675, closes #680