### PR TITLE
Bug fix for net_init code generation on GPUs with OpenACC backend

### DIFF
--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -67,6 +67,7 @@ jobs:
         working-directory: ${{runner.workspace}}/nmodl
         run:  |
           echo "------- Configure -------"
+          echo "github.event.head_commit.message=${{github.event.head_commit.message}}"
           if [[ "${{ startsWith(matrix.os, 'macos') }}" = "true" ]]; then
             export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:${PATH}
           fi
@@ -107,6 +108,12 @@ jobs:
           CCACHE_DIR: ${{runner.workspace}}/ccache
           CCACHE_DEBUG: 1
         run:  |
+          if ccache --version | grep -P '^ccache version 4\.4(|\.1)$'
+          then
+            echo "------- Disable ccache direct mode -------"
+            # https://github.com/ccache/ccache/issues/935
+            export CCACHE_NODIRECT=1
+          fi
           echo "------- Building -------"
           ccache -z
           # Older versions don't support -v (verbose)

--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -72,6 +72,7 @@ jobs:
           fi
           mkdir build && pushd build
           cmake .. -G Ninja \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DPYTHON_EXECUTABLE=$(which python3) \
             -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \

--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -130,7 +130,8 @@ jobs:
 
       # This step will set up an SSH connection on tmate.io for live debugging.
       # To trigger it, simply add 'live-debug-tests' to your last pushed commit message
+      # OL210928: this does not seem to work, at least for commits on PRs.
       - name: live debug session on failure
-        if: failure() && contains(github.event.head_commit.message, 'live-debug-tests')
+        if: failure() #&& contains(github.event.head_commit.message, 'live-debug-tests')
         uses: mxschmitt/action-tmate@v3
 

--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -108,9 +108,10 @@ jobs:
         run:  |
           echo "------- Building -------"
           ccache -z
-          ccache -s
+          # Older versions don't support -v (verbose)
+          ccache -sv || ccache -s
           cmake --build .
-          ccache -s
+          ccache -sv || ccache -s
 
       - name: Test
         shell: bash

--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -134,4 +134,4 @@ jobs:
       - name: live debug session on failure
         if: failure() #&& contains(github.event.head_commit.message, 'live-debug-tests')
         uses: mxschmitt/action-tmate@v3
-
+        timeout-minutes: 60

--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -108,7 +108,7 @@ jobs:
           CCACHE_DIR: ${{runner.workspace}}/ccache
           CCACHE_DEBUG: 1
         run:  |
-          if ccache --version | grep -P '^ccache version 4\.4(|\.1)$'
+          if ccache --version | grep -E '^ccache version 4\.(4|4\.1)$'
           then
             echo "------- Disable ccache direct mode -------"
             # https://github.com/ccache/ccache/issues/935

--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -72,7 +72,6 @@ jobs:
           fi
           mkdir build && pushd build
           cmake .. -G Ninja \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DPYTHON_EXECUTABLE=$(which python3) \
             -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \

--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -105,6 +105,7 @@ jobs:
         working-directory: ${{runner.workspace}}/nmodl/build
         env:
           CCACHE_DIR: ${{runner.workspace}}/ccache
+          CCACHE_DEBUG: 1
         run:  |
           echo "------- Building -------"
           ccache -z

--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -67,7 +67,6 @@ jobs:
         working-directory: ${{runner.workspace}}/nmodl
         run:  |
           echo "------- Configure -------"
-          echo "github.event.head_commit.message=${{github.event.head_commit.message}}"
           if [[ "${{ startsWith(matrix.os, 'macos') }}" = "true" ]]; then
             export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:${PATH}
           fi
@@ -106,7 +105,6 @@ jobs:
         working-directory: ${{runner.workspace}}/nmodl/build
         env:
           CCACHE_DIR: ${{runner.workspace}}/ccache
