### PR TITLE
partialPivLu: rework OpenMP workaround.

### DIFF
--- a/.clang-format.changes
+++ b/.clang-format.changes
@@ -1,0 +1,1 @@
+StatementMacros: [InstantiatePartialPivLu, nrn_pragma_acc, nrn_pragma_omp]

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -147,7 +147,7 @@ void CodegenAccVisitor::print_eigen_linear_solver(const std::string& float_type,
     if (N <= 4) {
         printer->add_line("{0} = {1}.inverse()*{2};"_format(Xm, Jm, Fm));
     } else {
-        printer->add_line("{0} = partialPivLu{1}({2}, {3});"_format(Xm, N, Jm, Fm));
+        printer->add_line("{0} = partialPivLu<{1}>({2}, {3});"_format(Xm, N, Jm, Fm));
     }
 }
 

--- a/src/solver/partial_piv_lu/partial_piv_lu.cu
+++ b/src/solver/partial_piv_lu/partial_piv_lu.cu
@@ -6,47 +6,55 @@
  *************************************************************************/
 #include "partial_piv_lu/partial_piv_lu.h"
 
-template<int dim>
-EIGEN_DEVICE_FUNC
-VecType<dim> partialPivLu(const MatType<dim>& A, const VecType<dim>& b)
-{
+// See explanation in partial_piv_lu.h
+EIGEN_DEVICE_FUNC VecType<1> partialPivLu1(const MatType<1>& A, const VecType<1>& b) {
     return A.partialPivLu().solve(b);
 }
-
-// Explicit Template Instantiation
-template EIGEN_DEVICE_FUNC VecType<1> partialPivLu<1>(const MatType<1>& A, const VecType<1>& b);
-template EIGEN_DEVICE_FUNC VecType<2> partialPivLu<2>(const MatType<2>& A, const VecType<2>& b);
-template EIGEN_DEVICE_FUNC VecType<3> partialPivLu<3>(const MatType<3>& A, const VecType<3>& b);
-template EIGEN_DEVICE_FUNC VecType<4> partialPivLu<4>(const MatType<4>& A, const VecType<4>& b);
-template EIGEN_DEVICE_FUNC VecType<5> partialPivLu<5>(const MatType<5>& A, const VecType<5>& b);
-template EIGEN_DEVICE_FUNC VecType<6> partialPivLu<6>(const MatType<6>& A, const VecType<6>& b);
-template EIGEN_DEVICE_FUNC VecType<7> partialPivLu<7>(const MatType<7>& A, const VecType<7>& b);
-template EIGEN_DEVICE_FUNC VecType<8> partialPivLu<8>(const MatType<8>& A, const VecType<8>& b);
-template EIGEN_DEVICE_FUNC VecType<9> partialPivLu<9>(const MatType<9>& A, const VecType<9>& b);
-template EIGEN_DEVICE_FUNC VecType<10> partialPivLu<10>(const MatType<10>& A, const VecType<10>& b);
-template EIGEN_DEVICE_FUNC VecType<11> partialPivLu<11>(const MatType<11>& A, const VecType<11>& b);
-template EIGEN_DEVICE_FUNC VecType<12> partialPivLu<12>(const MatType<12>& A, const VecType<12>& b);
-template EIGEN_DEVICE_FUNC VecType<13> partialPivLu<13>(const MatType<13>& A, const VecType<13>& b);
-template EIGEN_DEVICE_FUNC VecType<14> partialPivLu<14>(const MatType<14>& A, const VecType<14>& b);
-template EIGEN_DEVICE_FUNC VecType<15> partialPivLu<15>(const MatType<15>& A, const VecType<15>& b);
-template EIGEN_DEVICE_FUNC VecType<16> partialPivLu<16>(const MatType<16>& A, const VecType<16>& b);
-
-EIGEN_DEVICE_FUNC VecType<1> partialPivLu1(const MatType<1>& A, const VecType<1>& b) { return A.partialPivLu().solve(b); }
-EIGEN_DEVICE_FUNC VecType<2> partialPivLu2(const MatType<2>& A, const VecType<2>& b) { return A.partialPivLu().solve(b); }
-EIGEN_DEVICE_FUNC VecType<3> partialPivLu3(const MatType<3>& A, const VecType<3>& b) { return A.partialPivLu().solve(b); }
-EIGEN_DEVICE_FUNC VecType<4> partialPivLu4(const MatType<4>& A, const VecType<4>& b) { return A.partialPivLu().solve(b); }
-EIGEN_DEVICE_FUNC VecType<5> partialPivLu5(const MatType<5>& A, const VecType<5>& b) { return A.partialPivLu().solve(b); }
-EIGEN_DEVICE_FUNC VecType<6> partialPivLu6(const MatType<6>& A, const VecType<6>& b) { return A.partialPivLu().solve(b); }
-EIGEN_DEVICE_FUNC VecType<7> partialPivLu7(const MatType<7>& A, const VecType<7>& b) { return A.partialPivLu().solve(b); }
-EIGEN_DEVICE_FUNC VecType<8> partialPivLu8(const MatType<8>& A, const VecType<8>& b) { return A.partialPivLu().solve(b); }
-EIGEN_DEVICE_FUNC VecType<9> partialPivLu9(const MatType<9>& A, const VecType<9>& b) { return A.partialPivLu().solve(b); }
-EIGEN_DEVICE_FUNC VecType<10> partialPivLu10(const MatType<10>& A, const VecType<10>& b) { return A.partialPivLu().solve(b); }
-EIGEN_DEVICE_FUNC VecType<11> partialPivLu11(const MatType<11>& A, const VecType<11>& b) { return A.partialPivLu().solve(b); }
-EIGEN_DEVICE_FUNC VecType<12> partialPivLu12(const MatType<12>& A, const VecType<12>& b) { return A.partialPivLu().solve(b); }
-EIGEN_DEVICE_FUNC VecType<13> partialPivLu13(const MatType<13>& A, const VecType<13>& b) { return A.partialPivLu().solve(b); }
-EIGEN_DEVICE_FUNC VecType<14> partialPivLu14(const MatType<14>& A, const VecType<14>& b) { return A.partialPivLu().solve(b); }
-EIGEN_DEVICE_FUNC VecType<15> partialPivLu15(const MatType<15>& A, const VecType<15>& b) { return A.partialPivLu().solve(b); }
-EIGEN_DEVICE_FUNC VecType<16> partialPivLu16(const MatType<16>& A, const VecType<16>& b) { return A.partialPivLu().solve(b); }
+EIGEN_DEVICE_FUNC VecType<2> partialPivLu2(const MatType<2>& A, const VecType<2>& b) {
+    return A.partialPivLu().solve(b);
+}
+EIGEN_DEVICE_FUNC VecType<3> partialPivLu3(const MatType<3>& A, const VecType<3>& b) {
+    return A.partialPivLu().solve(b);
+}
+EIGEN_DEVICE_FUNC VecType<4> partialPivLu4(const MatType<4>& A, const VecType<4>& b) {
+    return A.partialPivLu().solve(b);
+}
+EIGEN_DEVICE_FUNC VecType<5> partialPivLu5(const MatType<5>& A, const VecType<5>& b) {
+    return A.partialPivLu().solve(b);
+}
+EIGEN_DEVICE_FUNC VecType<6> partialPivLu6(const MatType<6>& A, const VecType<6>& b) {
+    return A.partialPivLu().solve(b);
+}
+EIGEN_DEVICE_FUNC VecType<7> partialPivLu7(const MatType<7>& A, const VecType<7>& b) {
+    return A.partialPivLu().solve(b);
+}
+EIGEN_DEVICE_FUNC VecType<8> partialPivLu8(const MatType<8>& A, const VecType<8>& b) {
+    return A.partialPivLu().solve(b);
+}
+EIGEN_DEVICE_FUNC VecType<9> partialPivLu9(const MatType<9>& A, const VecType<9>& b) {
+    return A.partialPivLu().solve(b);
+}
+EIGEN_DEVICE_FUNC VecType<10> partialPivLu10(const MatType<10>& A, const VecType<10>& b) {
+    return A.partialPivLu().solve(b);
+}
+EIGEN_DEVICE_FUNC VecType<11> partialPivLu11(const MatType<11>& A, const VecType<11>& b) {
+    return A.partialPivLu().solve(b);
+}
+EIGEN_DEVICE_FUNC VecType<12> partialPivLu12(const MatType<12>& A, const VecType<12>& b) {
+    return A.partialPivLu().solve(b);
+}
+EIGEN_DEVICE_FUNC VecType<13> partialPivLu13(const MatType<13>& A, const VecType<13>& b) {
+    return A.partialPivLu().solve(b);
+}
+EIGEN_DEVICE_FUNC VecType<14> partialPivLu14(const MatType<14>& A, const VecType<14>& b) {
+    return A.partialPivLu().solve(b);
+}
+EIGEN_DEVICE_FUNC VecType<15> partialPivLu15(const MatType<15>& A, const VecType<15>& b) {
+    return A.partialPivLu().solve(b);
+}
+EIGEN_DEVICE_FUNC VecType<16> partialPivLu16(const MatType<16>& A, const VecType<16>& b) {
+    return A.partialPivLu().solve(b);
+}
 
 // Currently there is an issue in Eigen (GPU-branch) for matrices 17x17 and above.
 // ToDo: Check in a future release if this issue is resolved!


### PR DESCRIPTION
The explicitly named partialPivLuN(...) functions still seem to be
required, but by providing specialisations of partialPivLu<N>(...) in
the header then we seem to be able to revert one change to the code
generation and allow usage of nmodl::newton::newton_solver(...) in code
compiled with OpenMP. This includes the reduced dentate model after the
changes made in #804.

So far only tested locally with OpenMP and NVHPC 22.1. Being tested in the CI of https://github.com/BlueBrain/CoreNeuron/pull/766.

Closes https://github.com/BlueBrain/CoreNeuron/issues/767.