### PR TITLE
Fix race condition issue with STEADYSTATE code generation on GPU backends

### DIFF
--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -297,5 +297,10 @@ void CodegenAccVisitor::print_net_send_buf_count_update_to_device() const {
     printer->add_line("#pragma acc update device(nsb->_cnt) if (nt->compute_gpu)");
 }
 
+void CodegenAccVisitor::print_dt_update_to_device() const {
+    printer->add_line("#pragma acc update device({}) if (nt->compute_gpu)"_format(
+        get_variable_name(naming::NTHREAD_DT_VARIABLE)));
+}
+
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -100,6 +100,9 @@ class CodegenAccVisitor: public CodegenCVisitor {
     // update NetSendBuffer_t count from host to device
     virtual void print_net_send_buf_count_update_to_device() const override;
 
+    // update dt from host to device
+    virtual void print_dt_update_to_device() const override;
+
     // synchronise/wait on stream specific to NrnThread
     virtual void print_device_stream_wait() const override;
 

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1110,6 +1110,10 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      */
     virtual void print_net_send_buf_count_update_to_device() const;
 
+    /**
+     * Print the code to update dt from host to device
+     */
+    virtual void print_dt_update_to_device() const;
 
     /**
      * Print the code to synchronise/wait on stream specific to NrnThread
@@ -1923,6 +1927,7 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
     void visit_while_statement(const ast::WhileStatement& node) override;
     void visit_derivimplicit_callback(const ast::DerivimplicitCallback& node) override;
     void visit_for_netcon(const ast::ForNetcon& node) override;
+    void visit_update_dt(const ast::UpdateDt& node) override;
 };
 
 

--- a/src/codegen/codegen_cuda_visitor.cpp
+++ b/src/codegen/codegen_cuda_visitor.cpp
@@ -20,6 +20,12 @@ using symtab::syminfo::NmodlType;
 /*                      Routines must be overloaded in backend                          */
 /****************************************************************************************/
 
+// TODO: Update of dt and other variables on device via CUDA backend is not handled
+//       yet. We need to review device code generation in OpenACC backend.
+void CodegenCudaVisitor::print_dt_update_to_device() const {
+    throw std::runtime_error("CUDA backend doesn't handled dt update on GPU");
+}
+
 /**
  * As initial block is/can be executed on c/cpu backend, gpu/cuda
  * backend can mark the parameter as constant even if they have

--- a/src/codegen/codegen_cuda_visitor.hpp
+++ b/src/codegen/codegen_cuda_visitor.hpp
@@ -95,6 +95,8 @@ class CodegenCudaVisitor: public CodegenCVisitor {
     /// print wrapper function that calls cuda kernel
     void print_wrapper_routine(std::string wrapper_function, BlockType type);
 
+    // update dt from host to device
+    void print_dt_update_to_device() const override;
 
     /// wrapper/caller routines for nrn_state and nrn_cur
     void codegen_wrapper_routines();

--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -557,11 +557,13 @@ void CodegenHelperVisitor::visit_function_block(const ast::FunctionBlock& node) 
 void CodegenHelperVisitor::visit_eigen_newton_solver_block(
     const ast::EigenNewtonSolverBlock& node) {
     info.eigen_newton_solver_exist = true;
+    node.visit_children(*this);
 }
 
 void CodegenHelperVisitor::visit_eigen_linear_solver_block(
     const ast::EigenLinearSolverBlock& node) {
     info.eigen_linear_solver_exist = true;
+    node.visit_children(*this);
 }
 
 void CodegenHelperVisitor::visit_function_call(const FunctionCall& node) {
@@ -702,6 +704,10 @@ void CodegenHelperVisitor::visit_discrete_block(const ast::DiscreteBlock& node) 
 
 void CodegenHelperVisitor::visit_partial_block(const ast::PartialBlock& node) {
     info.vectorize = false;
+}
+
+void CodegenHelperVisitor::visit_update_dt(const ast::UpdateDt& node) {
+    info.changed_dt = node.get_value()->eval();
 }
 
 }  // namespace codegen

--- a/src/codegen/codegen_helper_visitor.hpp
+++ b/src/codegen/codegen_helper_visitor.hpp
@@ -110,6 +110,7 @@ class CodegenHelperVisitor: public visitor::ConstAstVisitor {
     void visit_non_linear_block(const ast::NonLinearBlock& node) override;
     void visit_discrete_block(const ast::DiscreteBlock& node) override;
     void visit_partial_block(const ast::PartialBlock& node) override;
+    void visit_update_dt(const ast::UpdateDt& node) override;
 };
 
 /** @} */  // end of codegen_details

--- a/src/codegen/codegen_info.hpp
+++ b/src/codegen/codegen_info.hpp
@@ -311,6 +311,10 @@ struct CodegenInfo {
     /// note that if tqitem doesn't exist then the default value should be 0
     int tqitem_index = 0;
 
+    // updated dt to use with steadystate solver (in initial block)
+    // empty string means no change in dt
+    std::string changed_dt;
+
     /// global variables
     std::vector<SymbolType> global_variables;
 

--- a/src/language/code_generator.cmake
+++ b/src/language/code_generator.cmake
@@ -181,6 +181,7 @@ set(AST_GENERATED_SOURCES
     ${PROJECT_BINARY_DIR}/src/ast/unit_block.hpp
     ${PROJECT_BINARY_DIR}/src/ast/unit_def.hpp
     ${PROJECT_BINARY_DIR}/src/ast/unit_state.hpp
+    ${PROJECT_BINARY_DIR}/src/ast/update_dt.hpp
     ${PROJECT_BINARY_DIR}/src/ast/useion.hpp
     ${PROJECT_BINARY_DIR}/src/ast/valence.hpp
     ${PROJECT_BINARY_DIR}/src/ast/var_name.hpp

--- a/src/language/codegen.yaml
+++ b/src/language/codegen.yaml
@@ -111,3 +111,13 @@
                             brief: "Block to be solved (callback node or solution node itself)"
                             type: Expression
             - Statement:
+                brief: "Statement base class"
+                children:
+                  - UpdateDt:
+                      nmodl: "dt"
+                      members:
+                        - value:
+                            brief: "Value of new timestep"
+                            type: Double
+                            prefix: {value: " = "}
+                      brief: "Statement to indicate a change in timestep in a given block"

--- a/test/unit/visitor/steadystate.cpp
+++ b/test/unit/visitor/steadystate.cpp
@@ -86,11 +86,8 @@ SCENARIO("Solving ODEs with STEADYSTATE solve method", "[visitor][steadystate]")
             })";
         std::string expected_text2 = R"(
             DERIVATIVE states_steadystate {
-                LOCAL dt_saved_value
-                dt_saved_value = dt
                 dt = 1000000000
                 m' = m+h
-                dt = dt_saved_value
             })";
         THEN("Construct DERIVATIVE block with steadystate solution & update SOLVE statement") {
             auto result = run_steadystate_visitor(nmodl_text);
@@ -115,11 +112,8 @@ SCENARIO("Solving ODEs with STEADYSTATE solve method", "[visitor][steadystate]")
             })";
         std::string expected_text2 = R"(
             DERIVATIVE states_steadystate {
-                LOCAL dt_saved_value
-                dt_saved_value = dt
                 dt = 1e-09
                 m' = m+h
-                dt = dt_saved_value
             })";
         THEN("Construct DERIVATIVE block with steadystate solution & update SOLVE statement") {
             auto result = run_steadystate_visitor(nmodl_text);
@@ -160,21 +154,15 @@ SCENARIO("Solving ODEs with STEADYSTATE solve method", "[visitor][steadystate]")
             })";
         std::string expected_text3 = R"(
             DERIVATIVE states0_steadystate {
-                LOCAL dt_saved_value
-                dt_saved_value = dt
                 dt = 1e-09
                 Z'[0] = Z[1]-Z[2]
                 Z'[1] = Z[0]+2*Z[2]
                 Z'[2] = Z[0]*Z[0]-3.10
-                dt = dt_saved_value
             })";
         std::string expected_text4 = R"(
             DERIVATIVE states1_steadystate {
-                LOCAL dt_saved_value
-                dt_saved_value = dt
                 dt = 1000000000
                 x' = x+c
-                dt = dt_saved_value
             })";
         THEN("Construct DERIVATIVE blocks with steadystate solution & update SOLVE statements") {
             auto result = run_steadystate_visitor(nmodl_text);


### PR DESCRIPTION
 * update of dt was done inside parallel/SIMD for loop
 * this leads to race condition and random failures on GPU
 * handle update of dt in code generation backend: pull dt
   update outside loop.
 * CUDA backend doesn't handle these updates yet. This should
   be handled in separate PR.
* Added new statement type `UpdateDt` because we can easily
   search and pull it outside loop to avoid the race condition.

fixes #729