### PR TITLE
Replace macro name by value

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -69,13 +69,8 @@ void CodegenCVisitor::visit_integer(const Integer& node) {
     if (!codegen) {
         return;
     }
-    const auto& macro = node.get_macro();
     const auto& value = node.get_value();
-    if (macro) {
-        macro->accept(*this);
-    } else {
-        printer->add_text(std::to_string(value));
-    }
+    printer->add_text(std::to_string(value));
 }
 
 

--- a/test/integration/mod/cabpump.mod
+++ b/test/integration/mod/cabpump.mod
@@ -53,6 +53,8 @@ DERIVATIVE state {
 	if (drive_channel <= 0.) { drive_channel = 0.  }   : cannot pump inward 
         ca' = drive_channel/18 + (cainf -ca)/taur*11
 	cai = ca
+
+    if (FOO == 0) { }
 }
 
 : to test code generation for TABLE statement

--- a/test/integration/mod/cabpump.mod
+++ b/test/integration/mod/cabpump.mod
@@ -1,5 +1,7 @@
 : simple first-order model of calcium dynamics
 
+DEFINE FOO 1
+
 NEURON {
         SUFFIX cadyn
         USEION ca READ cai,ica WRITE cai 
@@ -55,7 +57,7 @@ DERIVATIVE state {
 
 : to test code generation for TABLE statement
 PROCEDURE test_table(br) {
-    TABLE ainf FROM 0 TO 1 WITH 1
+    TABLE ainf FROM 0 TO FOO WITH 1
     ainf = 1
 }
 


### PR DESCRIPTION
macro is created by DEFINE statements, and always got a direct value
DEFINE NAME_PTR INTEGER_PTR is the only accepted way