### PR TITLE
Add nmodl_ prefix to find_python_module.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,11 +142,11 @@ endif()
 # =============================================================================
 message(STATUS "CHECKING FOR PYTHON")
 find_package(PythonInterp 3.5 REQUIRED)
-find_python_module(jinja2 2.9.3 REQUIRED)
-find_python_module(pytest 3.3.0 REQUIRED)
-find_python_module(sympy 1.2 REQUIRED)
-find_python_module(textwrap 0.9 REQUIRED)
-find_python_module(yaml 3.12 REQUIRED)
+nmodl_find_python_module(jinja2 2.9.3 REQUIRED)
+nmodl_find_python_module(pytest 3.3.0 REQUIRED)
+nmodl_find_python_module(sympy 1.2 REQUIRED)
+nmodl_find_python_module(textwrap 0.9 REQUIRED)
+nmodl_find_python_module(yaml 3.12 REQUIRED)
 
 # =============================================================================
 # Compiler specific flags for external submodules

--- a/cmake/FindPythonModule.cmake
+++ b/cmake/FindPythonModule.cmake
@@ -1,6 +1,6 @@
 # * Macro to find a python module
 #
-# Usage: find_python_module (module [VERSION] [REQUIRED])
+# Usage: nmodl_find_python_module (module [VERSION] [REQUIRED])
 #
 # Copyright 2005-2018 Airbus-EDF-IMACS-Phimeca
 #
@@ -9,7 +9,7 @@
 #
 # https://github.com/openturns/otsubsetinverse/blob/master/cmake/FindPythonModule.cmake
 
-macro(find_python_module module)
+macro(nmodl_find_python_module module)
 
   string(TOUPPER ${module} module_upper)
   if(NOT ${module_upper}_FOUND)
@@ -71,4 +71,4 @@ macro(find_python_module module)
     endif()
     mark_as_advanced(${module_upper}_LOCATION)
   endif(NOT ${module_upper}_FOUND)
-endmacro(find_python_module)
+endmacro(nmodl_find_python_module)


### PR DESCRIPTION
This should make things more robust against divergence between different
projects' definitions of `find_python_module`, in case many git
modules/subprojects are being configured in a single CMake run.

See also: https://github.com/neuronsimulator/nrn/pull/1410