### PR TITLE
Hardcode build parallelism.

### DIFF
--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -16,7 +16,6 @@ on:
 
 env:
   CTEST_PARALLEL_LEVEL: 1
-  CMAKE_BUILD_PARALLEL_LEVEL: 3
   DEFAULT_PY_VERSION: 3.8
   DESIRED_CMAKE_VERSION: 3.15.0
 
@@ -26,11 +25,20 @@ jobs:
     name: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-18.04, macos-10.15, ubuntu-20.04, macos-11 ]
+        # Core counts taken from https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        include:
+          - os: ubuntu-18.04
+            cores: 2
+          - os: ubuntu-20.04
+            cores: 2
+          - os: macos-10.15
+            cores: 3
+          - os: macos-11
+            cores: 3
       fail-fast: true
-
+    env:
+      CMAKE_BUILD_PARALLEL_LEVEL: ${{matrix.cores}}
     steps:
-
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.4
         with:
@@ -147,6 +155,8 @@ jobs:
     needs: ci
     name: ${{ matrix.sanitizer }}-sanitizer
     runs-on: ubuntu-20.04
+    env:
+      CMAKE_BUILD_PARALLEL_LEVEL: 2
     strategy:
       matrix:
         # TODO: might be interesting to add the thread sanitizer too


### PR DESCRIPTION
Still use 3 cores for macOS but only use 2 for Linux.

Alternative approach to https://github.com/BlueBrain/nmodl/pull/795 to making failures like https://github.com/BlueBrain/nmodl/runs/4726068015 rarer.