### PR TITLE
[LLVM][GPU] Separated CPU and GPU CLI options

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,26 +176,29 @@ int main(int argc, const char* argv[]) {
     /// use single precision floating-point types
     bool llvm_float_type(false);
 
-    /// llvm vector width
-    int llvm_vec_width = 1;
+    /// optimisation level for IR generation
+    int llvm_opt_level_ir = 0;
 
-    /// vector library name
-    std::string vector_library("none");
+    /// math library name
+    std::string llvm_math_library("none");
 
     /// disable debug information generation for the IR
-    bool disable_debug_information(false);
+    bool llvm_no_debug(false);
 
     /// fast math flags for LLVM backend
     std::vector<std::string> llvm_fast_math_flags;
 
+    /// traget CPU platform name
+    std::string llvm_cpu_name = "default";
+
+    /// traget GPU platform name
+    std::string llvm_gpu_name = "default";
+
+    /// llvm vector width if generating code for CPUs
+    int llvm_vector_width = 1;
+
     /// run llvm benchmark
-    bool run_llvm_benchmark(false);
-
-    /// do not assume that instance struct fields do not alias
-    bool llvm_assume_alias(false);
-
-    /// optimisation level for IR generation
-    int llvm_opt_level_ir = 0;
+    bool llvm_benchmark(false);
 
     /// optimisation level for machine code generation
     int llvm_opt_level_codegen = 0;
@@ -208,9 +211,6 @@ int main(int argc, const char* argv[]) {
 
     /// the number of repeated experiments for the benchmarking
     int num_experiments = 100;
-
-    /// specify the cpu for LLVM IR to target
-    std::string cpu = "default";
 #endif
 
     app.get_formatter()->column_width(40);
@@ -323,36 +323,57 @@ int main(int argc, const char* argv[]) {
 
     // LLVM IR code generation options.
     auto llvm_opt = app.add_subcommand("llvm", "LLVM code generation option")->ignore_case();
-    llvm_opt->add_flag("--ir",
+    auto llvm_ir_opt = llvm_opt->add_flag("--ir",
         llvm_ir,
         "Generate LLVM IR ({})"_format(llvm_ir))->ignore_case();
-    llvm_opt->add_flag("--disable-debug-info",
-                       disable_debug_information,
-                       "Disable debug information ({})"_format(disable_debug_information))->ignore_case();
+    llvm_ir_opt->required(true);
+    llvm_opt->add_flag("--no-debug",
+        llvm_no_debug,
+        "Disable debug information ({})"_format(llvm_no_debug))->ignore_case();
     llvm_opt->add_option("--opt-level-ir",
-                              llvm_opt_level_ir,
-                              "LLVM IR optimisation level (O{})"_format(llvm_opt_level_ir))->ignore_case()->check(CLI::IsMember({"0", "1", "2", "3"}));
+        llvm_opt_level_ir,
+        "LLVM IR optimisation level (O{})"_format(llvm_opt_level_ir))->ignore_case()->check(CLI::IsMember({"0", "1", "2", "3"}));
     llvm_opt->add_flag("--single-precision",
-                       llvm_float_type,
-                       "Use single precision floating-point types ({})"_format(llvm_float_type))->ignore_case();
-    llvm_opt->add_flag("--assume-may-alias",
-                       llvm_assume_alias,
-                       "Assume instance struct fields may alias ({})"_format(llvm_assume_alias))->ignore_case();
-    llvm_opt->add_option("--vector-width",
-        llvm_vec_width,
-        "LLVM explicit vectorisation width ({})"_format(llvm_vec_width))->ignore_case();
-    llvm_opt->add_option("--veclib",
-                         vector_library,
-                         "Vector library for maths functions ({})"_format(vector_library))->check(CLI::IsMember({"Accelerate", "libsystem_m", "libmvec", "MASSV", "SLEEF", "SVML", "none"}));
+        llvm_float_type,
+        "Use single precision floating-point types ({})"_format(llvm_float_type))->ignore_case();
     llvm_opt->add_option("--fmf",
-                         llvm_fast_math_flags,
-                         "Fast math flags for floating-point optimizations (none)")->check(CLI::IsMember({"afn", "arcp", "contract", "ninf", "nnan", "nsz", "reassoc", "fast"}));
+        llvm_fast_math_flags,
+        "Fast math flags for floating-point optimizations (none)")->check(CLI::IsMember({"afn", "arcp", "contract", "ninf", "nnan", "nsz", "reassoc", "fast"}));
+
+    // Platform options for LLVM code generation.
+    auto cpu_opt = app.add_subcommand("cpu", "LLVM CPU option")->ignore_case();
+    cpu_opt->needs(llvm_opt);
+    cpu_opt->add_option("--name",
+        llvm_cpu_name,
+        "Name of CPU platform to use")->ignore_case();
+    auto simd_math_library_opt = cpu_opt->add_option("--math-library",
+        llvm_math_library,
+        "Math library for SIMD code generation ({})"_format(llvm_math_library));
+    simd_math_library_opt->check(CLI::IsMember({"Accelerate", "libmvec", "libsystem_m", "MASSV", "SLEEF", "SVML", "none"}));
+    cpu_opt->add_option("--vector-width",
+        llvm_vector_width,
+        "Explicit vectorization width for IR generation ({})"_format(llvm_vector_width))->ignore_case();
+
+    auto gpu_opt = app.add_subcommand("gpu", "LLVM GPU option")->ignore_case();
+    gpu_opt->needs(llvm_opt);
+    gpu_opt->add_option("--name",
+        llvm_gpu_name,
+        "Name of GPU platform to use")->ignore_case();
+    auto gpu_math_library_opt = gpu_opt->add_option("--math-library",
+        llvm_math_library,
+        "Math library for GPU code generation ({})"_format(llvm_math_library));
+    gpu_math_library_opt->check(CLI::IsMember({"libdevice"}));
+
+    // Allow only one platform at a time.
+    cpu_opt->excludes(gpu_opt);
+    gpu_opt->excludes(cpu_opt);
 
     // LLVM IR benchmark options.
     auto benchmark_opt = app.add_subcommand("benchmark", "LLVM benchmark option")->ignore_case();
+    benchmark_opt->needs(llvm_opt);
     benchmark_opt->add_flag("--run",
-                            run_llvm_benchmark,
-                            "Run LLVM benchmark ({})"_format(run_llvm_benchmark))->ignore_case();
+                            llvm_benchmark,
+                            "Run LLVM benchmark ({})"_format(llvm_benchmark))->ignore_case();
     benchmark_opt->add_option("--opt-level-codegen",
                               llvm_opt_level_codegen,
                               "Machine code optimisation level (O{})"_format(llvm_opt_level_codegen))->ignore_case()->check(CLI::IsMember({"0", "1", "2", "3"}));
