### PR TITLE
Forbid PARAMETER if it is written and not a range

### DIFF
--- a/src/codegen/codegen_compatibility_visitor.cpp
+++ b/src/codegen/codegen_compatibility_visitor.cpp
@@ -18,6 +18,8 @@ using namespace fmt::literals;
 namespace nmodl {
 namespace codegen {
 
+using symtab::syminfo::NmodlType;
+
 const std::map<ast::AstNodeType, CodegenCompatibilityVisitor::FunctionPointer>
     CodegenCompatibilityVisitor::unhandled_ast_types_func(
         {{AstNodeType::MATCH_BLOCK,
@@ -37,6 +39,7 @@ const std::map<ast::AstNodeType, CodegenCompatibilityVisitor::FunctionPointer>
          {AstNodeType::SOLVE_BLOCK,
           &CodegenCompatibilityVisitor::return_error_if_solve_method_is_unhandled},
          {AstNodeType::GLOBAL_VAR, &CodegenCompatibilityVisitor::return_error_global_var},
+         {AstNodeType::PARAM_ASSIGN, &CodegenCompatibilityVisitor::return_error_param_var},
          {AstNodeType::POINTER_VAR, &CodegenCompatibilityVisitor::return_error_pointer},
          {AstNodeType::BBCORE_POINTER_VAR,
           &CodegenCompatibilityVisitor::return_error_if_no_bbcore_read_write}});
@@ -69,6 +72,20 @@ std::string CodegenCompatibilityVisitor::return_error_global_var(
         error_message_global_var
             << "\"{}\" variable found at [{}] should be defined as a RANGE variable instead of GLOBAL to enable backend transformations\n"_format(
                    global_var->get_node_name(), global_var->get_token()->position());
+    }
+    return error_message_global_var.str();
+}
+
+std::string CodegenCompatibilityVisitor::return_error_param_var(
+    ast::Ast& node,
+    const std::shared_ptr<ast::Ast>& ast_node) {
+    auto param_assign = std::dynamic_pointer_cast<ast::ParamAssign>(ast_node);
+    std::stringstream error_message_global_var;
+    auto symbol = node.get_symbol_table()->lookup(param_assign->get_node_name());
+    if (!symbol->has_any_property(NmodlType::range_var) && symbol->get_write_count() > 0) {
+        error_message_global_var
+            << "\"{}\" variable found at [{}] should be defined as a RANGE variable instead of GLOBAL to enable backend transformations\n"_format(
+                   symbol->get_name(), symbol->get_token().position());
     }
     return error_message_global_var.str();
 }

--- a/src/codegen/codegen_compatibility_visitor.cpp
+++ b/src/codegen/codegen_compatibility_visitor.cpp
@@ -82,9 +82,9 @@ std::string CodegenCompatibilityVisitor::return_error_param_var(
     auto param_assign = std::dynamic_pointer_cast<ast::ParamAssign>(ast_node);
     std::stringstream error_message_global_var;
     auto symbol = node.get_symbol_table()->lookup(param_assign->get_node_name());
-    if (!symbol->has_any_property(NmodlType::range_var) && symbol->get_write_count() > 0) {
+    if (!symbol->is_writable() && symbol->get_write_count() > 0) {
         error_message_global_var
-            << "\"{}\" variable found at [{}] should be defined as a RANGE variable instead of GLOBAL to enable backend transformations\n"_format(
+            << "\"{}\" variable found at [{}] should be writable if it needs to be written\n"_format(
                    symbol->get_name(), symbol->get_token().position());
     }
     return error_message_global_var.str();

--- a/src/codegen/codegen_compatibility_visitor.hpp
+++ b/src/codegen/codegen_compatibility_visitor.hpp
@@ -134,6 +134,8 @@ class CodegenCompatibilityVisitor: public visitor::AstVisitor {
     /// \return std::string error
     std::string return_error_global_var(ast::Ast& node, const std::shared_ptr<ast::Ast>& ast_node);
 
+    std::string return_error_param_var(ast::Ast& node, const std::shared_ptr<ast::Ast>& ast_node);
+
     /// Takes as parameter an std::shared_ptr<ast::Ast> node
     /// and returns a relative error with the name and the
     /// location of the pointer, as well as a suggestion to

--- a/src/symtab/symbol.hpp
+++ b/src/symtab/symbol.hpp
@@ -351,7 +351,10 @@ class Symbol {
 
     bool is_writable() const noexcept {
         return has_any_property(syminfo::NmodlType::range_var) ||
-               has_any_property(syminfo::NmodlType::write_ion_var);
+               has_any_property(syminfo::NmodlType::write_ion_var) ||
+               has_any_property(syminfo::NmodlType::assigned_definition) ||
+               has_any_property(syminfo::NmodlType::state_var) ||
+               has_any_property(syminfo::NmodlType::read_ion_var);
     }
 };
 

--- a/src/symtab/symbol.hpp
+++ b/src/symtab/symbol.hpp
@@ -350,7 +350,7 @@ class Symbol {
     std::string to_string() const;
 
     bool is_writable() const noexcept {
-        return has_any_property(NModlType::range_var) || (has_any_property(NModlType::useion) && !has_any_property(NmodlType::write_ion_var));
+        return has_any_property(syminfo::NmodlType::range_var) || has_any_property(syminfo::NmodlType::write_ion_var);
     }
 };
 

--- a/src/symtab/symbol.hpp
+++ b/src/symtab/symbol.hpp
@@ -350,7 +350,8 @@ class Symbol {
     std::string to_string() const;
 
     bool is_writable() const noexcept {
-        return has_any_property(syminfo::NmodlType::range_var) || has_any_property(syminfo::NmodlType::write_ion_var);
+        return has_any_property(syminfo::NmodlType::range_var) ||
+               has_any_property(syminfo::NmodlType::write_ion_var);
     }
 };
 

--- a/src/symtab/symbol.hpp
+++ b/src/symtab/symbol.hpp
@@ -348,6 +348,10 @@ class Symbol {
     bool is_variable() const noexcept;
 
     std::string to_string() const;
+
+    bool is_writable() const noexcept {
+        return has_any_property(NModlType::range_var) || (has_any_property(NModlType::useion) && !has_any_property(NmodlType::write_ion_var));
+    }
 };
 
 /** @} */  // end of sym_tab


### PR DESCRIPTION
Example of bad design:

```
NEURON {
  POINT_PROCESS two_exp_syn1
  RANGE onset
}

PARAMETER {
  onset = 0 (ms)
  T
}

INITIAL {
  T = -log(1/onset)
}
```

Here `T` is a `ast::ParamAssign` and is `GLOBAL` as not defined `RANGE` in `NEURON` block.
So `T` becomes a `GLOBAL`, but we try to write it in `INITIAL`.

As user can modify `PARAMETER` it leads to possible non-thread safe code.

Before this patch, when compiling the generated `cpp` file, it leads to several :
`x86_64/corenrn/mod2c/two_exp.cpp:96:28: error: ‘T’ was not declared in this scope`

After this patch, the `cpp` file is not generated and **nmodl** give an error:
`[NMODL] [error] :: Code Incompatibility :: "T" variable found at [UNKNOWN] should be defined as a RANGE variable instead of GLOBAL to enable backend transformations`


We don't fix it, we disable it by design.


