### PR TITLE
Fix NVHPC + OpenMP ~ OpenACC compilation

### DIFF
--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -147,7 +147,7 @@ void CodegenAccVisitor::print_eigen_linear_solver(const std::string& float_type,
     if (N <= 4) {
         printer->add_line("{0} = {1}.inverse()*{2};"_format(Xm, Jm, Fm));
     } else {
-        printer->add_line("{0} = partialPivLu<{1}>({2}, {3});"_format(Xm, N, Jm, Fm));
+        printer->add_line("{0} = partialPivLu{1}({2}, {3});"_format(Xm, N, Jm, Fm));
     }
 }
 

--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -11,7 +11,7 @@ file(GLOB NMODL_NEWTON_SOLVER_HEADER_FILES "${CMAKE_CURRENT_SOURCE_DIR}/newton/*
 file(COPY ${NMODL_NEWTON_SOLVER_HEADER_FILES} DESTINATION ${CMAKE_BINARY_DIR}/include/newton/)
 # partial_piv_lu
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/partial_piv_lu/partial_piv_lu.h"
-     DESTINATION "${CMAKE_BINARY_DIR}/include/partial_piv_lu/partial_piv_lu.h")
+     DESTINATION "${CMAKE_BINARY_DIR}/include/partial_piv_lu/")
 # Eigen
 file(COPY ${NMODL_PROJECT_SOURCE_DIR}/ext/eigen/Eigen DESTINATION ${CMAKE_BINARY_DIR}/include/)
 

--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -10,8 +10,8 @@ set(NEWTON_SOLVER_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/newton/newton.hpp)
 file(GLOB NMODL_NEWTON_SOLVER_HEADER_FILES "${CMAKE_CURRENT_SOURCE_DIR}/newton/*.h*")
 file(COPY ${NMODL_NEWTON_SOLVER_HEADER_FILES} DESTINATION ${CMAKE_BINARY_DIR}/include/newton/)
 # partial_piv_lu
-file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/partial_piv_lu/partial_piv_lu.h"
-     DESTINATION "${CMAKE_BINARY_DIR}/include/partial_piv_lu/")
+file(GLOB NMODL_PARTIAL_PIV_LU_API_FILES "${CMAKE_CURRENT_SOURCE_DIR}/partial_piv_lu/*")
+file(COPY ${NMODL_PARTIAL_PIV_LU_API_FILES} DESTINATION ${CMAKE_BINARY_DIR}/include/partial_piv_lu/)
 # Eigen
 file(COPY ${NMODL_PROJECT_SOURCE_DIR}/ext/eigen/Eigen DESTINATION ${CMAKE_BINARY_DIR}/include/)
 

--- a/src/solver/CMakeLists.txt
+++ b/src/solver/CMakeLists.txt
@@ -10,8 +10,8 @@ set(NEWTON_SOLVER_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/newton/newton.hpp)
 file(GLOB NMODL_NEWTON_SOLVER_HEADER_FILES "${CMAKE_CURRENT_SOURCE_DIR}/newton/*.h*")
 file(COPY ${NMODL_NEWTON_SOLVER_HEADER_FILES} DESTINATION ${CMAKE_BINARY_DIR}/include/newton/)
 # partial_piv_lu
-file(GLOB NMODL_PARTIAL_PIV_LU_API_FILES "${CMAKE_CURRENT_SOURCE_DIR}/partial_piv_lu/*")
-file(COPY ${NMODL_PARTIAL_PIV_LU_API_FILES} DESTINATION ${CMAKE_BINARY_DIR}/include/partial_piv_lu/)
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/partial_piv_lu/partial_piv_lu.h"
+     DESTINATION "${CMAKE_BINARY_DIR}/include/partial_piv_lu/partial_piv_lu.h")
 # Eigen
 file(COPY ${NMODL_PROJECT_SOURCE_DIR}/ext/eigen/Eigen DESTINATION ${CMAKE_BINARY_DIR}/include/)
 

--- a/src/solver/newton/newton.hpp
+++ b/src/solver/newton/newton.hpp
@@ -15,7 +15,7 @@
  * \brief Implementation of Newton method for solving system of non-linear equations
  */
 
