### PR TITLE
[LLVM][refactoring] Added platform abstraction

### DIFF
--- a/src/codegen/llvm/CMakeLists.txt
+++ b/src/codegen/llvm/CMakeLists.txt
@@ -11,7 +11,9 @@ set(LLVM_CODEGEN_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/llvm_ir_builder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/llvm_ir_builder.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/llvm_utils.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/llvm_utils.hpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/llvm_utils.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/target_platform.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/target_platform.hpp)
 
 # =============================================================================
 # LLVM codegen library and executable

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -81,33 +81,22 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
     /// Optimisation level for LLVM IR transformations.
     int opt_level_ir;
 
-    /// Vector library used for math functions.
-    std::string vector_library;
-
-    /// Explicit vectorisation width.
-    int vector_width;
+    /// Target platform for the code generation.
+    Platform platform;
 
   public:
     CodegenLLVMVisitor(const std::string& mod_filename,
                        const std::string& output_dir,
+                       Platform& platform,
                        int opt_level_ir,
-                       bool use_single_precision = false,
-                       int vector_width = 1,
-                       std::string vec_lib = "none",
                        bool add_debug_information = false,
-                       std::vector<std::string> fast_math_flags = {},
-                       bool llvm_assume_alias = false)
+                       std::vector<std::string> fast_math_flags = {})
         : mod_filename(mod_filename)
         , output_dir(output_dir)
+        , platform(platform)
         , opt_level_ir(opt_level_ir)
-        , vector_width(vector_width)
-        , vector_library(vec_lib)
         , add_debug_information(add_debug_information)
-        , ir_builder(*context,
-                     use_single_precision,
-                     vector_width,
-                     fast_math_flags,
-                     !llvm_assume_alias)
+        , ir_builder(*context, platform, fast_math_flags)
         , debug_builder(*module) {}
 
     /// Dumps the generated LLVM IR module to string.
