### PR TITLE
Move to manylinux2014

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -200,7 +200,7 @@ jobs:
         -w /root/nmodl \
         -v $PWD:/root/nmodl \
         -e NMODL_NIGHTLY_TAG=$TAG \
-        'bluebrain/nmodl:wheel' \
+        'bluebrain/nmodl:wheel2014' \
         packaging/build_wheels.bash linux $(python.version)
     condition: succeeded()
     displayName: 'Building ManyLinux Wheel'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -200,7 +200,7 @@ jobs:
         -w /root/nmodl \
         -v $PWD:/root/nmodl \
         -e NMODL_NIGHTLY_TAG=$TAG \
-        'bluebrain/nmodl:wheel2014' \
+        'bluebrain/nmodl:wheel' \
         packaging/build_wheels.bash linux $(python.version)
     condition: succeeded()
     displayName: 'Building ManyLinux Wheel'

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,16 +1,14 @@
-FROM quay.io/pypa/manylinux2010_x86_64
-LABEL authors="Omar Awile,Pramod Kumbhar"
+FROM quay.io/pypa/manylinux2014_x86_64
+LABEL authors="Omar Awile, Pramod Kumbhar, Alexandru Savulescu"
 
 # install basic packages
 RUN yum -y install \
     git \
     wget \
-    cmake3 \
     make \
     vim \
     curl \
     unzip \
-    pkg-config \
     autoconf \
     automake \
     make \
@@ -18,12 +16,6 @@ RUN yum -y install \
     libtool
 
 WORKDIR /root
-
-RUN curl -L -o cmake-3.12.3.tar.gz https://github.com/Kitware/CMake/releases/download/v3.12.3/cmake-3.12.3.tar.gz \
-    && tar -xvzf cmake-3.12.3.tar.gz \
-    && cd cmake-3.12.3 \
-    && ./bootstrap -- -DCMAKE_INSTALL_PREFIX=/nmodlwheel/cmake \
-    && make -j 3 install
 
 RUN curl -L -o flex-2.6.4.tar.gz https://github.com/westes/flex/files/981163/flex-2.6.4.tar.gz \
     && tar -xvzf flex-2.6.4.tar.gz \


### PR DESCRIPTION
To be done before merge:
- [x] tag `bluebrain/nmodl:wheel` as `bluebrain/nmodl:manylinux2010` and/or `bluebrain/nmodl:0.3` (this is current version? somebody forgot to tag 🤌 )
- [x] merge  `bluebrain/nmodl:wheel2014` into `bluebrain/nmodl:wheel`
- [x] revert `azure-pipelines.yml`

x-ref: https://github.com/neuronsimulator/nrn/pull/1365