-#if defined(_OPENACC) && !defined(DISABLE_OPENACC)
+#if defined(CORENEURON_ENABLE_GPU) && !defined(DISABLE_OPENACC)
 #include "partial_piv_lu/partial_piv_lu.h"
 #endif
 
@@ -73,7 +73,7 @@ EIGEN_DEVICE_FUNC int newton_solver(Eigen::Matrix<double, N, 1>& X,
             // we have converged: return iteration count
             return iter;
         }
-#if defined(_OPENACC) && !defined(DISABLE_OPENACC)
+#if defined(CORENEURON_ENABLE_GPU) && !defined(DISABLE_OPENACC)
         X -= partialPivLu<N>(J, F);
 #else
         // update X use in-place LU decomposition of J with partial pivoting
@@ -150,7 +150,7 @@ EIGEN_DEVICE_FUNC int newton_numerical_diff_solver(Eigen::Matrix<double, N, 1>& 
             // restore X
             X[i] += dX;
         }
-#if defined(_OPENACC) && !defined(DISABLE_OPENACC)
+#if defined(CORENEURON_ENABLE_GPU) && !defined(DISABLE_OPENACC)
         X -= partialPivLu<N>(J, F);
 #else
         // update X use in-place LU decomposition of J with partial pivoting

--- a/src/solver/partial_piv_lu/partial_piv_lu.cu
+++ b/src/solver/partial_piv_lu/partial_piv_lu.cu
@@ -1,36 +1,27 @@
 /*************************************************************************
- * Copyright (C) 2018-2019 Blue Brain Project
+ * Copyright (C) 2018-2021 Blue Brain Project
  *
  * This file is part of NMODL distributed under the terms of the GNU
  * Lesser General Public License. See top-level LICENSE file for details.
  *************************************************************************/
-
 #include "partial_piv_lu/partial_piv_lu.h"
 
