### PR TITLE
Support for BEFORE/AFTER blocks in code generation

### DIFF
--- a/.github/workflows/nmodl-doc.yml
+++ b/.github/workflows/nmodl-doc.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   ci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
 
     name: documentation
 
@@ -40,6 +40,7 @@ jobs:
           
       - name: Install apt packages
         run: |
+          sudo apt-get update
           sudo apt-get install bison ccache dvipng doxygen flex libfl-dev \
             ninja-build pandoc python3-dev python3-pip \
             texlive-latex-recommended texlive-latex-extra

--- a/.github/workflows/nmodl-doc.yml
+++ b/.github/workflows/nmodl-doc.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   ci:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     name: documentation
 

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -2929,7 +2929,7 @@ void CodegenCVisitor::print_mechanism_register() {
         // register type and associated function name for the block
         const auto& block = info.before_after_blocks[i];
         size_t register_type = get_register_type_for_ba_block(block);
-        std::string function_name("nrn_before_after_{}"_format(i));
+        std::string function_name = method_name("nrn_before_after_{}"_format(i));
         printer->add_line("hoc_reg_ba(mech_type, {}, {});"_format(function_name, register_type));
     }
 
@@ -3570,7 +3570,7 @@ void CodegenCVisitor::print_nrn_init(bool skip_init_check) {
 void CodegenCVisitor::print_before_after_block(const ast::Block* node, size_t block_id) {
     codegen = true;
     /// name of the before/after function
-    std::string function_name("nrn_before_after_{}"_format(block_id));
+    std::string function_name = method_name("nrn_before_after_{}"_format(block_id));
 
     /// print common function code like init/state/current
     printer->add_newline(2);
@@ -3591,14 +3591,14 @@ void CodegenCVisitor::print_before_after_block(const ast::Block* node, size_t bl
     }
 
     /// print main body
-    std::shared_ptr<ast::BABlock> ba_block;
+    std::shared_ptr<ast::StatementBlock> block;
     if (node->is_before_block()) {
-        ba_block = dynamic_cast<const ast::BeforeBlock*>(node)->get_bablock();
+        block = dynamic_cast<const ast::BeforeBlock*>(node)->get_bablock()->get_statement_block();
     } else {
-        ba_block = dynamic_cast<const ast::AfterBlock*>(node)->get_bablock();
+        block = dynamic_cast<const ast::AfterBlock*>(node)->get_bablock()->get_statement_block();
     }
     printer->add_indent();
-    ba_block->get_statement_block()->visit_children(*this);
+    print_statement_block(*block);
     printer->add_newline();
 
     // write ion statements

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -79,6 +79,9 @@ enum BlockType {
     /// net_receive block
     NetReceive,
 
+    /// before / after block
+    BeforeAfter,
+
     /// fake ending block type for loops on the enums. Keep it at the end
     BlockTypeEnd
 };
@@ -1610,7 +1613,8 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      * Print common code for global functions like nrn_init, nrn_cur and nrn_state
      * \param type The target backend code block type
      */
-    virtual void print_global_function_common_code(BlockType type);
+    virtual void print_global_function_common_code(BlockType type,
+                                                   const std::string& function_name = "");
 
 
     /**
@@ -1886,6 +1890,12 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      */
     virtual void print_procedure(const ast::ProcedureBlock& node);
 
+    /**
+     * Print NMODL before / after block in target backend code
+     * @param node AST node of type before/after type being printed
+     * @param block_id Index of the before/after block
+     */
+    virtual void print_before_after_block(const ast::Block* node, size_t block_id);
 
     /** Setup the target backend code generator
      *

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1535,7 +1535,7 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      * \param type      The target backend code block type
      * \return          The generated target backend code
      */
-    std::string process_shadow_update_statement(ShadowUseStatement& statement, BlockType type);
+    std::string process_shadow_update_statement(const ShadowUseStatement& statement, BlockType type);
 
 
     /**

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1535,7 +1535,8 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      * \param type      The target backend code block type
      * \return          The generated target backend code
      */
-    std::string process_shadow_update_statement(const ShadowUseStatement& statement, BlockType type);
+    std::string process_shadow_update_statement(const ShadowUseStatement& statement,
+                                                BlockType type);
 
 
     /**

--- a/src/codegen/codegen_compatibility_visitor.cpp
+++ b/src/codegen/codegen_compatibility_visitor.cpp
@@ -24,10 +24,6 @@ const std::map<ast::AstNodeType, CodegenCompatibilityVisitor::FunctionPointer>
     CodegenCompatibilityVisitor::unhandled_ast_types_func(
         {{AstNodeType::MATCH_BLOCK,
           &CodegenCompatibilityVisitor::return_error_without_name<MatchBlock>},
-         {AstNodeType::BEFORE_BLOCK,
-          &CodegenCompatibilityVisitor::return_error_without_name<BeforeBlock>},
-         {AstNodeType::AFTER_BLOCK,
-          &CodegenCompatibilityVisitor::return_error_without_name<AfterBlock>},
          {AstNodeType::TERMINAL_BLOCK,
           &CodegenCompatibilityVisitor::return_error_without_name<TerminalBlock>},
          {AstNodeType::DISCRETE_BLOCK,

--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -743,5 +743,13 @@ void CodegenHelperVisitor::visit_verbatim(const Verbatim& node) {
     }
 }
 
+void CodegenHelperVisitor::visit_before_block(const ast::BeforeBlock& node) {
+    info.before_after_blocks.push_back(&node);
+}
+
+void CodegenHelperVisitor::visit_after_block(const ast::AfterBlock& node) {
+    info.before_after_blocks.push_back(&node);
+}
+
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/codegen_helper_visitor.hpp
+++ b/src/codegen/codegen_helper_visitor.hpp
@@ -112,6 +112,8 @@ class CodegenHelperVisitor: public visitor::ConstAstVisitor {
     void visit_partial_block(const ast::PartialBlock& node) override;
     void visit_update_dt(const ast::UpdateDt& node) override;
     void visit_verbatim(const ast::Verbatim& node) override;
+    void visit_before_block(const ast::BeforeBlock& node) override;
+    void visit_after_block(const ast::AfterBlock& node) override;
 };
 
 /** @} */  // end of codegen_details

--- a/src/codegen/codegen_info.hpp
+++ b/src/codegen/codegen_info.hpp
@@ -364,6 +364,9 @@ struct CodegenInfo {
     /// all watch statements
     std::vector<const ast::WatchStatement*> watch_statements;
 
+    /// all before after blocks
+    std::vector<const ast::Block*> before_after_blocks;
+
     /// all variables/symbols used in the verbatim block
     std::unordered_set<std::string> variables_in_verbatim;
 

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -362,7 +362,8 @@ void CodegenIspcVisitor::print_procedure(const ast::ProcedureBlock& node) {
 }
 
 
-void CodegenIspcVisitor::print_global_function_common_code(BlockType type) {
+void CodegenIspcVisitor::print_global_function_common_code(BlockType type,
+                                                           const std::string& function_name) {
     // If we are printing the cpp file, we have to use the c version of this function
     if (wrapper_codegen) {
         return CodegenCVisitor::print_global_function_common_code(type);

--- a/src/codegen/codegen_ispc_visitor.hpp
+++ b/src/codegen/codegen_ispc_visitor.hpp
@@ -131,7 +131,8 @@ class CodegenIspcVisitor: public CodegenCVisitor {
     ParamVector get_global_function_parms(const std::string& arg_qualifier);
 
 
-    void print_global_function_common_code(BlockType type) override;
+    void print_global_function_common_code(BlockType type,
+                                           const std::string& function_name = "") override;
 
 
     /// backend specific channel instance iteration block start


### PR DESCRIPTION
* separate functions are generated for each before/after
       block just like other global functions init/state/current
* functions are then registed with coreneuron using `hoc_reg` api
* this will help to close BlueBrain/CoreNeuron/pull/748 and  neuronsimulator/nrn#1581
* there is no unit test but the code generation changes will be validated by integration test neuronsimulator/testcorenrn#8