### PR TITLE
[LLVM][GPU] Added GPU-specific AST transformations

### DIFF
--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -707,7 +707,7 @@ void CodegenLLVMHelperVisitor::create_gpu_compute_body(ast::StatementVector& bod
                                                        ast::StatementVector& function_statements,
                                                        std::vector<std::string>& int_variables,
                                                        std::vector<std::string>& double_variables) {
-    // Then, create condition for thread id. For now - reuse the same functionality as for
+    // Then, create condition for thread id. For now reuse the functionality from `loop_count_expression`.
     auto kernel_block = std::make_shared<ast::StatementBlock>(body);
     const auto& condition = loop_count_expression(INDUCTION_VAR, NODECOUNT_VAR, 1);
     ast::ElseIfStatementVector else_ifs = {};
@@ -746,7 +746,7 @@ void CodegenLLVMHelperVisitor::create_compute_body_loop(std::shared_ptr<ast::Sta
     // Clone the statement block if needed since it can be used by the remainder loop.
     auto loop_block = (is_remainder_loop || !platform.is_cpu_with_simd()) ? block : std::shared_ptr<ast::StatementBlock>(block->clone());
 
-    // Convert local statement to use CodegenVar statements and create  a FOR loop node. Also, if creating
+    // Convert local statement to use CodegenVar statements and create a FOR loop node. Also, if creating
     // a remainder loop then rename variables to avoid conflicts.
     if (is_remainder_loop)
         rename_local_variables(*loop_block);

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -443,7 +443,7 @@ void CodegenLLVMHelperVisitor::ion_write_statements(BlockType type,
  * @param node Ast node under which variables to be converted to instance type
  */
 void CodegenLLVMHelperVisitor::convert_to_instance_variable(ast::Node& node,
-                                                            std::string& index_var) {
+                                                            const std::string& index_var) {
     /// collect all variables in the node of type ast::VarName
     auto variables = collect_nodes(node, {ast::AstNodeType::VAR_NAME});
     for (const auto& v: variables) {
@@ -612,35 +612,29 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     /// statements for new function to be generated
     ast::StatementVector function_statements;
 
-    /// create variable definition for loop index and insert at the beginning
-    std::string loop_index_var = "id";
-    std::vector<std::string> induction_variables{"id"};
-    function_statements.push_back(
-        create_local_variable_statement(induction_variables, INTEGER_TYPE));
-
     /// create vectors of local variables that would be used in compute part
     std::vector<std::string> int_variables{"node_id"};
     std::vector<std::string> double_variables{"v"};
 
-    /// create now main compute part : for loop over channel instances
+    /// create now main compute part
 
-    /// loop body : initialization + solve blocks
-    ast::StatementVector loop_def_statements;
-    ast::StatementVector loop_index_statements;
-    ast::StatementVector loop_body_statements;
+    /// compute body : initialization + solve blocks
+    ast::StatementVector def_statements;
+    ast::StatementVector index_statements;
+    ast::StatementVector body_statements;
     {
         /// access node index and corresponding voltage
-        loop_index_statements.push_back(
+        index_statements.push_back(
             visitor::create_statement("node_id = node_index[{}]"_format(INDUCTION_VAR)));
-        loop_body_statements.push_back(
+        body_statements.push_back(
             visitor::create_statement("v = {}[node_id]"_format(VOLTAGE_VAR)));
 
         /// read ion variables
         ion_read_statements(BlockType::State,
                             int_variables,
                             double_variables,
-                            loop_index_statements,
-                            loop_body_statements);
+                            index_statements,
+                            body_statements);
 
         /// main compute node : extract solution expressions from the derivative block
         const auto& solutions = collect_nodes(node, {ast::AstNodeType::SOLUTION_EXPRESSION});
@@ -648,109 +642,41 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
             const auto& solution = std::dynamic_pointer_cast<ast::SolutionExpression>(statement);
             const auto& block = std::dynamic_pointer_cast<ast::StatementBlock>(
                 solution->get_node_to_solve());
-            append_statements_from_block(loop_body_statements, block);
+            append_statements_from_block(body_statements, block);
         }
 
         /// add breakpoint block if no current
         if (info.currents.empty() && info.breakpoint_node != nullptr) {
             auto block = info.breakpoint_node->get_statement_block();
-            append_statements_from_block(loop_body_statements, block);
+            append_statements_from_block(body_statements, block);
         }
 
         /// write ion statements
         ion_write_statements(BlockType::State,
                              int_variables,
                              double_variables,
-                             loop_index_statements,
-                             loop_body_statements);
+                             index_statements,
+                             body_statements);
 
         // \todo handle process_shadow_update_statement and wrote_conc_call yet
     }
 
-    ast::StatementVector loop_body;
-    loop_body.insert(loop_body.end(), loop_def_statements.begin(), loop_def_statements.end());
-    loop_body.insert(loop_body.end(), loop_index_statements.begin(), loop_index_statements.end());
-    loop_body.insert(loop_body.end(), loop_body_statements.begin(), loop_body_statements.end());
+    /// create target-specific compute body
+    ast::StatementVector compute_body;
+    compute_body.insert(compute_body.end(), def_statements.begin(), def_statements.end());
+    compute_body.insert(compute_body.end(), index_statements.begin(), index_statements.end());
+    compute_body.insert(compute_body.end(), body_statements.begin(), body_statements.end());
 
-    /// now construct a new code block which will become the body of the loop
-    auto loop_block = std::make_shared<ast::StatementBlock>(loop_body);
-
-    /// declare main FOR loop local variables
-    function_statements.push_back(create_local_variable_statement(int_variables, INTEGER_TYPE));
-    function_statements.push_back(create_local_variable_statement(double_variables, FLOAT_TYPE));
-
-    /// main loop possibly vectorized on vector_width
-    {
-        /// loop constructs : initialization, condition and increment
-        const auto& initialization = int_initialization_expression(INDUCTION_VAR);
-        const auto& condition = loop_count_expression(INDUCTION_VAR, NODECOUNT_VAR, vector_width);
-        const auto& increment = loop_increment_expression(INDUCTION_VAR, vector_width);
-
-        /// clone it
-        auto local_loop_block = std::shared_ptr<ast::StatementBlock>(loop_block->clone());
-
-        /// convert local statement to codegenvar statement
-        convert_local_statement(*local_loop_block);
-
-        auto for_loop_statement_main = std::make_shared<ast::CodegenForStatement>(initialization,
-                                                                                  condition,
-                                                                                  increment,
-                                                                                  local_loop_block);
-
-        /// convert all variables inside loop body to instance variables
-        convert_to_instance_variable(*for_loop_statement_main, loop_index_var);
-
-        /// loop itself becomes one of the statement in the function
-        function_statements.push_back(for_loop_statement_main);
-    }
-
-    /// vectors containing renamed FOR loop local variables
-    std::vector<std::string> renamed_int_variables;
-    std::vector<std::string> renamed_double_variables;
-
-    /// remainder loop possibly vectorized on vector_width
-    if (vector_width > 1) {
-        /// loop constructs : initialization, condition and increment
-        const auto& condition =
-            loop_count_expression(INDUCTION_VAR, NODECOUNT_VAR, /*vector_width=*/1);
-        const auto& increment = loop_increment_expression(INDUCTION_VAR, /*vector_width=*/1);
-
-        /// rename local variables to avoid conflict with main loop
-        rename_local_variables(*loop_block);
-
-        /// convert local statement to codegenvar statement
-        convert_local_statement(*loop_block);
-
-        auto for_loop_statement_remainder =
-            std::make_shared<ast::CodegenForStatement>(nullptr, condition, increment, loop_block);
-
-        const auto& loop_statements = for_loop_statement_remainder->get_statement_block();
-        // \todo: Change RenameVisitor to take a vector of names to which it would append a single
-        // prefix.
-        for (const auto& name: int_variables) {
-            std::string new_name = epilogue_variable_prefix + name;
-            renamed_int_variables.push_back(new_name);
-            visitor::RenameVisitor v(name, new_name);
-            loop_statements->accept(v);
-        }
-        for (const auto& name: double_variables) {
-            std::string new_name = epilogue_variable_prefix + name;
-            renamed_double_variables.push_back(new_name);
-            visitor::RenameVisitor v(name, epilogue_variable_prefix + name);
-            loop_statements->accept(v);
-        }
-
-        /// declare remainder FOR loop local variables
+    if (platform.is_gpu()) {
+        const auto& id_statement = std::make_shared<ast::CodegenThreadId>(create_varname(INDUCTION_VAR));
+        function_statements.push_back(id_statement);
+        create_gpu_compute_body(compute_body, function_statements, int_variables, double_variables);
+    } else {
+        // Create induction variable
+        std::vector<std::string> induction_variables{INDUCTION_VAR};
         function_statements.push_back(
-            create_local_variable_statement(renamed_int_variables, INTEGER_TYPE));
-        function_statements.push_back(
-            create_local_variable_statement(renamed_double_variables, FLOAT_TYPE));
-
-        /// convert all variables inside loop body to instance variables
-        convert_to_instance_variable(*for_loop_statement_remainder, loop_index_var);
-
-        /// loop itself becomes one of the statement in the function
-        function_statements.push_back(for_loop_statement_remainder);
+                create_local_variable_statement(induction_variables, INTEGER_TYPE));
+        create_cpu_compute_body(compute_body, function_statements, int_variables, double_variables);
     }
 
     /// new block for the function
@@ -775,6 +701,84 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     codegen_functions.push_back(function);
 
     std::cout << nmodl::to_nmodl(function) << std::endl;
+}
+
+void CodegenLLVMHelperVisitor::create_gpu_compute_body(ast::StatementVector& body,
+                                                       ast::StatementVector& function_statements,
+                                                       std::vector<std::string>& int_variables,
+                                                       std::vector<std::string>& double_variables) {
+    // Then, create condition for thread id. For now - reuse the same functionality as for
+    auto kernel_block = std::make_shared<ast::StatementBlock>(body);
+    const auto& condition = loop_count_expression(INDUCTION_VAR, NODECOUNT_VAR, 1);
+    ast::ElseIfStatementVector else_ifs = {};
+    auto if_statement = std::make_shared<ast::IfStatement>(condition, kernel_block, else_ifs, nullptr);
+
+    convert_to_instance_variable(*if_statement, INDUCTION_VAR);
+
+    // Push variables and the loop to the function statements vector.
+    function_statements.push_back(create_local_variable_statement(int_variables, INTEGER_TYPE));
+    function_statements.push_back(create_local_variable_statement(double_variables, FLOAT_TYPE));
+    function_statements.push_back(if_statement);
+}
+
+void CodegenLLVMHelperVisitor::create_cpu_compute_body(ast::StatementVector& body,
+                                                       ast::StatementVector& function_statements,
+                                                       std::vector<std::string>& int_variables,
+                                                       std::vector<std::string>& double_variables) {
+    auto loop_block = std::make_shared<ast::StatementBlock>(body);
+    create_compute_body_loop(loop_block, function_statements, int_variables, double_variables);
+    if (platform.is_cpu_with_simd())
+        create_compute_body_loop(loop_block, function_statements, int_variables, double_variables, /*is_remainder_loop=*/true);
+}
+
+void CodegenLLVMHelperVisitor::create_compute_body_loop(std::shared_ptr<ast::StatementBlock>& block,
+                                                        ast::StatementVector& function_statements,
+                                                        std::vector<std::string>& int_variables,
+                                                        std::vector<std::string>& double_variables,
+                                                        bool is_remainder_loop) {
+    // First, check if we are creating a main or remainder loop. If it is a remainder loop, then
+    // no initialization is needed and instruction width is simply 1.
+    int width = is_remainder_loop ? 1 : platform.get_instruction_width();
+    const auto& initialization = is_remainder_loop ? nullptr : int_initialization_expression(INDUCTION_VAR);
+    const auto& condition = loop_count_expression(INDUCTION_VAR, NODECOUNT_VAR, width);
+    const auto& increment = loop_increment_expression(INDUCTION_VAR, width);
+
+    // Clone the statement block if needed since it can be used by the remainder loop.
+    auto loop_block = (is_remainder_loop || !platform.is_cpu_with_simd()) ? block : std::shared_ptr<ast::StatementBlock>(block->clone());
+
+    // Convert local statement to use CodegenVar statements and create  a FOR loop node. Also, if creating
+    // a remainder loop then rename variables to avoid conflicts.
+    if (is_remainder_loop)
+        rename_local_variables(*loop_block);
+    convert_local_statement(*loop_block);
+    auto for_loop = std::make_shared<ast::CodegenForStatement>(initialization,
+                                                               condition,
+                                                               increment,
+                                                               loop_block);
+
+    // Convert all variables inside loop body to be instance variables.
+    convert_to_instance_variable(*for_loop, INDUCTION_VAR);
+
+    // Rename variables if processing remainder loop.
+    if (is_remainder_loop) {
+        const auto& loop_statements = for_loop->get_statement_block();
+        auto rename = [&](std::vector<std::string>& vars) {
+            for (int i = 0; i < vars.size(); ++i) {
+                std::string old_name = vars[i];
+                std::string new_name = epilogue_variable_prefix + vars[i];
+                vars[i] = new_name;
+                visitor::RenameVisitor v(old_name, new_name);
+                loop_statements->accept(v);
+            }
+        };
+        rename(int_variables);
+        rename(double_variables);
+    }
+
+    // Push variables and  the loop to the function statements vector.
+    function_statements.push_back(create_local_variable_statement(int_variables, INTEGER_TYPE));
+    function_statements.push_back(create_local_variable_statement(double_variables, FLOAT_TYPE));
+    function_statements.push_back(for_loop);
 }
 
 void CodegenLLVMHelperVisitor::remove_inlined_nodes(ast::Program& node) {

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -570,7 +570,7 @@ CodegenLLVMHelperVisitor::loop_increment_expression(const std::string& induction
                                                     bool is_remainder_loop) {
     const auto& id = create_varname(induction_var);
 
-    // For GPU platforms, increment by frid stride.
+    // For GPU platforms, increment by grid stride.
     if (platform.is_gpu()) {
         const auto& stride = new ast::CodegenGridStride();
         const auto& inc_expr =

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -549,48 +549,64 @@ void CodegenLLVMHelperVisitor::visit_function_block(ast::FunctionBlock& node) {
     create_function_for_node(node);
 }
 
-/**
- * Create loop increment expression `id = id + width`
- * \todo : same as int_initialization_expression()
- */
-static std::shared_ptr<ast::Expression> loop_increment_expression(const std::string& induction_var,
-                                                                  int vector_width) {
-    // first create id + x
+std::shared_ptr<ast::Expression>
+CodegenLLVMHelperVisitor::loop_initialization_expression(const std::string& induction_var,
+                                                         bool is_remainder_loop) {
+    if (platform.is_gpu()) {
+        const auto& id = create_varname(induction_var);
+        const auto& tid = new ast::CodegenThreadId();
+        return std::make_shared<ast::BinaryExpression>(id, ast::BinaryOperator(ast::BOP_ASSIGN), tid);
+    }
+
+  // Otherwise, platfrom is CPU. Since the loop can be a remainder loop, check if
+  // we need to initialize at all.
+    if (is_remainder_loop)
+        return nullptr;
+    return int_initialization_expression(induction_var);
+}
+
+std::shared_ptr<ast::Expression>
+CodegenLLVMHelperVisitor::loop_increment_expression(const std::string& induction_var,
+                                                    bool is_remainder_loop) {
     const auto& id = create_varname(induction_var);
-    const auto& inc = new ast::Integer(vector_width, nullptr);
+
+    // For GPU platforms, increment by frid stride.
+    if (platform.is_gpu()) {
+        const auto& stride = new ast::CodegenGridStride();
+        const auto& inc_expr =
+            new ast::BinaryExpression(id, ast::BinaryOperator(ast::BOP_ADDITION), stride);
+        return std::make_shared<ast::BinaryExpression>(id->clone(),
+                                                    ast::BinaryOperator(ast::BOP_ASSIGN),
+                                                    inc_expr);
+    }
+
+    // Otherwise, proceed with increment for CPU loop.
+    const int width = is_remainder_loop ? 1 : platform.get_instruction_width();
+    const auto& inc = new ast::Integer(width, nullptr);
     const auto& inc_expr =
         new ast::BinaryExpression(id, ast::BinaryOperator(ast::BOP_ADDITION), inc);
-    // now create id = id + x
     return std::make_shared<ast::BinaryExpression>(id->clone(),
                                                    ast::BinaryOperator(ast::BOP_ASSIGN),
                                                    inc_expr);
 }
 
-/**
- * Create loop count comparison expression
- *
- * Based on if loop is vectorised or not, the condition for loop
- * is different. For example:
- *  - serial loop : `id < node_count`
- *  - vector loop : `id < (node_count - vector_width + 1)`
- *
- * \todo : same as int_initialization_expression()
- */
-static std::shared_ptr<ast::Expression> loop_count_expression(const std::string& induction_var,
-                                                              const std::string& node_count,
-                                                              int vector_width) {
+std::shared_ptr<ast::Expression>
+CodegenLLVMHelperVisitor::loop_count_expression(const std::string& induction_var,
+                                                const std::string& node_count,
+                                                bool is_remainder_loop) {
+    const int width = is_remainder_loop ? 1 : platform.get_instruction_width();
     const auto& id = create_varname(induction_var);
     const auto& mech_node_count = create_varname(node_count);
 
     // For non-vectorised loop, the condition is id < mech->node_count
-    if (vector_width == 1) {
+    if (width == 1) {
         return std::make_shared<ast::BinaryExpression>(id->clone(),
                                                        ast::BinaryOperator(ast::BOP_LESS),
                                                        mech_node_count);
     }
 
-    // For vectorised loop, the condition is id < mech->node_count - vector_width + 1
-    const auto& remainder = new ast::Integer(vector_width - 1, /*macro=*/nullptr);
+    // For vectorised loop, the condition is id < mech->node_count - width + 1
+    const auto& remainder = new ast::Integer(width - 1, /*macro=*/nullptr);
     const auto& count = new ast::BinaryExpression(mech_node_count,
                                                   ast::BinaryOperator(ast::BOP_SUBTRACTION),
                                                   remainder);
@@ -667,15 +683,13 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     compute_body.insert(compute_body.end(), index_statements.begin(), index_statements.end());
     compute_body.insert(compute_body.end(), body_statements.begin(), body_statements.end());
 
+    std::vector<std::string> induction_variables{INDUCTION_VAR};
+    function_statements.push_back(
+            create_local_variable_statement(induction_variables, INTEGER_TYPE));
+
     if (platform.is_gpu()) {
-        const auto& id_statement = std::make_shared<ast::CodegenThreadId>(create_varname(INDUCTION_VAR));
-        function_statements.push_back(id_statement);
         create_gpu_compute_body(compute_body, function_statements, int_variables, double_variables);
     } else {
-        // Create induction variable
-        std::vector<std::string> induction_variables{INDUCTION_VAR};
-        function_statements.push_back(
-                create_local_variable_statement(induction_variables, INTEGER_TYPE));
         create_cpu_compute_body(compute_body, function_statements, int_variables, double_variables);
     }
 
@@ -707,18 +721,10 @@ void CodegenLLVMHelperVisitor::create_gpu_compute_body(ast::StatementVector& bod
                                                        ast::StatementVector& function_statements,
                                                        std::vector<std::string>& int_variables,
                                                        std::vector<std::string>& double_variables) {
-    // Then, create condition for thread id. For now reuse the functionality from `loop_count_expression`.
     auto kernel_block = std::make_shared<ast::StatementBlock>(body);
-    const auto& condition = loop_count_expression(INDUCTION_VAR, NODECOUNT_VAR, 1);
-    ast::ElseIfStatementVector else_ifs = {};
-    auto if_statement = std::make_shared<ast::IfStatement>(condition, kernel_block, else_ifs, nullptr);
 
-    convert_to_instance_variable(*if_statement, INDUCTION_VAR);
-
-    // Push variables and the loop to the function statements vector.
-    function_statements.push_back(create_local_variable_statement(int_variables, INTEGER_TYPE));
-    function_statements.push_back(create_local_variable_statement(double_variables, FLOAT_TYPE));
-    function_statements.push_back(if_statement);
+    // dispatch loop creation with right parameters
+    create_compute_body_loop(kernel_block, function_statements, int_variables, double_variables);
 }
 
 void CodegenLLVMHelperVisitor::create_cpu_compute_body(ast::StatementVector& body,
@@ -736,12 +742,9 @@ void CodegenLLVMHelperVisitor::create_compute_body_loop(std::shared_ptr<ast::Sta
                                                         std::vector<std::string>& int_variables,
                                                         std::vector<std::string>& double_variables,
                                                         bool is_remainder_loop) {
-    // First, check if we are creating a main or remainder loop. If it is a remainder loop, then
-    // no initialization is needed and instruction width is simply 1.
-    int width = is_remainder_loop ? 1 : platform.get_instruction_width();
-    const auto& initialization = is_remainder_loop ? nullptr : int_initialization_expression(INDUCTION_VAR);
-    const auto& condition = loop_count_expression(INDUCTION_VAR, NODECOUNT_VAR, width);
-    const auto& increment = loop_increment_expression(INDUCTION_VAR, width);
+    const auto& initialization = loop_initialization_expression(INDUCTION_VAR, is_remainder_loop);
+    const auto& condition = loop_count_expression(INDUCTION_VAR, NODECOUNT_VAR, is_remainder_loop);
+    const auto& increment = loop_increment_expression(INDUCTION_VAR, is_remainder_loop);
 
     // Clone the statement block if needed since it can be used by the remainder loop.
     auto loop_block = (is_remainder_loop || !platform.is_cpu_with_simd()) ? block : std::shared_ptr<ast::StatementBlock>(block->clone());

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -176,6 +176,15 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
     void visit_program(ast::Program& node) override;
 
   private:
+    /// Methods to create target-specific loop constructs.
+    std::shared_ptr<ast::Expression> loop_initialization_expression(const std::string& induction_var,
+                                                                    bool is_remainder_loop);
+    std::shared_ptr<ast::Expression> loop_count_expression(const std::string& induction_var,
+                                                           const std::string& node_count,
+                                                           bool is_remainder_loop);
+    std::shared_ptr<ast::Expression> loop_increment_expression(const std::string& induction_var,
+                                                               bool is_remainder_loop);
+
     /// Methods to populate`function_statements` with necessary AST constructs to form
     /// a kernel for a specific target.
     void create_gpu_compute_body(ast::StatementVector& body,

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -16,6 +16,7 @@
 
 #include "ast/instance_struct.hpp"
 #include "codegen/codegen_info.hpp"
+#include "codegen/llvm/target_platform.hpp"
 #include "symtab/symbol_table.hpp"
 #include "utils/logger.hpp"
 #include "visitors/ast_visitor.hpp"
@@ -101,8 +102,8 @@ struct InstanceVarHelper {
  * these will be common across all backends.
  */
 class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
-    /// explicit vectorisation width
-    int vector_width;
+    /// target platform
+    Platform platform;
 
     /// newly generated code generation specific functions
     CodegenFunctionVector codegen_functions;
@@ -135,8 +136,8 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
     static const std::string VOLTAGE_VAR;
     static const std::string NODE_INDEX_VAR;
 
-    CodegenLLVMHelperVisitor(int vector_width)
-        : vector_width(vector_width) {}
+    CodegenLLVMHelperVisitor(Platform& platform)
+        : platform(platform) {}
 
     const InstanceVarHelper& get_instance_var_helper() {
         return instance_var_helper;
@@ -161,7 +162,7 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
                               ast::StatementVector& index_statements,
                               ast::StatementVector& body_statements);
 
-    void convert_to_instance_variable(ast::Node& node, std::string& index_var);
+    void convert_to_instance_variable(ast::Node& node, const std::string& index_var);
 
     void convert_local_statement(ast::StatementBlock& node);
     void rename_local_variables(ast::StatementBlock& node);
@@ -173,6 +174,23 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
     void visit_function_block(ast::FunctionBlock& node) override;
     void visit_nrn_state_block(ast::NrnStateBlock& node) override;
     void visit_program(ast::Program& node) override;
+
+  private:
+    /// Methods to populate`function_statements` with necessary AST constructs to form
+    /// a kernel for a specific target.
+    void create_gpu_compute_body(ast::StatementVector& body,
+                                 ast::StatementVector& function_statements,
+                                 std::vector<std::string>& int_variables,
+                                 std::vector<std::string>& double_variables);
+    void create_cpu_compute_body(ast::StatementVector& body,
+                                 ast::StatementVector& function_statements,
+                                 std::vector<std::string>& int_variables,
+                                 std::vector<std::string>& double_variables);
+    void create_compute_body_loop(std::shared_ptr<ast::StatementBlock>& block,
+                                  ast::StatementVector& function_statements,
+                                  std::vector<std::string>& int_variables,
+                                  std::vector<std::string>& double_variables,
+                                  bool is_remainder_loop = false);
 };
 
 /** @} */  // end of llvm_codegen_details

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -815,11 +815,17 @@ void CodegenLLVMVisitor::visit_program(const ast::Program& node) {
     //   - convert function and procedure blocks into CodegenFunctions
     //   - gather information about AST. For now, information about functions
     //     and procedures is used only.
-    CodegenLLVMHelperVisitor v{platform.get_instruction_width()};
+    CodegenLLVMHelperVisitor v{platform};
     const auto& functions = v.get_codegen_functions(node);
     instance_var_helper = v.get_instance_var_helper();
     sym_tab = node.get_symbol_table();
     std::string kernel_id = v.get_kernel_id();
+
+    // \todo: implement GPU codegen functionality.
+    if (platform.is_gpu()) {
+      logger->warn("GPU code generation is not supported yet, aborting!");
+      return;
+    }
 
     // Initialize the builder for this NMODL program.
     ir_builder.initialize(*sym_tab, kernel_id);

--- a/src/language/code_generator.cmake
+++ b/src/language/code_generator.cmake
@@ -68,6 +68,7 @@ set(AST_GENERATED_SOURCES
     ${PROJECT_BINARY_DIR}/src/ast/codegen_atomic_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_for_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_function.hpp
+    ${PROJECT_BINARY_DIR}/src/ast/codegen_grid_stride.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_instance_var.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_return_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_struct.hpp

--- a/src/language/code_generator.cmake
+++ b/src/language/code_generator.cmake
@@ -71,6 +71,7 @@ set(AST_GENERATED_SOURCES
     ${PROJECT_BINARY_DIR}/src/ast/codegen_instance_var.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_return_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_struct.hpp
+    ${PROJECT_BINARY_DIR}/src/ast/codegen_thread_id.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_var.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_var_list_statement.hpp
     ${PROJECT_BINARY_DIR}/src/ast/codegen_var_type.hpp

--- a/src/language/codegen.yaml
+++ b/src/language/codegen.yaml
@@ -199,6 +199,27 @@
                             brief: "member functions of the class/struct"
                             type: CodegenFunction
                             vector: true
+                  - CodegenThreadId:
+                      brief: "Represents thread id expression for GPU code generation"
+                      description: |
+                        For GPU code generation, we use a special AST node to enocde the initial
+                        thread id calculation. In NMODL, this expression is usually of the form:
+                        \code{.cpp}
+                            tid = blockId.x * blockDim.x + threadId.x
+                        \endcode
+                        To be able to support multiple GPU backends, we choose to have a custom AST
+                        node. Therefore, the code generation for this node is kept very simple,
+                        mapping expression to target-specific GPU inrinsics.
+                      nmodl: "THREAD_ID"
+                  - CodegenGridStride:
+                      brief: "Represents grid stride for GPU code generation"
+                      description: |
+                        For GPU code generation, we use a special AST node to enocde the loop
+                        increment expression. In NMODL, this expression is usually of the form:
+                        \code{.cpp}
+                            for (int i = tid; i < n; i += blockDim.x * gridDim.x)
+                        \endcode
+                      nmodl: "GRID_STRIDE"
             - Statement:
                 brief: "Statement base class"
                 children:
@@ -286,19 +307,3 @@
                         - rhs:
                             brief: "Expression for atomic operation"
                             type: Expression
-                  - CodegenThreadId:
-                      brief: "Represents a generic thread id expression for GPU code generation"
-                      description: |
-                        For GPU code generation, we use a special AST node to enocde the thread
-                        id calculation. In NMODL, this expression is usually of the form:
-                        \code{.cpp}
-                            id = blockId.x * blockDim.x + threadId.x
-                        \endcode
-                        To be able to support multiple GPU backends, we choose to have a custom AST
-                        node. Therefore, the code generation for this node is kept very simple,
-                        mapping expression to target-specific GPU inrinsics.
-                      nmodl: "GPU_ID "
-                      members:
-                        - name:
-                            brief: "Name of the thread id variable"
-                            type: Identifier

--- a/src/language/codegen.yaml
+++ b/src/language/codegen.yaml
@@ -286,3 +286,19 @@
                         - rhs:
                             brief: "Expression for atomic operation"
                             type: Expression
+                  - CodegenThreadId:
+                      brief: "Represents a generic thread id expression for GPU code generation"
+                      description: |
+                        For GPU code generation, we use a special AST node to enocde the thread
+                        id calculation. In NMODL, this expression is usually of the form:
+                        \code{.cpp}
+                            id = blockId.x * blockDim.x + threadId.x
+                        \endcode
+                        To be able to support multiple GPU backends, we choose to have a custom AST
+                        node. Therefore, the code generation for this node is kept very simple,
+                        mapping expression to target-specific GPU inrinsics.
+                      nmodl: "GPU_ID "
+                      members:
+                        - name:
+                            brief: "Name of the thread id variable"
+                            type: Identifier

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -1552,29 +1552,24 @@ SCENARIO("GPU kernel body", "[visitor][llvm][gpu]") {
         )";
 
 
-        std::string expected_kernel = R"(
-            VOID nrn_state_test(INSTANCE_STRUCT *mech){
-                GPU_ID id
-                INTEGER node_id
-                DOUBLE v
-                IF (id<mech->node_count) {
-                    node_id = mech->node_index[id]
-                    v = mech->voltage[node_id]
-                    mech->m[id] = mech->y[id]+2
-                }
+        std::string expected_loop = R"(
+            for(id = THREAD_ID; id<mech->node_count; id = id+GRID_STRIDE) {
+                node_id = mech->node_index[id]
+                v = mech->voltage[node_id]
+                mech->m[id] = mech->y[id]+2
             })";
 
-        THEN("a kernel with thread id and if statement is created") {
+        THEN("a loop with GPU-specific AST nodes is constructed") {
             std::string name = "default";
             std::string math_library = "none";
             codegen::Platform gpu_platform(codegen::PlatformID::GPU, name, math_library);
             auto result = run_llvm_visitor_helper(nmodl_text,
                                                   gpu_platform,
-                                                  {ast::AstNodeType::CODEGEN_FUNCTION});
+                                                  {ast::AstNodeType::CODEGEN_FOR_STATEMENT});
             REQUIRE(result.size() == 1);
 
-            auto kernel = reindent_text(to_nmodl(result[0]));
-            REQUIRE(kernel == reindent_text(expected_kernel));
+            auto loop = reindent_text(to_nmodl(result[0]));
+            REQUIRE(loop == reindent_text(expected_loop));
         }
     }
 }

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -68,14 +68,14 @@ std::string run_llvm_visitor(const std::string& text,
 
 std::vector<std::shared_ptr<ast::Ast>> run_llvm_visitor_helper(
     const std::string& text,
-    int vector_width,
+    codegen::Platform& platform,
     const std::vector<ast::AstNodeType>& nodes_to_collect) {
     NmodlDriver driver;
     const auto& ast = driver.parse_string(text);
 
     SymtabVisitor().visit_program(*ast);
     SolveBlockVisitor().visit_program(*ast);
-    CodegenLLVMHelperVisitor(vector_width).visit_program(*ast);
+    CodegenLLVMHelperVisitor(platform).visit_program(*ast);
 
     const auto& nodes = collect_nodes(*ast, nodes_to_collect);
 
@@ -1228,8 +1228,9 @@ SCENARIO("Scalar derivative block", "[visitor][llvm][derivative]") {
             })";
 
         THEN("a single scalar loops is constructed") {
+            codegen::Platform default_platform;
             auto result = run_llvm_visitor_helper(nmodl_text,
-                                                  /*vector_width=*/1,
+                                                  default_platform,
                                                   {ast::AstNodeType::CODEGEN_FOR_STATEMENT});
             REQUIRE(result.size() == 1);
 
@@ -1279,8 +1280,9 @@ SCENARIO("Vectorised derivative block", "[visitor][llvm][derivative]") {
 
 
         THEN("vector and epilogue scalar loops are constructed") {
+            codegen::Platform simd_platform(/*use_single_precision=*/false, /*instruction_width=*/8);
             auto result = run_llvm_visitor_helper(nmodl_text,
-                                                  /*vector_width=*/8,
+                                                  simd_platform,
                                                   {ast::AstNodeType::CODEGEN_FOR_STATEMENT});
             REQUIRE(result.size() == 2);
 
@@ -1520,6 +1522,59 @@ SCENARIO("Removal of inlined functions and procedures", "[visitor][llvm][inline]
             REQUIRE(!std::regex_search(module_string, m, add_proc));
             std::regex sub_func(R"(define double @test_sub\(double %a[0-9].*, double %b[0-9].*\))");
             REQUIRE(!std::regex_search(module_string, m, sub_func));
+        }
+    }
+}
+
+//=============================================================================
+// Basic GPU kernel AST generation
+//=============================================================================
+
+SCENARIO("GPU kernel body", "[visitor][llvm][gpu]") {
+    GIVEN("For GPU platforms") {
+        std::string nmodl_text = R"(
+            NEURON {
+                SUFFIX test
+                RANGE x, y
+            }
+
+            ASSIGNED { x y }
+
+            STATE { m }
+
+            BREAKPOINT {
+                SOLVE states METHOD cnexp
+            }
+
+            DERIVATIVE states {
+              m = y + 2
+            }
+        )";
+
+
+        std::string expected_kernel = R"(
+            VOID nrn_state_test(INSTANCE_STRUCT *mech){
+                GPU_ID id
+                INTEGER node_id
+                DOUBLE v
+                IF (id<mech->node_count) {
+                    node_id = mech->node_index[id]
+                    v = mech->voltage[node_id]
+                    mech->m[id] = mech->y[id]+2
+                }
+            })";
+
+        THEN("a kernel with thread id and if statement is created") {
+            std::string name = "default";
+            std::string math_library = "none";
+            codegen::Platform gpu_platform(codegen::PlatformID::GPU, name, math_library);
+            auto result = run_llvm_visitor_helper(nmodl_text,
+                                                  gpu_platform,
+                                                  {ast::AstNodeType::CODEGEN_FUNCTION});
+            REQUIRE(result.size() == 1);
+
+            auto kernel = reindent_text(to_nmodl(result[0]));
+            REQUIRE(kernel == reindent_text(expected_kernel));
         }
     }
 }


### PR DESCRIPTION
This commit adds a new AST node: `CodegenThreadId` that
represents thread id used in GPU computation. Thanks to
the new platform class abstraction, the code to generate
compute body of NEURON block was readapted to support
AST transformations needed for GPU.

Example of the transformation:
```
INTEGER id
for(id = THREAD_ID; id<mech->node_count; id = id+GRID_STRIDE) {
    ...
}
```