-template<int dim>
-EIGEN_DEVICE_FUNC 
-VecType<dim> partialPivLu(const MatType<dim>& A, const VecType<dim>& b)
-{
-    return A.partialPivLu().solve(b);
-}
-
-// Explicit Template Instantiation
-template EIGEN_DEVICE_FUNC VecType<1> partialPivLu<1>(const MatType<1>& A, const VecType<1>& b);
-template EIGEN_DEVICE_FUNC VecType<2> partialPivLu<2>(const MatType<2>& A, const VecType<2>& b);
-template EIGEN_DEVICE_FUNC VecType<3> partialPivLu<3>(const MatType<3>& A, const VecType<3>& b);
-template EIGEN_DEVICE_FUNC VecType<4> partialPivLu<4>(const MatType<4>& A, const VecType<4>& b);
-template EIGEN_DEVICE_FUNC VecType<5> partialPivLu<5>(const MatType<5>& A, const VecType<5>& b);
-template EIGEN_DEVICE_FUNC VecType<6> partialPivLu<6>(const MatType<6>& A, const VecType<6>& b);
-template EIGEN_DEVICE_FUNC VecType<7> partialPivLu<7>(const MatType<7>& A, const VecType<7>& b);
-template EIGEN_DEVICE_FUNC VecType<8> partialPivLu<8>(const MatType<8>& A, const VecType<8>& b);
-template EIGEN_DEVICE_FUNC VecType<9> partialPivLu<9>(const MatType<9>& A, const VecType<9>& b);
-template EIGEN_DEVICE_FUNC VecType<10> partialPivLu<10>(const MatType<10>& A, const VecType<10>& b);
-template EIGEN_DEVICE_FUNC VecType<11> partialPivLu<11>(const MatType<11>& A, const VecType<11>& b);
-template EIGEN_DEVICE_FUNC VecType<12> partialPivLu<12>(const MatType<12>& A, const VecType<12>& b);
-template EIGEN_DEVICE_FUNC VecType<13> partialPivLu<13>(const MatType<13>& A, const VecType<13>& b);
-template EIGEN_DEVICE_FUNC VecType<14> partialPivLu<14>(const MatType<14>& A, const VecType<14>& b);
-template EIGEN_DEVICE_FUNC VecType<15> partialPivLu<15>(const MatType<15>& A, const VecType<15>& b);
-template EIGEN_DEVICE_FUNC VecType<16> partialPivLu<16>(const MatType<16>& A, const VecType<16>& b);
+EIGEN_DEVICE_FUNC VecType<1> partialPivLu1(const MatType<1>& A, const VecType<1>& b) { return A.partialPivLu().solve(b); }
+EIGEN_DEVICE_FUNC VecType<2> partialPivLu2(const MatType<2>& A, const VecType<2>& b) { return A.partialPivLu().solve(b); }
+EIGEN_DEVICE_FUNC VecType<3> partialPivLu3(const MatType<3>& A, const VecType<3>& b) { return A.partialPivLu().solve(b); }
+EIGEN_DEVICE_FUNC VecType<4> partialPivLu4(const MatType<4>& A, const VecType<4>& b) { return A.partialPivLu().solve(b); }
+EIGEN_DEVICE_FUNC VecType<5> partialPivLu5(const MatType<5>& A, const VecType<5>& b) { return A.partialPivLu().solve(b); }
+EIGEN_DEVICE_FUNC VecType<6> partialPivLu6(const MatType<6>& A, const VecType<6>& b) { return A.partialPivLu().solve(b); }
+EIGEN_DEVICE_FUNC VecType<7> partialPivLu7(const MatType<7>& A, const VecType<7>& b) { return A.partialPivLu().solve(b); }
+EIGEN_DEVICE_FUNC VecType<8> partialPivLu8(const MatType<8>& A, const VecType<8>& b) { return A.partialPivLu().solve(b); }
+EIGEN_DEVICE_FUNC VecType<9> partialPivLu9(const MatType<9>& A, const VecType<9>& b) { return A.partialPivLu().solve(b); }
+EIGEN_DEVICE_FUNC VecType<10> partialPivLu10(const MatType<10>& A, const VecType<10>& b) { return A.partialPivLu().solve(b); }
+EIGEN_DEVICE_FUNC VecType<11> partialPivLu11(const MatType<11>& A, const VecType<11>& b) { return A.partialPivLu().solve(b); }
+EIGEN_DEVICE_FUNC VecType<12> partialPivLu12(const MatType<12>& A, const VecType<12>& b) { return A.partialPivLu().solve(b); }
+EIGEN_DEVICE_FUNC VecType<13> partialPivLu13(const MatType<13>& A, const VecType<13>& b) { return A.partialPivLu().solve(b); }
+EIGEN_DEVICE_FUNC VecType<14> partialPivLu14(const MatType<14>& A, const VecType<14>& b) { return A.partialPivLu().solve(b); }
+EIGEN_DEVICE_FUNC VecType<15> partialPivLu15(const MatType<15>& A, const VecType<15>& b) { return A.partialPivLu().solve(b); }
+EIGEN_DEVICE_FUNC VecType<16> partialPivLu16(const MatType<16>& A, const VecType<16>& b) { return A.partialPivLu().solve(b); }
 
 // Currently there is an issue in Eigen (GPU-branch) for matrices 17x17 and above.
 // ToDo: Check in a future release if this issue is resolved!

--- a/src/solver/partial_piv_lu/partial_piv_lu.cu
+++ b/src/solver/partial_piv_lu/partial_piv_lu.cu
@@ -6,6 +6,31 @@
  *************************************************************************/
 #include "partial_piv_lu/partial_piv_lu.h"
 