-          CCACHE_DEBUG: 1
         run:  |
           if ccache --version | grep -E '^ccache version 4\.(4|4\.1)$'
           then
@@ -139,6 +137,6 @@ jobs:
       # To trigger it, simply add 'live-debug-tests' to your last pushed commit message
       # OL210928: this does not seem to work, at least for commits on PRs.
       - name: live debug session on failure
-        if: failure() #&& contains(github.event.head_commit.message, 'live-debug-tests')
+        if: failure() && contains(github.event.head_commit.message, 'live-debug-tests')
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: 60

--- a/.github/workflows/nmodl-doc.yml
+++ b/.github/workflows/nmodl-doc.yml
@@ -64,15 +64,15 @@ jobs:
         if: failure() && contains(github.event.head_commit.message, 'live-debug-docs')
         uses: mxschmitt/action-tmate@v3
 
-      #- name: Restore compiler cache
-      #  uses: actions/cache@v2
-      #  with:
-      #    path: |
-      #      ${{runner.workspace}}/ccache
-      #    key: docs-${{github.ref}}-${{github.sha}}
-      #    restore-keys: |
-      #      docs-${{github.ref}}-
-      #      docs-
+      - name: Restore compiler cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{runner.workspace}}/ccache
+          key: docs-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            docs-${{github.ref}}-
+            docs-
 
       - name: Documentation 
         id: documentation

--- a/.github/workflows/nmodl-doc.yml
+++ b/.github/workflows/nmodl-doc.yml
@@ -64,15 +64,15 @@ jobs:
         if: failure() && contains(github.event.head_commit.message, 'live-debug-docs')
         uses: mxschmitt/action-tmate@v3
 
