### PR TITLE
Reorganise code generation for Python bindings, improve build speed

### DIFF
--- a/src/language/code_generator.cmake
+++ b/src/language/code_generator.cmake
@@ -12,6 +12,7 @@ set(CODE_GENERATOR_JINJA_FILES
     ${PROJECT_SOURCE_DIR}/src/language/templates/ast/node_class.template
     ${PROJECT_SOURCE_DIR}/src/language/templates/pybind/pyast.cpp
     ${PROJECT_SOURCE_DIR}/src/language/templates/pybind/pyast.hpp
+    ${PROJECT_SOURCE_DIR}/src/language/templates/pybind/pynode.cpp
     ${PROJECT_SOURCE_DIR}/src/language/templates/pybind/pysymtab.cpp
     ${PROJECT_SOURCE_DIR}/src/language/templates/pybind/pyvisitor.cpp
     ${PROJECT_SOURCE_DIR}/src/language/templates/pybind/pyvisitor.hpp
@@ -195,6 +196,8 @@ set(AST_GENERATED_SOURCES
 set(PYBIND_GENERATED_SOURCES
     ${PROJECT_BINARY_DIR}/src/pybind/pyast.cpp
     ${PROJECT_BINARY_DIR}/src/pybind/pyast.hpp
+    ${PROJECT_BINARY_DIR}/src/pybind/pynode_0.cpp
+    ${PROJECT_BINARY_DIR}/src/pybind/pynode_1.cpp
     ${PROJECT_BINARY_DIR}/src/pybind/pysymtab.cpp
     ${PROJECT_BINARY_DIR}/src/pybind/pyvisitor.cpp
     ${PROJECT_BINARY_DIR}/src/pybind/pyvisitor.hpp

--- a/src/language/code_generator.cmake
+++ b/src/language/code_generator.cmake
@@ -10,7 +10,6 @@ set(CODE_GENERATOR_JINJA_FILES
     ${PROJECT_SOURCE_DIR}/src/language/templates/ast/ast_decl.hpp
     ${PROJECT_SOURCE_DIR}/src/language/templates/ast/node.hpp
     ${PROJECT_SOURCE_DIR}/src/language/templates/ast/node_class.template
-    ${PROJECT_SOURCE_DIR}/src/language/templates/ast/node_class_inline_definition.template
     ${PROJECT_SOURCE_DIR}/src/language/templates/pybind/pyast.cpp
     ${PROJECT_SOURCE_DIR}/src/language/templates/pybind/pyast.hpp
     ${PROJECT_SOURCE_DIR}/src/language/templates/pybind/pysymtab.cpp

--- a/src/language/code_generator.py
+++ b/src/language/code_generator.py
@@ -158,19 +158,19 @@ class CodeGenerator(
         # special template only included by other templates
         node_class_tpl = self.jinja_templates_dir / "ast" / "node_class.template"
         # Additional dependencies Path -> [Path, ...]
-        extradeps = collections.defaultdict(
-            list,
-            {
-                node_hpp_tpl: [node_class_tpl],
-            },
-        )
+        extradeps = collections.defaultdict(list, {node_hpp_tpl: [node_class_tpl]})
         # Additional Jinja context set when rendering the template
         num_pybind_files = 2
         extracontext = collections.defaultdict(
             dict,
             {
-                pyast_cpp_tpl: {'setup_pybind_methods': ['init_pybind_classes_{}'.format(x) for x in range(num_pybind_files)]}
-            }
+                pyast_cpp_tpl: {
+                    "setup_pybind_methods": [
+                        "init_pybind_classes_{}".format(x)
+                        for x in range(num_pybind_files)
+                    ]
+                }
+            },
         )
 
         tasks = []
@@ -199,7 +199,12 @@ class CodeGenerator(
                             app=self,
                             input=filepath,
                             output=self.base_dir / sub_dir / "pynode_{}.cpp".format(n),
-                            context=dict(nodes=self.nodes[n*chunk_length:(n+1)*chunk_length], setup_pybind_method='init_pybind_classes_{}'.format(n)),
+                            context=dict(
+                                nodes=self.nodes[
+                                    n * chunk_length : (n + 1) * chunk_length
+                                ],
+                                setup_pybind_method="init_pybind_classes_{}".format(n),
+                            ),
                             extradeps=extradeps[filepath],
                         )
                         tasks.append(task)

--- a/src/language/code_generator.py
+++ b/src/language/code_generator.py
@@ -10,6 +10,7 @@ import collections
 import filecmp
 import itertools
 import logging
+import math
 import os
 from pathlib import Path, PurePath
 import shutil
@@ -192,12 +193,13 @@ class CodeGenerator(
                         tasks.append(task)
                         yield task
                 elif filepath == pynode_cpp_tpl:
+                    chunk_length = math.ceil(len(self.nodes) / num_pybind_files)
                     for n in range(num_pybind_files):
                         task = JinjaTask(
                             app=self,
                             input=filepath,
                             output=self.base_dir / sub_dir / "pynode_{}.cpp".format(n),
-                            context=dict(nodes=[node for i, node in enumerate(self.nodes) if i%num_pybind_files == n], setup_pybind_method='init_pybind_classes_{}'.format(n)),
+                            context=dict(nodes=self.nodes[n*chunk_length:(n+1)*chunk_length], setup_pybind_method='init_pybind_classes_{}'.format(n)),
                             extradeps=extradeps[filepath],
                         )
                         tasks.append(task)

--- a/src/language/code_generator.py
+++ b/src/language/code_generator.py
@@ -194,16 +194,16 @@ class CodeGenerator(
                         yield task
                 elif filepath == pynode_cpp_tpl:
                     chunk_length = math.ceil(len(self.nodes) / num_pybind_files)
-                    for n in range(num_pybind_files):
+                    for chunk_k in range(num_pybind_files):
                         task = JinjaTask(
                             app=self,
                             input=filepath,
-                            output=self.base_dir / sub_dir / "pynode_{}.cpp".format(n),
+                            output=self.base_dir / sub_dir / "pynode_{}.cpp".format(chunk_k),
                             context=dict(
                                 nodes=self.nodes[
-                                    n * chunk_length : (n + 1) * chunk_length
+                                    chunk_k * chunk_length : (chunk_k + 1) * chunk_length
                                 ],
-                                setup_pybind_method="init_pybind_classes_{}".format(n),
+                                setup_pybind_method="init_pybind_classes_{}".format(chunk_k),
                             ),
                             extradeps=extradeps[filepath],
                         )

--- a/src/language/nodes.py
+++ b/src/language/nodes.py
@@ -1,5 +1,5 @@
 # ***********************************************************************
-# Copyright (C) 2018-2019 Blue Brain Project
+# Copyright (C) 2018-2021 Blue Brain Project
 #
 # This file is part of NMODL distributed under the terms of the GNU
 # Lesser General Public License. See top-level LICENSE file for details.
@@ -44,17 +44,6 @@ class BaseNode:
     def cpp_header(self):
         """Path to C++ header file of this class relative to BUILD_DIR"""
         return "ast/" + to_snake_case(self.class_name) + ".hpp"
-
-    @property
-    def cpp_fence(self):
-        """Preprocessor macro to use to prevent symbol redefinition
-
-            #ifndef {{ node.cpp_fence }}
-            #define {{ node.cpp_fence }}
-            // ...
-            # endif
-        """
-        return "NMODL_AST_" + to_snake_case(self.class_name).upper() + '_HPP'
 
     @property
     def is_statement_block_node(self):

--- a/src/language/templates/ast/all.hpp
+++ b/src/language/templates/ast/all.hpp
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 2018-2019 Blue Brain Project
+ * Copyright (C) 2018-2021 Blue Brain Project
  *
  * This file is part of NMODL distributed under the terms of the GNU
  * Lesser General Public License. See top-level LICENSE file for details.
@@ -22,25 +22,5 @@
 #include "ast/ast.hpp"
 
 {% for node in nodes %}
-#ifndef {{ node.cpp_fence }}
-#define {{ node.cpp_fence }}
-{% if node.has_template_methods %}
-#define {{ node.cpp_fence }}_INLINE_DEFINITION_REQUIRED
-{% endif %}
-{% include "ast/node_class.template" %}
-#endif // !{{ node.cpp_fence }}
+#include "{{node.cpp_header}}"
 {% endfor %}
-
-{# add inline definitions of template member methods #}
-namespace nmodl {
-namespace ast {
-{% for node in nodes %}
-{%- if node.has_template_methods %}
-#ifdef {{ node.cpp_fence }}_INLINE_DEFINITION_REQUIRED
-  {% include "ast/node_class_inline_definition.template" %}
-#endif  // !{{ node.cpp_fence }}_INLINE_DEFINITION_REQUIRED
-
-{% endif %}
-{%- endfor %}
-}  // namespace ast
-}  // namespace nmodl

--- a/src/language/templates/ast/node.hpp
+++ b/src/language/templates/ast/node.hpp
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 2018-2020 Blue Brain Project
+ * Copyright (C) 2018-2021 Blue Brain Project
  *
  * This file is part of NMODL distributed under the terms of the GNU
  * Lesser General Public License. See top-level LICENSE file for details.
@@ -10,9 +10,6 @@
 ///
 
 #pragma once
-
-#ifndef {{ node.cpp_fence }}
-# define {{ node.cpp_fence }}
 
 /**
  * \dir
@@ -28,6 +25,3 @@
 {% endfor %}
 
 {% include "ast/node_class.template" %}
-
-#endif  // {{ node.cpp_fence }}
-

--- a/src/language/templates/ast/node_class.template
+++ b/src/language/templates/ast/node_class.template
@@ -401,9 +401,9 @@ class {{ node.class_name }} : public {{ node.base_class }} {
 
 /** @} */  // end of ast_class
 
-{% if render_ast_all is not defined %}
-{% include "ast/node_class_inline_definition.template" %}
-{% endif %}
+{% for child in node.children %}
+  {{ child.get_add_methods_inline_definition(node) }}
+{% endfor %}
 
 }  // namespace ast
 }  // namespace nmodl

--- a/src/language/templates/ast/node_class_inline_definition.template
+++ b/src/language/templates/ast/node_class_inline_definition.template
@@ -1,8 +1,0 @@
-{#
-   this Jinja template is not used to directly generate
-   a file but included by other templates.
-#}
-{# doxygen for these methods is handled by nodes.py #}
-{% for child in node.children %}
-  {{ child.get_add_methods_inline_definition(node) }}
-{% endfor %}

--- a/src/language/templates/pybind/pyast.cpp
+++ b/src/language/templates/pybind/pyast.cpp
@@ -9,8 +9,8 @@
 /// THIS FILE IS GENERATED AT BUILD TIME AND SHALL NOT BE EDITED.
 ///
 
-#include "pybind/docstrings.hpp"
 #include "pybind/pyast.hpp"
+#include "pybind/docstrings.hpp"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -29,9 +29,9 @@ namespace pybind {
 {% for setup_pybind_method in setup_pybind_methods %}
 void {{setup_pybind_method}}(pybind11::module&);
 {% endfor %}
-}
-}
-}
+}  // namespace pybind
+}  // namespace ast
+}  // namespace nmodl
 
 namespace py = pybind11;
 using namespace nmodl::ast;
@@ -41,7 +41,7 @@ using namespace pybind11::literals;
 void init_ast_module(py::module& m) {
     py::module m_ast = m.def_submodule("ast", "Abstract Syntax Tree (AST) related implementations");
 
-    py::enum_<BinaryOp>(m_ast, "BinaryOp", docstring::binary_op_enum)
+    py::enum_<BinaryOp>(m_ast, "BinaryOp", docstring::binary_op_enum())
         .value("BOP_ADDITION", BinaryOp::BOP_ADDITION)
         .value("BOP_SUBTRACTION", BinaryOp::BOP_SUBTRACTION)
         .value("BOP_MULTIPLICATION", BinaryOp::BOP_MULTIPLICATION)
@@ -58,7 +58,7 @@ void init_ast_module(py::module& m) {
         .value("BOP_EXACT_EQUAL", BinaryOp::BOP_EXACT_EQUAL)
         .export_values();
 
-    py::enum_<AstNodeType>(m_ast, "AstNodeType", docstring::ast_nodetype_enum)
+    py::enum_<AstNodeType>(m_ast, "AstNodeType", docstring::ast_nodetype_enum())
     // clang-format off
     {% for node in nodes %}
             .value("{{ node.class_name|snake_case|upper }}", AstNodeType::{{ node.class_name|snake_case|upper }}, "AST node of type ast.{{ node.class_name}}")
@@ -66,27 +66,36 @@ void init_ast_module(py::module& m) {
             .export_values();
     // clang-format on
 
-    py::class_<Ast, PyAst, std::shared_ptr<Ast>> ast_(m_ast, "Ast", docstring::ast_class);
+    py::class_<Ast, PyAst, std::shared_ptr<Ast>> ast_(m_ast, "Ast", docstring::ast_class());
     ast_.def(py::init<>())
-        .def("visit_children", static_cast<void (Ast::*)(visitor::Visitor&)>(&Ast::visit_children), "v"_a, docstring::visit_children_method)
-        .def("accept", static_cast<void (Ast::*)(visitor::Visitor&)>(&Ast::accept), "v"_a, docstring::accept_method)
-        .def("accept", static_cast<void (Ast::*)(visitor::ConstVisitor&) const>(&Ast::accept), "v"_a, docstring::accept_method)
-        .def("get_node_type", &Ast::get_node_type, docstring::get_node_type_method)
-        .def("get_node_type_name", &Ast::get_node_type_name, docstring::get_node_type_name_method)
-        .def("get_node_name", &Ast::get_node_name, docstring::get_node_name_method)
-        .def("get_nmodl_name", &Ast::get_nmodl_name, docstring::get_nmodl_name_method)
-        .def("get_token", &Ast::get_token, docstring::get_token_method)
+        .def("visit_children",
+             static_cast<void (Ast::*)(visitor::Visitor&)>(&Ast::visit_children),
+             "v"_a,
+             docstring::visit_children_method())
+        .def("accept",
+             static_cast<void (Ast::*)(visitor::Visitor&)>(&Ast::accept),
+             "v"_a,
+             docstring::accept_method())
+        .def("accept",
+             static_cast<void (Ast::*)(visitor::ConstVisitor&) const>(&Ast::accept),
+             "v"_a,
+             docstring::accept_method())
+        .def("get_node_type", &Ast::get_node_type, docstring::get_node_type_method())
+        .def("get_node_type_name", &Ast::get_node_type_name, docstring::get_node_type_name_method())
+        .def("get_node_name", &Ast::get_node_name, docstring::get_node_name_method())
+        .def("get_nmodl_name", &Ast::get_nmodl_name, docstring::get_nmodl_name_method())
+        .def("get_token", &Ast::get_token, docstring::get_token_method())
         .def("get_symbol_table",
              &Ast::get_symbol_table,
              py::return_value_policy::reference,
-             docstring::get_symbol_table_method)
+             docstring::get_symbol_table_method())
         .def("get_statement_block",
              &Ast::get_statement_block,
-             docstring::get_statement_block_method)
-        .def("clone", &Ast::clone, docstring::clone_method)
-        .def("negate", &Ast::negate, docstring::negate_method)
-        .def("set_name", &Ast::set_name, docstring::set_name_method)
-        .def("is_ast", &Ast::is_ast, docstring::is_ast_method)
+             docstring::get_statement_block_method())
+        .def("clone", &Ast::clone, docstring::clone_method())
+        .def("negate", &Ast::negate, docstring::negate_method())
+        .def("set_name", &Ast::set_name, docstring::set_name_method())
+        .def("is_ast", &Ast::is_ast, docstring::is_ast_method())
     // clang-format off
     {% for node in nodes %}
     .def("is_{{ node.class_name | snake_case }}", &Ast::is_{{ node.class_name | snake_case }}, "Check if node is of type ast.{{ node.class_name}}")

--- a/src/language/templates/pybind/pyast.cpp
+++ b/src/language/templates/pybind/pyast.cpp
@@ -28,12 +28,8 @@
 
 
 // clang-format off
-{% macro var(node) -%}
-{{ node.class_name | snake_case }}_
-{%- endmacro -%}
-
 {% macro args(children) %}
-{% for c in children %} {{ c.get_shared_typename() }} {%- if not loop.last %}, {% endif %} {% endfor %}
+{% for c in children %}{{ c.get_shared_typename() }}{%- if not loop.last %}, {% endif %}{% endfor %}
 {%- endmacro -%}
 // clang-format on
 
@@ -227,65 +223,62 @@ void init_ast_module(py::module& m) {
     {% endfor %}
 
     {% for node in nodes %}
-    py::class_<{{ node.class_name }}, std::shared_ptr<{{ node.class_name }}>> {{ var(node) }}(m_ast, "{{ node.class_name }}", {{ node.base_class | snake_case }}_);
-    {{ var(node) }}.doc() = "{{ node.brief }}";
-    {% if node.children %}
-    {{ var(node) }}.def(py::init<{{ args(node.children) }}>());
-    {% endif %}
-    {% if node.is_program_node or node.is_ptr_excluded_node %}
-    {{ var(node) }}.def(py::init<>());
-    {% endif %}
-    // clang-format on
+    {
+        py::class_<{{ node.class_name }}, {{node.base_class}}, std::shared_ptr<{{ node.class_name }}>> tmp{m_ast, "{{ node.class_name }}"};
+        tmp.doc() = "{{ node.brief }}";
+        {% if node.children %}
+        tmp.def(py::init<{{ args(node.children) }}>());
+        {% endif %}
+        {% if node.is_program_node or node.is_ptr_excluded_node %}
+        tmp.def(py::init<>());
+        {% endif %}
+        // clang-format on
 
-    {{var(node)}}
-        .def("__repr__", []({{node.class_name}} & n) {
-            std::stringstream ss;
-            JSONVisitor v(ss);
-            v.compact_json(true);
-            n.accept(v);
-            v.flush();
-            return ss.str();
-        });
+        tmp.def("__repr__", []({{node.class_name}} & n) {
+                std::stringstream ss;
+                JSONVisitor v(ss);
+                v.compact_json(true);
+                n.accept(v);
+                v.flush();
+                return ss.str();
+            });
+        tmp.def("__str__", []({{node.class_name}} & n) {
+                std::stringstream ss;
+                NmodlPrintVisitor v(ss);
+                n.accept(v);
+                return ss.str();
+            });
 
-    {{var(node)}}
-        .def("__str__", []({{node.class_name}} & n) {
-            std::stringstream ss;
-            NmodlPrintVisitor v(ss);
-            n.accept(v);
-            return ss.str();
-        });
+        // clang-format off
+        {% for member in node.public_members() %}
+        tmp.def_readwrite("{{ member[1] }}", &{{ node.class_name }}::{{ member[1] }});
+        {% endfor %}
 
-    // clang-format off
-    {% for member in node.public_members() %}
-    {{ var(node) }}.def_readwrite("{{ member[1] }}", &{{ node.class_name }}::{{ member[1] }});
+        {% for member in node.properties() %}
+        {% if member[2] == True %}
+        tmp.def_property("{{ member[1] }}", &{{ node.class_name }}::get_{{ member[1] }}, &{{ node.class_name }}::set_{{ member[1] }});
+        {% else %}
+        tmp.def_property("{{ member[1] }}", &{{ node.class_name }}::get_{{ member[1] }}, static_cast<void ({{ node.class_name }}::*)(const {{ member[0] }}&)>(&{{ node.class_name }}::set_{{ member[1] }}));
+        {% endif %}
+        {% endfor %}
+
+        tmp.def("visit_children", static_cast<void ({{ node.class_name }}::*)(visitor::Visitor&)>(&{{ node.class_name }}::visit_children), docstring::visit_children_method)
+           .def("accept", static_cast<void ({{ node.class_name }}::*)(visitor::Visitor&)>(&{{ node.class_name }}::accept), docstring::accept_method)
+           .def("accept", static_cast<void ({{ node.class_name }}::*)(visitor::ConstVisitor&) const>(&{{ node.class_name }}::accept), docstring::accept_method)
+           .def("clone", &{{ node.class_name }}::clone, docstring::clone_method)
+           .def("get_node_type", &{{ node.class_name }}::get_node_type, docstring::get_node_type_method)
+           .def("get_node_type_name", &{{ node.class_name }}::get_node_type_name, docstring::get_node_type_name_method)
+        {% if node.nmodl_name %}
+           .def("get_nmodl_name", &{{ node.class_name }}::get_nmodl_name, docstring::get_nmodl_name_method)
+        {% endif %}
+        {% if node.is_data_type_node %}
+           .def("eval", &{{ node.class_name }}::eval, docstring::eval_method)
+        {% endif %}
+           .def("is_{{ node.class_name | snake_case }}", &{{ node.class_name }}::is_{{ node.class_name | snake_case }}, "Check if node is of type ast.{{ node.class_name}}");
+
+        // clang-format on
+    }
     {% endfor %}
-
-    {% for member in node.properties() %}
-    {% if member[2] == True %}
-        {{ var(node) }}.def_property("{{ member[1] }}", &{{ node.class_name }}::get_{{ member[1] }},
-            &{{ node.class_name }}::set_{{ member[1] }});
-    {% else %}
-        {{ var(node) }}.def_property("{{ member[1] }}", &{{ node.class_name }}::get_{{ member[1] }},
-                static_cast<void ({{ node.class_name }}::*)(const {{ member[0] }}&)>(&{{ node.class_name }}::set_{{ member[1] }}));
-    {% endif %}
-    {% endfor %}
-
-    {{ var(node) }}.def("visit_children", static_cast<void ({{ node.class_name }}::*)(visitor::Visitor&)>(&{{ node.class_name }}::visit_children), docstring::visit_children_method)
-    .def("accept", static_cast<void ({{ node.class_name }}::*)(visitor::Visitor&)>(&{{ node.class_name }}::accept), docstring::accept_method)
-    .def("accept", static_cast<void ({{ node.class_name }}::*)(visitor::ConstVisitor&) const>(&{{ node.class_name }}::accept), docstring::accept_method)
-    .def("clone", &{{ node.class_name }}::clone, docstring::clone_method)
-    .def("get_node_type", &{{ node.class_name }}::get_node_type, docstring::get_node_type_method)
-    .def("get_node_type_name", &{{ node.class_name }}::get_node_type_name, docstring::get_node_type_name_method)
-    {% if node.nmodl_name %}
-    .def("get_nmodl_name", &{{ node.class_name }}::get_nmodl_name, docstring::get_nmodl_name_method)
-    {% endif %}
-    {% if node.is_data_type_node %}
-    .def("eval", &{{ node.class_name }}::eval, docstring::eval_method)
-    {% endif %}
-    .def("is_{{ node.class_name | snake_case }}", &{{ node.class_name }}::is_{{ node.class_name | snake_case }}, "Check if node is of type ast.{{ node.class_name}}");
-
-    {% endfor %}
-    // clang-format on
 }
 
 #pragma clang diagnostic pop

--- a/src/language/templates/pybind/pynode.cpp
+++ b/src/language/templates/pybind/pynode.cpp
@@ -1,0 +1,89 @@
+/*************************************************************************
+ * Copyright (C) 2018-2021 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+///
+/// THIS FILE IS GENERATED AT BUILD TIME AND SHALL NOT BE EDITED.
+///
+#include "ast/all.hpp"
+#include "pybind/docstrings.hpp"
+#include "visitors/json_visitor.hpp"
+#include "visitors/nmodl_visitor.hpp"
+
+#include <pybind11/pybind11.h>
+
+// clang-format off
+{% macro args(children) %}
+{% for c in children %}{{ c.get_shared_typename() }}{%- if not loop.last %}, {% endif %}{% endfor %}
+{%- endmacro -%}
+// clang-format on
+
+namespace nmodl {
+namespace ast {
+namespace pybind {
+
+void {{setup_pybind_method}}(pybind11::module& m_ast) {
+    {% for node in nodes %}
+    {
+        pybind11::class_<{{ node.class_name }}, {{node.base_class}}, std::shared_ptr<{{ node.class_name }}>> tmp{m_ast, "{{ node.class_name }}"};
+        tmp.doc() = "{{ node.brief }}";
+        {% if node.children %}
+        tmp.def(pybind11::init<{{ args(node.children) }}>());
+        {% endif %}
+        {% if node.is_program_node or node.is_ptr_excluded_node %}
+        tmp.def(pybind11::init<>());
+        {% endif %}
+        // clang-format on
+
+        tmp.def("__repr__", []({{node.class_name}} & n) {
+                std::stringstream ss;
+                nmodl::visitor::JSONVisitor v(ss);
+                v.compact_json(true);
+                n.accept(v);
+                v.flush();
+                return ss.str();
+            });
+        tmp.def("__str__", []({{node.class_name}} & n) {
+                std::stringstream ss;
+                nmodl::visitor::NmodlPrintVisitor v(ss);
+                n.accept(v);
+                return ss.str();
+            });
+
+        // clang-format off
+        {% for member in node.public_members() %}
+        tmp.def_readwrite("{{ member[1] }}", &{{ node.class_name }}::{{ member[1] }});
+        {% endfor %}
+
+        {% for member in node.properties() %}
+        {% if member[2] == True %}
+        tmp.def_property("{{ member[1] }}", &{{ node.class_name }}::get_{{ member[1] }}, &{{ node.class_name }}::set_{{ member[1] }});
+        {% else %}
+        tmp.def_property("{{ member[1] }}", &{{ node.class_name }}::get_{{ member[1] }}, static_cast<void ({{ node.class_name }}::*)(const {{ member[0] }}&)>(&{{ node.class_name }}::set_{{ member[1] }}));
+        {% endif %}
+        {% endfor %}
+
+        tmp.def("visit_children", static_cast<void ({{ node.class_name }}::*)(visitor::Visitor&)>(&{{ node.class_name }}::visit_children), docstring::visit_children_method)
+           .def("accept", static_cast<void ({{ node.class_name }}::*)(visitor::Visitor&)>(&{{ node.class_name }}::accept), docstring::accept_method)
+           .def("accept", static_cast<void ({{ node.class_name }}::*)(visitor::ConstVisitor&) const>(&{{ node.class_name }}::accept), docstring::accept_method)
+           .def("clone", &{{ node.class_name }}::clone, docstring::clone_method)
+           .def("get_node_type", &{{ node.class_name }}::get_node_type, docstring::get_node_type_method)
+           .def("get_node_type_name", &{{ node.class_name }}::get_node_type_name, docstring::get_node_type_name_method)
+        {% if node.nmodl_name %}
+           .def("get_nmodl_name", &{{ node.class_name }}::get_nmodl_name, docstring::get_nmodl_name_method)
+        {% endif %}
+        {% if node.is_data_type_node %}
+           .def("eval", &{{ node.class_name }}::eval, docstring::eval_method)
+        {% endif %}
+           .def("is_{{ node.class_name | snake_case }}", &{{ node.class_name }}::is_{{ node.class_name | snake_case }}, "Check if node is of type ast.{{ node.class_name}}");
+
+        // clang-format on
+    }
+    {% endfor %}
+}
+}
+}
+}

--- a/src/language/templates/pybind/pynode.cpp
+++ b/src/language/templates/pybind/pynode.cpp
@@ -14,6 +14,7 @@
 #include "visitors/nmodl_visitor.hpp"
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 // clang-format off
 {% macro args(children) %}

--- a/src/language/templates/pybind/pynode.cpp
+++ b/src/language/templates/pybind/pynode.cpp
@@ -37,22 +37,21 @@ void {{setup_pybind_method}}(pybind11::module& m_ast) {
         {% if node.is_program_node or node.is_ptr_excluded_node %}
         tmp.def(pybind11::init<>());
         {% endif %}
-        // clang-format on
 
         tmp.def("__repr__", []({{node.class_name}} & n) {
-                std::stringstream ss;
-                nmodl::visitor::JSONVisitor v(ss);
-                v.compact_json(true);
-                n.accept(v);
-                v.flush();
-                return ss.str();
-            });
+            std::stringstream ss;
+            nmodl::visitor::JSONVisitor v(ss);
+            v.compact_json(true);
+            n.accept(v);
+            v.flush();
+            return ss.str();
+        });
         tmp.def("__str__", []({{node.class_name}} & n) {
-                std::stringstream ss;
-                nmodl::visitor::NmodlPrintVisitor v(ss);
-                n.accept(v);
-                return ss.str();
-            });
+            std::stringstream ss;
+            nmodl::visitor::NmodlPrintVisitor v(ss);
+            n.accept(v);
+            return ss.str();
+        });
 
         // clang-format off
         {% for member in node.public_members() %}
@@ -67,17 +66,17 @@ void {{setup_pybind_method}}(pybind11::module& m_ast) {
         {% endif %}
         {% endfor %}
 
-        tmp.def("visit_children", static_cast<void ({{ node.class_name }}::*)(visitor::Visitor&)>(&{{ node.class_name }}::visit_children), docstring::visit_children_method)
-           .def("accept", static_cast<void ({{ node.class_name }}::*)(visitor::Visitor&)>(&{{ node.class_name }}::accept), docstring::accept_method)
-           .def("accept", static_cast<void ({{ node.class_name }}::*)(visitor::ConstVisitor&) const>(&{{ node.class_name }}::accept), docstring::accept_method)
-           .def("clone", &{{ node.class_name }}::clone, docstring::clone_method)
-           .def("get_node_type", &{{ node.class_name }}::get_node_type, docstring::get_node_type_method)
-           .def("get_node_type_name", &{{ node.class_name }}::get_node_type_name, docstring::get_node_type_name_method)
+        tmp.def("visit_children", static_cast<void ({{ node.class_name }}::*)(visitor::Visitor&)>(&{{ node.class_name }}::visit_children), docstring::visit_children_method())
+           .def("accept", static_cast<void ({{ node.class_name }}::*)(visitor::Visitor&)>(&{{ node.class_name }}::accept), docstring::accept_method())
+           .def("accept", static_cast<void ({{ node.class_name }}::*)(visitor::ConstVisitor&) const>(&{{ node.class_name }}::accept), docstring::accept_method())
+           .def("clone", &{{ node.class_name }}::clone, docstring::clone_method())
+           .def("get_node_type", &{{ node.class_name }}::get_node_type, docstring::get_node_type_method())
+           .def("get_node_type_name", &{{ node.class_name }}::get_node_type_name, docstring::get_node_type_name_method())
         {% if node.nmodl_name %}
-           .def("get_nmodl_name", &{{ node.class_name }}::get_nmodl_name, docstring::get_nmodl_name_method)
+           .def("get_nmodl_name", &{{ node.class_name }}::get_nmodl_name, docstring::get_nmodl_name_method())
         {% endif %}
         {% if node.is_data_type_node %}
-           .def("eval", &{{ node.class_name }}::eval, docstring::eval_method)
+           .def("eval", &{{ node.class_name }}::eval, docstring::eval_method())
         {% endif %}
            .def("is_{{ node.class_name | snake_case }}", &{{ node.class_name }}::is_{{ node.class_name | snake_case }}, "Check if node is of type ast.{{ node.class_name}}");
 
@@ -85,6 +84,6 @@ void {{setup_pybind_method}}(pybind11::module& m_ast) {
     }
     {% endfor %}
 }
-}
-}
-}
+}  // namespace pybind
+}  // namespace ast
+}  // namespace nmodl

--- a/src/pybind/docstrings.hpp
+++ b/src/pybind/docstrings.hpp
@@ -1,0 +1,133 @@
+/*************************************************************************
+ * Copyright (C) 2018-2021 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+#pragma once
+
+namespace nmodl {
+namespace docstring {
+
+static const char* binary_op_enum = R"(
+    Enum type for binary operators in NMODL
+
+    NMODL support different binary operators and this
+    type is used to store their value in the AST. See
+    nmodl::ast::Ast for details.
+)";
+
+static const char* ast_nodetype_enum = R"(
+    Enum type for every AST node type
+
+    Every node in the ast has associated type represented by
+    this enum class. See nmodl::ast::AstNodeType for details.
+
+)";
+
+static const char* ast_class = R"(
+    Base class for all Abstract Syntax Tree node types
+
+    Every node in the Abstract Syntax Tree is inherited from base class
+    Ast. This class provides base properties and functions that are implemented
+    by base classes.
+)";
+
+static const char* accept_method = R"(
+    Accept (or visit) the current AST node using current visitor
+
+    Instead of visiting children of AST node, like Ast::visit_children,
+    accept allows to visit the current node itself using the concrete
+    visitor provided.
+
+    Args:
+        v (Visitor):  Concrete visitor that will be used to recursively visit node
+)";
+
+static const char* visit_children_method = R"(
+    Visit children i.e. member of current AST node using provided visitor
+
+    Different nodes in the AST have different members (i.e. children). This method
+    recursively visits children using provided concrete visitor.
+
+    Args:
+        v (Visitor):  Concrete visitor that will be used to recursively visit node
+)";
+
+static const char* get_node_type_method = R"(
+    Return type (ast.AstNodeType) of the ast node
+)";
+
+static const char* get_node_type_name_method = R"(
+    Return type (ast.AstNodeType) of the ast node as string
+)";
+
+static const char* get_node_name_method = R"(
+    Return name of the node
+
+    Some ast nodes have a member designated as node name. For example,
+    in case of ast.FunctionCall, name of the function is returned as a node
+    name. Note that this is different from ast node type name and not every
+    ast node has name.
+)";
+
+static const char* get_nmodl_name_method = R"(
+    Return nmodl statement of the node
+
+    Some ast nodes have a member designated as nmodl name. For example,
+    in case of "NEURON { }" the statement of NMODL which is stored as nmodl
+    name is "NEURON". This function is only implemented by node types that
+    have a nmodl statement.
+)";
+
+
+static const char* clone_method = R"(
+    Create a copy of the AST node
+)";
+
+static const char* get_token_method = R"(
+    Return associated token for the AST node
+)";
+
+static const char* get_symbol_table_method = R"(
+    Return associated symbol table for the AST node
+
+    Certain ast nodes (e.g. inherited from ast.Block) have associated
+    symbol table. These nodes have nmodl.symtab.SymbolTable as member
+    and it can be accessed using this method.
+)";
+
+static const char* get_statement_block_method = R"(
+    Return associated statement block for the AST node
+
+    Top level block nodes encloses all statements in the ast::StatementBlock.
+    For example, ast.BreakpointBlock has all statements in curly brace (`{ }`)
+    stored in ast.StatementBlock :
+
+    BREAKPOINT {
+        SOLVE states METHOD cnexp
+        gNaTs2_t = gNaTs2_tbar*m*m*m*h
+        ina = gNaTs2_t*(v-ena)
+    }
+
+    This method return enclosing statement block.
+)";
+
+static const char* negate_method = R"(
+    Negate the value of AST node
+)";
+
+static const char* set_name_method = R"(
+    Set name for the AST node
+)";
+
+static const char* is_ast_method = R"(
+    Check if current node is of type ast.Ast
+)";
+
+static const char* eval_method = R"(
+    Return value of the ast node
+)";
+
+}  // namespace docstring
+}  // namespace nmodl

--- a/src/pybind/docstrings.hpp
+++ b/src/pybind/docstrings.hpp
@@ -9,31 +9,38 @@
 namespace nmodl {
 namespace docstring {
 
-static const char* binary_op_enum = R"(
+constexpr const char* binary_op_enum() {
+    return R"(
     Enum type for binary operators in NMODL
 
     NMODL support different binary operators and this
     type is used to store their value in the AST. See
     nmodl::ast::Ast for details.
 )";
+}
 
-static const char* ast_nodetype_enum = R"(
+constexpr const char* ast_nodetype_enum() {
+    return R"(
     Enum type for every AST node type
 
     Every node in the ast has associated type represented by
     this enum class. See nmodl::ast::AstNodeType for details.
 
 )";
+}
 
-static const char* ast_class = R"(
+constexpr const char* ast_class() {
+    return R"(
     Base class for all Abstract Syntax Tree node types
 
     Every node in the Abstract Syntax Tree is inherited from base class
     Ast. This class provides base properties and functions that are implemented
     by base classes.
 )";
+}
 
-static const char* accept_method = R"(
+constexpr const char* accept_method() {
+    return R"(
     Accept (or visit) the current AST node using current visitor
 
     Instead of visiting children of AST node, like Ast::visit_children,
@@ -43,8 +50,10 @@ static const char* accept_method = R"(
     Args:
         v (Visitor):  Concrete visitor that will be used to recursively visit node
 )";
+}
 
-static const char* visit_children_method = R"(
+constexpr const char* visit_children_method() {
+    return R"(
     Visit children i.e. member of current AST node using provided visitor
 
     Different nodes in the AST have different members (i.e. children). This method
@@ -53,16 +62,22 @@ static const char* visit_children_method = R"(
     Args:
         v (Visitor):  Concrete visitor that will be used to recursively visit node
 )";
+}
 
-static const char* get_node_type_method = R"(
+constexpr const char* get_node_type_method() {
+    return R"(
     Return type (ast.AstNodeType) of the ast node
 )";
+}
 
-static const char* get_node_type_name_method = R"(
+constexpr const char* get_node_type_name_method() {
+    return R"(
     Return type (ast.AstNodeType) of the ast node as string
 )";
+}
 
-static const char* get_node_name_method = R"(
+constexpr const char* get_node_name_method() {
+    return R"(
     Return name of the node
 
     Some ast nodes have a member designated as node name. For example,
@@ -70,8 +85,10 @@ static const char* get_node_name_method = R"(
     name. Note that this is different from ast node type name and not every
     ast node has name.
 )";
+}
 
-static const char* get_nmodl_name_method = R"(
+constexpr const char* get_nmodl_name_method() {
+    return R"(
     Return nmodl statement of the node
 
     Some ast nodes have a member designated as nmodl name. For example,
@@ -79,25 +96,33 @@ static const char* get_nmodl_name_method = R"(
     name is "NEURON". This function is only implemented by node types that
     have a nmodl statement.
 )";
+}
 
 
-static const char* clone_method = R"(
+constexpr const char* clone_method() {
+    return R"(
     Create a copy of the AST node
 )";
+}
 
-static const char* get_token_method = R"(
+constexpr const char* get_token_method() {
+    return R"(
     Return associated token for the AST node
 )";
+}
 
-static const char* get_symbol_table_method = R"(
+constexpr const char* get_symbol_table_method() {
+    return R"(
     Return associated symbol table for the AST node
 
     Certain ast nodes (e.g. inherited from ast.Block) have associated
     symbol table. These nodes have nmodl.symtab.SymbolTable as member
     and it can be accessed using this method.
 )";
+}
 
-static const char* get_statement_block_method = R"(
+constexpr const char* get_statement_block_method() {
+    return R"(
     Return associated statement block for the AST node
 
     Top level block nodes encloses all statements in the ast::StatementBlock.
@@ -112,22 +137,31 @@ static const char* get_statement_block_method = R"(
 
     This method return enclosing statement block.
 )";
+}
 
-static const char* negate_method = R"(
+constexpr const char* negate_method() {
+    return R"(
     Negate the value of AST node
 )";
+}
 
-static const char* set_name_method = R"(
+constexpr const char* set_name_method() {
+    return R"(
     Set name for the AST node
 )";
+}
 
-static const char* is_ast_method = R"(
+constexpr const char* is_ast_method() {
+    return R"(
     Check if current node is of type ast.Ast
 )";
+}
 
-static const char* eval_method = R"(
+constexpr const char* eval_method() {
+    return R"(
     Return value of the ast node
 )";
+}
 
 }  // namespace docstring
 }  // namespace nmodl

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -10,6 +10,7 @@ set(UTIL_SOURCE_FILES
     logger.hpp
     perf_stat.cpp
     perf_stat.hpp
+    string_utils.cpp
     string_utils.hpp
     table_data.cpp
     table_data.hpp

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -1,0 +1,30 @@
+/*************************************************************************
+ * Copyright (C) 2018-2021 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+#include "utils/string_utils.hpp"
+
+#include <spdlog/spdlog.h>
+
+#include <limits>
+#include <string>
+
+namespace nmodl {
+namespace stringutils {
+
+std::string to_string(double value, const std::string& format_spec) {
+    // double containing integer value
+    if (std::ceil(value) == value &&
+        value < static_cast<double>(std::numeric_limits<long long>::max()) &&
+        value > static_cast<double>(std::numeric_limits<long long>::min())) {
+        return std::to_string(static_cast<long long>(value));
+    }
+
+    // actual float value
+    return fmt::format(format_spec, value);
+}
+
+}  // namespace stringutils
+}  // namespace nmodl

--- a/src/utils/string_utils.hpp
+++ b/src/utils/string_utils.hpp
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 2018-2019 Blue Brain Project
+ * Copyright (C) 2018-2021 Blue Brain Project
  *
  * This file is part of NMODL distributed under the terms of the GNU
  * Lesser General Public License. See top-level LICENSE file for details.
@@ -21,8 +21,6 @@
 #include <functional>
 #include <sstream>
 #include <vector>
-
-#include <spdlog/spdlog.h>
 
 namespace nmodl {
 /// string utility functions
@@ -135,17 +133,7 @@ static inline std::string tolower(std::string text) {
  * and testing/validation. To avoid this issue, we use to_string
  * for integer values and stringstream for the rest.
  */
-static inline std::string to_string(double value, const std::string& format_spec = "{:.16g}") {
-    // double containing integer value
-    if (std::ceil(value) == value &&
-        value < static_cast<double>(std::numeric_limits<long long>::max()) &&
-        value > static_cast<double>(std::numeric_limits<long long>::min())) {
-        return std::to_string(static_cast<long long>(value));
-    }
-
-    // actual float value
-    return fmt::format(format_spec, value);
-}
+std::string to_string(double value, const std::string& format_spec = "{:.16g}");
 
 /** @} */  // end of utils
 


### PR DESCRIPTION
These changes aim to make NMODL less slow to build when Python bindings are enabled (and, to a lesser extent, when they're not). One standalone change is to avoid including `spdlog` header in `utils/string_utils.hpp` just to get `fmt`, which apparently makes the build O(20%) faster 🤷

The other changes are all around code generation for Python bindings:
- e9202435626e7784cd6161189e757a51660f90d9 `all.hpp` now includes other headers instead of duplicating their content in one massive file (no particular speed difference)
- 240ac8dd5e8c2c12a30ee20d4fd929ab32505e38 uses type names explicitly in template arguments, instead of passing instances of those types around. This makes the different `py::class_` declarations independent from one another.
- c0470be08e999653c103c72bcf405e74853bdaf4 exploits this independence by splitting the generated code across more .cpp files (2 instead of 1 seems enough to make a meaningful difference)

Together, this makes NMODL compile in around 2m40s instead of 6m20s in my test setup.