### PR TITLE
Fix NMODL compilation when clang-format was found.

### DIFF
--- a/src/language/CMakeLists.txt
+++ b/src/language/CMakeLists.txt
@@ -7,7 +7,7 @@ set_source_files_properties(${NMODL_GENERATED_SOURCES} PROPERTIES GENERATED TRUE
 # .clang-format configuration file. It's important that we only try to format code if formatting was
 # enabled and NMODL's .clang-format exists, otherwise clang-format will search too far up the
 # directory tree and find the wrong configuration file. This can break compilation.
-if(NMODL_CLANG_FORMAT)
+if(NMODL_CLANG_FORMAT OR NMODL_FORMATTING)
   set(CODE_GENERATOR_OPTS -v --clang-format=${ClangFormat_EXECUTABLE})
   foreach(clang_format_opt ${NMODL_ClangFormat_OPTIONS} --style=file)
     list(APPEND CODE_GENERATOR_OPTS --clang-format-opts=${clang_format_opt})

--- a/src/language/CMakeLists.txt
+++ b/src/language/CMakeLists.txt
@@ -3,18 +3,21 @@
 # =============================================================================
 set_source_files_properties(${NMODL_GENERATED_SOURCES} PROPERTIES GENERATED TRUE)
 
-if(ClangFormat_FOUND AND (NOT ClangFormat_VERSION_MAJOR LESS 4))
+# clang-format is handled by the HPC coding conventions scripts, which also handle generating the
+# .clang-format configuration file. It's important that we only try to format code if formatting was
+# enabled and NMODL's .clang-format exists, otherwise clang-format will search too far up the
+# directory tree and find the wrong configuration file. This can break compilation.
+if(NMODL_CLANG_FORMAT)
   set(CODE_GENERATOR_OPTS -v --clang-format=${ClangFormat_EXECUTABLE})
-  if(nmodl_ClangFormat_OPTIONS)
-    set(CODE_GENERATOR_OPTS ${CODE_GENERATOR_OPTS} --clang-format-opts ${nmodl_ClangFormat_OPTIONS})
-  endif(nmodl_ClangFormat_OPTIONS)
+  foreach(clang_format_opt ${NMODL_ClangFormat_OPTIONS} --style=file)
+    list(APPEND CODE_GENERATOR_OPTS --clang-format-opts=${clang_format_opt})
+  endforeach()
 endif()
 
 add_custom_command(
   OUTPUT ${NMODL_GENERATED_SOURCES}
-  COMMAND
-    ${PYTHON_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/code_generator.py ${CODE_GENERATOR_OPTS}
-    --base-dir ${PROJECT_BINARY_DIR}/src --clang-format-opts="--style=file"
+  COMMAND ${PYTHON_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/code_generator.py
+          ${CODE_GENERATOR_OPTS} --base-dir ${PROJECT_BINARY_DIR}/src
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${CODE_GENERATOR_PY_FILES}
   DEPENDS ${CODE_GENERATOR_YAML_FILES}

--- a/src/language/code_generator.py
+++ b/src/language/code_generator.py
@@ -335,7 +335,9 @@ def parse_args(args=None):
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("--clang-format", help="Path to clang-format executable")
-    parser.add_argument("--clang-format-opts", help="clang-format options", nargs="+")
+    parser.add_argument(
+        "--clang-format-opts", help="clang-format options", action="append"
+    )
     parser.add_argument("--base-dir", help="output root directory")
     parser.add_argument(
         "-v", "--verbosity", action="count", default=0, help="increase output verbosity"


### PR DESCRIPTION
Without this fix then building NMODL-as-a-submodule-of-CoreNEURON-as-a-submodule-of-NEURON would not
work if code formatting was enabled in NEURON following the recipe of https://github.com/neuronsimulator/nrn/pull/1460.

This was apparently because NMODL was formatting NMODL generated code using a clang-format configuration file from NEURON, which uses `Standard: Cpp03` (we should change that too). That breaks NMODL code compilation by adding a space before `_format` in `"..{}.."_format("bar")`, which is not valid.

Also change the handling of the --clang-format-opts option so that the `${NMODL_ClangFormat_OPTIONS}` option should actually work.
Previously the CMake code would generate something like:
```
  --clang-format-opts A B --clang-format-opts="--style=file"
```
where the `A B` part would then be ignored.