### PR TITLE
Avoid use of assert in the OpenACC kernel

### DIFF
--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -121,10 +121,7 @@ void CodegenAccVisitor::print_abort_routine() const {
 }
 
 void CodegenAccVisitor::print_net_send_buffering_grow() {
-    auto error = add_escape_quote("Error : netsend buffer size (%d) exceeded\\n");
-
-    printer->add_line("printf({}, nsb->_cnt);"_format(error));
-    printer->add_line("coreneuron_abort();");
+    // can not grow buffer during gpu execution
 }
 
 /**

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3796,7 +3796,9 @@ void CodegenCVisitor::print_net_receive_buffering(bool need_mech_inst) {
 }
 
 void CodegenCVisitor::print_net_send_buffering_grow() {
-    printer->add_line("nsb->grow();");
+    printer->add_line("if(i >= nsb->_size) {");
+    printer->add_line("    nsb->grow();");
+    printer->add_line("}");
 }
 
 void CodegenCVisitor::print_net_send_buffering() {
@@ -3813,17 +3815,15 @@ void CodegenCVisitor::print_net_send_buffering() {
     printer->add_line("int i = 0;");
     print_device_atomic_capture_annotation();
     printer->add_line("i = nsb->_cnt++;");
-    printer->add_line("if(i >= nsb->_size) {");
-    printer->increase_indent();
     print_net_send_buffering_grow();
-    printer->decrease_indent();
+    printer->add_line("if(i < nsb->_size) {");
+    printer->add_line("    nsb->_sendtype[i] = type;");
+    printer->add_line("    nsb->_vdata_index[i] = vdata_index;");
+    printer->add_line("    nsb->_weight_index[i] = weight_index;");
+    printer->add_line("    nsb->_pnt_index[i] = point_index;");
+    printer->add_line("    nsb->_nsb_t[i] = t;");
+    printer->add_line("    nsb->_nsb_flag[i] = flag;");
     printer->add_line("}");
-    printer->add_line("nsb->_sendtype[i] = type;");
-    printer->add_line("nsb->_vdata_index[i] = vdata_index;");
-    printer->add_line("nsb->_weight_index[i] = weight_index;");
-    printer->add_line("nsb->_pnt_index[i] = point_index;");
-    printer->add_line("nsb->_nsb_t[i] = t;");
-    printer->add_line("nsb->_nsb_flag[i] = flag;");
     printer->end_block(1);
 }
 


### PR DESCRIPTION
* Use of assert with atomic capture result
  into wrong results
* See details in https://github.com/BlueBrain/mod2c/pull/68