+template<int dim>
+EIGEN_DEVICE_FUNC
+VecType<dim> partialPivLu(const MatType<dim>& A, const VecType<dim>& b)
+{
+    return A.partialPivLu().solve(b);
+}
+
+// Explicit Template Instantiation
+template EIGEN_DEVICE_FUNC VecType<1> partialPivLu<1>(const MatType<1>& A, const VecType<1>& b);
+template EIGEN_DEVICE_FUNC VecType<2> partialPivLu<2>(const MatType<2>& A, const VecType<2>& b);
+template EIGEN_DEVICE_FUNC VecType<3> partialPivLu<3>(const MatType<3>& A, const VecType<3>& b);
+template EIGEN_DEVICE_FUNC VecType<4> partialPivLu<4>(const MatType<4>& A, const VecType<4>& b);
+template EIGEN_DEVICE_FUNC VecType<5> partialPivLu<5>(const MatType<5>& A, const VecType<5>& b);
+template EIGEN_DEVICE_FUNC VecType<6> partialPivLu<6>(const MatType<6>& A, const VecType<6>& b);
+template EIGEN_DEVICE_FUNC VecType<7> partialPivLu<7>(const MatType<7>& A, const VecType<7>& b);
+template EIGEN_DEVICE_FUNC VecType<8> partialPivLu<8>(const MatType<8>& A, const VecType<8>& b);
+template EIGEN_DEVICE_FUNC VecType<9> partialPivLu<9>(const MatType<9>& A, const VecType<9>& b);
+template EIGEN_DEVICE_FUNC VecType<10> partialPivLu<10>(const MatType<10>& A, const VecType<10>& b);
+template EIGEN_DEVICE_FUNC VecType<11> partialPivLu<11>(const MatType<11>& A, const VecType<11>& b);
+template EIGEN_DEVICE_FUNC VecType<12> partialPivLu<12>(const MatType<12>& A, const VecType<12>& b);
+template EIGEN_DEVICE_FUNC VecType<13> partialPivLu<13>(const MatType<13>& A, const VecType<13>& b);
+template EIGEN_DEVICE_FUNC VecType<14> partialPivLu<14>(const MatType<14>& A, const VecType<14>& b);
+template EIGEN_DEVICE_FUNC VecType<15> partialPivLu<15>(const MatType<15>& A, const VecType<15>& b);
+template EIGEN_DEVICE_FUNC VecType<16> partialPivLu<16>(const MatType<16>& A, const VecType<16>& b);
+
 EIGEN_DEVICE_FUNC VecType<1> partialPivLu1(const MatType<1>& A, const VecType<1>& b) { return A.partialPivLu().solve(b); }
 EIGEN_DEVICE_FUNC VecType<2> partialPivLu2(const MatType<2>& A, const VecType<2>& b) { return A.partialPivLu().solve(b); }
 EIGEN_DEVICE_FUNC VecType<3> partialPivLu3(const MatType<3>& A, const VecType<3>& b) { return A.partialPivLu().solve(b); }

--- a/src/solver/partial_piv_lu/partial_piv_lu.h
+++ b/src/solver/partial_piv_lu/partial_piv_lu.h
@@ -26,37 +26,37 @@ using VecType = Eigen::Matrix<double, dim, 1, Eigen::ColMajor, dim, 1>;
 nrn_pragma_omp(declare target)
 nrn_pragma_acc(routine seq)
 template<int dim>
-VecType<dim> partialPivLu(const MatType<dim>&, const VecType<dim>&);
+EIGEN_DEVICE_FUNC VecType<dim> partialPivLu(const MatType<dim>&, const VecType<dim>&);
 nrn_pragma_acc(routine seq)
-VecType<1> partialPivLu1(const MatType<1>&, const VecType<1>&);
+EIGEN_DEVICE_FUNC VecType<1> partialPivLu1(const MatType<1>&, const VecType<1>&);
 nrn_pragma_acc(routine seq)
-VecType<2> partialPivLu2(const MatType<2>&, const VecType<2>&);
+EIGEN_DEVICE_FUNC VecType<2> partialPivLu2(const MatType<2>&, const VecType<2>&);
 nrn_pragma_acc(routine seq)
-VecType<3> partialPivLu3(const MatType<3>&, const VecType<3>&);
+EIGEN_DEVICE_FUNC VecType<3> partialPivLu3(const MatType<3>&, const VecType<3>&);
 nrn_pragma_acc(routine seq)
