### PR TITLE
Don't update net send buffer on host if it's null

### DIFF
--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -302,9 +302,14 @@ void CodegenAccVisitor::print_device_stream_wait() const {
 
 
 void CodegenAccVisitor::print_net_send_buf_count_update_to_host() const {
+    printer->add_line("#pragma acc update self(nsb->_cnt) if(nt->compute_gpu)");
+}
+
+
+void CodegenAccVisitor::print_net_send_buf_update_to_host() const {
     print_device_stream_wait();
     printer->start_block("if (nsb) ");
-    printer->add_line("#pragma acc update self(nsb->_cnt) if(nt->compute_gpu)");
+    print_net_send_buf_count_update_to_host();
     printer->add_line("update_net_send_buffer_on_host(nt, nsb);");
     printer->end_block(1);
 }
@@ -313,6 +318,7 @@ void CodegenAccVisitor::print_net_send_buf_count_update_to_host() const {
 void CodegenAccVisitor::print_net_send_buf_count_update_to_device() const {
     printer->add_line("#pragma acc update device(nsb->_cnt) if (nt->compute_gpu)");
 }
+
 
 void CodegenAccVisitor::print_dt_update_to_device() const {
     printer->add_line("#pragma acc update device({}) if (nt->compute_gpu)"_format(

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -308,7 +308,7 @@ void CodegenAccVisitor::print_net_send_buf_count_update_to_host() const {
 
 void CodegenAccVisitor::print_net_send_buf_update_to_host() const {
     print_device_stream_wait();
-    printer->start_block("if (nsb) ");
+    printer->start_block("if (nsb)");
     print_net_send_buf_count_update_to_host();
     printer->add_line("update_net_send_buffer_on_host(nt, nsb);");
     printer->end_block(1);

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -303,7 +303,10 @@ void CodegenAccVisitor::print_device_stream_wait() const {
 
 void CodegenAccVisitor::print_net_send_buf_count_update_to_host() const {
     print_device_stream_wait();
+    printer->start_block("if (nsb) ");
     printer->add_line("#pragma acc update self(nsb->_cnt) if(nt->compute_gpu)");
+    printer->add_line("update_net_send_buffer_on_host(nt, nsb);");
+    printer->end_block(1);
 }
 
 

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -105,6 +105,9 @@ class CodegenAccVisitor: public CodegenCVisitor {
     // update NetSendBuffer_t count from device to host
     void print_net_send_buf_count_update_to_host() const override;
 
+    // update NetSendBuffer_t from device to host
+    void print_net_send_buf_update_to_host() const override;
+
     // update NetSendBuffer_t count from host to device
     virtual void print_net_send_buf_count_update_to_device() const override;
 

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1061,6 +1061,10 @@ void CodegenCVisitor::print_net_send_buf_count_update_to_host() const {
     // backend specific, do nothing
 }
 
+void CodegenCVisitor::print_net_send_buf_update_to_host() const {
+    // backend specific, do nothing
+}
+
 void CodegenCVisitor::print_net_send_buf_count_update_to_device() const {
     // backend specific, do nothing
 }
@@ -3836,7 +3840,7 @@ void CodegenCVisitor::print_net_init() {
             print_net_init_acc_serial_annotation_block_end();
             print_kernel_data_present_annotation_block_end();
             printer->add_line("auto nsb = ml->_net_send_buffer;");
-            print_net_send_buf_count_update_to_host();
+            print_net_send_buf_update_to_host();
         }
     }
     printer->end_block(1);
@@ -3847,8 +3851,7 @@ void CodegenCVisitor::print_net_init() {
 void CodegenCVisitor::print_send_event_move() {
     printer->add_newline();
     printer->add_line("NetSendBuffer_t* nsb = ml->_net_send_buffer;");
-    print_net_send_buf_count_update_to_host();
-    printer->add_line("update_net_send_buffer_on_host(nt, nsb);");
+    print_net_send_buf_update_to_host();
     printer->add_line("for (int i=0; i < nsb->_cnt; i++) {");
     printer->add_line("    int type = nsb->_sendtype[i];");
     printer->add_line("    int tid = nt->id;");

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3837,7 +3837,6 @@ void CodegenCVisitor::print_net_init() {
             print_kernel_data_present_annotation_block_end();
             printer->add_line("auto nsb = ml->_net_send_buffer;");
             print_net_send_buf_count_update_to_host();
-            printer->add_line("update_net_send_buffer_on_host(nt, nsb);");
         }
     }
     printer->end_block(1);

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1104,6 +1104,11 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      */
     virtual void print_net_send_buf_count_update_to_host() const;
 
+    /**
+     * Print the code to update NetSendBuffer_t from device to host
+     */
+    virtual void print_net_send_buf_update_to_host() const;
+
 
     /**
      * Print the code to update NetSendBuffer_t count from host to device


### PR DESCRIPTION
Some mod files are not setting the `NetSendBuffer_t` in the `net_init()` function so when we tried to update it to the CPU using the OpenACC backend it failed with a segfault.
With this PR the update is done only when `nsb` is not null. For example for [fi.mod](https://github.com/HumanBrainProject/olfactory-bulb-3d/blob/883cb52d958770401f2e345d3a650b67906796bf/sim/fi.mod) we had before:
```
304     /** initialize block for net receive */
305     static void net_init(Point_process* pnt, int weight_index, double flag)  {
306         int tid = pnt->_tid;
307         int id = pnt->_i_instance;
308         double v = 0;
309         NrnThread* nt = nrn_threads + tid;
310         Memb_list* ml = nt->_ml_list[pnt->_type];
311         #pragma acc data present(nt, ml, FastInhib_global) if(nt->compute_gpu)
312         {
313             int nodecount = ml->nodecount;
314             int pnodecount = ml->_nodecount_padded;
315             double* data = ml->data;
316             double* weights = nt->weights;
317             Datum* indexes = ml->pdata;
318             ThreadDatum* thread = ml->_thread;
319             FastInhib_Instance* inst = (FastInhib_Instance*) ml->instance;
320             #pragma acc serial present(inst, indexes, weights) if(nt->compute_gpu)
321             {
322
323                 double* weight = weights + weight_index + 0;
324                 double* s = weights + weight_index + 1;
325                 double* w = weights + weight_index + 2;
326                 double* tlast = weights + weight_index + 3;
327                 if ((*s) == 0.0) {
328                     (*w) = 0.0;
329                 } else {
330                     double plast_in_0;
331                     {
332                         double step_in_0;
333                         step_in_0 = (*s);
334                         plast_in_0 = pow((1.0 - 1.0 / (1.0 + exp((step_in_0 - FastInhib_global.sighalf) / FastInhib_global.sigslope))), FastInhib_global.sigexp);
335                     }
336                     (*w) = (*weight) * plast_in_0;
337                 }
338                 (*tlast) =  -1e9;
339                 }
340         }
341         auto nsb = ml->_net_send_buffer;
342         #pragma acc wait(nt->stream_id)
343         #pragma acc update self(nsb->_cnt) if(nt->compute_gpu)
344         update_net_send_buffer_on_host(nt, nsb);
345     }
```
And now
```
/** initialize block for net receive */
    static void net_init(Point_process* pnt, int weight_index, double flag)  {
        int tid = pnt->_tid;
        int id = pnt->_i_instance;
        double v = 0;
        NrnThread* nt = nrn_threads + tid;
        Memb_list* ml = nt->_ml_list[pnt->_type];
        #pragma acc data present(nt, ml, FastInhib_global) if(nt->compute_gpu)
        {
            int nodecount = ml->nodecount;
            int pnodecount = ml->_nodecount_padded;
            double* data = ml->data;
            double* weights = nt->weights;
            Datum* indexes = ml->pdata;
            ThreadDatum* thread = ml->_thread;
            FastInhib_Instance* inst = (FastInhib_Instance*) ml->instance;
            #pragma acc serial present(inst, indexes, weights) if(nt->compute_gpu)
            {

                double* weight = weights + weight_index + 0;
                double* s = weights + weight_index + 1;
                double* w = weights + weight_index + 2;
                double* tlast = weights + weight_index + 3;
                if ((*s) == 0.0) {
                    (*w) = 0.0;
                } else {
                    (*w) = (*weight) * plast_FastInhib(id, pnodecount, inst, data, indexes, thread, nt, v, (*s));
                }
                (*tlast) =  -1e9;
                }
        }
        auto nsb = ml->_net_send_buffer;
        #pragma acc wait(nt->stream_id)
        if (nsb) {
            #pragma acc update self(nsb->_cnt) if(nt->compute_gpu)
            update_net_send_buffer_on_host(nt, nsb);
        }
    }
```