### PR TITLE
Bug fix: Parameter updated in VERBATIM block shouldn't be const

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -746,8 +746,12 @@ bool CodegenCVisitor::is_constant_variable(const std::string& name) const {
         // per mechanism ion variables needs to be updated from neuron/coreneuron values
         if (info.is_ion_variable(name)) {
             is_constant = false;
-        } else if (symbol->has_any_property(NmodlType::param_assign) &&
-                   symbol->get_write_count() == 0) {
+        }
+        // for parameter variable to be const, make sure it's write count is 0
+        // and it's not used in the verbatim block
+        else if (symbol->has_any_property(NmodlType::param_assign) &&
+                 info.variables_in_verbatim.find(name) == info.variables_in_verbatim.end() &&
+                 symbol->get_write_count() == 0) {
             is_constant = true;
         }
     }

--- a/src/codegen/codegen_helper_visitor.hpp
+++ b/src/codegen/codegen_helper_visitor.hpp
@@ -111,6 +111,7 @@ class CodegenHelperVisitor: public visitor::ConstAstVisitor {
     void visit_discrete_block(const ast::DiscreteBlock& node) override;
     void visit_partial_block(const ast::PartialBlock& node) override;
     void visit_update_dt(const ast::UpdateDt& node) override;
+    void visit_verbatim(const ast::Verbatim& node) override;
 };
 
 /** @} */  // end of codegen_details

--- a/src/codegen/codegen_info.hpp
+++ b/src/codegen/codegen_info.hpp
@@ -13,6 +13,7 @@
  */
 
 #include <string>
+#include <unordered_set>
 
 #include "ast/ast.hpp"
 #include "symtab/symbol_table.hpp"
@@ -362,6 +363,9 @@ struct CodegenInfo {
 
     /// all watch statements
     std::vector<const ast::WatchStatement*> watch_statements;
+
+    /// all variables/symbols used in the verbatim block
+    std::unordered_set<std::string> variables_in_verbatim;
 
     /// true if eigen newton solver is used
     bool eigen_newton_solver_exist = false;


### PR DESCRIPTION
 * if PARAMETER variable of RANGE type is updated in VERBATIM
   block then it's write_count could be 0 even though it's
   updated in VERBATIM block
   - such variable can not be declared as `const` instance variable
   - one such example is https://github.com/nrnhines/tqperf/blob/master/mod/invlfire.mod
 * Codegen helper visitor now keep track of all symbols that
   are used in all verbatim blocks and the codegen visitor
   check this list before deciding if variable can be const or not.
   - note that variable could be read-only in verbatim block but
     currently we don't have robut C code analysis capability
     and it's not worth (yet)
 * this issue was encountered in https://github.com/BlueBrain/CoreNeuron/pull/701