-VecType<4> partialPivLu4(const MatType<4>&, const VecType<4>&);
+EIGEN_DEVICE_FUNC VecType<4> partialPivLu4(const MatType<4>&, const VecType<4>&);
 nrn_pragma_acc(routine seq)
-VecType<5> partialPivLu5(const MatType<5>&, const VecType<5>&);
+EIGEN_DEVICE_FUNC VecType<5> partialPivLu5(const MatType<5>&, const VecType<5>&);
 nrn_pragma_acc(routine seq)
-VecType<6> partialPivLu6(const MatType<6>&, const VecType<6>&);
+EIGEN_DEVICE_FUNC VecType<6> partialPivLu6(const MatType<6>&, const VecType<6>&);
 nrn_pragma_acc(routine seq)
-VecType<7> partialPivLu7(const MatType<7>&, const VecType<7>&);
+EIGEN_DEVICE_FUNC VecType<7> partialPivLu7(const MatType<7>&, const VecType<7>&);
 nrn_pragma_acc(routine seq)
-VecType<8> partialPivLu8(const MatType<8>&, const VecType<8>&);
+EIGEN_DEVICE_FUNC VecType<8> partialPivLu8(const MatType<8>&, const VecType<8>&);
 nrn_pragma_acc(routine seq)
-VecType<9> partialPivLu9(const MatType<9>&, const VecType<9>&);
+EIGEN_DEVICE_FUNC VecType<9> partialPivLu9(const MatType<9>&, const VecType<9>&);
 nrn_pragma_acc(routine seq)
-VecType<10> partialPivLu10(const MatType<10>&, const VecType<10>&);
+EIGEN_DEVICE_FUNC VecType<10> partialPivLu10(const MatType<10>&, const VecType<10>&);
 nrn_pragma_acc(routine seq)
-VecType<11> partialPivLu11(const MatType<11>&, const VecType<11>&);
+EIGEN_DEVICE_FUNC VecType<11> partialPivLu11(const MatType<11>&, const VecType<11>&);
 nrn_pragma_acc(routine seq)
-VecType<12> partialPivLu12(const MatType<12>&, const VecType<12>&);
+EIGEN_DEVICE_FUNC VecType<12> partialPivLu12(const MatType<12>&, const VecType<12>&);
 nrn_pragma_acc(routine seq)
-VecType<13> partialPivLu13(const MatType<13>&, const VecType<13>&);
+EIGEN_DEVICE_FUNC VecType<13> partialPivLu13(const MatType<13>&, const VecType<13>&);
 nrn_pragma_acc(routine seq)
-VecType<14> partialPivLu14(const MatType<14>&, const VecType<14>&);
+EIGEN_DEVICE_FUNC VecType<14> partialPivLu14(const MatType<14>&, const VecType<14>&);
 nrn_pragma_acc(routine seq)
-VecType<15> partialPivLu15(const MatType<15>&, const VecType<15>&);
+EIGEN_DEVICE_FUNC VecType<15> partialPivLu15(const MatType<15>&, const VecType<15>&);
 nrn_pragma_acc(routine seq)
-VecType<16> partialPivLu16(const MatType<16>&, const VecType<16>&);
+EIGEN_DEVICE_FUNC VecType<16> partialPivLu16(const MatType<16>&, const VecType<16>&);
 nrn_pragma_omp(end declare target)

--- a/src/solver/partial_piv_lu/partial_piv_lu.h
+++ b/src/solver/partial_piv_lu/partial_piv_lu.h
@@ -25,6 +25,9 @@ using VecType = Eigen::Matrix<double, dim, 1, Eigen::ColMajor, dim, 1>;
 
 nrn_pragma_omp(declare target)
 nrn_pragma_acc(routine seq)
+template<int dim>
+VecType<dim> partialPivLu(const MatType<dim>&, const VecType<dim>&);
+nrn_pragma_acc(routine seq)
 VecType<1> partialPivLu1(const MatType<1>&, const VecType<1>&);
 nrn_pragma_acc(routine seq)
 VecType<2> partialPivLu2(const MatType<2>&, const VecType<2>&);

