### PR TITLE
Removed POINTER compatibility error

### DIFF
--- a/src/codegen/codegen_compatibility_visitor.cpp
+++ b/src/codegen/codegen_compatibility_visitor.cpp
@@ -36,7 +36,6 @@ const std::map<ast::AstNodeType, CodegenCompatibilityVisitor::FunctionPointer>
           &CodegenCompatibilityVisitor::return_error_if_solve_method_is_unhandled},
          {AstNodeType::GLOBAL_VAR, &CodegenCompatibilityVisitor::return_error_global_var},
          {AstNodeType::PARAM_ASSIGN, &CodegenCompatibilityVisitor::return_error_param_var},
-         {AstNodeType::POINTER_VAR, &CodegenCompatibilityVisitor::return_error_pointer},
          {AstNodeType::BBCORE_POINTER_VAR,
           &CodegenCompatibilityVisitor::return_error_if_no_bbcore_read_write}});
 
@@ -84,14 +83,6 @@ std::string CodegenCompatibilityVisitor::return_error_param_var(
                    symbol->get_name(), symbol->get_token().position());
     }
     return error_message_global_var.str();
-}
-
-std::string CodegenCompatibilityVisitor::return_error_pointer(
-    ast::Ast& node,
-    const std::shared_ptr<ast::Ast>& ast_node) {
-    auto pointer_var = std::dynamic_pointer_cast<ast::PointerVar>(ast_node);
-    return "\"{}\" POINTER found at [{}] should be defined as BBCOREPOINTER to use it in CoreNeuron\n"_format(
-        pointer_var->get_node_name(), pointer_var->get_token()->position());
 }
 
 std::string CodegenCompatibilityVisitor::return_error_if_no_bbcore_read_write(

--- a/src/codegen/codegen_compatibility_visitor.hpp
+++ b/src/codegen/codegen_compatibility_visitor.hpp
@@ -136,16 +136,6 @@ class CodegenCompatibilityVisitor: public visitor::AstVisitor {
 
     std::string return_error_param_var(ast::Ast& node, const std::shared_ptr<ast::Ast>& ast_node);
 
-    /// Takes as parameter an std::shared_ptr<ast::Ast> node
-    /// and returns a relative error with the name and the
-    /// location of the pointer, as well as a suggestion to
-    /// define it as BBCOREPOINTER
-    ///
-    /// \param node Not used by the function
-    /// \param ast_node Ast node which is checked
-    /// \return std::string error
-    std::string return_error_pointer(ast::Ast& node, const std::shared_ptr<ast::Ast>& ast_node);
-
     /// Takes as parameter the ast::Ast and checks if the
     /// functions "bbcore_read" and "bbcore_write" are defined
     /// in any of the ast::Ast VERBATIM blocks. The function is


### PR DESCRIPTION
After merge of https://github.com/neuronsimulator/nrn/pull/1622 `POINTER` variable shouldn't throw a compatibility error