@@ -365,9 +386,6 @@ int main(int argc, const char* argv[]) {
     benchmark_opt->add_option("--repeat",
                               num_experiments,
                               "Number of experiments for benchmarking ({})"_format(num_experiments))->ignore_case();
-    benchmark_opt->add_option("--cpu",
-                       cpu,
-                       "Target's backend ({})"_format(cpu))->ignore_case();
 #endif
     // clang-format on
 
@@ -673,38 +691,33 @@ int main(int argc, const char* argv[]) {
             }
 
 #ifdef NMODL_LLVM_BACKEND
-            if (llvm_ir || run_llvm_benchmark) {
-                // If benchmarking, we want to optimize the IR with target information and not in
-                // LLVM visitor.
-                int llvm_opt_level = run_llvm_benchmark ? 0 : llvm_opt_level_ir;
+            if (llvm_ir || llvm_benchmark) {
+              // If benchmarking, we want to optimize the IR with target
+              // information and not in LLVM visitor.
+              int llvm_opt_level = llvm_benchmark ? 0 : llvm_opt_level_ir;
 
-                logger->info("Running LLVM backend code generator");
-                CodegenLLVMVisitor visitor(modfile,
-                                           output_dir,
-                                           llvm_opt_level,
-                                           llvm_float_type,
-                                           llvm_vec_width,
-                                           vector_library,
-                                           !disable_debug_information,
-                                           llvm_fast_math_flags,
-                                           llvm_assume_alias);
-                visitor.visit_program(*ast);
-                ast_to_nmodl(*ast, filepath("llvm", "mod"));
-                ast_to_json(*ast, filepath("llvm", "json"));
+              if (llvm_gpu_name != "default") {
+                logger->warn("GPU code generation is not supported, targeting "
+                             "CPU instead");
+              }
 
-                if (run_llvm_benchmark) {
-                    logger->info("Running LLVM benchmark");
-                    benchmark::LLVMBenchmark benchmark(visitor,
-                                                       modfile,
-                                                       output_dir,
-                                                       shared_lib_paths,
-                                                       num_experiments,
-                                                       instance_size,
-                                                       cpu,
-                                                       llvm_opt_level_ir,
-                                                       llvm_opt_level_codegen);
-                    benchmark.run(ast);
-                }
+              logger->info("Running LLVM backend code generator");
+              CodegenLLVMVisitor visitor(modfile, output_dir, llvm_opt_level,
+                                         llvm_float_type, llvm_vector_width,
+                                         llvm_math_library, !llvm_no_debug,
+                                         llvm_fast_math_flags, true);
+              visitor.visit_program(*ast);
+              ast_to_nmodl(*ast, filepath("llvm", "mod"));
+              ast_to_json(*ast, filepath("llvm", "json"));
+
+              if (llvm_benchmark) {
+                logger->info("Running LLVM benchmark");
+                benchmark::LLVMBenchmark benchmark(
+                    visitor, modfile, output_dir, shared_lib_paths,
+                    num_experiments, instance_size, llvm_cpu_name,
+                    llvm_opt_level_ir, llvm_opt_level_codegen);
+                benchmark.run(ast);
+              }
             }
 #endif
         }


### PR DESCRIPTION
Now, CLI has two options: `cpu` and `gpu` that allow
users to target different platforms. For example,

```
bin/nmodl mod/test.mod -o out llvm --ir

bin/nmodl mod/test.mod -o out llvm --ir cpu --name skylake --vector-width 2

bin/nmodl mod/test.mod -o out llvm --ir gpu --name cuda
```

Moreover, `assume_no_alias` option was dropped and
made default (it didn't affect the computation in
our experiments).

The new CLI looks like:
```
llvm
  LLVM code generation option
  Options:
    --ir REQUIRED                         Generate LLVM IR (false)
    --no-debug                            Disable debug information (false)
    --opt-level-ir INT:{0,1,2,3}          LLVM IR optimisation level (O0)
    --single-precision                    Use single precision floating-point types (false)
    --fmf TEXT:{afn,arcp,contract,ninf,nnan,nsz,reassoc,fast} ...
                                          Fast math flags for floating-point optimizations (none)

cpu
  LLVM CPU option
  Options:
    --name TEXT                           Name of CPU platform to use
    --math-library TEXT:{Accelerate,libmvec,libsystem_m,MASSV,SLEEF,SVML,none}
                                          Math library for SIMD code generation (none)
    --vector-width INT                    Explicit vectorization width for IR generation (1)

gpu
  LLVM GPU option
  Options:
    --name TEXT                           Name of GPU platform to use
    --math-library TEXT:{libdevice}       Math library for GPU code generation (none)

benchmark
  LLVM benchmark option
  Options:
    --run                                 Run LLVM benchmark (false)
    --opt-level-codegen INT:{0,1,2,3}     Machine code optimisation level (O0)
    --libs TEXT:FILE ...                  Shared libraries to link IR against
    --instance-size INT                   Instance struct size (10000)
    --repeat INT                          Number of experiments for benchmarking (100)
```