### PR TITLE
[For CI TESTING ONLY] Print kernel wrappers and nrn_init based on Instance Struct #551

### DIFF
--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1091,6 +1091,12 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
 
 
     /**
+     * Print the for loop statement going through all the mechanism instances
+     */
+    void print_channel_iteration_loop(const std::string& start, const std::string& end);
+
+
+    /**
      * Print channel iterations from which tasks are created
      *
      * \note This is not used for the C backend

--- a/src/codegen/codegen_naming.hpp
+++ b/src/codegen/codegen_naming.hpp
@@ -158,6 +158,12 @@ static constexpr char THREAD_ARGS_PROTO[] = "_threadargsproto_";
 /// prefix for ion variable
 static constexpr char ION_VARNAME_PREFIX[] = "ion_";
 
+/// name of the mechanism instance parameter in LLVM IR
+static constexpr char MECH_INSTANCE_VAR[] = "mech";
+static constexpr char MECH_NODECOUNT_VAR[] = "node_count";
+
+/// name of induction variable used in the kernel.
+static constexpr char INDUCTION_VAR[] = "id";
 
 /// commonly used variables in verbatim block and how they
 /// should be mapped to new code generation backends

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -244,7 +244,7 @@ std::shared_ptr<ast::InstanceStruct> CodegenLLVMHelperVisitor::create_instance_s
     add_var_with_type(naming::NTHREAD_DT_VARIABLE, FLOAT_TYPE, /*is_pointer=*/0);
     add_var_with_type(naming::CELSIUS_VARIABLE, FLOAT_TYPE, /*is_pointer=*/0);
     add_var_with_type(naming::SECOND_ORDER_VARIABLE, INTEGER_TYPE, /*is_pointer=*/0);
-    add_var_with_type(NODECOUNT_VAR, INTEGER_TYPE, /*is_pointer=*/0);
+    add_var_with_type(naming::MECH_NODECOUNT_VAR, INTEGER_TYPE, /*is_pointer=*/0);
 
     return std::make_shared<ast::InstanceStruct>(codegen_vars);
 }
