### PR TITLE
Update bison files with last updates

### DIFF
--- a/src/parser/verbatim.yy
+++ b/src/parser/verbatim.yy
@@ -26,7 +26,7 @@
 %define api.pure
 
 /** parser prefix */
-%define api.prefix {Verbatim_}
+%name-prefix "Verbatim_"
 
 /** enable location tracking */
 %locations


### PR DESCRIPTION
%pure-parser and %name-prefix are deprecated for, respectively,
%define api.pure, %define api.prefix

Partially fix #717 