--- a/src/solver/partial_piv_lu/partial_piv_lu.h
+++ b/src/solver/partial_piv_lu/partial_piv_lu.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "coreneuron/utils/offload.hpp"
+
 #include "Eigen/Dense"
 #include "Eigen/LU"
 
@@ -21,8 +23,8 @@ using VecType = Eigen::Matrix<double, dim, 1, Eigen::ColMajor, dim, 1>;
 // them with __device__ & acc routine tokens), which allows us to eventually call them from OpenACC.
 // Calling these functions from CUDA kernels presents no issue ...
 
-#if defined(_OPENACC) && !defined(DISABLE_OPENACC)
-#pragma acc routine seq
-#endif
+nrn_pragma_acc(routine seq)
+nrn_pragma_omp(declare target)
 template<int dim>
 VecType<dim> partialPivLu(const MatType<dim>&, const VecType<dim>&);
+nrn_pragma_omp(end declare target)

--- a/src/solver/partial_piv_lu/partial_piv_lu.h
+++ b/src/solver/partial_piv_lu/partial_piv_lu.h
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (C) 2018-2019 Blue Brain Project
+ * Copyright (C) 2018-2021 Blue Brain Project
  *
  * This file is part of NMODL distributed under the terms of the GNU
  * Lesser General Public License. See top-level LICENSE file for details.
@@ -23,8 +23,37 @@ using VecType = Eigen::Matrix<double, dim, 1, Eigen::ColMajor, dim, 1>;
 // them with __device__ & acc routine tokens), which allows us to eventually call them from OpenACC.
 // Calling these functions from CUDA kernels presents no issue ...
 
-nrn_pragma_acc(routine seq)
 nrn_pragma_omp(declare target)
-template<int dim>
-VecType<dim> partialPivLu(const MatType<dim>&, const VecType<dim>&);
+nrn_pragma_acc(routine seq)
+VecType<1> partialPivLu1(const MatType<1>&, const VecType<1>&);
+nrn_pragma_acc(routine seq)
+VecType<2> partialPivLu2(const MatType<2>&, const VecType<2>&);
+nrn_pragma_acc(routine seq)
+VecType<3> partialPivLu3(const MatType<3>&, const VecType<3>&);
+nrn_pragma_acc(routine seq)
+VecType<4> partialPivLu4(const MatType<4>&, const VecType<4>&);
+nrn_pragma_acc(routine seq)
+VecType<5> partialPivLu5(const MatType<5>&, const VecType<5>&);
+nrn_pragma_acc(routine seq)
+VecType<6> partialPivLu6(const MatType<6>&, const VecType<6>&);
+nrn_pragma_acc(routine seq)
+VecType<7> partialPivLu7(const MatType<7>&, const VecType<7>&);
+nrn_pragma_acc(routine seq)
+VecType<8> partialPivLu8(const MatType<8>&, const VecType<8>&);
+nrn_pragma_acc(routine seq)
+VecType<9> partialPivLu9(const MatType<9>&, const VecType<9>&);
+nrn_pragma_acc(routine seq)
+VecType<10> partialPivLu10(const MatType<10>&, const VecType<10>&);
+nrn_pragma_acc(routine seq)
+VecType<11> partialPivLu11(const MatType<11>&, const VecType<11>&);
+nrn_pragma_acc(routine seq)
+VecType<12> partialPivLu12(const MatType<12>&, const VecType<12>&);
+nrn_pragma_acc(routine seq)
+VecType<13> partialPivLu13(const MatType<13>&, const VecType<13>&);
+nrn_pragma_acc(routine seq)
+VecType<14> partialPivLu14(const MatType<14>&, const VecType<14>&);
+nrn_pragma_acc(routine seq)
+VecType<15> partialPivLu15(const MatType<15>&, const VecType<15>&);
+nrn_pragma_acc(routine seq)
+VecType<16> partialPivLu16(const MatType<16>&, const VecType<16>&);
 nrn_pragma_omp(end declare target)


### PR DESCRIPTION
`#pragma acc routine seq` seems to play better with templates than `#pragma omp declare target` does. Here is a hideous workaround...