### PR TITLE
Fix codegen with multiple DERIVATIVE blocks.

### DIFF
--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -264,6 +264,11 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
     std::string float_type = codegen::naming::DEFAULT_FLOAT_TYPE;
 
     /**
+     * All ast information for code generation
+     */
+    codegen::CodegenInfo info;
+
+    /**
      * Code printer object for target (C, CUDA, ispc, ...)
      */
     std::shared_ptr<CodePrinter> target_printer;
@@ -1714,11 +1719,6 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
 
 
   public:
-    /**
-     * All ast information for code generation
-     */
-    codegen::CodegenInfo info;
-
     /**
      * \brief Constructs the C code generator visitor
      *


### PR DESCRIPTION
Without this patch, and with `-DCORENRN_NMODL_FLAGS="sympy --analytic"`, NMODL translates [SH_na8st.mod](https://github.com/pramodk/reduced_dentate/blob/c09a5288ef6c7e576157a73e8d913f022683274e/mechanisms/SH_na8st.mod) to C++ code including:
```c++
        na8st_global.slist1 = (int*) mem_alloc(8, sizeof(int));
        na8st_global.dlist1 = (int*) mem_alloc(8, sizeof(int));
        na8st_global.slist1[0] = 22;
        na8st_global.dlist1[0] = 39;
        // ...
        na8st_global.slist1[6] = 28;
        na8st_global.dlist1[6] = 45;
        na8st_global.slist1[7] = 29;
        na8st_global.dlist1[7] = 46;
        na8st_global.slist1[8] = 22;
        na8st_global.dlist1[8] = 39;
        // ...
        na8st_global.slist1[15] = 29;
        na8st_global.dlist1[15] = 46;
```
The duplication seems to be because the internal AST has two `DERIVATIVE` blocks, and this is not handled correctly. 

I have not seen #736 again with this PR, so I assume this was the underlying cause.

This adds an exception that would have caught the issue earlier. It also adds a test case, but this requires several visitor passes to trigger the error and it may be a bit fragile.

Closes #736.