-      - name: Restore compiler cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ${{runner.workspace}}/ccache
-          key: docs-${{github.ref}}-${{github.sha}}
-          restore-keys: |
-            docs-${{github.ref}}-
-            docs-
+      #- name: Restore compiler cache
+      #  uses: actions/cache@v2
+      #  with:
+      #    path: |
+      #      ${{runner.workspace}}/ccache
+      #    key: docs-${{github.ref}}-${{github.sha}}
+      #    restore-keys: |
+      #      docs-${{github.ref}}-
+      #      docs-
 
       - name: Documentation 
         id: documentation

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -302,14 +302,23 @@ void CodegenAccVisitor::print_device_stream_wait() const {
 
 
 void CodegenAccVisitor::print_net_send_buf_count_update_to_host() const {
-    print_device_stream_wait();
     printer->add_line("#pragma acc update self(nsb->_cnt) if(nt->compute_gpu)");
+}
+
+
+void CodegenAccVisitor::print_net_send_buf_update_to_host() const {
+    print_device_stream_wait();
+    printer->start_block("if (nsb)");
+    print_net_send_buf_count_update_to_host();
+    printer->add_line("update_net_send_buffer_on_host(nt, nsb);");
+    printer->end_block(1);
 }
 
 
 void CodegenAccVisitor::print_net_send_buf_count_update_to_device() const {
     printer->add_line("#pragma acc update device(nsb->_cnt) if (nt->compute_gpu)");
 }
+
 
 void CodegenAccVisitor::print_dt_update_to_device() const {
     printer->add_line("#pragma acc update device({}) if (nt->compute_gpu)"_format(

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -172,6 +172,20 @@ void CodegenAccVisitor::print_kernel_data_present_annotation_block_begin() {
     }
 }
 
+void CodegenAccVisitor::print_net_init_acc_serial_annotation_block_begin() {
+    if (!info.artificial_cell) {
+        printer->add_line("#pragma acc serial present(inst, indexes, weights) if(nt->compute_gpu)");
+        printer->add_line("{");
+        printer->increase_indent();
+    }
+}
+
+void CodegenAccVisitor::print_net_init_acc_serial_annotation_block_end() {
+    if (!info.artificial_cell) {
+        printer->add_line("}");
+        printer->decrease_indent();
+    }
+}
 
 void CodegenAccVisitor::print_nrn_cur_matrix_shadow_update() {
     auto rhs_op = operator_for_rhs();

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -172,6 +172,15 @@ void CodegenAccVisitor::print_kernel_data_present_annotation_block_begin() {
     }
 }
 
+/**
+ * `INITIAL` block from `NET_RECEIVE` generates `net_init` function. The `net_init`
+ * function pointer is registered with the coreneuron and called from the CPU.
+ * As the data is on GPU, we need to launch `net_init` on the GPU.
+ *
+ * \todo: With the current code structure for NMODL and MOD2C, we use `serial`
+ *        construct to launch serial kernels. This is during initialization
+ *        but still inefficient. This should be improved when we drop MOD2C.
+ */
 void CodegenAccVisitor::print_net_init_acc_serial_annotation_block_begin() {
     if (!info.artificial_cell) {
         printer->add_line("#pragma acc serial present(inst, indexes, weights) if(nt->compute_gpu)");

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -61,6 +61,14 @@ class CodegenAccVisitor: public CodegenCVisitor {
     void print_kernel_data_present_annotation_block_end() override;
 
 
+    /// start of annotation "acc kernels" for net_init kernel
+    void print_net_init_acc_serial_annotation_block_begin() override;
+
+
+    /// end of annotation "acc kernels" for net_init kernel
+    void print_net_init_acc_serial_annotation_block_end() override;
+
+
     /// update to matrix elements with/without shadow vectors
     void print_nrn_cur_matrix_shadow_update() override;
 

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -105,6 +105,9 @@ class CodegenAccVisitor: public CodegenCVisitor {
     // update NetSendBuffer_t count from device to host
     void print_net_send_buf_count_update_to_host() const override;
 
+    // update NetSendBuffer_t from device to host
+    void print_net_send_buf_update_to_host() const override;
+
     // update NetSendBuffer_t count from host to device
     virtual void print_net_send_buf_count_update_to_device() const override;
 

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3839,7 +3839,7 @@ void CodegenCVisitor::print_net_init() {
         if (node->is_initial_block()) {
             print_net_init_acc_serial_annotation_block_end();
             print_kernel_data_present_annotation_block_end();
-            printer->add_line("auto nsb = ml->_net_send_buffer;");
+            printer->add_line("auto& nsb = ml->_net_send_buffer;");
             print_net_send_buf_update_to_host();
         }
     }

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1061,6 +1061,10 @@ void CodegenCVisitor::print_net_send_buf_count_update_to_host() const {
     // backend specific, do nothing
 }
 
+void CodegenCVisitor::print_net_send_buf_update_to_host() const {
+    // backend specific, do nothing
+}
+
 void CodegenCVisitor::print_net_send_buf_count_update_to_device() const {
     // backend specific, do nothing
 }
@@ -3836,8 +3840,7 @@ void CodegenCVisitor::print_net_init() {
             print_net_init_acc_serial_annotation_block_end();
             print_kernel_data_present_annotation_block_end();
             printer->add_line("auto nsb = ml->_net_send_buffer;");
-            print_net_send_buf_count_update_to_host();
-            printer->add_line("update_net_send_buffer_on_host(nt, nsb);");
+            print_net_send_buf_update_to_host();
         }
     }
     printer->end_block(1);
@@ -3848,8 +3851,7 @@ void CodegenCVisitor::print_net_init() {
 void CodegenCVisitor::print_send_event_move() {
     printer->add_newline();
     printer->add_line("NetSendBuffer_t* nsb = ml->_net_send_buffer;");
-    print_net_send_buf_count_update_to_host();
-    printer->add_line("update_net_send_buffer_on_host(nt, nsb);");
+    print_net_send_buf_update_to_host();
     printer->add_line("for (int i=0; i < nsb->_cnt; i++) {");
     printer->add_line("    int type = nsb->_sendtype[i];");
     printer->add_line("    int tid = nt->id;");

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1096,6 +1096,13 @@ void CodegenCVisitor::print_kernel_data_present_annotation_block_end() {
     // backend specific, do nothing
 }
 
+void CodegenCVisitor::print_net_init_acc_serial_annotation_block_begin() {
+    // backend specific, do nothing
+}
+
+void CodegenCVisitor::print_net_init_acc_serial_annotation_block_end() {
+    // backend specific, do nothing
+}
 
 /**
  * \details Depending programming model and compiler, we print compiler hint
@@ -3655,6 +3662,10 @@ void CodegenCVisitor::print_net_receive_common_code(const Block& node, bool need
         printer->add_line("NrnThread* nt = nrn_threads + tid;");
         printer->add_line("Memb_list* ml = nt->_ml_list[pnt->_type];");
     }
+    if (node.is_initial_block()) {
+        print_kernel_data_present_annotation_block_begin();
+    }
+
     printer->add_line("{}int nodecount = ml->nodecount;"_format(param_type_qualifier()));
     printer->add_line("{}int pnodecount = ml->_nodecount_padded;"_format(param_type_qualifier()));
     printer->add_line("double* data = ml->data;");
@@ -3663,6 +3674,10 @@ void CodegenCVisitor::print_net_receive_common_code(const Block& node, bool need
     printer->add_line("ThreadDatum* thread = ml->_thread;");
     if (need_mech_inst) {
         printer->add_line("{0}* inst = ({0}*) ml->instance;"_format(instance_struct()));
+    }
+
+    if (node.is_initial_block()) {
+        print_net_init_acc_serial_annotation_block_begin();
     }
 
     // rename variables but need to see if they are actually used
@@ -3817,6 +3832,13 @@ void CodegenCVisitor::print_net_init() {
     } else {
         print_net_receive_common_code(*node);
         print_statement_block(*block, false, false);
+        if (node->is_initial_block()) {
+            print_net_init_acc_serial_annotation_block_end();
+            print_kernel_data_present_annotation_block_end();
+            printer->add_line("auto nsb = ml->_net_send_buffer;");
+            print_net_send_buf_count_update_to_host();
+            printer->add_line("update_net_send_buffer_on_host(nt, nsb);");
+        }
     }
     printer->end_block(1);
     codegen = false;

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1309,6 +1309,18 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
 
 
     /**
+     * Print accelerator kernels begin annotation for net_init kernel
+     */
+    virtual void print_net_init_acc_serial_annotation_block_begin();
+
+
+    /**
+     * Print accelerator kernels end annotation for net_init kernel
+     */
+    virtual void print_net_init_acc_serial_annotation_block_end();
+
+
+    /**
      * Print backend specific channel instance iteration block start
      * \param type The block type in which we currently are
      */

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1104,6 +1104,11 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      */
     virtual void print_net_send_buf_count_update_to_host() const;
 
+    /**
+     * Print the code to update NetSendBuffer_t from device to host
+     */
+    virtual void print_net_send_buf_update_to_host() const;
+
 
     /**
      * Print the code to update NetSendBuffer_t count from host to device


### PR DESCRIPTION
 * net_init was being executed on CPU but it was dereferencing
   gpu pointers on CPU via instance structure
 * Currently there is no support for getting device function pointers
 * As net_init is called from cpu side, a simple approach is to launch
   serial kernel for each invocation of net_init.
 * This is bit inefficient as large number of kernels could be launched.
   But, as this happens only during initialialization, we can use this
   solution for time being.
 * Note that mod2c "get away" by launching kernels on CPU because the
   net_init kernel is just handling spike events and those are handled
   on CPU anyway.

fixes #740

### Before merge

- [x] @olupton to confirm if the hippocampus model runs on the GPU with this PR
- [x] Update docs/clang-format