### PR TITLE
Use myst_parser instead of m2r

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ subprocess.call('doxygen Doxyfile', shell=True)
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "m2r",
+    "myst_parser",
     "nbsphinx",
     "sphinx.ext.autodoc",
     "sphinx.ext.coverage",

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,2 +1,3 @@
 
-.. mdinclude:: ../CONTRIBUTING.md
+.. include:: ../CONTRIBUTING.md
+   :parser: myst_parser.sphinx_

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,3 +1,4 @@
 
-.. mdinclude:: ../INSTALL.md
+.. include:: ../INSTALL.md
+   :parser: myst_parser.sphinx_
 

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,5 +1,6 @@
 Introduction
 ============
 
-.. mdinclude:: ../README.md
+.. include:: ../README.md
+   :parser: myst_parser.sphinx_
 

--- a/setup.py
+++ b/setup.py
@@ -126,13 +126,12 @@ setup(
         "jinja2>=2.9.3",
         "jupyter-client<7", # try and work around: TypeError in notebooks/nmodl-kinetic-schemes.ipynb: 'coroutine' object is not subscriptable
         "jupyter",
-        "m2r",
+        "myst_parser",
         "mistune<2",  # prevents a version conflict with nbconvert
         "nbconvert<6.0",  # prevents issues with nbsphinx
         "nbsphinx>=0.3.2",
         "pytest>=3.7.2",
         "sphinx>=2.0",
-        "sphinx<3.0",  # prevents issue with m2r where m2r uses an old API no more supported with sphinx>=3.0
         "sphinx-rtd-theme",
     ]
     + install_requirements,


### PR DESCRIPTION
m2r seems outdated with sphinx > 3.0
myst_parser is the supported markdown ext in sphinx

https://www.sphinx-doc.org/en/master/usage/markdown.html