### PR TITLE
call get_node_name only on nodes that get it

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1412,12 +1412,15 @@ void CodegenCVisitor::print_function_call(const FunctionCall& node) {
     auto arguments = node.get_arguments();
     printer->add_text("{}("_format(function_name));
 
-    auto possible_nt_variable_types = arguments.front()->get_node_type() == AstNodeType::NAME &&
-                                      arguments.front()->get_node_type() == AstNodeType::STRING &&
-                                      arguments.front()->get_node_type() ==
-                                          AstNodeType::CONSTANT_VAR &&
-                                      arguments.front()->get_node_type() == AstNodeType::VAR_NAME &&
-                                      arguments.front()->get_node_type() == AstNodeType::LOCAL_VAR;
+    bool possible_nt_variable_types;
+    if (!defined_method(name)) {
+        possible_nt_variable_types = arguments.front()->get_node_type() == AstNodeType::NAME &&
+                                     arguments.front()->get_node_type() == AstNodeType::STRING &&
+                                     arguments.front()->get_node_type() ==
+                                         AstNodeType::CONSTANT_VAR &&
+                                     arguments.front()->get_node_type() == AstNodeType::VAR_NAME &&
+                                     arguments.front()->get_node_type() == AstNodeType::LOCAL_VAR;
+    }
     if (defined_method(name)) {
         printer->add_text(internal_method_arguments());
         if (!arguments.empty()) {

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1412,13 +1412,22 @@ void CodegenCVisitor::print_function_call(const FunctionCall& node) {
     auto arguments = node.get_arguments();
     printer->add_text("{}("_format(function_name));
 
+    auto possible_nt_variable_types = arguments.front()->get_node_type() == AstNodeType::NAME &&
+                                      arguments.front()->get_node_type() == AstNodeType::STRING &&
+                                      arguments.front()->get_node_type() ==
+                                          AstNodeType::CONSTANT_VAR &&
+                                      arguments.front()->get_node_type() == AstNodeType::VAR_NAME &&
+                                      arguments.front()->get_node_type() == AstNodeType::LOCAL_VAR;
     if (defined_method(name)) {
         printer->add_text(internal_method_arguments());
         if (!arguments.empty()) {
             printer->add_text(", ");
         }
     } else if (nmodl::details::needs_neuron_thread_first_arg(function_name) &&
-               arguments.front()->get_node_name() != "nt") {
+               (!possible_nt_variable_types || arguments.front()->get_node_name() != "nt")) {
+        // If the first argument is not `nt` we should add it.
+        // We compare with type because expression `a+b` is not `nt` but don't have `get_node_name`
+        // implemented
         arguments.insert(arguments.begin(), std::make_shared<ast::String>("nt"));
     }
 

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1412,7 +1412,7 @@ void CodegenCVisitor::print_function_call(const FunctionCall& node) {
     auto arguments = node.get_arguments();
     printer->add_text("{}("_format(function_name));
 
-    bool possible_nt_variable_types;
+    bool possible_nt_variable_types{false};
     if (!defined_method(name)) {
         possible_nt_variable_types = arguments.front()->get_node_type() == AstNodeType::NAME &&
                                      arguments.front()->get_node_type() == AstNodeType::STRING &&

--- a/src/codegen/codegen_compatibility_visitor.cpp
+++ b/src/codegen/codegen_compatibility_visitor.cpp
@@ -36,7 +36,6 @@ const std::map<ast::AstNodeType, CodegenCompatibilityVisitor::FunctionPointer>
           &CodegenCompatibilityVisitor::return_error_if_solve_method_is_unhandled},
          {AstNodeType::GLOBAL_VAR, &CodegenCompatibilityVisitor::return_error_global_var},
          {AstNodeType::PARAM_ASSIGN, &CodegenCompatibilityVisitor::return_error_param_var},
-         {AstNodeType::POINTER_VAR, &CodegenCompatibilityVisitor::return_error_pointer},
          {AstNodeType::BBCORE_POINTER_VAR,
           &CodegenCompatibilityVisitor::return_error_if_no_bbcore_read_write}});
 
@@ -84,14 +83,6 @@ std::string CodegenCompatibilityVisitor::return_error_param_var(
                    symbol->get_name(), symbol->get_token().position());
     }
     return error_message_global_var.str();
-}
-
-std::string CodegenCompatibilityVisitor::return_error_pointer(
-    ast::Ast& node,
-    const std::shared_ptr<ast::Ast>& ast_node) {
-    auto pointer_var = std::dynamic_pointer_cast<ast::PointerVar>(ast_node);
-    return "\"{}\" POINTER found at [{}] should be defined as BBCOREPOINTER to use it in CoreNeuron\n"_format(
-        pointer_var->get_node_name(), pointer_var->get_token()->position());
 }
 
 std::string CodegenCompatibilityVisitor::return_error_if_no_bbcore_read_write(

--- a/src/codegen/codegen_compatibility_visitor.hpp
+++ b/src/codegen/codegen_compatibility_visitor.hpp
@@ -136,16 +136,6 @@ class CodegenCompatibilityVisitor: public visitor::AstVisitor {
 
     std::string return_error_param_var(ast::Ast& node, const std::shared_ptr<ast::Ast>& ast_node);
 
-    /// Takes as parameter an std::shared_ptr<ast::Ast> node
-    /// and returns a relative error with the name and the
-    /// location of the pointer, as well as a suggestion to
-    /// define it as BBCOREPOINTER
-    ///
-    /// \param node Not used by the function
-    /// \param ast_node Ast node which is checked
-    /// \return std::string error
-    std::string return_error_pointer(ast::Ast& node, const std::shared_ptr<ast::Ast>& ast_node);
-
     /// Takes as parameter the ast::Ast and checks if the
     /// functions "bbcore_read" and "bbcore_write" are defined
     /// in any of the ast::Ast VERBATIM blocks. The function is


### PR DESCRIPTION
When a function is called sometimes we need to have nt first, if the user did not add it, we do it for him.
The current process was broken because expression such as `a+b` does not have `get_node_name` function.