### PR TITLE
Add PRCELLSTATE mechanism to nmodl

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -4329,15 +4329,15 @@ void CodegenCVisitor::print_data_structures() {
 }
 
 void CodegenCVisitor::print_v_unused() const {
-        printer->add_line("#if PRCELLSTATE");
-        printer->add_line("inst->v_unused[id] = v;");
-        printer->add_line("#endif");
+    printer->add_line("#if PRCELLSTATE");
+    printer->add_line("inst->v_unused[id] = v;");
+    printer->add_line("#endif");
 }
 
 void CodegenCVisitor::print_g_unused() const {
-        printer->add_line("#if PRCELLSTATE");
-        printer->add_line("inst->g_unused[id] = v;");
-        printer->add_line("#endif");
+    printer->add_line("#if PRCELLSTATE");
+    printer->add_line("inst->g_unused[id] = v;");
+    printer->add_line("#endif");
 }
 
 void CodegenCVisitor::print_compute_functions() {

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -2505,8 +2505,8 @@ void CodegenCVisitor::print_mechanism_global_var_structure() {
 
 
 void CodegenCVisitor::print_prcellstate_macros() const {
-    printer->add_line("#ifndef PRCELLSTATE");
-    printer->add_line("#define PRCELLSTATE 0");
+    printer->add_line("#ifndef NRN_PRCELLSTATE");
+    printer->add_line("#define NRN_PRCELLSTATE 0");
     printer->add_line("#endif");
 }
 
@@ -4329,13 +4329,13 @@ void CodegenCVisitor::print_data_structures() {
 }
 
 void CodegenCVisitor::print_v_unused() const {
-    printer->add_line("#if PRCELLSTATE");
+    printer->add_line("#if NRN_PRCELLSTATE");
     printer->add_line("inst->v_unused[id] = v;");
     printer->add_line("#endif");
 }
 
 void CodegenCVisitor::print_g_unused() const {
-    printer->add_line("#if PRCELLSTATE");
+    printer->add_line("#if NRN_PRCELLSTATE");
     printer->add_line("inst->g_unused[id] = v;");
     printer->add_line("#endif");
 }

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -4158,9 +4158,9 @@ void CodegenCVisitor::print_nrn_cur_conductance_kernel(const BreakpointBlock& no
         }
     }
 
-    if(!info.conductances.empty()) {
+    if (!info.conductances.empty()) {
         printer->add_line("#if PRCELLSTATE");
-        printer->add_line("inst->g_unused[id] = g;"); //
+        printer->add_line("inst->g_unused[id] = g;");  //
         printer->add_line("#endif");
     }
 }

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -4336,7 +4336,7 @@ void CodegenCVisitor::print_v_unused() const {
 
 void CodegenCVisitor::print_g_unused() const {
     printer->add_line("#if NRN_PRCELLSTATE");
-    printer->add_line("inst->g_unused[id] = v;");
+    printer->add_line("inst->g_unused[id] = g;");
     printer->add_line("#endif");
 }
 

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3197,9 +3197,7 @@ void CodegenCVisitor::print_initial_block(const InitialBlock* node) {
     } else {
         printer->add_line("int node_id = node_index[id];");
         printer->add_line("double v = voltage[node_id];");
-        printer->add_line("#if PRCELLSTATE");
-        printer->add_line("inst->v_unused[id] = v;");
-        printer->add_line("#endif");
+        print_v_unused();
     }
 
     if (ion_variable_struct_required()) {
@@ -3430,9 +3428,7 @@ void CodegenCVisitor::print_watch_check() {
     if (info.is_voltage_used_by_watch_statements()) {
         printer->add_line("int node_id = node_index[id];");
         printer->add_line("double v = voltage[node_id];");
-        printer->add_line("#if PRCELLSTATE");
-        printer->add_line("inst->v_unused[id] = v;");
-        printer->add_line("#endif");
+        print_v_unused();
     }
 
     for (int i = 0; i < info.watch_statements.size(); i++) {
@@ -4056,9 +4052,7 @@ void CodegenCVisitor::print_nrn_state() {
 
     printer->add_line("int node_id = node_index[id];");
     printer->add_line("double v = voltage[node_id];");
-    printer->add_line("#if PRCELLSTATE");
-    printer->add_line("inst->v_unused[id] = v;");
-    printer->add_line("#endif");
+    print_v_unused();
 
     /**
      * \todo Eigen solver node also emits IonCurVar variable in the functor
@@ -4193,9 +4187,7 @@ void CodegenCVisitor::print_nrn_cur_non_conductance_kernel() {
 void CodegenCVisitor::print_nrn_cur_kernel(const BreakpointBlock& node) {
     printer->add_line("int node_id = node_index[id];");
     printer->add_line("double v = voltage[node_id];");
-    printer->add_line("#if PRCELLSTATE");
-    printer->add_line("inst->v_unused[id] = v;");
-    printer->add_line("#endif");
+    print_v_unused();
     if (ion_variable_struct_required()) {
         print_ion_variable();
     }
@@ -4224,9 +4216,7 @@ void CodegenCVisitor::print_nrn_cur_kernel(const BreakpointBlock& node) {
         printer->add_line("rhs = rhs*mfactor;");
     }
 
-    printer->add_line("#if PRCELLSTATE");
-    printer->add_line("inst->g_unused[id] = g;");  //
-    printer->add_line("#endif");
+    print_g_unused();
 }
 
 void CodegenCVisitor::print_fast_imem_calculation() {
@@ -4338,6 +4328,17 @@ void CodegenCVisitor::print_data_structures() {
     print_ion_var_structure();
 }
 
+void CodegenCVisitor::print_v_unused() const {
+        printer->add_line("#if PRCELLSTATE");
+        printer->add_line("inst->v_unused[id] = v;");
+        printer->add_line("#endif");
+}
+
+void CodegenCVisitor::print_g_unused() const {
+        printer->add_line("#if PRCELLSTATE");
+        printer->add_line("inst->g_unused[id] = v;");
+        printer->add_line("#endif");
+}
 
 void CodegenCVisitor::print_compute_functions() {
     print_top_verbatim_blocks();

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -4137,17 +4137,17 @@ void CodegenCVisitor::print_nrn_cur_conductance_kernel(const BreakpointBlock& no
         }
         printer->add_line("double rhs = {};"_format(sum));
     }
-    if (!info.conductances.empty()) {
-        std::string sum;
-        for (const auto& conductance: info.conductances) {
-            auto var = breakpoint_current(conductance.variable);
-            sum += get_variable_name(var);
-            if (&conductance != &info.conductances.back()) {
-                sum += "+";
-            }
+
+    std::string sum;
+    for (const auto& conductance: info.conductances) {
+        auto var = breakpoint_current(conductance.variable);
+        sum += get_variable_name(var);
+        if (&conductance != &info.conductances.back()) {
+            sum += "+";
         }
-        printer->add_line("double g = {};"_format(sum));
     }
+    printer->add_line("double g = {};"_format(sum));
+
     for (const auto& conductance: info.conductances) {
         if (!conductance.ion.empty()) {
             auto lhs = "ion_di" + conductance.ion + "dv";
@@ -4156,12 +4156,6 @@ void CodegenCVisitor::print_nrn_cur_conductance_kernel(const BreakpointBlock& no
             auto text = process_shadow_update_statement(statement, BlockType::Equation);
             printer->add_line(text);
         }
-    }
-
-    if (!info.conductances.empty()) {
-        printer->add_line("#if PRCELLSTATE");
-        printer->add_line("inst->g_unused[id] = g;");  //
-        printer->add_line("#endif");
     }
 }
 
@@ -4229,6 +4223,10 @@ void CodegenCVisitor::print_nrn_cur_kernel(const BreakpointBlock& node) {
         printer->add_line("g = g*mfactor;");
         printer->add_line("rhs = rhs*mfactor;");
     }
+
+    printer->add_line("#if PRCELLSTATE");
+    printer->add_line("inst->g_unused[id] = g;");  //
+    printer->add_line("#endif");
 }
 
 void CodegenCVisitor::print_fast_imem_calculation() {

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -2504,6 +2504,13 @@ void CodegenCVisitor::print_mechanism_global_var_structure() {
 }
 
 
+void CodegenCVisitor::print_prcellstate_macros() const {
+    printer->add_line("#ifndef PRCELLSTATE");
+    printer->add_line("#define PRCELLSTATE 0");
+    printer->add_line("#endif");
+}
+
+
 void CodegenCVisitor::print_mechanism_info() {
     auto variable_printer = [&](std::vector<SymbolType>& variables) {
         for (const auto& v: variables) {
@@ -3190,6 +3197,9 @@ void CodegenCVisitor::print_initial_block(const InitialBlock* node) {
     } else {
         printer->add_line("int node_id = node_index[id];");
         printer->add_line("double v = voltage[node_id];");
+        printer->add_line("#if PRCELLSTATE");
+        printer->add_line("inst->v_unused[id] = v;");
+        printer->add_line("#endif");
     }
 
     if (ion_variable_struct_required()) {
@@ -3420,6 +3430,9 @@ void CodegenCVisitor::print_watch_check() {
     if (info.is_voltage_used_by_watch_statements()) {
         printer->add_line("int node_id = node_index[id];");
         printer->add_line("double v = voltage[node_id];");
+        printer->add_line("#if PRCELLSTATE");
+        printer->add_line("inst->v_unused[id] = v;");
+        printer->add_line("#endif");
     }
 
     for (int i = 0; i < info.watch_statements.size(); i++) {
@@ -4043,6 +4056,9 @@ void CodegenCVisitor::print_nrn_state() {
 
     printer->add_line("int node_id = node_index[id];");
     printer->add_line("double v = voltage[node_id];");
+    printer->add_line("#if PRCELLSTATE");
+    printer->add_line("inst->v_unused[id] = v;");
+    printer->add_line("#endif");
 
     /**
      * \todo Eigen solver node also emits IonCurVar variable in the functor
@@ -4141,6 +4157,12 @@ void CodegenCVisitor::print_nrn_cur_conductance_kernel(const BreakpointBlock& no
             printer->add_line(text);
         }
     }
+
+    if(!info.conductances.empty()) {
+        printer->add_line("#if PRCELLSTATE");
+        printer->add_line("inst->g_unused[id] = g;"); //
+        printer->add_line("#endif");
+    }
 }
 
 
@@ -4177,6 +4199,9 @@ void CodegenCVisitor::print_nrn_cur_non_conductance_kernel() {
 void CodegenCVisitor::print_nrn_cur_kernel(const BreakpointBlock& node) {
     printer->add_line("int node_id = node_index[id];");
     printer->add_line("double v = voltage[node_id];");
+    printer->add_line("#if PRCELLSTATE");
+    printer->add_line("inst->v_unused[id] = v;");
+    printer->add_line("#endif");
     if (ion_variable_struct_required()) {
         print_ion_variable();
     }
@@ -4348,6 +4373,7 @@ void CodegenCVisitor::print_codegen_routines() {
     print_headers_include();
     print_namespace_begin();
     print_nmodl_constants();
+    print_prcellstate_macros();
     print_mechanism_info();
     print_data_structures();
     print_global_variables_for_hoc();

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1596,6 +1596,18 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
 
 
     /**
+     * Set v_unused (voltage) for PRCELLSTATE feature
+     */
+    void print_v_unused() const;
+
+
+    /**
+     * Set g_unused (conductance) for PRCELLSTATE feature
+     */
+    void print_g_unused() const;
+
+
+    /**
      * Print all compute functions for every backend
      *
      */

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1037,6 +1037,11 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
 
 
     /**
+     * Print declaration of macro PRCELLSTATE for debugging
+     */
+    void print_prcellstate_macros() const;
+
+    /**
      * Print backend code for byte array that has mechanism information (to be registered
      * with coreneuron)
      */

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1037,7 +1037,7 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
 
 
     /**
-     * Print declaration of macro PRCELLSTATE for debugging
+     * Print declaration of macro NRN_PRCELLSTATE for debugging
      */
     void print_prcellstate_macros() const;
 
@@ -1596,13 +1596,13 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
 
 
     /**
-     * Set v_unused (voltage) for PRCELLSTATE feature
+     * Set v_unused (voltage) for NRN_PRCELLSTATE feature
      */
     void print_v_unused() const;
 
 
     /**
-     * Set g_unused (conductance) for PRCELLSTATE feature
+     * Set g_unused (conductance) for NRN_PRCELLSTATE feature
      */
     void print_g_unused() const;
 

--- a/src/codegen/codegen_naming.hpp
+++ b/src/codegen/codegen_naming.hpp
@@ -66,7 +66,7 @@ static constexpr char POINT_PROCESS_VARIABLE[] = "point_process";
 static constexpr char TQITEM_VARIABLE[] = "tqitem";
 
 /// range variable for conductance
-static constexpr char CONDUCTANCE_VARIABLE[] = "_g";
+static constexpr char CONDUCTANCE_VARIABLE[] = "g";
 
 /// global variable to indicate if table is used
 static constexpr char USE_TABLE_VARIABLE[] = "usetable";

--- a/src/codegen/fast_math.hpp
+++ b/src/codegen/fast_math.hpp
@@ -133,7 +133,7 @@ static inline double vexpm1(double initial_x) {
     double px = std::floor(LOG2E * x + 0.5);
     const int32_t n = px;
 
-    const uint64_t twopnm1 = (((uint64_t) (n - 1)) + 1023) << 52;
+    const uint64_t twopnm1 = (((uint64_t)(n - 1)) + 1023) << 52;
     x = 2 * (uint642dp(twopnm1) * egm1(x, px) + uint642dp(twopnm1)) - 1;
 
     if (initial_x > EXP_LIMIT)

--- a/src/codegen/fast_math.hpp
+++ b/src/codegen/fast_math.hpp
@@ -133,7 +133,7 @@ static inline double vexpm1(double initial_x) {
     double px = std::floor(LOG2E * x + 0.5);
     const int32_t n = px;
 
-    const uint64_t twopnm1 = (((uint64_t)(n - 1)) + 1023) << 52;
+    const uint64_t twopnm1 = (((uint64_t) (n - 1)) + 1023) << 52;
     x = 2 * (uint642dp(twopnm1) * egm1(x, px) + uint642dp(twopnm1)) - 1;
 
     if (initial_x > EXP_LIMIT)

--- a/test/unit/codegen/codegen_ispc.cpp
+++ b/test/unit/codegen/codegen_ispc.cpp
@@ -151,6 +151,9 @@ SCENARIO("ISPC codegen", "[codegen][ispc]") {
                 foreach (id = start ... end) {
                     int node_id = node_index[id];
                     double v = voltage[node_id];
+                    #if PRCELLSTATE
+                    inst->v_unused[id] = v;
+                    #endif
                     inst->a[id] = 0.0d;
                     inst->b[id] = 0.0d;
                 }
@@ -172,6 +175,9 @@ SCENARIO("ISPC codegen", "[codegen][ispc]") {
                 foreach (id = start ... end) {
                     int node_id = node_index[id];
                     double v = voltage[node_id];
+                    #if PRCELLSTATE
+                    inst->v_unused[id] = v;
+                    #endif
                     inst->a[id] = inst->b[id] + FARADAY;
                 }
             }

--- a/test/unit/codegen/codegen_ispc.cpp
+++ b/test/unit/codegen/codegen_ispc.cpp
@@ -151,7 +151,7 @@ SCENARIO("ISPC codegen", "[codegen][ispc]") {
                 foreach (id = start ... end) {
                     int node_id = node_index[id];
                     double v = voltage[node_id];
-                    #if PRCELLSTATE
+                    #if NRN_PRCELLSTATE
                     inst->v_unused[id] = v;
                     #endif
                     inst->a[id] = 0.0d;
@@ -175,7 +175,7 @@ SCENARIO("ISPC codegen", "[codegen][ispc]") {
                 foreach (id = start ... end) {
                     int node_id = node_index[id];
                     double v = voltage[node_id];
-                    #if PRCELLSTATE
+                    #if NRN_PRCELLSTATE
                     inst->v_unused[id] = v;
                     #endif
                     inst->a[id] = inst->b[id] + FARADAY;


### PR DESCRIPTION
PRCELLSTATE mechanism is a feature helpful to debug code.

Once nmodl is compiled you can use PRCELLSTATE by setting the variable "NRN_PRCELLSTATE" to 1.

Closes #701.