### PR TITLE
Fixing \r as return char inside comments

### DIFF
--- a/src/lexer/nmodl.ll
+++ b/src/lexer/nmodl.ll
@@ -418,8 +418,8 @@ ELSE                    {
                             loc.step();
                         }
 
-:.* |
-\?.*                    {
+:[^\r\n]* |
+\?[^\r\n]*              {
                             /** Todo : add grammar support for inline vs single-line comments
                               auto str = std::string(yytext);
                               return NmodlParser::make_LINE_COMMENT(str, loc);

--- a/test/integration/mod/cabpump.mod
+++ b/test/integration/mod/cabpump.mod
@@ -40,8 +40,7 @@ STATE {
 
  
 BREAKPOINT {
-	SOLVE state METHOD euler
-}
+	SOLVE state METHOD euler : this comment is terminated by a \r only, and it should not break the parser}
 
 INCLUDE "var_init.inc"
 
@@ -62,6 +61,9 @@ PROCEDURE test_table(br) {
     TABLE ainf FROM 0 TO FOO WITH 1
     ainf = 1
 }
+
+: to test \r only as newlinePROCEDURE test_r(){
+} : add something that will breaks the parser
 
 INITIAL {
     var_init(var)

--- a/test/unit/parser/parser.cpp
+++ b/test/unit/parser/parser.cpp
@@ -34,6 +34,17 @@ bool is_valid_construct(const std::string& construct) {
 }
 
 
+SCENARIO("NMODL can accept \\r as return char for one line comment", "[parser]") {
+    GIVEN("A comment defined with \\r as return char") {
+        WHEN("parsing") {
+            THEN("success") {
+                REQUIRE(is_valid_construct(R"(: see you next linePROCEDURE foo() {
+                })"));
+            }
+        }
+    }
+}
+
 SCENARIO("NMODL can define macros using DEFINE keyword", "[parser]") {
     GIVEN("A valid macro definition") {
         WHEN("DEFINE NSTEP 6") {


### PR DESCRIPTION
If a single line comment in a mod file is end by only \r (not \r\n or \n),
currently it breaks because until the next \r\n or \n everything is inside
the comment