### PR TITLE
Use nrn_pragma_acc(...) macro and add nrn_pragma_omp(...) alternatives.

### DIFF
--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -315,7 +315,8 @@ void CodegenAccVisitor::print_deriv_advance_flag_transfer_to_device() const {
 
 
 void CodegenAccVisitor::print_device_atomic_capture_annotation() const {
-    printer->add_line("#pragma acc atomic capture");
+    printer->add_line("nrn_pragma_acc(atomic capture)");
+    printer->add_line("nrn_pragma_omp(atomic capture)");
 }
 
 
@@ -328,7 +329,8 @@ void CodegenAccVisitor::print_device_stream_wait() const {
 
 
 void CodegenAccVisitor::print_net_send_buf_count_update_to_host() const {
-    printer->add_line("#pragma acc update self(nsb->_cnt) if(nt->compute_gpu)");
+    printer->add_line("nrn_pragma_acc(update self(nsb->_cnt) if(nt->compute_gpu))");
+    printer->add_line("nrn_pragma_omp(target update from(nsb->_cnt) if(nt->compute_gpu))");
 }
 
 
@@ -342,7 +344,8 @@ void CodegenAccVisitor::print_net_send_buf_update_to_host() const {
 
 
 void CodegenAccVisitor::print_net_send_buf_count_update_to_device() const {
-    printer->add_line("#pragma acc update device(nsb->_cnt) if (nt->compute_gpu)");
+    printer->add_line("nrn_pragma_acc(update device(nsb->_cnt) if(nt->compute_gpu))");
+    printer->add_line("nrn_pragma_omp(target update to(nsb->_cnt) if(nt->compute_gpu))");
 }
 
 

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -54,7 +54,8 @@ void CodegenAccVisitor::print_channel_iteration_block_parallel_hint(BlockType ty
         "nrn_pragma_acc(parallel loop {} async(nt->stream_id) if(nt->compute_gpu))"_format(
             present_clause.str()));
     printer->add_line(
-        "nrn_pragma_omp(target teams distribute parallel for simd depend(inout: nt) is_device_ptr(inst) "
+        "nrn_pragma_omp(target teams distribute parallel for simd depend(inout: nt) "
+        "is_device_ptr(inst) nowait "
         "if(nt->compute_gpu))");
 }
 
@@ -308,7 +309,8 @@ void CodegenAccVisitor::print_instance_variable_transfer_to_device() const {
 
 
 void CodegenAccVisitor::print_deriv_advance_flag_transfer_to_device() const {
-    printer->add_line("#pragma acc update device (deriv_advance_flag) if (nt->compute_gpu)");
+    printer->add_line("nrn_pragma_acc(update device (deriv_advance_flag) if(nt->compute_gpu))");
+    printer->add_line("nrn_pragma_omp(target update to(deriv_advance_flag) if(nt->compute_gpu))");
 }
 
 
@@ -320,6 +322,7 @@ void CodegenAccVisitor::print_device_atomic_capture_annotation() const {
 void CodegenAccVisitor::print_device_stream_wait() const {
     printer->start_block("if(nt->compute_gpu)");
     printer->add_line("nrn_pragma_acc(wait(nt->stream_id))");
+    printer->add_line("nrn_pragma_omp(taskwait)");
     printer->end_block(1);
 }
 

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -54,8 +54,7 @@ void CodegenAccVisitor::print_channel_iteration_block_parallel_hint(BlockType ty
         "nrn_pragma_acc(parallel loop {} async(nt->stream_id) if(nt->compute_gpu))"_format(
             present_clause.str()));
     printer->add_line(
-        "nrn_pragma_omp(target teams distribute parallel for simd depend(inout: nt) "
-        "is_device_ptr(inst) nowait "
+        "nrn_pragma_omp(target teams distribute parallel for simd is_device_ptr(inst) "
         "if(nt->compute_gpu))");
 }
 

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -88,7 +88,8 @@ class CodegenAccVisitor: public CodegenCVisitor {
 
 
     /// create global variable on the device
-    void print_global_variable_device_create_annotation() override;
+    void print_global_variable_device_create_annotation_pre() override;
+    void print_global_variable_device_create_annotation_post() override;
 
     /// update global variable from host to the device
     void print_global_variable_device_update_annotation() override;

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -2636,10 +2636,11 @@ void CodegenCVisitor::print_mechanism_global_var_structure() {
 
     printer->add_newline(1);
     printer->add_line("/** holds object of global variable */");
+    print_global_variable_device_create_annotation_pre();
     print_global_var_struct_decl();
 
     // create copy on the device
-    print_global_variable_device_create_annotation();
+    print_global_variable_device_create_annotation_post();
 }
 
 
@@ -3037,7 +3038,11 @@ void CodegenCVisitor::print_ion_variable() {
 }
 
 
-void CodegenCVisitor::print_global_variable_device_create_annotation() {
+void CodegenCVisitor::print_global_variable_device_create_annotation_pre() {
+    // nothing for cpu
+}
+
+void CodegenCVisitor::print_global_variable_device_create_annotation_post() {
     // nothing for cpu
 }
 

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1187,8 +1187,14 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      *
      * \note This is not used for the C backend
      */
-    virtual void print_global_variable_device_create_annotation();
+    virtual void print_global_variable_device_create_annotation_pre();
 
+    /**
+     * Print the pragma annotation to create global variables on the device
+     *
+     * \note This is not used for the C backend
+     */
+    virtual void print_global_variable_device_create_annotation_post();
 
     /**
      * Print the pragma annotation to update global variables from host to the device

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1183,14 +1183,18 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
 
 
     /**
-     * Print the pragma annotation to create global variables on the device
+     * Print the pragma annotation needed before a global variable that must be
+     * created on the device. This always comes before a matching call to
+     * print_global_variable_device_create_annotation_post.
      *
      * \note This is not used for the C backend
      */
     virtual void print_global_variable_device_create_annotation_pre();
 
     /**
-     * Print the pragma annotation to create global variables on the device
+     * Print the pragma annotation needed after a global variables that must be
+     * created on the device. This always comes after a matching call to
+     * print_global_variable_device_create_annotation_pre.
      *
      * \note This is not used for the C backend
      */


### PR DESCRIPTION
Instead of directly printing
```c++
#pragma acc ...
```
we now print pairs of macros
```c++
nrn_pragma_acc(...)
nrn_pragma_omp(...)
```
so the translated sources can be compiled both with OpenACC and with OpenMP target offload.

The current OpenMP implementation does not include any `depend` or `nowait` clauses, as an early attempt to do this caused crashes with NVHPC 21.9. This will be revisited later.