### PR TITLE
Bug fix for net_init code generation on GPUs with OpenACC backend

### DIFF
--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ${{runner.workspace}}/nmodl-ccache
+            ${{runner.workspace}}/ccache
           key: ${{matrix.os}}-${{github.ref}}-${{github.sha}}
           restore-keys: |
             ${{matrix.os}}-${{github.ref}}-
@@ -104,7 +104,7 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/nmodl/build
         env:
-          CCACHE_DIR: ${{runner.workspace}}/nmodl-ccache
+          CCACHE_DIR: ${{runner.workspace}}/ccache
         run:  |
           echo "------- Building -------"
           ccache -z

--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ${{runner.workspace}}/ccache
+            ${{runner.workspace}}/nmodl-ccache
           key: ${{matrix.os}}-${{github.ref}}-${{github.sha}}
           restore-keys: |
             ${{matrix.os}}-${{github.ref}}-
@@ -104,7 +104,7 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/nmodl/build
         env:
-          CCACHE_DIR: ${{runner.workspace}}/ccache
+          CCACHE_DIR: ${{runner.workspace}}/nmodl-ccache
         run:  |
           echo "------- Building -------"
           ccache -z

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -61,6 +61,14 @@ class CodegenAccVisitor: public CodegenCVisitor {
     void print_kernel_data_present_annotation_block_end() override;
 
 
+    /// start of annotation "acc kernels" for net_init kernel
+    void print_net_init_acc_serial_annotation_block_begin() override;
+
+
+    /// end of annotation "acc kernels" for net_init kernel
+    void print_net_init_acc_serial_annotation_block_end() override;
+
+
     /// update to matrix elements with/without shadow vectors
     void print_nrn_cur_matrix_shadow_update() override;
 
@@ -96,6 +104,9 @@ class CodegenAccVisitor: public CodegenCVisitor {
 
     // update NetSendBuffer_t count from device to host
     void print_net_send_buf_count_update_to_host() const override;
+
+    // update NetSendBuffer_t from device to host
+    void print_net_send_buf_update_to_host() const override;
 
     // update NetSendBuffer_t count from host to device
     virtual void print_net_send_buf_count_update_to_device() const override;

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1104,6 +1104,11 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      */
     virtual void print_net_send_buf_count_update_to_host() const;
 
+    /**
+     * Print the code to update NetSendBuffer_t from device to host
+     */
+    virtual void print_net_send_buf_update_to_host() const;
+
 
     /**
      * Print the code to update NetSendBuffer_t count from host to device
@@ -1306,6 +1311,18 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      * Print matching block end of accelerator annotations for data presence on device
      */
     virtual void print_kernel_data_present_annotation_block_end();
+
+
+    /**
+     * Print accelerator kernels begin annotation for net_init kernel
+     */
+    virtual void print_net_init_acc_serial_annotation_block_begin();
+
+
+    /**
+     * Print accelerator kernels end annotation for net_init kernel
+     */
+    virtual void print_net_init_acc_serial_annotation_block_end();
 
 
     /**


### PR DESCRIPTION
 * net_init was being executed on CPU but it was dereferencing
   gpu pointers on CPU via instance structure
 * Currently there is no support for getting device function pointers
 * As net_init is called from cpu side, a simple approach is to launch
   serial kernel for each invocation of net_init.
 * This is bit inefficient as large number of kernels could be launched.
   But, as this happens only during initialialization, we can use this
   fix for time being.
 * Note that mod2c "get away" by launching kernels on CPU because the
   net_init kernel is just handling spike events and those are handled
   on CPU anyway.

Don't update net send buffer on host if it's null (#742)
* Fix for fi.mod and ampanmda.mod from olfactory
* Remove call to update_net_send_buffer_on_host
* Add function print_net_send_buf_update_to_host()

fixes #740

(P.S. Completely new branch to avoid a possible ccache issue in #741)