### PR TITLE
Get rid of one unnecessary shared_ptr

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -355,7 +355,7 @@ int main(int argc, const char* argv[]) {
             // make sure to run the GlobalToRange visitor after all the
             // reinitializations of Symtab
             logger->info("Running GlobalToRange visitor");
-            GlobalToRangeVisitor(ast).visit_program(*ast);
+            GlobalToRangeVisitor(*ast).visit_program(*ast);
             SymtabVisitor(update_symtab).visit_program(*ast);
             ast_to_nmodl(*ast, filepath("global_to_range"));
         }

--- a/src/visitors/global_var_visitor.cpp
+++ b/src/visitors/global_var_visitor.cpp
@@ -27,7 +27,7 @@ void GlobalToRangeVisitor::visit_neuron_block(ast::NeuronBlock& node) {
 
     auto& statement_block = node.get_statement_block();
     auto& statements = (*statement_block).get_statements();
-    const auto& symbol_table = ast->get_symbol_table();
+    const auto& symbol_table = ast.get_symbol_table();
 
     for (auto& statement: statements) {
         /// only process global statements

--- a/src/visitors/global_var_visitor.hpp
+++ b/src/visitors/global_var_visitor.hpp
@@ -61,7 +61,7 @@ namespace visitor {
 class GlobalToRangeVisitor: public AstVisitor {
   private:
     /// ast::Ast* node
-    std::shared_ptr<ast::Program> ast;
+    const ast::Program& ast;
 
   public:
     /// \name Ctor & dtor
@@ -71,8 +71,8 @@ class GlobalToRangeVisitor: public AstVisitor {
     GlobalToRangeVisitor() = delete;
 
     /// Constructor that takes as parameter the AST
-    explicit GlobalToRangeVisitor(std::shared_ptr<ast::Program> node)
-        : ast(std::move(node)) {}
+    explicit GlobalToRangeVisitor(const ast::Program& node)
+        : ast(node) {}
 
     /// \}
 

--- a/test/unit/visitor/global_to_range.cpp
+++ b/test/unit/visitor/global_to_range.cpp
@@ -33,7 +33,7 @@ std::shared_ptr<ast::Program> run_global_to_var_visitor(const std::string& text)
 
     SymtabVisitor().visit_program(*ast);
     PerfVisitor().visit_program(*ast);
-    GlobalToRangeVisitor(ast).visit_program(*ast);
+    GlobalToRangeVisitor(*ast).visit_program(*ast);
     SymtabVisitor().visit_program(*ast);
     return ast;
 }


### PR DESCRIPTION
The field ast in GlobalToRangeVisitor doesn't need to be a shared pointer,
so we store it as a reference that is initialized at construction time.