### PR TITLE
Fixup GitLab CI environment.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ test intel:
     # We cloned in .pre
     GIT_STRATEGY: none
 
-build pgi:
+build nvhpc:
   needs: ["setup virtualenv"]
   extends: .common
   stage: build
@@ -71,8 +71,8 @@ build pgi:
     GIT_STRATEGY: none
     bb5_constraint: volta
 
-test pgi:
-  needs: ["build pgi"]
+test nvhpc:
+  needs: ["build nvhpc"]
   extends: .common
   stage: test
   variables:


### PR DESCRIPTION
After HELP-14436(?) flex and bison could no longer be found:
```
++ /usr/bin/modulecmd bash load archive/2020-10 cmake bison flex python-dev doxygen
bison(20):ERROR:105: Unable to locate a modulefile for 'bison'
flex(20):ERROR:105: Unable to locate a modulefile for 'flex'
```
This updates the bash-based GitLab CI pipeline to use newer modules.

I suggest we merge this as a quick fix, and then after https://github.com/BlueBrain/nmodl/pull/735 use the `hpc/gitlab-pipelines` helpers to build/test NMODL with Intel/NVHPC on BB5.