### PR TITLE
TITLE can end with only \r

### DIFF
--- a/src/lexer/nmodl.ll
+++ b/src/lexer/nmodl.ll
@@ -475,7 +475,8 @@ ELSE                    {
                         }
 
 <LINE_MODE>\n   |
-<LINE_MODE>\r\n         {
+<LINE_MODE>\r\n |
+<LINE_MODE>\r           {
                             /** For title return string without new line character */
                             loc.lines(1);
                             std::string str(yytext);


### PR DESCRIPTION
This mod file https://github.com/BlueBrain/nmodldb/blob/downloader/models/db/modeldb/260967/mod/Cad.mod
Use only `\r` and use a `TITLE`.
`TITLE` is parse as a `LINE` but `LINE` cannot terminate with a `\r`
So the whole file is considered as a `TITLE` and so empty.
Fix it.