### PR TITLE
Fix nrn_state_required

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -375,7 +375,7 @@ bool CodegenCVisitor::nrn_state_required() const noexcept {
     if (info.artificial_cell) {
         return false;
     }
-    return info.nrn_state_block != nullptr || info.currents.empty();
+    return info.nrn_state_block != nullptr || !info.currents.empty();
 }
 
 

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -375,7 +375,7 @@ bool CodegenCVisitor::nrn_state_required() const noexcept {
     if (info.artificial_cell) {
         return false;
     }
-    return info.nrn_state_block != nullptr || !info.currents.empty();
+    return info.nrn_state_block != nullptr || breakpoint_exist();
 }
 
 


### PR DESCRIPTION
- Register and print nrn_state if there is breakpoint block similar to how it is handled in `mod2c`: https://github.com/BlueBrain/mod2c/blob/4898ef45064804f9c7815765721d2b23b67e40b3/src/mod2c_core/nocpout.c#L305
- This PR will also stop generating the `nrn_state` if it's not required