### PR TITLE
Suppress spammy warnings in NVHPC 20.7+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,9 @@ include(cmake/PythonLinkHelper.cmake)
 include(cmake/RpathHelper.cmake)
 include(cmake/ExternalProjectHelper.cmake)
 
+# This should apply to all NMODL targets but should not leak out when NMODL is built as a submodule.
+add_compile_options(${NMODL_COMPILER_WARNING_SUPPRESSIONS})
+
 # =============================================================================
 # Set the project version now using git
 # =============================================================================

--- a/cmake/CompilerHelper.cmake
+++ b/cmake/CompilerHelper.cmake
@@ -19,7 +19,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "PGI" OR CMAKE_CXX_COMPILER_ID MATCHES "NVHPC")
   # TODO : fix these warnings from template modification (#272)
   # ~~~
   if(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 20.7)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --diag_suppress 1,82,111,115,177,186,611,997,1097,1625")
+    set(NMODL_COMPILER_WARNING_SUPPRESSIONS --diag_suppress=1,82,111,115,177,186,611,997,1097,1625)
   else()
     # https://forums.developer.nvidia.com/t/many-all-diagnostic-numbers-increased-by-1-from-previous-values/146268/3
     # changed the numbering scheme in newer versions. The following list is from a clean start 13
@@ -38,6 +38,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "PGI" OR CMAKE_CXX_COMPILER_ID MATCHES "NVHPC")
     # "src/codegen/codegen_cuda_visitor.cpp", NVC++-W-0277-Cannot inline function - data type mismatch
     # "nvc++IkWUbMugiSgNH.s: Warning: stand-alone `data16' prefix
     # ~~~
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --diag_suppress=1,111,186,998,1098,1626")
+    set(NMODL_COMPILER_WARNING_SUPPRESSIONS --diag_suppress=1,111,186,998,1098,1626)
   endif()
 endif()

--- a/cmake/CompilerHelper.cmake
+++ b/cmake/CompilerHelper.cmake
@@ -18,5 +18,26 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "PGI" OR CMAKE_CXX_COMPILER_ID MATCHES "NVHPC")
   # messages specifically for AST. Disable these verbose warnings for now.
   # TODO : fix these warnings from template modification (#272)
   # ~~~
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --diag_suppress 1,82,111,115,177,186,611,997,1097,1625")
+  if(${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 20.7)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --diag_suppress 1,82,111,115,177,186,611,997,1097,1625")
+  else()
+    # https://forums.developer.nvidia.com/t/many-all-diagnostic-numbers-increased-by-1-from-previous-values/146268/3
+    # changed the numbering scheme in newer versions. The following list is from a clean start 13
+    # August 2021. It would clearly be nicer to apply these suppressions only to relevant files.
+    # Examples of the suppressed warnings are given below.
+    # ~~~
+    # "ext/spdlog/include/spdlog/fmt/fmt.h", warning #1-D: last line of file ends without a newline
+    # "ext/fmt/include/fmt/format.h", warning #111-D: statement is unreachable
+    # "ext/json/json.hpp", warning #186-D: pointless comparison of unsigned integer with zero
+    # "src/ast/all.hpp", warning #998-D: function "..." is hidden by "..." -- virtual function override intended?
+    # "ext/spdlog/include/spdlog/fmt/bundled/format.h", warning #1098-D: unknown attribute "fallthrough"
+    # "ext/pybind11/include/pybind11/detail/common.h", warning #1626-D: routine is both "inline" and "noinline"
+    # ~~~
+    # The following warnings do not seem to be suppressible with --diag_suppress:
+    # ~~~
+    # "src/codegen/codegen_cuda_visitor.cpp", NVC++-W-0277-Cannot inline function - data type mismatch
+    # "nvc++IkWUbMugiSgNH.s: Warning: stand-alone `data16' prefix
+    # ~~~
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --diag_suppress=1,111,186,998,1098,1626")
+  endif()
 endif()

--- a/src/lexer/CMakeLists.txt
+++ b/src/lexer/CMakeLists.txt
@@ -59,6 +59,12 @@ set(LEXER_SOURCE_FILES
     ${C_DRIVER_FILES}
     ${UNIT_DRIVER_FILES})
 
+if(NMODL_PGI_COMPILER)
+  # "verbatim_lexer.cpp", warning #550-D: variable "..." was set but never used
+  set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/verbatim_lexer.cpp
+                              PROPERTIES COMPILE_FLAGS "--diag_suppress 550")
+endif()
+
 # =============================================================================
 # Directories for parsers (as they need to be in separate directories)
 # =============================================================================


### PR DESCRIPTION
Apparently the diagnostic numbers changed in the rebranding from PGI to NVHPC: https://forums.developer.nvidia.com/t/many-all-diagnostic-numbers-increased-by-1-from-previous-values/146268/3

We might be able to fix a couple of these at source:
```
# "src/ast/all.hpp", warning #998-D: function "..." is hidden by "..." -- virtual function override intended?
# "src/codegen/codegen_cuda_visitor.cpp", NVC++-W-0277-Cannot inline function - data type mismatch
```
otherwise fixes will involve updating external packages and/or patching them.