### PR TITLE
Cast index of array to int

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -133,7 +133,7 @@ void CodegenCVisitor::visit_var_name(const VarName& node) {
     }
     if (index) {
         printer->add_text("[");
-        printer->add_text("((int)");
+        printer->add_text("static_cast<int>(");
         index->accept(*this);
         printer->add_text(")");
         printer->add_text("]");
@@ -147,7 +147,7 @@ void CodegenCVisitor::visit_indexed_name(const IndexedName& node) {
     }
     node.get_name()->accept(*this);
     printer->add_text("[");
-    printer->add_text("((int)");
+    printer->add_text("static_cast<int>(");
     node.get_length()->accept(*this);
     printer->add_text(")");
     printer->add_text("]");

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -133,7 +133,9 @@ void CodegenCVisitor::visit_var_name(const VarName& node) {
     }
     if (index) {
         printer->add_text("[");
+        printer->add_text("((int)");
         index->accept(*this);
+        printer->add_text(")");
         printer->add_text("]");
     }
 }
@@ -145,7 +147,9 @@ void CodegenCVisitor::visit_indexed_name(const IndexedName& node) {
     }
     node.get_name()->accept(*this);
     printer->add_text("[");
+    printer->add_text("((int)");
     node.get_length()->accept(*this);
+    printer->add_text(")");
     printer->add_text("]");
 }
 

--- a/src/language/nmodl.yaml
+++ b/src/language/nmodl.yaml
@@ -262,7 +262,7 @@
                                   type: Identifier
                                   node_name: true
                               - length:
-                                  brief: "legth of an array or index position"
+                                  brief: "length of an array or index position"
                                   type: Expression
                                   prefix: {value: "["}
                                   suffix: {value: "]"}
@@ -271,7 +271,7 @@
                                     If variable is declared as an array or when array element is accessed,
                                     it is stored in the ast as ast::IndexedName. For example, in below NMODL,
                                     construct `m[4]` is stored as ast::IndexedName with `m` as ast::IndexedName::name
-                                    and `4` as ast::IndexedName::legth.
+                                    and `4` as ast::IndexedName::length.
 
                                     \code
                                         STATE {


### PR DESCRIPTION
Sometimes variables are double, so cast them to int, to have valid c.

Fix #776