@@ -139,7 +128,7 @@ class CodegenLLVMVisitor: public visitor::ConstAstVisitor {
 
     /// Returns vector width
     int get_vector_width() const {
-        return vector_width;
+        return platform.get_instruction_width();
     }
 
     // Visitors.

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -41,13 +41,13 @@ llvm::Type* IRBuilder::get_i64_type() {
 }
 
 llvm::Type* IRBuilder::get_fp_type() {
-    if (fp_precision == single_precision)
+    if (platform.is_single_precision())
         return llvm::Type::getFloatTy(builder.getContext());
     return llvm::Type::getDoubleTy(builder.getContext());
 }
 
 llvm::Type* IRBuilder::get_fp_ptr_type() {
-    if (fp_precision == single_precision)
+    if (platform.is_single_precision())
         return llvm::Type::getFloatPtrTy(builder.getContext());
     return llvm::Type::getDoublePtrTy(builder.getContext());
 }
@@ -92,7 +92,7 @@ llvm::Value* IRBuilder::pop_last_value() {
 /****************************************************************************************/
 
 void IRBuilder::create_boolean_constant(int value) {
-    if (vector_width > 1 && vectorize) {
+    if (platform.is_cpu_with_simd() && vectorize) {
         value_stack.push_back(get_vector_constant<llvm::ConstantInt>(get_boolean_type(), value));
     } else {
         value_stack.push_back(get_scalar_constant<llvm::ConstantInt>(get_boolean_type(), value));
@@ -100,7 +100,7 @@ void IRBuilder::create_boolean_constant(int value) {
 }
 
 void IRBuilder::create_fp_constant(const std::string& value) {
-    if (vector_width > 1 && vectorize) {
+    if (platform.is_cpu_with_simd() && vectorize) {
         value_stack.push_back(get_vector_constant<llvm::ConstantFP>(get_fp_type(), value));
     } else {
         value_stack.push_back(get_scalar_constant<llvm::ConstantFP>(get_fp_type(), value));
@@ -112,7 +112,7 @@ llvm::Value* IRBuilder::create_global_string(const ast::String& node) {
 }
 
 void IRBuilder::create_i32_constant(int value) {
-    if (vector_width > 1 && vectorize) {
+    if (platform.is_cpu_with_simd() && vectorize) {
         value_stack.push_back(get_vector_constant<llvm::ConstantInt>(get_i32_type(), value));
     } else {
         value_stack.push_back(get_scalar_constant<llvm::ConstantInt>(get_i32_type(), value));
@@ -126,6 +126,8 @@ llvm::Value* IRBuilder::get_scalar_constant(llvm::Type* type, V value) {
 
 template <typename C, typename V>
 llvm::Value* IRBuilder::get_vector_constant(llvm::Type* type, V value) {
+    int vector_width = platform.get_instruction_width();
+
     ConstantVector constants;
     for (unsigned i = 0; i < vector_width; ++i) {
         const auto& element = C::get(type, value);
@@ -206,9 +208,7 @@ void IRBuilder::set_kernel_attributes() {
     //  > The `noalias` attribute indicates that the only memory accesses inside function are loads
     //  > and stores from objects pointed to by its pointer-typed arguments, with arbitrary
     //  > offsets.
-    if (assume_noalias) {
-        current_function->addParamAttr(0, llvm::Attribute::NoAlias);
-    }
+    current_function->addParamAttr(0, llvm::Attribute::NoAlias);
 
     // Finally, specify that the struct pointer does not capture and is read-only.
     current_function->addParamAttr(0, llvm::Attribute::NoCapture);
@@ -227,7 +227,7 @@ void IRBuilder::set_loop_metadata(llvm::BranchInst* branch) {
     loop_metadata.push_back(nullptr);
 
     // If `vector_width` is 1, explicitly disable vectorization for benchmarking purposes.
-    if (vector_width == 1) {
+    if (platform.is_cpu() && platform.get_instruction_width() == 1) {
         llvm::MDString* name = llvm::MDString::get(context, "llvm.loop.vectorize.enable");
         llvm::Value* false_value = llvm::ConstantInt::get(get_boolean_type(), 0);
         llvm::ValueAsMetadata* value = llvm::ValueAsMetadata::get(false_value);
@@ -376,6 +376,7 @@ llvm::Value* IRBuilder::create_index(llvm::Value* value) {
     const auto& element_type = llvm::cast<llvm::IntegerType>(vector_type->getElementType());
     if (element_type->getBitWidth() == i64_type->getIntegerBitWidth())
         return value;
+    int vector_width = platform.get_instruction_width();
     return builder.CreateSExtOrTrunc(value, llvm::FixedVectorType::get(i64_type, vector_width));
 }
 
@@ -449,7 +450,8 @@ void IRBuilder::create_scalar_or_vector_alloca(const std::string& name,
     // Even if generating vectorised code, some variables still need to be scalar. Particularly, the
     // induction variable "id" and remainder loop variables (that start with "epilogue" prefix).
     llvm::Type* type;
-    if (vector_width > 1 && vectorize && name != kernel_id && name.rfind("epilogue", 0)) {
+    if (platform.is_cpu_with_simd() && vectorize && name != kernel_id && name.rfind("epilogue", 0)) {
+        int vector_width = platform.get_instruction_width();
         type = llvm::FixedVectorType::get(element_or_scalar_type, vector_width);
     } else {
         type = element_or_scalar_type;
@@ -495,7 +497,7 @@ llvm::Value* IRBuilder::load_to_or_store_from_array(const std::string& id_name,
     llvm::Value* element_ptr = create_inbounds_gep(array, id_value);
 
     // Find out if the vector code is generated.
-    bool generating_vector_ir = vector_width > 1 && vectorize;
+    bool generating_vector_ir = platform.is_cpu_with_simd() && vectorize;
 
     // If the vector code is generated, we need to distinguish between two cases. If the array is
     // indexed indirectly (i.e. not by an induction variable `kernel_id`), create gather/scatter
@@ -523,7 +525,7 @@ llvm::Value* IRBuilder::load_to_or_store_from_array(const std::string& id_name,
         // to a vector pointer
         llvm::Type* vector_type = llvm::PointerType::get(
             llvm::FixedVectorType::get(element_ptr->getType()->getPointerElementType(),
-                                       vector_width),
+                                       platform.get_instruction_width()),
             /*AddressSpace=*/0);
         ptr = builder.CreateBitCast(element_ptr, vector_type);
     } else {
@@ -541,11 +543,12 @@ llvm::Value* IRBuilder::load_to_or_store_from_array(const std::string& id_name,
 
 void IRBuilder::maybe_replicate_value(llvm::Value* value) {
     // If the value should not be vectorised, or it is already a vector, add it to the stack.
-    if (!vectorize || vector_width == 1 || value->getType()->isVectorTy()) {
+    if (!vectorize || !platform.is_cpu_with_simd() || value->getType()->isVectorTy()) {
         value_stack.push_back(value);
     } else {
         // Otherwise, we generate vectorized code inside the loop, so replicate the value to form a
         // vector.
+        int vector_width = platform.get_instruction_width();
         llvm::Value* vector_value = builder.CreateVectorSplat(vector_width, value);
         value_stack.push_back(vector_value);
     }

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "codegen/llvm/codegen_llvm_helper_visitor.hpp"
+#include "codegen/llvm/target_platform.hpp"
 #include "symtab/symbol_table.hpp"
 
 #include "llvm/IR/IRBuilder.h"
@@ -52,14 +53,8 @@ class IRBuilder {
     /// Flag to indicate that the generated IR should be vectorized.
     bool vectorize;
 
-    /// Precision of the floating-point numbers (32 or 64 bit).
-    unsigned fp_precision;
-
-    /// The vector width used for the vectorized code.
-    unsigned vector_width;
-
-    /// Instance struct fields do not alias.
-    bool assume_noalias;
+    /// Target platform for which IR is built.
+    Platform platform;
 
     /// Masked value used to predicate vector instructions.
     llvm::Value* mask;
@@ -72,21 +67,17 @@ class IRBuilder {
 
   public:
     IRBuilder(llvm::LLVMContext& context,
-              bool use_single_precision = false,
-              unsigned vector_width = 1,
-              std::vector<std::string> fast_math_flags = {},
-              bool assume_noalias = true)
+              Platform& platform,
+              std::vector<std::string> fast_math_flags = {})
         : builder(context)
+        , platform(platform)
         , symbol_table(nullptr)
         , current_function(nullptr)
         , vectorize(false)
         , alloca_ip(nullptr)
-        , fp_precision(use_single_precision ? single_precision : double_precision)
-        , vector_width(vector_width)
         , mask(nullptr)
         , kernel_id("")
-        , fast_math_flags(fast_math_flags)
-        , assume_noalias(assume_noalias) {}
+        , fast_math_flags(fast_math_flags) {}
 
     /// Transforms the fast math flags provided to the builder into LLVM's representation.
     llvm::FastMathFlags transform_to_fmf(std::vector<std::string>& flags) {

--- a/src/codegen/llvm/main.cpp
+++ b/src/codegen/llvm/main.cpp
@@ -47,8 +47,11 @@ int main(int argc, const char* argv[]) {
     logger->info("Running Symtab Visitor");
     visitor::SymtabVisitor().visit_program(*ast);
 
+    // Use default platform for this toy example.
+    codegen::Platform platform;
+
     logger->info("Running LLVM Visitor");
-    codegen::CodegenLLVMVisitor llvm_visitor(filename, /*output_dir=*/".", /*opt_level_ir=*/0);
+    codegen::CodegenLLVMVisitor llvm_visitor(filename, /*output_dir=*/".", platform, /*opt_level_ir=*/0);
     llvm_visitor.visit_program(*ast);
     std::unique_ptr<llvm::Module> module = llvm_visitor.get_module();
 

--- a/src/codegen/llvm/target_platform.cpp
+++ b/src/codegen/llvm/target_platform.cpp
@@ -1,0 +1,54 @@
+/*************************************************************************
+ * Copyright (C) 2018-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#include "codegen/llvm/target_platform.hpp"
+
+namespace nmodl {
+namespace codegen {
+
+const std::string Platform::DEFAULT_PLATFORM_NAME = "default";
+const std::string Platform::DEFAULT_MATH_LIBRARY = "none";
+
+bool Platform::is_default_platform() {
+    // Default platform is a CPU.
+    return platform_id == PlatformID::CPU &&  name == Platform::DEFAULT_PLATFORM_NAME;
+}
+
+bool Platform::is_cpu() {
+    return platform_id == PlatformID::CPU;
+}
+
+bool Platform::is_cpu_with_simd() {
+    return platform_id == PlatformID::CPU && instruction_width > 1;
+}
+
+bool Platform::is_gpu() {
+    return platform_id == PlatformID::GPU;
+}
+
+bool Platform::is_single_precision() {
+  return use_single_precision;
+}
+
+std::string Platform::get_name() const {
+    return name;
+}
+
+std::string Platform::get_math_library() const {
+    return math_library;
+}
+
+int Platform::get_instruction_width() const {
+    return instruction_width;
+}
+
+int Platform::get_precision() const {
+    return use_single_precision? 32 : 64;
+}
+
+}  // namespace codegen
+}  // namespace nmodl

--- a/src/codegen/llvm/target_platform.hpp
+++ b/src/codegen/llvm/target_platform.hpp
@@ -1,0 +1,92 @@
+/*************************************************************************
+ * Copyright (C) 2018-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#pragma once
+
+#include <string>
+
+namespace nmodl {
+namespace codegen {
+
+enum PlatformID {
+    CPU,
+    GPU
+};
+
+/**
+ * \class Platform
+ * \brief A class that represents the target platform. It is needed to
+ * reduce the amount of code passed to LLVM visitor and its helpers.
+ */
+class Platform {
+  public:
+    /// Default name of the target and math library.
+    static const std::string DEFAULT_PLATFORM_NAME;
+    static const std::string DEFAULT_MATH_LIBRARY;
+
+  private:
+    /// Name of the platform.
+    const std::string name = Platform::DEFAULT_PLATFORM_NAME;
+
+    /// Target-specific id to compare platforms easily.
+    PlatformID platform_id;
+
+    /// User-provided width that is used to construct LLVM instructions
+    //  and types.
+    int instruction_width = 1;
+
+    /// Use single-precision floating-point types.
+    bool use_single_precision = false;
+
+    /// A name of user-provided math library.
+    std::string math_library = Platform::DEFAULT_MATH_LIBRARY;
+
+  public:
+    Platform(PlatformID platform_id,
+             const std::string& name,
+             std::string& math_library,
+             bool use_single_precision = false,
+             int instruction_width = 1)
+              : platform_id(platform_id)
+              , name(name)
+              , math_library(math_library)
+              , use_single_precision(use_single_precision)
+              , instruction_width(instruction_width) {}
+
+    Platform(bool use_single_precision,
+             int instruction_width)
+            : platform_id(PlatformID::CPU)
+            , use_single_precision(use_single_precision)
+            , instruction_width(instruction_width) {}
+
+    Platform() : platform_id(PlatformID::CPU) {}
+
+    /// Checks if this platform is a default platform.
+    bool is_default_platform();
+
+    /// Checks if this platform is a CPU.
+    bool is_cpu();
+
+    /// Checks if this platform is a CPU with SIMD support.
+    bool is_cpu_with_simd();
+
+    /// Checks if this platform is a GPU.
+    bool is_gpu();
+
+    bool is_single_precision();
+
+    std::string get_name() const;
+
+    std::string get_math_library() const;
+
+    int get_instruction_width() const;
+
+    int get_precision() const;
+};
+
+}  // namespace codegen
+}  // namespace nmodl

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -124,8 +124,12 @@ SCENARIO("Arithmetic expression", "[llvm][runner]") {
         const auto& ast = driver.parse_string(nmodl_text);
 
         SymtabVisitor().visit_program(*ast);
+
+        codegen::Platform cpu_platform(/*use_single_precision=*/false,
+                                       /*instruction_width=*/1);
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
+                                                 cpu_platform,
                                                  /*opt_level_ir=*/0);
         llvm_visitor.visit_program(*ast);
 
@@ -226,8 +230,12 @@ SCENARIO("Optimised arithmetic expression", "[llvm][runner]") {
         const auto& ast = driver.parse_string(nmodl_text);
 
         SymtabVisitor().visit_program(*ast);
+
+        codegen::Platform cpu_platform(/*use_single_precision=*/false,
+                                       /*instruction_width=*/1);
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
+                                                 cpu_platform,
                                                  /*opt_level_ir=*/3);
         llvm_visitor.visit_program(*ast);
 
@@ -299,11 +307,13 @@ SCENARIO("Simple scalar kernel", "[llvm][runner]") {
         SymtabVisitor().visit_program(*ast);
         NeuronSolveVisitor().visit_program(*ast);
         SolveBlockVisitor().visit_program(*ast);
+
+        codegen::Platform cpu_platform(/*use_single_precision=*/false,
+                                       /*instruction_width=*/1);
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
-                                                 /*opt_level_ir=*/0,
-                                                 /*use_single_precision=*/false,
-                                                 /*vector_width=*/1);
+                                                 cpu_platform,
+                                                 /*opt_level_ir=*/0);
         llvm_visitor.visit_program(*ast);
         llvm_visitor.wrap_kernel_functions();
 
@@ -381,11 +391,13 @@ SCENARIO("Simple vectorised kernel", "[llvm][runner]") {
         SymtabVisitor().visit_program(*ast);
         NeuronSolveVisitor().visit_program(*ast);
         SolveBlockVisitor().visit_program(*ast);
+
+        codegen::Platform simd_cpu_platform(/*use_single_precision=*/false,
+                                            /*instruction_width=*/4);
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
-                                                 /*opt_level_ir=*/3,
-                                                 /*use_single_precision=*/false,
-                                                 /*vector_width=*/4);
+                                                 simd_cpu_platform,
+                                                 /*opt_level_ir=*/3);
         llvm_visitor.visit_program(*ast);
         llvm_visitor.wrap_kernel_functions();
 
@@ -463,11 +475,13 @@ SCENARIO("Vectorised kernel with scatter instruction", "[llvm][runner]") {
         SymtabVisitor().visit_program(*ast);
         NeuronSolveVisitor().visit_program(*ast);
         SolveBlockVisitor().visit_program(*ast);
+
+        codegen::Platform simd_cpu_platform(/*use_single_precision=*/false,
+                                            /*instruction_width=*/2);
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
-                                                 /*opt_level_ir=*/0,
-                                                 /*use_single_precision=*/false,
-                                                 /*vector_width=*/2);
+                                                 simd_cpu_platform,
+                                                 /*opt_level_ir=*/0);
         llvm_visitor.visit_program(*ast);
         llvm_visitor.wrap_kernel_functions();
 
@@ -554,11 +568,13 @@ SCENARIO("Vectorised kernel with simple control flow", "[llvm][runner]") {
         SymtabVisitor().visit_program(*ast);
         NeuronSolveVisitor().visit_program(*ast);
         SolveBlockVisitor().visit_program(*ast);
+
+        codegen::Platform simd_cpu_platform(/*use_single_precision=*/false,
+                                            /*instruction_width=*/2);
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
-                                                 /*opt_level_ir=*/0,
-                                                 /*use_single_precision=*/false,
-                                                 /*vector_width=*/2);
+                                                 simd_cpu_platform,
+                                                 /*opt_level_ir=*/0);
         llvm_visitor.visit_program(*ast);
         llvm_visitor.wrap_kernel_functions();
 

--- a/test/unit/codegen/codegen_llvm_instance_struct.cpp
+++ b/test/unit/codegen/codegen_llvm_instance_struct.cpp
@@ -39,11 +39,11 @@ codegen::CodegenInstanceData generate_instance_data(const std::string& text,
     SymtabVisitor().visit_program(*ast);
     NeuronSolveVisitor().visit_program(*ast);
 
+    codegen::Platform cpu_platform(use_single_precision, vector_width);
     codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"test",
                                              /*output_dir=*/".",
-                                             opt_level,
-                                             use_single_precision,
-                                             vector_width);
+                                             cpu_platform,
+                                             opt_level);
     llvm_visitor.visit_program(*ast);
     llvm_visitor.dump_module();
     const auto& generated_instance_struct = llvm_visitor.get_instance_struct_ptr();

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -51,14 +51,12 @@ std::string run_llvm_visitor(const std::string& text,
     NeuronSolveVisitor().visit_program(*ast);
     SolveBlockVisitor().visit_program(*ast);
 
-    codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
-                                             /*output_dir=*/".",
-                                             opt_level,
-                                             use_single_precision,
-                                             vector_width,
-                                             vec_lib,
-                                             /*add_debug_information=*/false,
-                                             fast_math_flags);
+    codegen::Platform cpu_platform(codegen::PlatformID::CPU, /*name=*/"default",
+                                   vec_lib, use_single_precision, vector_width);
+    codegen::CodegenLLVMVisitor llvm_visitor(
+        /*mod_filename=*/"unknown",
+        /*output_dir=*/".", cpu_platform, opt_level,
+        /*add_debug_information=*/false, fast_math_flags);
 
     llvm_visitor.visit_program(*ast);
     return llvm_visitor.dump_module();


### PR DESCRIPTION
This commit introduces a handy `Plarform` class
that is designed to incorporate target information
for IR  generation, such as precision, vectorization
width (if applicable), type of target (CPU/GPU), etc.

In future, more functionality can be added to `Platform`,
e.g. we can move functionality of handling `llvm::Target`,
math SIMD libraries, etc.

Note: this is just a very basic implementation that enables
easier integration of GPU code generation.