@@ -462,7 +462,7 @@ void CodegenLLVMHelperVisitor::convert_to_instance_variable(ast::Node& node,
         /// instance_var_helper check of instance variables from mod file as well
         /// as extra variables like ion index variables added for code generation
         if (instance_var_helper.is_an_instance_variable(variable_name)) {
-            auto name = new ast::Name(new ast::String(MECH_INSTANCE_VAR));
+            auto name = new ast::Name(new ast::String(naming::MECH_INSTANCE_VAR));
             auto var = std::make_shared<ast::CodegenInstanceVar>(name, variable->clone());
             variable->set_name(var);
         }
@@ -631,7 +631,7 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     {
         /// access node index and corresponding voltage
         loop_index_statements.push_back(
-            visitor::create_statement("node_id = node_index[{}]"_format(INDUCTION_VAR)));
+            visitor::create_statement("node_id = node_index[{}]"_format(naming::INDUCTION_VAR)));
         loop_body_statements.push_back(
             visitor::create_statement("v = {}[node_id]"_format(VOLTAGE_VAR)));
 
@@ -682,9 +682,10 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     /// main loop possibly vectorized on vector_width
     {
         /// loop constructs : initialization, condition and increment
-        const auto& initialization = int_initialization_expression(INDUCTION_VAR);
-        const auto& condition = loop_count_expression(INDUCTION_VAR, NODECOUNT_VAR, vector_width);
-        const auto& increment = loop_increment_expression(INDUCTION_VAR, vector_width);
+        const auto& initialization = int_initialization_expression(naming::INDUCTION_VAR);
+        const auto& condition =
+            loop_count_expression(naming::INDUCTION_VAR, NODECOUNT_VAR, vector_width);
+        const auto& increment = loop_increment_expression(naming::INDUCTION_VAR, vector_width);
 
         /// clone it
         auto local_loop_block = std::shared_ptr<ast::StatementBlock>(loop_block->clone());
@@ -712,8 +713,9 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     if (vector_width > 1) {
         /// loop constructs : initialization, condition and increment
         const auto& condition =
-            loop_count_expression(INDUCTION_VAR, NODECOUNT_VAR, /*vector_width=*/1);
-        const auto& increment = loop_increment_expression(INDUCTION_VAR, /*vector_width=*/1);
+            loop_count_expression(naming::INDUCTION_VAR, NODECOUNT_VAR, /*vector_width=*/1);
+        const auto& increment = loop_increment_expression(naming::INDUCTION_VAR,
+                                                          /*vector_width=*/1);
 
         /// rename local variables to avoid conflict with main loop
         rename_local_variables(*loop_block);
@@ -765,7 +767,7 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     ast::CodegenVarWithTypeVector code_arguments;
 
     auto instance_var_type = new ast::CodegenVarType(ast::AstNodeType::INSTANCE_STRUCT);
-    auto instance_var_name = new ast::Name(new ast::String(MECH_INSTANCE_VAR));
+    auto instance_var_name = new ast::Name(new ast::String(naming::MECH_INSTANCE_VAR));
     auto instance_var = new ast::CodegenVarWithType(instance_var_type, 1, instance_var_name);
     code_arguments.emplace_back(instance_var);
 

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -113,12 +113,6 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
     /// mechanism data helper
     InstanceVarHelper instance_var_helper;
 
-    /// name of the mechanism instance parameter
-    const std::string MECH_INSTANCE_VAR = "mech";
-
-    /// name of induction variable used in the kernel.
-    const std::string INDUCTION_VAR = "id";
-
     /// create new function for FUNCTION or PROCEDURE block
     void create_function_for_node(ast::Block& node);
 
@@ -143,7 +137,7 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
     }
 
     std::string get_kernel_id() {
-        return INDUCTION_VAR;
+        return naming::INDUCTION_VAR;
     }
 
     /// run visitor and return code generation functions

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -322,7 +322,7 @@ int CodegenLLVMVisitor::get_num_elements(const ast::IndexedName& node) {
         return integer->get_value();
 
     // Otherwise, the length is taken from the macro.
-    const auto& macro = sym_tab->lookup(integer->get_macro()->get_node_name());
+    const auto& macro = program_symtab->lookup(integer->get_macro()->get_node_name());
     return static_cast<int>(*macro->get_value());
 }
 
@@ -729,7 +729,7 @@ void CodegenLLVMVisitor::visit_function_call(const ast::FunctionCall& node) {
     if (func) {
         create_function_call(func, name, node.get_arguments());
     } else {
-        auto symbol = sym_tab->lookup(name);
+        auto symbol = program_symtab->lookup(name);
         if (symbol && symbol->has_any_property(symtab::syminfo::NmodlType::extern_method)) {
             create_external_function_call(name, node.get_arguments());
         } else {
@@ -818,11 +818,11 @@ void CodegenLLVMVisitor::visit_program(const ast::Program& node) {
     CodegenLLVMHelperVisitor v{vector_width};
     const auto& functions = v.get_codegen_functions(node);
     instance_var_helper = v.get_instance_var_helper();
-    sym_tab = node.get_symbol_table();
+    program_symtab = node.get_symbol_table();
     std::string kernel_id = v.get_kernel_id();
 
     // Initialize the builder for this NMODL program.
-    ir_builder.initialize(*sym_tab, kernel_id);
+    ir_builder.initialize(*program_symtab, kernel_id);
 
     // Create compile unit if adding debug information to the module.
     if (add_debug_information) {
@@ -834,6 +834,9 @@ void CodegenLLVMVisitor::visit_program(const ast::Program& node) {
     for (const auto& func: functions) {
         create_function_declaration(*func);
     }
+
+    // Set the AST symbol table.
+    program_symtab = node.get_symbol_table();
 
     // Proceed with code generation. Right now, we do not do
     //     node.visit_children(*this);
@@ -895,6 +898,263 @@ void CodegenLLVMVisitor::visit_program(const ast::Program& node) {
     }
 
     logger->debug("Dumping generated IR...\n" + dump_module());
+    // Setup CodegenHelper for C++ wrapper file
+    setup(node);
+    print_wrapper_routines();
+    print_target_file();
+}
+
+void CodegenLLVMVisitor::print_wrapper_headers_include() {
+    print_standard_includes();
+    print_coreneuron_includes();
+}
+
+void CodegenLLVMVisitor::print_mechanism_range_var_structure() {
+    printer->add_newline(2);
+    printer->add_line("/** Instance Struct passed as argument to LLVM IR kernels */");
+    printer->start_block("struct {} "_format(mod_filename + instance_struct_type_name));
+    for (const auto& variable: instance_var_helper.instance->get_codegen_vars()) {
+        auto is_pointer = variable->get_is_pointer();
+        auto name = to_nmodl(variable->get_name());
+        auto qualifier = is_constant_variable(name) ? k_const() : "";
+        auto nmodl_type = variable->get_type()->get_type();
+        auto pointer = is_pointer ? "*" : "";
+        auto var_name = variable->get_node_name();
+        switch (nmodl_type) {
+#define DISPATCH(type, c_type)                                                              \
+    case type:                                                                              \
+        printer->add_line("{}{}{} {}{};"_format(                                            \
+            qualifier, c_type, pointer, is_pointer ? ptr_type_qualifier() : "", var_name)); \
+        break;
+
+            DISPATCH(ast::AstNodeType::DOUBLE, "double");
+            DISPATCH(ast::AstNodeType::INTEGER, "int");
+
+#undef DISPATCH
+        default:
+            throw std::runtime_error("Error: unsupported type found in instance struct");
+        }
+    }
+    printer->end_block();
+}
+
+void CodegenLLVMVisitor::print_instance_variable_setup() {
+    if (range_variable_setup_required()) {
+        print_setup_range_variable();
+    }
+
+    if (shadow_vector_setup_required()) {
+        print_shadow_vector_setup();
+    }
+    printer->add_newline(2);
+    printer->add_line("/** initialize mechanism instance variables */");
+    printer->start_block("static inline void setup_instance(NrnThread* nt, Memb_list* ml) ");
+    printer->add_line("{0}* inst = ({0}*) mem_alloc(1, sizeof({0}));"_format(
+        mod_filename + instance_struct_type_name));
+    if (channel_task_dependency_enabled() && !info.codegen_shadow_variables.empty()) {
+        printer->add_line("setup_shadow_vectors(inst, ml);");
+    }
+
+    std::string stride;
+    printer->add_line("int pnodecount = ml->_nodecount_padded;");
+    stride = "*pnodecount";
+
+    printer->add_line("Datum* indexes = ml->pdata;");
+
+    std::string float_type = default_float_data_type();
+    std::string int_type = default_int_data_type();
+    std::string float_type_pointer = float_type + "*";
+    std::string int_type_pointer = int_type + "*";
+
+    int id = 0;
+    std::vector<std::string> variables_to_free;
+
+    for (auto& var: info.codegen_float_variables) {
+        auto name = var->get_name();
+        auto range_var_type = get_range_var_float_type(var);
+        if (float_type == range_var_type) {
+            auto variable = "ml->data+{}{}"_format(id, stride);
+            auto device_variable = get_variable_device_pointer(variable, float_type_pointer);
+            printer->add_line("inst->{} = {};"_format(name, device_variable));
+        } else {
+            printer->add_line("inst->{} = setup_range_variable(ml->data+{}{}, pnodecount);"_format(
+                name, id, stride));
+            variables_to_free.push_back(name);
+        }
+        id += var->get_length();
+    }
+
+    for (auto& var: info.codegen_int_variables) {
+        auto name = var.symbol->get_name();
+        std::string variable = name;
+        std::string type = "";
+        if (var.is_index || var.is_integer) {
+            variable = "ml->pdata";
+            type = int_type_pointer;
+        } else if (var.is_vdata) {
+            variable = "nt->_vdata";
+            type = "void**";
+        } else {
+            variable = "nt->_data";
+            type = info.artificial_cell ? "void*" : float_type_pointer;
+        }
+        auto device_variable = get_variable_device_pointer(variable, type);
+        printer->add_line("inst->{} = {};"_format(name, device_variable));
+    }
+
+    int index_id = 0;
+    // for integer variables, there should be index
+    for (const auto& int_var: info.codegen_int_variables) {
+        std::string var_name = int_var.symbol->get_name() + "_index";
+        // Create for loop that instantiates the ion_<var>_index with
+        // indexes[<var_id>*pdnodecount+id] where id is from 0 to nodecount
+        printer->add_line("inst->{} = mem_alloc(pnodecount, sizeof(int));"_format(var_name));
+        print_channel_iteration_loop("0", "pnodecount");
+        printer->add_line("inst->{}[id] = indexes[{}*pnodecount+id];"_format(var_name, index_id));
+        printer->end_block(1);
+        index_id++;
+    }
+
+    // Pass voltage pointer to the the instance struct
+    printer->add_line("inst->voltage = nt->_actual_v;");
+
+    // Pass ml->nodeindices pointer to node_index
+    printer->add_line("inst->node_index = ml->nodeindices;");
+
+    // Setup global variables
+    printer->add_line("inst->{0} = nt->{0};"_format(naming::NTHREAD_T_VARIABLE));
+    printer->add_line("inst->{0} = nt->{0};"_format(naming::NTHREAD_DT_VARIABLE));
+    printer->add_line("inst->{0} = {0};"_format(naming::CELSIUS_VARIABLE));
+    printer->add_line("inst->{0} = {0};"_format(naming::SECOND_ORDER_VARIABLE));
+    printer->add_line("inst->{} = ml->nodecount;"_format(naming::MECH_NODECOUNT_VAR));
+
+    printer->add_line("ml->instance = (void*) inst;");
+    printer->end_block(3);
+
+    printer->add_line("/** cleanup mechanism instance variables */");
+    printer->start_block("static inline void cleanup_instance(Memb_list* ml) ");
+    printer->add_line(
+        "{0}* inst = ({0}*) ml->instance;"_format(mod_filename + instance_struct_type_name));
+    for (const auto& int_var: info.codegen_int_variables) {
+        std::string var_name = int_var.symbol->get_name() + "_index";
+        printer->add_line("mem_free((void*)inst->{});"_format(var_name));
+    }
+    if (range_variable_setup_required()) {
+        for (auto& var: variables_to_free) {
+            printer->add_line("mem_free((void*)inst->{});"_format(var));
+        }
+    }
+    printer->add_line("mem_free((void*)inst);");
+    printer->end_block(1);
+}
+
+CodegenLLVMVisitor::ParamVector CodegenLLVMVisitor::get_compute_function_parameter() {
+    auto params = ParamVector();
+    params.emplace_back(param_type_qualifier(),
+                        "{}*"_format(mod_filename + instance_struct_type_name),
+                        ptr_type_qualifier(),
+                        "inst");
+    return params;
+}
+
+void CodegenLLVMVisitor::print_backend_compute_routine_decl() {
+    auto params = get_compute_function_parameter();
+    auto compute_function = compute_method_name(BlockType::Initial);
+
+    printer->add_newline(2);
+    printer->add_line("extern void {}({});"_format(compute_function, get_parameter_str(params)));
+
+    if (info.nrn_cur_required()) {
+        compute_function = compute_method_name(BlockType::Equation);
+        printer->add_line(
+            "extern void {}({});"_format(compute_function, get_parameter_str(params)));
+    }
+
+    if (info.nrn_state_required()) {
+        compute_function = compute_method_name(BlockType::State);
+        printer->add_line(
+            "extern void {}({});"_format(compute_function, get_parameter_str(params)));
+    }
+}
+
+// Copied from CodegenIspcVisitor
+void CodegenLLVMVisitor::print_wrapper_routine(const std::string& wrapper_function,
+                                               BlockType type) {
+    static const auto args = "NrnThread* nt, Memb_list* ml, int type";
+    const auto function_name = method_name(wrapper_function);
+    auto compute_function = compute_method_name(type);
+
+    printer->add_newline(2);
+    printer->start_block("void {}({})"_format(function_name, args));
+    printer->add_line("int nodecount = ml->nodecount;");
+    // clang-format off
+    printer->add_line("{0}* {1}inst = ({0}*) ml->instance;"_format(mod_filename +
+        instance_struct_type_name, ptr_type_qualifier()));
+    // clang-format on
+
+    if (type == BlockType::Initial) {
+        printer->add_newline();
+        printer->add_line("setup_instance(nt, ml);");
+        printer->add_newline();
+        printer->start_block("if (_nrn_skip_initmodel)");
+        printer->add_line("return;");
+        printer->end_block();
+        printer->add_newline();
+    }
+
+    printer->add_line("{}(inst);"_format(compute_function));
+    printer->end_block();
+    printer->add_newline();
+}
+
+void CodegenLLVMVisitor::print_backend_compute_routine() {
+    print_wrapper_routine(naming::NRN_INIT_METHOD, BlockType::Initial);
+    print_wrapper_routine(naming::NRN_CUR_METHOD, BlockType::Equation);
+    print_wrapper_routine(naming::NRN_STATE_METHOD, BlockType::State);
+}
+
+void CodegenLLVMVisitor::print_data_structures() {
+    print_mechanism_global_var_structure();
+    print_mechanism_range_var_structure();
+    print_ion_var_structure();
+}
+
+void CodegenLLVMVisitor::print_compute_functions() {
+    print_top_verbatim_blocks();
+    print_backend_compute_routine_decl();
+    print_net_send_buffering();
+    print_net_init();
+    print_watch_activate();
+    print_watch_check();
+    print_net_receive_kernel();
+    print_net_receive();
+    print_net_receive_buffering();
+    print_backend_compute_routine();
+}
+
+void CodegenLLVMVisitor::print_wrapper_routines() {
+    printer = wrapper_printer;
+    wrapper_codegen = true;
+    print_backend_info();
+    print_wrapper_headers_include();
+    print_namespace_begin();
+
+    CodegenCVisitor::print_nmodl_constants();
+    print_mechanism_info();
+    print_data_structures();
+    print_global_variables_for_hoc();
+    print_common_getters();
+
+    print_memory_allocation_routine();
+    print_thread_memory_callbacks();
+    print_abort_routine();
+    print_global_variable_setup();
+    print_instance_variable_setup();
+    print_nrn_alloc();
+    print_compute_functions();
+    print_check_table_thread_function();
+    print_mechanism_register();
+    print_namespace_end();
 }
 
 void CodegenLLVMVisitor::visit_procedure_block(const ast::ProcedureBlock& node) {

--- a/src/printer/code_printer.cpp
+++ b/src/printer/code_printer.cpp
@@ -40,6 +40,13 @@ void CodePrinter::start_block(std::string&& text) {
     indent_level++;
 }
 
+void CodePrinter::start_block(const std::string& text) {
+    add_indent();
+    *result << text << " {";
+    add_newline();
+    indent_level++;
+}
+
 void CodePrinter::add_indent() {
     *result << std::string(indent_level * NUM_SPACES, ' ');
 }

--- a/src/printer/code_printer.hpp
+++ b/src/printer/code_printer.hpp
@@ -66,6 +66,8 @@ class CodePrinter {
 
     void start_block(std::string&&);
 
+    void start_block(const std::string& text);
+
     void add_text(const std::string&);
 
     void add_line(const std::string&, int num_new_lines = 1);


### PR DESCRIPTION
- Setup all the parameters of `<mod>__instance_var__type` in `setup_instance`
- Free allocated vectors in `cleanup_instance`
- Generate wrapper functions for `nrn_cur_<mod>`, `nrn_init_<mod>` and `nrn_state_<mod>`
- Print LLVM IR code to `<mod_filename>.ll`
- Check whether some of the added printing related to `net_receive`, etc are really needed
  in `CodegenLLVMVisitor` (I tried to mimic the `CodegenISPCVisitor`)
- Check whether we should add `const` qualifier in some of the instance members