### PR TITLE
Replace placeholder arg_v with the correct name in function containin…

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1606,12 +1606,17 @@ void CodegenCVisitor::print_table_replacement_function(const ast::Block& node) {
     print_function_declaration(node, name);
     printer->start_block();
     {
-        printer->add_line("if ( {} == 0) {}"_format(use_table_var, "{"));
-        printer->add_line("    {}({}, arg_v);"_format(function_name, internal_method_arguments()));
+        const auto& params = node.get_parameters();
+        printer->add_line("if ( {} == 0) {{"_format(use_table_var));
+        printer->add_line("    {}({}, {});"_format(function_name,
+                                                   internal_method_arguments(),
+                                                   params[0].get()->get_node_name()));
         printer->add_line("     return 0;");
         printer->add_line("}");
 
-        printer->add_line("double xi = {} * (arg_v - {});"_format(mfac_name, tmin_name));
+        printer->add_line("double xi = {} * ({} - {});"_format(mfac_name,
+                                                               params[0].get()->get_node_name(),
+                                                               tmin_name));
         printer->add_line("if (isnan(xi)) {");
         for (const auto& var: table_variables) {
             auto name = get_variable_name(var->get_node_name());

--- a/test/integration/mod/cabpump.mod
+++ b/test/integration/mod/cabpump.mod
@@ -6,7 +6,7 @@ NEURON {
         RANGE ca 
         GLOBAL depth,cainf,taur
         RANGE var
-     
+        RANGE ainf
 }
 
 UNITS {
@@ -16,18 +16,6 @@ UNITS {
         (mA) = (milliamp)
 	(msM)	= (ms mM)  
         FARADAY    = (faraday) (coul)
-}
-
-CONSTRUCTOR {
-VERBATIM
-// Nothing only to verify that it is well handled
-ENDVERBATIM
-}
-
-DESTRUCTOR {
-VERBATIM
-// Nothing only to verify that it is well handled
-ENDVERBATIM
 }
 
 PARAMETER {
@@ -41,6 +29,7 @@ ASSIGNED {
 	ica		(mA/cm2)
 	drive_channel	(mM/ms)
     var     (mV)
+    ainf
 }
 
 STATE {
@@ -64,8 +53,8 @@ DERIVATIVE state {
 	cai = ca
 }
 
+: to test code generation for TABLE statement
 PROCEDURE test_table(br) {
-    LOCAL ainf
     TABLE ainf FROM 0 TO 1 WITH 1
     ainf = 1
 }

--- a/test/integration/mod/cabpump.mod
+++ b/test/integration/mod/cabpump.mod
@@ -64,6 +64,11 @@ DERIVATIVE state {
 	cai = ca
 }
 
+PROCEDURE test_table(br) {
+    TABLE ainf FROM 0 TO 1 WITH 1
+    ainf = 1
+}
+
 INITIAL {
     var_init(var)
     ca = cainf

--- a/test/integration/mod/cabpump.mod
+++ b/test/integration/mod/cabpump.mod
@@ -65,6 +65,7 @@ DERIVATIVE state {
 }
 
 PROCEDURE test_table(br) {
+    LOCAL ainf
     TABLE ainf FROM 0 TO 1 WITH 1
     ainf = 1
 }

--- a/test/integration/mod/watch_test.mod
+++ b/test/integration/mod/watch_test.mod
@@ -27,6 +27,18 @@ ASSIGNED {
   g (umho)
 }
 
+CONSTRUCTOR {
+  VERBATIM
+  // only to verify that it is well handled
+  ENDVERBATIM
+}
+
+DESTRUCTOR {
+  VERBATIM
+  // only to verify that it is well handled
+  ENDVERBATIM
+}
+
 DEFINE init 1
 DEFINE rise 2
 DEFINE fall 3


### PR DESCRIPTION
…g table stmt

Fixing:
```
PROCEDURE settables(b) {
    TABLE minf FROM 1 TO 2 WITH 1
    minf = 0
}
```

Checking that the following construct is not valid because `PROCEDURE` with `TABLE` statement should have exactly one parameter.
```
PROCEDURE settables(a, b) {
    TABLE <...>
    <...>
```