### PR TITLE
JIT invocation from python for benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 # =============================================================================
 # Build options for NMODL
 # =============================================================================
-option(NMODL_ENABLE_PYTHON_BINDINGS "Enable pybind11 based python bindings" OFF)
+option(NMODL_ENABLE_PYTHON_BINDINGS "Enable pybind11 based python bindings" ON)
 option(NMODL_ENABLE_LEGACY_UNITS "Use original faraday, R, etc. instead of 2019 nist constants" OFF)
 option(NMODL_ENABLE_LLVM "Enable LLVM based code generation" ON)
 option(NMODL_ENABLE_LLVM_GPU "Enable LLVM based GPU code generation" ON)

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -20,7 +20,11 @@ set(CODEGEN_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_ispc_visitor.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_naming.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_utils.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/codegen_utils.hpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/codegen_utils.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/codegen_driver.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/codegen_driver.hpp)
+
+include_directories(${PYBIND11_INCLUDE_DIR} ${PYTHON_INCLUDE_DIRS})
 
 # =============================================================================
 # Codegen library and executable

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -31,12 +31,12 @@
 #include "visitors/ast_visitor.hpp"
 
 
-using namespace fmt::literals;
 
 namespace nmodl {
 /// encapsulates code generation backend implementations
 namespace codegen {
 
+using namespace fmt::literals;
 /**
  * @defgroup codegen Code Generation Implementation
  * @brief Implementations of code generation backends

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -31,7 +31,6 @@
 #include "visitors/ast_visitor.hpp"
 
 
-
 namespace nmodl {
 /// encapsulates code generation backend implementations
 namespace codegen {

--- a/src/codegen/codegen_driver.cpp
+++ b/src/codegen/codegen_driver.cpp
@@ -1,0 +1,246 @@
+/*************************************************************************
+ * Copyright (C) 2018-2022 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#include <string>
+
+#include "codegen/codegen_driver.hpp"
+#include "codegen_compatibility_visitor.hpp"
+#include "visitors/ast_visitor.hpp"
+#include "visitors/semantic_analysis_visitor.hpp"
+#include "visitors/symtab_visitor.hpp"
+#include "visitors/after_cvode_to_cnexp_visitor.hpp"
+#include "visitors/perf_visitor.hpp"
+#include "visitors/global_var_visitor.hpp"
+#include "visitors/local_to_assigned_visitor.hpp"
+#include "visitors/verbatim_var_rename_visitor.hpp"
+#include "visitors/constant_folder_visitor.hpp"
+#include "visitors/loop_unroll_visitor.hpp"
+#include "visitors/kinetic_block_visitor.hpp"
+#include "visitors/steadystate_visitor.hpp"
+#include "visitors/inline_visitor.hpp"
+#include "visitors/local_var_rename_visitor.hpp"
+#include "visitors/localize_visitor.hpp"
+#include "visitors/sympy_conductance_visitor.hpp"
+#include "visitors/sympy_solver_visitor.hpp"
+#include "visitors/neuron_solve_visitor.hpp"
+#include "visitors/solve_block_visitor.hpp"
+#include "visitors/nmodl_visitor.hpp"
+#include "visitors/units_visitor.hpp"
+
+using namespace nmodl;
+using namespace codegen;
+using namespace visitor;
+
+bool CodegenDriver::prepare_mod(ast::Program& node) {
+    /// whether to update existing symbol table or create new
+    /// one whenever we run symtab visitor.
+    bool update_symtab = false;
+
+    std::string modfile;
+    std::string scratch_dir = "tmp";
+    auto filepath = [scratch_dir, modfile](const std::string& suffix, const std::string& ext) {
+        static int count = 0;
+        return "{}/{}.{}.{}.{}"_format(
+            scratch_dir, modfile, std::to_string(count++), suffix, ext);
+    };
+
+    /// just visit the ast
+    AstVisitor().visit_program(node);
+
+    /// Check some rules that ast should follow
+    {
+        logger->info("Running semantic analysis visitor");
+        if (nmodl::visitor::SemanticAnalysisVisitor().check(node)) {
+            return false;
+        }
+    }
+
+    /// construct symbol table
+    {
+        logger->info("Running symtab visitor");
+        nmodl::visitor::SymtabVisitor(update_symtab).visit_program(node);
+    }
+
+    /// use cnexp instead of after_cvode solve method
+    {
+        logger->info("Running CVode to cnexp visitor");
+        nmodl::visitor::AfterCVodeToCnexpVisitor().visit_program(node);
+        ast_to_nmodl(node, filepath("after_cvode_to_cnexp", "mod"));
+    }
+
+    /// GLOBAL to RANGE rename visitor
+    if (cfg.nmodl_global_to_range) {
+        // make sure to run perf visitor because code generator
+        // looks for read/write counts const/non-const declaration
+        PerfVisitor().visit_program(node);
+        // make sure to run the GlobalToRange visitor after all the
+        // reinitializations of Symtab
+        logger->info("Running GlobalToRange visitor");
+        GlobalToRangeVisitor(node).visit_program(node);
+        SymtabVisitor(update_symtab).visit_program(node);
+        ast_to_nmodl(node, filepath("ispc_double_rename", "mod"));
+    }
+
+    /// LOCAL to ASSIGNED visitor
+    if (cfg.nmodl_local_to_range) {
+        logger->info("Running LOCAL to ASSIGNED visitor");
+        PerfVisitor().visit_program(node);
+        LocalToAssignedVisitor().visit_program(node);
+        SymtabVisitor(update_symtab).visit_program(node);
+        ast_to_nmodl(node, filepath("global_to_range", "mod"));
+    }
+
+    {
+        // Compatibility Checking
+        logger->info("Running code compatibility checker");
+        // run perfvisitor to update read/write counts
+        PerfVisitor().visit_program(node);
+
+        auto ast_has_unhandled_nodes = CodegenCompatibilityVisitor().find_unhandled_ast_nodes(node);
+        // If we want to just check compatibility we return the result
+        if (cfg.only_check_compatibility) {
+            return !ast_has_unhandled_nodes; // negate since this function returns false on failure
+
+        }
+
+        // If there is an incompatible construct and code generation is not forced exit NMODL
+        if (ast_has_unhandled_nodes && !cfg.force_codegen) {
+            return false;
+        }
+    }
+
+    ast_to_nmodl(node, filepath("ast", "mod"));
+    ast_to_json(node, filepath("ast", "json"));
+
+    if (cfg.verbatim_rename) {
+        logger->info("Running verbatim rename visitor");
+        VerbatimVarRenameVisitor().visit_program(node);
+        ast_to_nmodl(node, filepath("verbatim_rename", "mod"));
+    }
+
+    if (cfg.nmodl_const_folding) {
+        logger->info("Running nmodl constant folding visitor");
+        ConstantFolderVisitor().visit_program(node);
+        ast_to_nmodl(node, filepath("constfold", "mod"));
+    }
+
+    if (cfg.nmodl_unroll) {
+        logger->info("Running nmodl loop unroll visitor");
+        LoopUnrollVisitor().visit_program(node);
+        ConstantFolderVisitor().visit_program(node);
+        ast_to_nmodl(node, filepath("unroll", "mod"));
+        SymtabVisitor(update_symtab).visit_program(node);
+    }
+
+    /// note that we can not symtab visitor in update mode as we
+    /// replace kinetic block with derivative block of same name
+    /// in global scope
+    {
+        logger->info("Running KINETIC block visitor");
+        auto kineticBlockVisitor = KineticBlockVisitor();
+        kineticBlockVisitor.visit_program(node);
+        SymtabVisitor(update_symtab).visit_program(node);
+        const auto filename = filepath("kinetic", "mod");
+        ast_to_nmodl(node, filename);
+        if (cfg.nmodl_ast && kineticBlockVisitor.get_conserve_statement_count()) {
+            logger->warn(
+                "{} presents non-standard CONSERVE statements in DERIVATIVE blocks. Use it only for debugging/developing"_format(
+                    filename));
+        }
+    }
+
+    {
+        logger->info("Running STEADYSTATE visitor");
+        SteadystateVisitor().visit_program(node);
+        SymtabVisitor(update_symtab).visit_program(node);
+        ast_to_nmodl(node, filepath("steadystate", "mod"));
+    }
+
+    /// Parsing units fron "nrnunits.lib" and mod files
+    {
+        logger->info("Parsing Units");
+        UnitsVisitor(cfg.units_dir).visit_program(node);
+    }
+
+    /// once we start modifying (especially removing) older constructs
+    /// from ast then we should run symtab visitor in update mode so
+    /// that old symbols (e.g. prime variables) are not lost
+    update_symtab = true;
+
+    if (cfg.nmodl_inline) {
+        logger->info("Running nmodl inline visitor");
+        InlineVisitor().visit_program(node);
+        ast_to_nmodl(node, filepath("inline", "mod"));
+    }
+
+    if (cfg.local_rename) {
+        logger->info("Running local variable rename visitor");
+        LocalVarRenameVisitor().visit_program(node);
+        SymtabVisitor(update_symtab).visit_program(node);
+        ast_to_nmodl(node, filepath("local_rename", "mod"));
+    }
+
+    if (cfg.nmodl_localize) {
+        // localize pass must follow rename pass to avoid conflict
+        logger->info("Running localize visitor");
+        LocalizeVisitor(cfg.localize_verbatim).visit_program(node);
+        LocalVarRenameVisitor().visit_program(node);
+        SymtabVisitor(update_symtab).visit_program(node);
+        ast_to_nmodl(node, filepath("localize", "mod"));
+    }
+
+    if (cfg.sympy_conductance) {
+        logger->info("Running sympy conductance visitor");
+        SympyConductanceVisitor().visit_program(node);
+        SymtabVisitor(update_symtab).visit_program(node);
+        ast_to_nmodl(node, filepath("sympy_conductance", "mod"));
+    }
+
+    if (cfg.sympy_analytic || sparse_solver_exists(node)) {
+        if (!cfg.sympy_analytic) {
+            logger->info(
+                "Automatically enable sympy_analytic because it exists solver of type sparse");
+        }
+        logger->info("Running sympy solve visitor");
+        SympySolverVisitor(cfg.sympy_pade, cfg.sympy_cse).visit_program(node);
+        SymtabVisitor(update_symtab).visit_program(node);
+        ast_to_nmodl(node, filepath("sympy_solve", "mod"));
+    }
+
+    {
+        logger->info("Running cnexp visitor");
+        NeuronSolveVisitor().visit_program(node);
+        ast_to_nmodl(node, filepath("cnexp", "mod"));
+    }
+
+    {
+        SolveBlockVisitor().visit_program(node);
+        SymtabVisitor(update_symtab).visit_program(node);
+        ast_to_nmodl(node, filepath("solveblock", "mod"));
+    }
+
+    {
+        // make sure to run perf visitor because code generator
+        // looks for read/write counts const/non-const declaration
+        PerfVisitor().visit_program(node);
+    }
+    return true;
+}
+
+void CodegenDriver::ast_to_nmodl(Program& ast, const std::string& filepath) const {
+    if (cfg.nmodl_ast) {
+        NmodlPrintVisitor(filepath).visit_program(ast);
+        logger->info("AST to NMODL transformation written to {}", filepath);
+    }
+};
+
+void CodegenDriver::ast_to_json(ast::Program& ast, const std::string& filepath) const {
+    if (cfg.json_ast) {
+        JSONVisitor(filepath).write(ast);
+        logger->info("AST to JSON transformation written to {}", filepath);
+    }
+};

--- a/src/codegen/codegen_driver.cpp
+++ b/src/codegen/codegen_driver.cpp
@@ -9,6 +9,7 @@
 
 #include "codegen/codegen_driver.hpp"
 #include "codegen_compatibility_visitor.hpp"
+#include "utils/logger.hpp"
 #include "visitors/ast_visitor.hpp"
 #include "visitors/semantic_analysis_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"

--- a/src/codegen/codegen_driver.cpp
+++ b/src/codegen/codegen_driver.cpp
@@ -37,7 +37,7 @@ using namespace nmodl;
 using namespace codegen;
 using namespace visitor;
 
-bool CodegenDriver::prepare_mod(ast::Program& node) {
+bool CodegenDriver::prepare_mod(std::shared_ptr<ast::Program> node) {
     /// whether to update existing symbol table or create new
     /// one whenever we run symtab visitor.
     bool update_symtab = false;
@@ -51,12 +51,12 @@ bool CodegenDriver::prepare_mod(ast::Program& node) {
     };
 
     /// just visit the ast
-    AstVisitor().visit_program(node);
+    AstVisitor().visit_program(*node);
 
     /// Check some rules that ast should follow
     {
         logger->info("Running semantic analysis visitor");
-        if (nmodl::visitor::SemanticAnalysisVisitor().check(node)) {
+        if (SemanticAnalysisVisitor().check(*node)) {
             return false;
         }
     }
@@ -64,53 +64,53 @@ bool CodegenDriver::prepare_mod(ast::Program& node) {
     /// construct symbol table
     {
         logger->info("Running symtab visitor");
-        nmodl::visitor::SymtabVisitor(update_symtab).visit_program(node);
+        SymtabVisitor(update_symtab).visit_program(*node);
     }
 
     /// use cnexp instead of after_cvode solve method
     {
         logger->info("Running CVode to cnexp visitor");
-        nmodl::visitor::AfterCVodeToCnexpVisitor().visit_program(node);
-        ast_to_nmodl(node, filepath("after_cvode_to_cnexp", "mod"));
+        AfterCVodeToCnexpVisitor().visit_program(*node);
+        ast_to_nmodl(*node, filepath("after_cvode_to_cnexp", "mod"));
     }
 
     /// Rename variables that match ISPC compiler double constants
     if (cfg.ispc_backend) {
         logger->info("Running ISPC variables rename visitor");
-        IspcRenameVisitor(std::make_shared<ast::Program>(node)).visit_program(node);
-        SymtabVisitor(update_symtab).visit_program(node);
-        ast_to_nmodl(node, filepath("ispc_double_rename", "mod"));
+        IspcRenameVisitor(node).visit_program(*node);
+        SymtabVisitor(update_symtab).visit_program(*node);
+        ast_to_nmodl(*node, filepath("ispc_double_rename", "mod"));
     }
 
     /// GLOBAL to RANGE rename visitor
     if (cfg.nmodl_global_to_range) {
         // make sure to run perf visitor because code generator
         // looks for read/write counts const/non-const declaration
-        PerfVisitor().visit_program(node);
+        PerfVisitor().visit_program(*node);
         // make sure to run the GlobalToRange visitor after all the
         // reinitializations of Symtab
         logger->info("Running GlobalToRange visitor");
-        GlobalToRangeVisitor(node).visit_program(node);
-        SymtabVisitor(update_symtab).visit_program(node);
-        ast_to_nmodl(node, filepath("ispc_double_rename", "mod"));
+        GlobalToRangeVisitor(*node).visit_program(*node);
+        SymtabVisitor(update_symtab).visit_program(*node);
+        ast_to_nmodl(*node, filepath("ispc_double_rename", "mod"));
     }
 
     /// LOCAL to ASSIGNED visitor
     if (cfg.nmodl_local_to_range) {
         logger->info("Running LOCAL to ASSIGNED visitor");
-        PerfVisitor().visit_program(node);
-        LocalToAssignedVisitor().visit_program(node);
-        SymtabVisitor(update_symtab).visit_program(node);
-        ast_to_nmodl(node, filepath("global_to_range", "mod"));
+        PerfVisitor().visit_program(*node);
+        LocalToAssignedVisitor().visit_program(*node);
+        SymtabVisitor(update_symtab).visit_program(*node);
+        ast_to_nmodl(*node, filepath("global_to_range", "mod"));
     }
 
     {
         // Compatibility Checking
         logger->info("Running code compatibility checker");
         // run perfvisitor to update read/write counts
-        PerfVisitor().visit_program(node);
+        PerfVisitor().visit_program(*node);
 
-        auto ast_has_unhandled_nodes = CodegenCompatibilityVisitor().find_unhandled_ast_nodes(node);
+        auto ast_has_unhandled_nodes = CodegenCompatibilityVisitor().find_unhandled_ast_nodes(*node);
         // If we want to just check compatibility we return the result
         if (cfg.only_check_compatibility) {
             return !ast_has_unhandled_nodes; // negate since this function returns false on failure
@@ -123,27 +123,27 @@ bool CodegenDriver::prepare_mod(ast::Program& node) {
         }
     }
 
-    ast_to_nmodl(node, filepath("ast", "mod"));
-    ast_to_json(node, filepath("ast", "json"));
+    ast_to_nmodl(*node, filepath("ast", "mod"));
+    ast_to_json(*node, filepath("ast", "json"));
 
     if (cfg.verbatim_rename) {
         logger->info("Running verbatim rename visitor");
-        VerbatimVarRenameVisitor().visit_program(node);
-        ast_to_nmodl(node, filepath("verbatim_rename", "mod"));
+        VerbatimVarRenameVisitor().visit_program(*node);
+        ast_to_nmodl(*node, filepath("verbatim_rename", "mod"));
     }
 
     if (cfg.nmodl_const_folding) {
         logger->info("Running nmodl constant folding visitor");
-        ConstantFolderVisitor().visit_program(node);
-        ast_to_nmodl(node, filepath("constfold", "mod"));
+        ConstantFolderVisitor().visit_program(*node);
+        ast_to_nmodl(*node, filepath("constfold", "mod"));
     }
 
     if (cfg.nmodl_unroll) {
         logger->info("Running nmodl loop unroll visitor");
-        LoopUnrollVisitor().visit_program(node);
-        ConstantFolderVisitor().visit_program(node);
-        ast_to_nmodl(node, filepath("unroll", "mod"));
-        SymtabVisitor(update_symtab).visit_program(node);
+        LoopUnrollVisitor().visit_program(*node);
+        ConstantFolderVisitor().visit_program(*node);
+        ast_to_nmodl(*node, filepath("unroll", "mod"));
+        SymtabVisitor(update_symtab).visit_program(*node);
     }
 
     /// note that we can not symtab visitor in update mode as we
@@ -152,10 +152,10 @@ bool CodegenDriver::prepare_mod(ast::Program& node) {
     {
         logger->info("Running KINETIC block visitor");
         auto kineticBlockVisitor = KineticBlockVisitor();
-        kineticBlockVisitor.visit_program(node);
-        SymtabVisitor(update_symtab).visit_program(node);
+        kineticBlockVisitor.visit_program(*node);
+        SymtabVisitor(update_symtab).visit_program(*node);
         const auto filename = filepath("kinetic", "mod");
-        ast_to_nmodl(node, filename);
+        ast_to_nmodl(*node, filename);
         if (cfg.nmodl_ast && kineticBlockVisitor.get_conserve_statement_count()) {
             logger->warn(
                 "{} presents non-standard CONSERVE statements in DERIVATIVE blocks. Use it only for debugging/developing"_format(
@@ -165,15 +165,15 @@ bool CodegenDriver::prepare_mod(ast::Program& node) {
 
     {
         logger->info("Running STEADYSTATE visitor");
-        SteadystateVisitor().visit_program(node);
-        SymtabVisitor(update_symtab).visit_program(node);
-        ast_to_nmodl(node, filepath("steadystate", "mod"));
+        SteadystateVisitor().visit_program(*node);
+        SymtabVisitor(update_symtab).visit_program(*node);
+        ast_to_nmodl(*node, filepath("steadystate", "mod"));
     }
 
     /// Parsing units fron "nrnunits.lib" and mod files
     {
         logger->info("Parsing Units");
-        UnitsVisitor(cfg.units_dir).visit_program(node);
+        UnitsVisitor(cfg.units_dir).visit_program(*node);
     }
 
     /// once we start modifying (especially removing) older constructs
@@ -183,66 +183,66 @@ bool CodegenDriver::prepare_mod(ast::Program& node) {
 
     if (cfg.nmodl_inline) {
         logger->info("Running nmodl inline visitor");
-        InlineVisitor().visit_program(node);
-        ast_to_nmodl(node, filepath("inline", "mod"));
+        InlineVisitor().visit_program(*node);
+        ast_to_nmodl(*node, filepath("inline", "mod"));
     }
 
     if (cfg.local_rename) {
         logger->info("Running local variable rename visitor");
-        LocalVarRenameVisitor().visit_program(node);
-        SymtabVisitor(update_symtab).visit_program(node);
-        ast_to_nmodl(node, filepath("local_rename", "mod"));
+        LocalVarRenameVisitor().visit_program(*node);
+        SymtabVisitor(update_symtab).visit_program(*node);
+        ast_to_nmodl(*node, filepath("local_rename", "mod"));
     }
 
     if (cfg.nmodl_localize) {
         // localize pass must follow rename pass to avoid conflict
         logger->info("Running localize visitor");
-        LocalizeVisitor(cfg.localize_verbatim).visit_program(node);
-        LocalVarRenameVisitor().visit_program(node);
-        SymtabVisitor(update_symtab).visit_program(node);
-        ast_to_nmodl(node, filepath("localize", "mod"));
+        LocalizeVisitor(cfg.localize_verbatim).visit_program(*node);
+        LocalVarRenameVisitor().visit_program(*node);
+        SymtabVisitor(update_symtab).visit_program(*node);
+        ast_to_nmodl(*node, filepath("localize", "mod"));
     }
 
     if (cfg.sympy_conductance) {
         logger->info("Running sympy conductance visitor");
-        SympyConductanceVisitor().visit_program(node);
-        SymtabVisitor(update_symtab).visit_program(node);
-        ast_to_nmodl(node, filepath("sympy_conductance", "mod"));
+        SympyConductanceVisitor().visit_program(*node);
+        SymtabVisitor(update_symtab).visit_program(*node);
+        ast_to_nmodl(*node, filepath("sympy_conductance", "mod"));
     }
 
-    if (cfg.sympy_analytic || sparse_solver_exists(node)) {
+    if (cfg.sympy_analytic || sparse_solver_exists(*node)) {
         if (!cfg.sympy_analytic) {
             logger->info(
                 "Automatically enable sympy_analytic because it exists solver of type sparse");
         }
         logger->info("Running sympy solve visitor");
-        SympySolverVisitor(cfg.sympy_pade, cfg.sympy_cse).visit_program(node);
-        SymtabVisitor(update_symtab).visit_program(node);
-        ast_to_nmodl(node, filepath("sympy_solve", "mod"));
+        SympySolverVisitor(cfg.sympy_pade, cfg.sympy_cse).visit_program(*node);
+        SymtabVisitor(update_symtab).visit_program(*node);
+        ast_to_nmodl(*node, filepath("sympy_solve", "mod"));
     }
 
     {
         logger->info("Running cnexp visitor");
-        NeuronSolveVisitor().visit_program(node);
-        ast_to_nmodl(node, filepath("cnexp", "mod"));
+        NeuronSolveVisitor().visit_program(*node);
+        ast_to_nmodl(*node, filepath("cnexp", "mod"));
     }
 
     {
-        SolveBlockVisitor().visit_program(node);
-        SymtabVisitor(update_symtab).visit_program(node);
-        ast_to_nmodl(node, filepath("solveblock", "mod"));
+        SolveBlockVisitor().visit_program(*node);
+        SymtabVisitor(update_symtab).visit_program(*node);
+        ast_to_nmodl(*node, filepath("solveblock", "mod"));
     }
 
     if (cfg.json_perfstat) {
         auto file = scratch_dir + "/" + modfile + ".perf.json";
         logger->info("Writing performance statistics to {}", file);
-        PerfVisitor(file).visit_program(node);
+        PerfVisitor(file).visit_program(*node);
     }
 
     {
         // make sure to run perf visitor because code generator
         // looks for read/write counts const/non-const declaration
-        PerfVisitor().visit_program(node);
+        PerfVisitor().visit_program(*node);
     }
     return true;
 }

--- a/src/codegen/codegen_driver.hpp
+++ b/src/codegen/codegen_driver.hpp
@@ -89,7 +89,7 @@ struct CodeGenConfig {
     bool optimize_ionvar_copies_codegen = false;
 
     /// directory where code will be generated
-    std::string output_dir  = ".";
+    std::string output_dir = ".";
 
     /// directory where intermediate file will be generated
     std::string scratch_dir = "tmp";
@@ -146,14 +146,12 @@ struct CodeGenConfig {
     /// list of shared libraries to link against in JIT
     std::vector<std::string> shared_lib_paths;
 #endif
-
 };
 
 class CodegenDriver {
-
   public:
-    explicit CodegenDriver(CodeGenConfig  _cfg) :
-        cfg(std::move(_cfg)) {}
+    explicit CodegenDriver(CodeGenConfig _cfg)
+        : cfg(std::move(_cfg)) {}
 
     bool prepare_mod(std::shared_ptr<nmodl::ast::Program> node);
 
@@ -161,11 +159,10 @@ class CodegenDriver {
     CodeGenConfig cfg;
 
 
-
     /// write ast to nmodl
     void ast_to_nmodl(ast::Program& ast, const std::string& filepath) const;
     void ast_to_json(ast::Program& ast, const std::string& filepath) const;
 };
 
-}
-}
+}  // namespace codegen
+}  // namespace nmodl

--- a/src/codegen/codegen_driver.hpp
+++ b/src/codegen/codegen_driver.hpp
@@ -1,0 +1,166 @@
+/*************************************************************************
+ * Copyright (C) 2018-2022 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include "ast/program.hpp"
+#include "config/config.h"
+#include "utils/logger.hpp"
+
+namespace nmodl {
+namespace codegen {
+
+struct CodeGenConfig {
+    /// true if serial c code to be generated
+    bool c_backend = true;
+
+    /// true if c code with openmp to be generated
+    bool omp_backend = false;
+
+    /// true if ispc code to be generated
+    bool ispc_backend = false;
+
+    /// true if c code with openacc to be generated
+    bool oacc_backend = false;
+
+    /// true if cuda code to be generated
+    bool cuda_backend = false;
+
+    /// true if llvm code to be generated
+    bool llvm_backend = false;
+
+    /// true if sympy should be used for solving ODEs analytically
+    bool sympy_analytic = false;
+
+    /// true if Pade approximation to be used
+    bool sympy_pade = false;
+
+    /// true if CSE (temp variables) to be used
+    bool sympy_cse = false;
+
+    /// true if conductance keyword can be added to breakpoint
+    bool sympy_conductance = false;
+
+    /// true if inlining at nmodl level to be done
+    bool nmodl_inline = false;
+
+    /// true if unroll at nmodl level to be done
+    bool nmodl_unroll = false;
+
+    /// true if perform constant folding at nmodl level to be done
+    bool nmodl_const_folding = false;
+
+    /// true if range variables to be converted to local
+    bool nmodl_localize = false;
+
+    /// true if global variables to be converted to range
+    bool nmodl_global_to_range = false;
+
+    /// true if top level local variables to be converted to range
+    bool nmodl_local_to_range = false;
+
+    /// true if localize variables even if verbatim block is used
+    bool localize_verbatim = false;
+
+    /// true if local variables to be renamed
+    bool local_rename = true;
+
+    /// true if inline even if verbatim block exist
+    bool verbatim_inline = false;
+
+    /// true if verbatim blocks
+    bool verbatim_rename = true;
+
+    /// true if code generation is forced to happen even if there
+    /// is any incompatibility
+    bool force_codegen = false;
+
+    /// true if we want to only check compatibility without generating code
+    bool only_check_compatibility = false;
+
+    /// true if ion variable copies should be avoided
+    bool optimize_ionvar_copies_codegen = false;
+
+    /// directory where code will be generated
+    std::string output_dir  = ".";
+
+    /// directory where intermediate file will be generated
+    std::string scratch_dir = "tmp";
+
+    /// directory where units lib file is located
+    std::string units_dir = NrnUnitsLib::get_path();
+
+    /// floating point data type
+    std::string data_type = "double";
+
+    /// true if ast should be converted to nmodl
+    bool nmodl_ast = false;
+
+    /// true if ast should be converted to json
+    bool json_ast = false;
+
+#ifdef NMODL_LLVM_BACKEND
+    /// generate llvm IR
+    bool llvm_ir = false;
+
+    /// use single precision floating-point types
+    bool llvm_float_type = false;
+
+    /// optimisation level for IR generation
+    int llvm_opt_level_ir = 0;
+
+    /// math library name
+    std::string llvm_math_library = "none";
+
+    /// disable debug information generation for the IR
+    bool llvm_no_debug = false;
+
+    /// fast math flags for LLVM backend
+    std::vector<std::string> llvm_fast_math_flags;
+
+    /// traget CPU platform name
+    std::string llvm_cpu_name = "default";
+
+    /// traget GPU platform name
+    std::string llvm_gpu_name = "default";
+
+    /// llvm vector width if generating code for CPUs
+    int llvm_vector_width = 1;
+
+    /// optimisation level for machine code generation
+    int llvm_opt_level_codegen = 0;
+
+    /// list of shared libraries to link against in JIT
+    std::vector<std::string> shared_lib_paths;
+#endif
+
+};
+
+class CodegenDriver {
+
+  public:
+    explicit CodegenDriver(CodeGenConfig  _cfg) :
+        cfg(std::move(_cfg)) {}
+
+    bool prepare_mod(nmodl::ast::Program& node);
+
+  private:
+    CodeGenConfig cfg;
+
+
+
+    /// write ast to nmodl
+    void ast_to_nmodl(ast::Program& ast, const std::string& filepath) const;
+    void ast_to_json(ast::Program& ast, const std::string& filepath) const;
+};
+
+}
+}

--- a/src/codegen/codegen_driver.hpp
+++ b/src/codegen/codegen_driver.hpp
@@ -107,6 +107,9 @@ struct CodeGenConfig {
     /// true if ast should be converted to json
     bool json_ast = false;
 
+    /// true if performance stats should be converted to json
+    bool json_perfstat = false;
+
 #ifdef NMODL_LLVM_BACKEND
     /// generate llvm IR
     bool llvm_ir = false;

--- a/src/codegen/codegen_driver.hpp
+++ b/src/codegen/codegen_driver.hpp
@@ -13,7 +13,6 @@
 
 #include "ast/program.hpp"
 #include "config/config.h"
-#include "utils/logger.hpp"
 
 namespace nmodl {
 namespace codegen {

--- a/src/codegen/codegen_driver.hpp
+++ b/src/codegen/codegen_driver.hpp
@@ -155,7 +155,7 @@ class CodegenDriver {
     explicit CodegenDriver(CodeGenConfig  _cfg) :
         cfg(std::move(_cfg)) {}
 
-    bool prepare_mod(nmodl::ast::Program& node);
+    bool prepare_mod(std::shared_ptr<nmodl::ast::Program> node);
 
   private:
     CodeGenConfig cfg;

--- a/src/codegen/codegen_driver.hpp
+++ b/src/codegen/codegen_driver.hpp
@@ -135,6 +135,9 @@ struct CodeGenConfig {
     /// traget GPU platform name
     std::string llvm_gpu_name = "default";
 
+    /// GPU target architecture
+    std::string llvm_gpu_target_architecture = "sm_70";
+
     /// llvm vector width if generating code for CPUs
     int llvm_vector_width = 1;
 

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -9,6 +9,7 @@
 #include "codegen/llvm/llvm_utils.hpp"
 
 #include "ast/all.hpp"
+#include "utils/logger.hpp"
 #include "visitors/rename_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
 

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -23,7 +23,6 @@
 #include "codegen/llvm/llvm_debug_builder.hpp"
 #include "codegen/llvm/llvm_ir_builder.hpp"
 #include "symtab/symbol_table.hpp"
-#include "utils/logger.hpp"
 #include "visitors/ast_visitor.hpp"
 
 #include "llvm/IR/DIBuilder.h"

--- a/src/codegen/llvm/target_platform.hpp
+++ b/src/codegen/llvm/target_platform.hpp
@@ -30,7 +30,7 @@ class Platform {
 
   private:
     /// Name of the platform.
-    const std::string name = Platform::DEFAULT_PLATFORM_NAME;
+    std::string name = Platform::DEFAULT_PLATFORM_NAME;
 
     /// Target-specific id to compare platforms easily.
     PlatformID platform_id;

--- a/src/codegen/llvm/target_platform.hpp
+++ b/src/codegen/llvm/target_platform.hpp
@@ -32,7 +32,7 @@ class Platform {
     /// Target chip for GPUs.
     /// TODO: this should only be available to GPUs! If we refactor target
     /// classes so that GPUPlatform <: Platform, it will be nicer!
-    const std::string subtarget_name = "sm_70";
+    std::string subtarget_name = "sm_70";
 
     /// Target-specific id to compare platforms easily.
     PlatformID platform_id;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -288,7 +288,7 @@ int main(int argc, const char* argv[]) {
         const auto& ast = nmodl_driver.parse_file(file);
 
         auto cg_driver = CodegenDriver(cfg);
-        auto success = cg_driver.prepare_mod(*ast);
+        auto success = cg_driver.prepare_mod(ast);
 
         if (show_symtab) {
             logger->info("Printing symbol table");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@
 #include "test/benchmark/llvm_benchmark.hpp"
 #endif
 
+#include "codegen/codegen_driver.hpp"
 #include "config/config.h"
 #include "parser/nmodl_driver.hpp"
 #include "pybind/pyembed.hpp"
@@ -28,7 +29,6 @@
 #include "utils/logger.hpp"
 #include "visitors/json_visitor.hpp"
 #include "visitors/nmodl_visitor.hpp"
-#include "codegen/codegen_driver.hpp"
 
 /**
  * \dir
@@ -89,17 +89,29 @@ int main(int argc, const char* argv[]) {
     app.add_option("--units", cfg.units_dir, "Directory of units lib file", true)->ignore_case();
 
     auto host_opt = app.add_subcommand("host", "HOST/CPU code backends")->ignore_case();
-    host_opt->add_flag("--c", cfg.c_backend, "C/C++ backend ({})"_format(cfg.c_backend))->ignore_case();
-    host_opt->add_flag("--omp", cfg.omp_backend, "C/C++ backend with OpenMP ({})"_format(cfg.omp_backend))
+    host_opt->add_flag("--c", cfg.c_backend, "C/C++ backend ({})"_format(cfg.c_backend))
         ->ignore_case();
-    host_opt->add_flag("--ispc", cfg.ispc_backend, "C/C++ backend with ISPC ({})"_format(cfg.ispc_backend))
+    host_opt
+        ->add_flag("--omp",
+                   cfg.omp_backend,
+                   "C/C++ backend with OpenMP ({})"_format(cfg.omp_backend))
+        ->ignore_case();
+    host_opt
+        ->add_flag("--ispc",
+                   cfg.ispc_backend,
+                   "C/C++ backend with ISPC ({})"_format(cfg.ispc_backend))
         ->ignore_case();
 
     auto acc_opt = app.add_subcommand("acc", "Accelerator code backends")->ignore_case();
     acc_opt
-        ->add_flag("--oacc", cfg.oacc_backend, "C/C++ backend with OpenACC ({})"_format(cfg.oacc_backend))
+        ->add_flag("--oacc",
+                   cfg.oacc_backend,
+                   "C/C++ backend with OpenACC ({})"_format(cfg.oacc_backend))
         ->ignore_case();
-    acc_opt->add_flag("--cuda", cfg.cuda_backend, "C/C++ backend with CUDA ({})"_format(cfg.cuda_backend))
+    acc_opt
+        ->add_flag("--cuda",
+                   cfg.cuda_backend,
+                   "C/C++ backend with CUDA ({})"_format(cfg.cuda_backend))
         ->ignore_case();
 
     // clang-format off
@@ -268,7 +280,6 @@ int main(int argc, const char* argv[]) {
     logger->set_level(spdlog::level::from_str(verbose));
 
 
-
     for (const auto& file: mod_files) {
         logger->info("Processing {}", file);
 
@@ -356,10 +367,9 @@ int main(int argc, const char* argv[]) {
                 int llvm_opt_level = llvm_benchmark ? 0 : cfg.llvm_opt_level_ir;
 
                 // Create platform abstraction.
-                PlatformID pid = cfg.llvm_gpu_name == "default" ? PlatformID::CPU
-                                                                : PlatformID::GPU;
-                const std::string name =
-                    cfg.llvm_gpu_name == "default" ? cfg.llvm_cpu_name : cfg.llvm_gpu_name;
+                PlatformID pid = cfg.llvm_gpu_name == "default" ? PlatformID::CPU : PlatformID::GPU;
+                const std::string name = cfg.llvm_gpu_name == "default" ? cfg.llvm_cpu_name
+                                                                        : cfg.llvm_gpu_name;
                 Platform platform(pid,
                                   name,
                                   cfg.llvm_cpu_name,
@@ -377,11 +387,13 @@ int main(int argc, const char* argv[]) {
                 visitor.visit_program(*ast);
                 if (cfg.nmodl_ast) {
                     NmodlPrintVisitor(filepath("llvm", "mod")).visit_program(*ast);
-                    logger->info("AST to NMODL transformation written to {}", filepath("llvm", "mod"));
+                    logger->info("AST to NMODL transformation written to {}",
+                                 filepath("llvm", "mod"));
                 }
                 if (cfg.json_ast) {
                     JSONVisitor(filepath("llvm", "json")).write(*ast);
-                    logger->info("AST to JSON transformation written to {}", filepath("llvm", "json"));
+                    logger->info("AST to JSON transformation written to {}",
+                                 filepath("llvm", "json"));
                 }
 
                 if (llvm_benchmark) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,10 +10,8 @@
 
 #include <CLI/CLI.hpp>
 
-#include "ast/program.hpp"
 #include "codegen/codegen_acc_visitor.hpp"
 #include "codegen/codegen_c_visitor.hpp"
-#include "codegen/codegen_compatibility_visitor.hpp"
 #include "codegen/codegen_cuda_visitor.hpp"
 #include "codegen/codegen_ispc_visitor.hpp"
 #include "codegen/codegen_omp_visitor.hpp"
@@ -28,31 +26,9 @@
 #include "pybind/pyembed.hpp"
 #include "utils/common_utils.hpp"
 #include "utils/logger.hpp"
-#include "visitors/after_cvode_to_cnexp_visitor.hpp"
-#include "visitors/ast_visitor.hpp"
-#include "visitors/constant_folder_visitor.hpp"
-#include "visitors/global_var_visitor.hpp"
-#include "visitors/indexedname_visitor.hpp"
-#include "visitors/inline_visitor.hpp"
-#include "visitors/ispc_rename_visitor.hpp"
 #include "visitors/json_visitor.hpp"
-#include "visitors/kinetic_block_visitor.hpp"
-#include "visitors/local_to_assigned_visitor.hpp"
-#include "visitors/local_var_rename_visitor.hpp"
-#include "visitors/localize_visitor.hpp"
-#include "visitors/loop_unroll_visitor.hpp"
-#include "visitors/neuron_solve_visitor.hpp"
 #include "visitors/nmodl_visitor.hpp"
-#include "visitors/perf_visitor.hpp"
-#include "visitors/semantic_analysis_visitor.hpp"
-#include "visitors/solve_block_visitor.hpp"
-#include "visitors/steadystate_visitor.hpp"
-#include "visitors/sympy_conductance_visitor.hpp"
-#include "visitors/sympy_solver_visitor.hpp"
-#include "visitors/symtab_visitor.hpp"
-#include "visitors/units_visitor.hpp"
-#include "visitors/verbatim_var_rename_visitor.hpp"
-#include "visitors/verbatim_visitor.hpp"
+#include "codegen/codegen_driver.hpp"
 
 /**
  * \dir
@@ -75,90 +51,6 @@ int main(int argc, const char* argv[]) {
     /// true if debug logger statements should be shown
     std::string verbose("info");
 
-    /// true if serial c code to be generated
-    bool c_backend(true);
-
-    /// true if c code with openmp to be generated
-    bool omp_backend(false);
-
-    /// true if ispc code to be generated
-    bool ispc_backend(false);
-
-    /// true if c code with openacc to be generated
-    bool oacc_backend(false);
-
-    /// true if cuda code to be generated
-    bool cuda_backend(false);
-
-    /// true if llvm code to be generated
-    bool llvm_backend(false);
-
-    /// true if sympy should be used for solving ODEs analytically
-    bool sympy_analytic(false);
-
-    /// true if Pade approximation to be used
-    bool sympy_pade(false);
-
-    /// true if CSE (temp variables) to be used
-    bool sympy_cse(false);
-
-    /// true if conductance keyword can be added to breakpoint
-    bool sympy_conductance(false);
-
-    /// true if inlining at nmodl level to be done
-    bool nmodl_inline(false);
-
-    /// true if unroll at nmodl level to be done
-    bool nmodl_unroll(false);
-
-    /// true if perform constant folding at nmodl level to be done
-    bool nmodl_const_folding(false);
-
-    /// true if range variables to be converted to local
-    bool nmodl_localize(false);
-
-    /// true if global variables to be converted to range
-    bool nmodl_global_to_range(false);
-
-    /// true if top level local variables to be converted to range
-    bool nmodl_local_to_range(false);
-
-    /// true if localize variables even if verbatim block is used
-    bool localize_verbatim(false);
-
-    /// true if local variables to be renamed
-    bool local_rename(true);
-
-    /// true if inline even if verbatim block exist
-    bool verbatim_inline(false);
-
-    /// true if verbatim blocks
-    bool verbatim_rename(true);
-
-    /// true if code generation is forced to happen even if there
-    /// is any incompatibility
-    bool force_codegen(false);
-
-    /// true if we want to only check compatibility without generating code
-    bool only_check_compatibility(false);
-
-    /// true if ion variable copies should be avoided
-    bool optimize_ionvar_copies_codegen(false);
-
-    /// directory where code will be generated
-    std::string output_dir(".");
-
-    /// directory where intermediate file will be generated
-    std::string scratch_dir("tmp");
-
-    /// directory where units lib file is located
-    std::string units_dir(NrnUnitsLib::get_path());
-
-    /// true if ast should be converted to json
-    bool json_ast(false);
-
-    /// true if ast should be converted to nmodl
-    bool nmodl_ast(false);
 
     /// true if performance stats should be converted to json
     bool json_perfstat(false);
@@ -170,41 +62,8 @@ int main(int argc, const char* argv[]) {
     std::string data_type("double");
 
 #ifdef NMODL_LLVM_BACKEND
-    /// generate llvm IR
-    bool llvm_ir(false);
-
-    /// use single precision floating-point types
-    bool llvm_float_type(false);
-
-    /// optimisation level for IR generation
-    int llvm_opt_level_ir = 0;
-
-    /// math library name
-    std::string llvm_math_library("none");
-
-    /// disable debug information generation for the IR
-    bool llvm_no_debug(false);
-
-    /// fast math flags for LLVM backend
-    std::vector<std::string> llvm_fast_math_flags;
-
-    /// traget CPU platform name
-    std::string llvm_cpu_name = "default";
-
-    /// traget GPU platform name
-    std::string llvm_gpu_name = "default";
-
-    /// llvm vector width if generating code for CPUs
-    int llvm_vector_width = 1;
-
     /// run llvm benchmark
     bool llvm_benchmark(false);
-
-    /// optimisation level for machine code generation
-    int llvm_opt_level_codegen = 0;
-
-    /// list of shared libraries to link against in JIT
-    std::vector<std::string> shared_lib_paths;
 
     /// the size of the instance struct for the benchmark
     int instance_size = 10000;
@@ -212,6 +71,8 @@ int main(int argc, const char* argv[]) {
     /// the number of repeated experiments for the benchmarking
     int num_experiments = 100;
 #endif
+
+    CodeGenConfig cfg;
 
     app.get_formatter()->column_width(40);
     app.set_help_all_flag("-H,--help-all", "Print this help message including all sub-commands");
@@ -225,78 +86,78 @@ int main(int argc, const char* argv[]) {
         ->required()
         ->check(CLI::ExistingFile);
 
-    app.add_option("-o,--output", output_dir, "Directory for backend code output", true)
+    app.add_option("-o,--output", cfg.output_dir, "Directory for backend code output", true)
         ->ignore_case();
-    app.add_option("--scratch", scratch_dir, "Directory for intermediate code output", true)
+    app.add_option("--scratch", cfg.scratch_dir, "Directory for intermediate code output", true)
         ->ignore_case();
-    app.add_option("--units", units_dir, "Directory of units lib file", true)->ignore_case();
+    app.add_option("--units", cfg.units_dir, "Directory of units lib file", true)->ignore_case();
 
     auto host_opt = app.add_subcommand("host", "HOST/CPU code backends")->ignore_case();
-    host_opt->add_flag("--c", c_backend, "C/C++ backend ({})"_format(c_backend))->ignore_case();
-    host_opt->add_flag("--omp", omp_backend, "C/C++ backend with OpenMP ({})"_format(omp_backend))
+    host_opt->add_flag("--c", cfg.c_backend, "C/C++ backend ({})"_format(cfg.c_backend))->ignore_case();
+    host_opt->add_flag("--omp", cfg.omp_backend, "C/C++ backend with OpenMP ({})"_format(cfg.omp_backend))
         ->ignore_case();
-    host_opt->add_flag("--ispc", ispc_backend, "C/C++ backend with ISPC ({})"_format(ispc_backend))
+    host_opt->add_flag("--ispc", cfg.ispc_backend, "C/C++ backend with ISPC ({})"_format(cfg.ispc_backend))
         ->ignore_case();
 
     auto acc_opt = app.add_subcommand("acc", "Accelerator code backends")->ignore_case();
     acc_opt
-        ->add_flag("--oacc", oacc_backend, "C/C++ backend with OpenACC ({})"_format(oacc_backend))
+        ->add_flag("--oacc", cfg.oacc_backend, "C/C++ backend with OpenACC ({})"_format(cfg.oacc_backend))
         ->ignore_case();
-    acc_opt->add_flag("--cuda", cuda_backend, "C/C++ backend with CUDA ({})"_format(cuda_backend))
+    acc_opt->add_flag("--cuda", cfg.cuda_backend, "C/C++ backend with CUDA ({})"_format(cfg.cuda_backend))
         ->ignore_case();
 
     // clang-format off
     auto sympy_opt = app.add_subcommand("sympy", "SymPy based analysis and optimizations")->ignore_case();
     sympy_opt->add_flag("--analytic",
-        sympy_analytic,
-        "Solve ODEs using SymPy analytic integration ({})"_format(sympy_analytic))->ignore_case();
+        cfg.sympy_analytic,
+        "Solve ODEs using SymPy analytic integration ({})"_format(cfg.sympy_analytic))->ignore_case();
     sympy_opt->add_flag("--pade",
-        sympy_pade,
-        "Pade approximation in SymPy analytic integration ({})"_format(sympy_pade))->ignore_case();
+        cfg.sympy_pade,
+        "Pade approximation in SymPy analytic integration ({})"_format(cfg.sympy_pade))->ignore_case();
     sympy_opt->add_flag("--cse",
-        sympy_cse,
-        "CSE (Common Subexpression Elimination) in SymPy analytic integration ({})"_format(sympy_cse))->ignore_case();
+        cfg.sympy_cse,
+        "CSE (Common Subexpression Elimination) in SymPy analytic integration ({})"_format(cfg.sympy_cse))->ignore_case();
     sympy_opt->add_flag("--conductance",
-        sympy_conductance,
-        "Add CONDUCTANCE keyword in BREAKPOINT ({})"_format(sympy_conductance))->ignore_case();
+        cfg.sympy_conductance,
+        "Add CONDUCTANCE keyword in BREAKPOINT ({})"_format(cfg.sympy_conductance))->ignore_case();
 
     auto passes_opt = app.add_subcommand("passes", "Analyse/Optimization passes")->ignore_case();
     passes_opt->add_flag("--inline",
-        nmodl_inline,
-        "Perform inlining at NMODL level ({})"_format(nmodl_inline))->ignore_case();
+        cfg.nmodl_inline,
+        "Perform inlining at NMODL level ({})"_format(cfg.nmodl_inline))->ignore_case();
     passes_opt->add_flag("--unroll",
-        nmodl_unroll,
-        "Perform loop unroll at NMODL level ({})"_format(nmodl_unroll))->ignore_case();
+        cfg.nmodl_unroll,
+        "Perform loop unroll at NMODL level ({})"_format(cfg.nmodl_unroll))->ignore_case();
     passes_opt->add_flag("--const-folding",
-        nmodl_const_folding,
-        "Perform constant folding at NMODL level ({})"_format(nmodl_const_folding))->ignore_case();
+        cfg.nmodl_const_folding,
+        "Perform constant folding at NMODL level ({})"_format(cfg.nmodl_const_folding))->ignore_case();
     passes_opt->add_flag("--localize",
-        nmodl_localize,
-        "Convert RANGE variables to LOCAL ({})"_format(nmodl_localize))->ignore_case();
+        cfg.nmodl_localize,
+        "Convert RANGE variables to LOCAL ({})"_format(cfg.nmodl_localize))->ignore_case();
     passes_opt->add_flag("--global-to-range",
-         nmodl_global_to_range,
-         "Convert GLOBAL variables to RANGE ({})"_format(nmodl_global_to_range))->ignore_case();
+         cfg.nmodl_global_to_range,
+         "Convert GLOBAL variables to RANGE ({})"_format(cfg.nmodl_global_to_range))->ignore_case();
     passes_opt->add_flag("--local-to-range",
-         nmodl_local_to_range,
-         "Convert top level LOCAL variables to RANGE ({})"_format(nmodl_local_to_range))->ignore_case();
+         cfg.nmodl_local_to_range,
+         "Convert top level LOCAL variables to RANGE ({})"_format(cfg.nmodl_local_to_range))->ignore_case();
     passes_opt->add_flag("--localize-verbatim",
-        localize_verbatim,
-        "Convert RANGE variables to LOCAL even if verbatim block exist ({})"_format(localize_verbatim))->ignore_case();
+        cfg.localize_verbatim,
+        "Convert RANGE variables to LOCAL even if verbatim block exist ({})"_format(cfg.localize_verbatim))->ignore_case();
     passes_opt->add_flag("--local-rename",
-        local_rename,
-        "Rename LOCAL variable if variable of same name exist in global scope ({})"_format(local_rename))->ignore_case();
+        cfg.local_rename,
+        "Rename LOCAL variable if variable of same name exist in global scope ({})"_format(cfg.local_rename))->ignore_case();
     passes_opt->add_flag("--verbatim-inline",
-        verbatim_inline,
-        "Inline even if verbatim block exist ({})"_format(verbatim_inline))->ignore_case();
+        cfg.verbatim_inline,
+        "Inline even if verbatim block exist ({})"_format(cfg.verbatim_inline))->ignore_case();
     passes_opt->add_flag("--verbatim-rename",
-        verbatim_rename,
-        "Rename variables in verbatim block ({})"_format(verbatim_rename))->ignore_case();
+        cfg.verbatim_rename,
+        "Rename variables in verbatim block ({})"_format(cfg.verbatim_rename))->ignore_case();
     passes_opt->add_flag("--json-ast",
-        json_ast,
-        "Write AST to JSON file ({})"_format(json_ast))->ignore_case();
+        cfg.json_ast,
+        "Write AST to JSON file ({})"_format(cfg.json_ast))->ignore_case();
     passes_opt->add_flag("--nmodl-ast",
-        nmodl_ast,
-        "Write AST to NMODL file ({})"_format(nmodl_ast))->ignore_case();
+        cfg.nmodl_ast,
+        "Write AST to NMODL file ({})"_format(cfg.nmodl_ast))->ignore_case();
     passes_opt->add_flag("--json-perf",
         json_perfstat,
         "Write performance statistics to JSON file ({})"_format(json_perfstat))->ignore_case();
@@ -306,62 +167,62 @@ int main(int argc, const char* argv[]) {
 
     auto codegen_opt = app.add_subcommand("codegen", "Code generation options")->ignore_case();
     codegen_opt->add_option("--datatype",
-        data_type,
+        cfg.data_type,
         "Data type for floating point variables",
         true)->ignore_case()->check(CLI::IsMember({"float", "double"}));
     codegen_opt->add_flag("--force",
-        force_codegen,
+        cfg.force_codegen,
         "Force code generation even if there is any incompatibility");
     codegen_opt->add_flag("--only-check-compatibility",
-                          only_check_compatibility,
+                          cfg.only_check_compatibility,
                           "Check compatibility and return without generating code");
     codegen_opt->add_flag("--opt-ionvar-copy",
-        optimize_ionvar_copies_codegen,
-        "Optimize copies of ion variables ({})"_format(optimize_ionvar_copies_codegen))->ignore_case();
+        cfg.optimize_ionvar_copies_codegen,
+        "Optimize copies of ion variables ({})"_format(cfg.optimize_ionvar_copies_codegen))->ignore_case();
 
 #ifdef NMODL_LLVM_BACKEND
 
     // LLVM IR code generation options.
     auto llvm_opt = app.add_subcommand("llvm", "LLVM code generation option")->ignore_case();
     auto llvm_ir_opt = llvm_opt->add_flag("--ir",
-        llvm_ir,
-        "Generate LLVM IR ({})"_format(llvm_ir))->ignore_case();
+        cfg.llvm_ir,
+        "Generate LLVM IR ({})"_format(cfg.llvm_ir))->ignore_case();
     llvm_ir_opt->required(true);
     llvm_opt->add_flag("--no-debug",
-        llvm_no_debug,
-        "Disable debug information ({})"_format(llvm_no_debug))->ignore_case();
+        cfg.llvm_no_debug,
+        "Disable debug information ({})"_format(cfg.llvm_no_debug))->ignore_case();
     llvm_opt->add_option("--opt-level-ir",
-        llvm_opt_level_ir,
-        "LLVM IR optimisation level (O{})"_format(llvm_opt_level_ir))->ignore_case()->check(CLI::IsMember({"0", "1", "2", "3"}));
+        cfg.llvm_opt_level_ir,
+        "LLVM IR optimisation level (O{})"_format(cfg.llvm_opt_level_ir))->ignore_case()->check(CLI::IsMember({"0", "1", "2", "3"}));
     llvm_opt->add_flag("--single-precision",
-        llvm_float_type,
-        "Use single precision floating-point types ({})"_format(llvm_float_type))->ignore_case();
+        cfg.llvm_float_type,
+        "Use single precision floating-point types ({})"_format(cfg.llvm_float_type))->ignore_case();
     llvm_opt->add_option("--fmf",
-        llvm_fast_math_flags,
+        cfg.llvm_fast_math_flags,
         "Fast math flags for floating-point optimizations (none)")->check(CLI::IsMember({"afn", "arcp", "contract", "ninf", "nnan", "nsz", "reassoc", "fast"}));
 
     // Platform options for LLVM code generation.
     auto cpu_opt = app.add_subcommand("cpu", "LLVM CPU option")->ignore_case();
     cpu_opt->needs(llvm_opt);
     cpu_opt->add_option("--name",
-        llvm_cpu_name,
+        cfg.llvm_cpu_name,
         "Name of CPU platform to use")->ignore_case();
     auto simd_math_library_opt = cpu_opt->add_option("--math-library",
-        llvm_math_library,
-        "Math library for SIMD code generation ({})"_format(llvm_math_library));
+        cfg.llvm_math_library,
+        "Math library for SIMD code generation ({})"_format(cfg.llvm_math_library));
     simd_math_library_opt->check(CLI::IsMember({"Accelerate", "libmvec", "libsystem_m", "MASSV", "SLEEF", "SVML", "none"}));
     cpu_opt->add_option("--vector-width",
-        llvm_vector_width,
-        "Explicit vectorization width for IR generation ({})"_format(llvm_vector_width))->ignore_case();
+        cfg.llvm_vector_width,
+        "Explicit vectorization width for IR generation ({})"_format(cfg.llvm_vector_width))->ignore_case();
 
     auto gpu_opt = app.add_subcommand("gpu", "LLVM GPU option")->ignore_case();
     gpu_opt->needs(llvm_opt);
     gpu_opt->add_option("--name",
-        llvm_gpu_name,
+        cfg.llvm_gpu_name,
         "Name of GPU platform to use")->ignore_case();
     auto gpu_math_library_opt = gpu_opt->add_option("--math-library",
-        llvm_math_library,
-        "Math library for GPU code generation ({})"_format(llvm_math_library));
+        cfg.llvm_math_library,
+        "Math library for GPU code generation ({})"_format(cfg.llvm_math_library));
     gpu_math_library_opt->check(CLI::IsMember({"libdevice"}));
 
     // Allow only one platform at a time.
@@ -375,9 +236,9 @@ int main(int argc, const char* argv[]) {
                             llvm_benchmark,
                             "Run LLVM benchmark ({})"_format(llvm_benchmark))->ignore_case();
     benchmark_opt->add_option("--opt-level-codegen",
-                              llvm_opt_level_codegen,
-                              "Machine code optimisation level (O{})"_format(llvm_opt_level_codegen))->ignore_case()->check(CLI::IsMember({"0", "1", "2", "3"}));
-    benchmark_opt->add_option("--libs", shared_lib_paths, "Shared libraries to link IR against")
+                              cfg.llvm_opt_level_codegen,
+                              "Machine code optimisation level (O{})"_format(cfg.llvm_opt_level_codegen))->ignore_case()->check(CLI::IsMember({"0", "1", "2", "3"}));
+    benchmark_opt->add_option("--libs", cfg.shared_lib_paths, "Shared libraries to link IR against")
             ->ignore_case()
             ->check(CLI::ExistingFile);
     benchmark_opt->add_option("--instance-size",
@@ -392,12 +253,12 @@ int main(int argc, const char* argv[]) {
     CLI11_PARSE(app, argc, argv);
 
     // if any of the other backends is used we force the C backend to be off.
-    if (omp_backend || ispc_backend) {
-        c_backend = false;
+    if (cfg.omp_backend || cfg.ispc_backend) {
+        cfg.c_backend = false;
     }
 
-    utils::make_path(output_dir);
-    utils::make_path(scratch_dir);
+    utils::make_path(cfg.output_dir);
+    utils::make_path(cfg.scratch_dir);
 
     if (sympy_opt) {
         nmodl::pybind_wrappers::EmbeddedPythonLoader::get_instance()
@@ -407,21 +268,7 @@ int main(int argc, const char* argv[]) {
 
     logger->set_level(spdlog::level::from_str(verbose));
 
-    /// write ast to nmodl
-    const auto ast_to_nmodl = [nmodl_ast](ast::Program& ast, const std::string& filepath) {
-        if (nmodl_ast) {
-            NmodlPrintVisitor(filepath).visit_program(ast);
-            logger->info("AST to NMODL transformation written to {}", filepath);
-        }
-    };
 
-    /// write ast to nmodl
-    const auto ast_to_json = [json_ast](ast::Program& ast, const std::string& filepath) {
-        if (json_ast) {
-            JSONVisitor(filepath).write(ast);
-            logger->info("AST to JSON transformation written to {}", filepath);
-        }
-    };
 
     for (const auto& file: mod_files) {
         logger->info("Processing {}", file);
@@ -429,302 +276,114 @@ int main(int argc, const char* argv[]) {
         const auto modfile = utils::remove_extension(utils::base_name(file));
 
         /// create file path for nmodl file
-        auto filepath = [scratch_dir, modfile](const std::string& suffix, const std::string& ext) {
+        auto filepath = [cfg, modfile](const std::string& suffix, const std::string& ext) {
             static int count = 0;
             return "{}/{}.{}.{}.{}"_format(
-                scratch_dir, modfile, std::to_string(count++), suffix, ext);
+                cfg.scratch_dir, modfile, std::to_string(count++), suffix, ext);
         };
 
-        /// driver object creates lexer and parser, just call parser method
-        NmodlDriver driver;
+        /// nmodl_driver object creates lexer and parser, just call parser method
+        NmodlDriver nmodl_driver;
 
         /// parse mod file and construct ast
-        const auto& ast = driver.parse_file(file);
+        const auto& ast = nmodl_driver.parse_file(file);
 
-        /// whether to update existing symbol table or create new
-        /// one whenever we run symtab visitor.
-        bool update_symtab = false;
-
-        /// just visit the ast
-        AstVisitor().visit_program(*ast);
-
-        /// Check some rules that ast should follow
-        {
-            logger->info("Running semantic analysis visitor");
-            if (SemanticAnalysisVisitor().check(*ast)) {
-                return 1;
-            }
+        auto cg_driver = CodegenDriver(cfg);
+        auto success = cg_driver.prepare_mod(*ast);
+        if (cfg.only_check_compatibility) {
+            return !success;
         }
-
-        /// construct symbol table
-        {
-            logger->info("Running symtab visitor");
-            SymtabVisitor(update_symtab).visit_program(*ast);
-        }
-
-        /// use cnexp instead of after_cvode solve method
-        {
-            logger->info("Running CVode to cnexp visitor");
-            AfterCVodeToCnexpVisitor().visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("after_cvode_to_cnexp", "mod"));
-        }
-
-        /// Rename variables that match ISPC compiler double constants
-        if (ispc_backend) {
-            logger->info("Running ISPC variables rename visitor");
-            IspcRenameVisitor(ast).visit_program(*ast);
-            SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("ispc_double_rename", "mod"));
-        }
-
-        /// GLOBAL to RANGE rename visitor
-        if (nmodl_global_to_range) {
-            // make sure to run perf visitor because code generator
-            // looks for read/write counts const/non-const declaration
-            PerfVisitor().visit_program(*ast);
-            // make sure to run the GlobalToRange visitor after all the
-            // reinitializations of Symtab
-            logger->info("Running GlobalToRange visitor");
-            GlobalToRangeVisitor(*ast).visit_program(*ast);
-            SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("global_to_range", "mod"));
-        }
-
-        /// LOCAL to ASSIGNED visitor
-        if (nmodl_local_to_range) {
-            logger->info("Running LOCAL to ASSIGNED visitor");
-            PerfVisitor().visit_program(*ast);
-            LocalToAssignedVisitor().visit_program(*ast);
-            SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("local_to_assigned", "mod"));
+        if (!success && !cfg.force_codegen) {
+            return 1;
         }
 
         {
-            // Compatibility Checking
-            logger->info("Running code compatibility checker");
-            // run perfvisitor to update read/write counts
-            PerfVisitor().visit_program(*ast);
-
-            // If we want to just check compatibility we return the result
-            if (only_check_compatibility) {
-                return CodegenCompatibilityVisitor().find_unhandled_ast_nodes(*ast);
-            }
-
-            // If there is an incompatible construct and code generation is not forced exit NMODL
-            if (CodegenCompatibilityVisitor().find_unhandled_ast_nodes(*ast) && !force_codegen) {
-                return 1;
-            }
-        }
-
-        if (show_symtab) {
-            logger->info("Printing symbol table");
-            auto symtab = ast->get_model_symbol_table();
-            symtab->print(std::cout);
-        }
-
-        ast_to_nmodl(*ast, filepath("ast", "mod"));
-        ast_to_json(*ast, filepath("ast", "json"));
-
-        if (verbatim_rename) {
-            logger->info("Running verbatim rename visitor");
-            VerbatimVarRenameVisitor().visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("verbatim_rename", "mod"));
-        }
-
-        if (nmodl_const_folding) {
-            logger->info("Running nmodl constant folding visitor");
-            ConstantFolderVisitor().visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("constfold", "mod"));
-        }
-
-        if (nmodl_unroll) {
-            logger->info("Running nmodl loop unroll visitor");
-            LoopUnrollVisitor().visit_program(*ast);
-            ConstantFolderVisitor().visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("unroll", "mod"));
-            SymtabVisitor(update_symtab).visit_program(*ast);
-        }
-
-        /// note that we can not symtab visitor in update mode as we
-        /// replace kinetic block with derivative block of same name
-        /// in global scope
-        {
-            logger->info("Running KINETIC block visitor");
-            auto kineticBlockVisitor = KineticBlockVisitor();
-            kineticBlockVisitor.visit_program(*ast);
-            SymtabVisitor(update_symtab).visit_program(*ast);
-            const auto filename = filepath("kinetic", "mod");
-            ast_to_nmodl(*ast, filename);
-            if (nmodl_ast && kineticBlockVisitor.get_conserve_statement_count()) {
-                logger->warn(
-                    "{} presents non-standard CONSERVE statements in DERIVATIVE blocks. Use it only for debugging/developing"_format(
-                        filename));
-            }
-        }
-
-        {
-            logger->info("Running STEADYSTATE visitor");
-            SteadystateVisitor().visit_program(*ast);
-            SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("steadystate", "mod"));
-        }
-
-        /// Parsing units fron "nrnunits.lib" and mod files
-        {
-            logger->info("Parsing Units");
-            UnitsVisitor(units_dir).visit_program(*ast);
-        }
-
-        /// once we start modifying (especially removing) older constructs
-        /// from ast then we should run symtab visitor in update mode so
-        /// that old symbols (e.g. prime variables) are not lost
-        update_symtab = true;
-
-        if (nmodl_inline) {
-            logger->info("Running nmodl inline visitor");
-            InlineVisitor().visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("inline", "mod"));
-        }
-
-        if (local_rename) {
-            logger->info("Running local variable rename visitor");
-            LocalVarRenameVisitor().visit_program(*ast);
-            SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("local_rename", "mod"));
-        }
-
-        if (nmodl_localize) {
-            // localize pass must follow rename pass to avoid conflict
-            logger->info("Running localize visitor");
-            LocalizeVisitor(localize_verbatim).visit_program(*ast);
-            LocalVarRenameVisitor().visit_program(*ast);
-            SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("localize", "mod"));
-        }
-
-        if (sympy_conductance) {
-            logger->info("Running sympy conductance visitor");
-            SympyConductanceVisitor().visit_program(*ast);
-            SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("sympy_conductance", "mod"));
-        }
-
-        if (sympy_analytic || sparse_solver_exists(*ast)) {
-            if (!sympy_analytic) {
-                logger->info(
-                    "Automatically enable sympy_analytic because it exists solver of type sparse");
-            }
-            logger->info("Running sympy solve visitor");
-            SympySolverVisitor(sympy_pade, sympy_cse).visit_program(*ast);
-            SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("sympy_solve", "mod"));
-        }
-
-        {
-            logger->info("Running cnexp visitor");
-            NeuronSolveVisitor().visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("cnexp", "mod"));
-        }
-
-        {
-            SolveBlockVisitor().visit_program(*ast);
-            SymtabVisitor(update_symtab).visit_program(*ast);
-            ast_to_nmodl(*ast, filepath("solveblock", "mod"));
-        }
-
-        if (json_perfstat) {
-            auto file = scratch_dir + "/" + modfile + ".perf.json";
-            logger->info("Writing performance statistics to {}", file);
-            PerfVisitor(file).visit_program(*ast);
-        }
-
-        {
-            // make sure to run perf visitor because code generator
-            // looks for read/write counts const/non-const declaration
-            PerfVisitor().visit_program(*ast);
-        }
-
-        {
-            if (ispc_backend) {
+            if (cfg.ispc_backend) {
                 logger->info("Running ISPC backend code generator");
                 CodegenIspcVisitor visitor(modfile,
-                                           output_dir,
+                                           cfg.output_dir,
                                            data_type,
-                                           optimize_ionvar_copies_codegen);
+                                           cfg.optimize_ionvar_copies_codegen);
                 visitor.visit_program(*ast);
             }
 
-            else if (oacc_backend) {
+            else if (cfg.oacc_backend) {
                 logger->info("Running OpenACC backend code generator");
                 CodegenAccVisitor visitor(modfile,
-                                          output_dir,
+                                          cfg.output_dir,
                                           data_type,
-                                          optimize_ionvar_copies_codegen);
+                                          cfg.optimize_ionvar_copies_codegen);
                 visitor.visit_program(*ast);
             }
 
-            else if (omp_backend) {
+            else if (cfg.omp_backend) {
                 logger->info("Running OpenMP backend code generator");
                 CodegenOmpVisitor visitor(modfile,
-                                          output_dir,
+                                          cfg.output_dir,
                                           data_type,
-                                          optimize_ionvar_copies_codegen);
+                                          cfg.optimize_ionvar_copies_codegen);
                 visitor.visit_program(*ast);
             }
 
-            else if (c_backend) {
+            else if (cfg.c_backend) {
                 logger->info("Running C backend code generator");
                 CodegenCVisitor visitor(modfile,
-                                        output_dir,
+                                        cfg.output_dir,
                                         data_type,
-                                        optimize_ionvar_copies_codegen);
+                                        cfg.optimize_ionvar_copies_codegen);
                 visitor.visit_program(*ast);
             }
 
-            if (cuda_backend) {
+            if (cfg.cuda_backend) {
                 logger->info("Running CUDA backend code generator");
                 CodegenCudaVisitor visitor(modfile,
-                                           output_dir,
+                                           cfg.output_dir,
                                            data_type,
-                                           optimize_ionvar_copies_codegen);
+                                           cfg.optimize_ionvar_copies_codegen);
                 visitor.visit_program(*ast);
             }
 
 #ifdef NMODL_LLVM_BACKEND
-            if (llvm_ir || llvm_benchmark) {
+            if (cfg.llvm_ir || llvm_benchmark) {
               // If benchmarking, we want to optimize the IR with target
               // information and not in LLVM visitor.
-              int llvm_opt_level = llvm_benchmark ? 0 : llvm_opt_level_ir;
+              int llvm_opt_level = llvm_benchmark ? 0 : cfg.llvm_opt_level_ir;
 
               // Create platform abstraction.
-              PlatformID pid = llvm_gpu_name == "default" ? PlatformID::CPU
+              PlatformID pid = cfg.llvm_gpu_name == "default" ? PlatformID::CPU
                                                           : PlatformID::GPU;
               const std::string name =
-                  llvm_gpu_name == "default" ? llvm_cpu_name : llvm_gpu_name;
-              Platform platform(pid, name, llvm_math_library, llvm_float_type,
-                                llvm_vector_width);
+                  cfg.llvm_gpu_name == "default" ? cfg.llvm_cpu_name : cfg.llvm_gpu_name;
+              Platform platform(pid, name, cfg.llvm_math_library, cfg.llvm_float_type,
+                                cfg.llvm_vector_width);
 
               logger->info("Running LLVM backend code generator");
-              CodegenLLVMVisitor visitor(modfile, output_dir, platform,
-                                         llvm_opt_level, !llvm_no_debug,
-                                         llvm_fast_math_flags);
+              CodegenLLVMVisitor visitor(modfile, cfg.output_dir, platform,
+                                         llvm_opt_level, !cfg.llvm_no_debug,
+                                         cfg.llvm_fast_math_flags);
               visitor.visit_program(*ast);
-              ast_to_nmodl(*ast, filepath("llvm", "mod"));
-              ast_to_json(*ast, filepath("llvm", "json"));
+              if (cfg.nmodl_ast) {
+                  NmodlPrintVisitor(filepath("llvm", "mod")).visit_program(*ast);
+                  logger->info("AST to NMODL transformation written to {}", filepath("llvm", "mod"));
+              }
+              if (cfg.json_ast) {
+                  JSONVisitor(filepath("llvm", "json")).write(*ast);
+                  logger->info("AST to JSON transformation written to {}", filepath("llvm", "json"));
+              }
 
               if (llvm_benchmark) {
                 // \todo integrate Platform class here
-                if (llvm_gpu_name != "default") {
+                if (cfg.llvm_gpu_name != "default") {
                   logger->warn("GPU benchmarking is not supported, targeting "
                                "CPU instead");
                 }
 
                 logger->info("Running LLVM benchmark");
                 benchmark::LLVMBenchmark benchmark(
-                    visitor, modfile, output_dir, shared_lib_paths,
-                    num_experiments, instance_size, llvm_cpu_name,
-                    llvm_opt_level_ir, llvm_opt_level_codegen);
-                benchmark.run(ast);
+                    visitor, modfile, cfg.output_dir, cfg.shared_lib_paths,
+                    num_experiments, instance_size, cfg.llvm_cpu_name,
+                    cfg.llvm_opt_level_ir, cfg.llvm_opt_level_codegen);
+                benchmark.run();
               }
             }
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,10 +51,6 @@ int main(int argc, const char* argv[]) {
     /// true if debug logger statements should be shown
     std::string verbose("info");
 
-
-    /// true if performance stats should be converted to json
-    bool json_perfstat(false);
-
     /// true if symbol table should be printed
     bool show_symtab(false);
 
@@ -159,8 +155,8 @@ int main(int argc, const char* argv[]) {
         cfg.nmodl_ast,
         "Write AST to NMODL file ({})"_format(cfg.nmodl_ast))->ignore_case();
     passes_opt->add_flag("--json-perf",
-        json_perfstat,
-        "Write performance statistics to JSON file ({})"_format(json_perfstat))->ignore_case();
+        cfg.json_perfstat,
+        "Write performance statistics to JSON file ({})"_format(cfg.json_perfstat))->ignore_case();
     passes_opt->add_flag("--show-symtab",
         show_symtab,
         "Write symbol table to stdout ({})"_format(show_symtab))->ignore_case();
@@ -290,6 +286,13 @@ int main(int argc, const char* argv[]) {
 
         auto cg_driver = CodegenDriver(cfg);
         auto success = cg_driver.prepare_mod(*ast);
+
+        if (show_symtab) {
+            logger->info("Printing symbol table");
+            auto symtab = ast->get_model_symbol_table();
+            symtab->print(std::cout);
+        }
+
         if (cfg.only_check_compatibility) {
             return !success;
         }

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -70,7 +70,9 @@ if(NMODL_ENABLE_PYTHON_BINDINGS)
 
   add_dependencies(_nmodl pyastgen lexer_obj util_obj)
   target_link_libraries(_nmodl PRIVATE fmt::fmt pyembed)
-
+  if(NMODL_ENABLE_LLVM)
+    target_link_libraries(_nmodl PRIVATE codegen llvm_codegen llvm_benchmark benchmark_data ${LLVM_LIBS_TO_LINK})
+  endif()
   # in case of wheel, python module shouldn't link to wrapper library
   if(LINK_AGAINST_PYTHON)
     target_link_libraries(_nmodl PRIVATE pywrapper)

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -77,7 +77,8 @@ if(NMODL_ENABLE_PYTHON_BINDINGS)
     set_property(TARGET llvm_codegen PROPERTY POSITION_INDEPENDENT_CODE ON)
     set_property(TARGET llvm_benchmark PROPERTY POSITION_INDEPENDENT_CODE ON)
     set_property(TARGET benchmark_data PROPERTY POSITION_INDEPENDENT_CODE ON)
-    target_link_libraries(_nmodl PRIVATE codegen llvm_codegen llvm_benchmark benchmark_data ${LLVM_LIBS_TO_LINK})
+    target_link_libraries(_nmodl PRIVATE codegen llvm_codegen llvm_benchmark benchmark_data
+                                         ${LLVM_LIBS_TO_LINK})
   endif()
   # in case of wheel, python module shouldn't link to wrapper library
   if(LINK_AGAINST_PYTHON)

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -73,10 +73,7 @@ if(NMODL_ENABLE_PYTHON_BINDINGS)
 
   # Additional options are needed when LLVM JIT functionality is built
   if(NMODL_ENABLE_LLVM)
-    set_property(TARGET codegen PROPERTY POSITION_INDEPENDENT_CODE ON)
-    set_property(TARGET llvm_codegen PROPERTY POSITION_INDEPENDENT_CODE ON)
-    set_property(TARGET llvm_benchmark PROPERTY POSITION_INDEPENDENT_CODE ON)
-    set_property(TARGET benchmark_data PROPERTY POSITION_INDEPENDENT_CODE ON)
+    set_property(TARGET codegen llvm_codegen llvm_benchmark benchmark_data PROPERTY POSITION_INDEPENDENT_CODE ON)
     target_link_libraries(_nmodl PRIVATE codegen llvm_codegen llvm_benchmark benchmark_data
                                          ${LLVM_LIBS_TO_LINK})
   endif()

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -70,7 +70,13 @@ if(NMODL_ENABLE_PYTHON_BINDINGS)
 
   add_dependencies(_nmodl pyastgen lexer_obj util_obj)
   target_link_libraries(_nmodl PRIVATE fmt::fmt pyembed)
+
+  # Additional options are needed when LLVM JIT functionality is built
   if(NMODL_ENABLE_LLVM)
+    set_property(TARGET codegen PROPERTY POSITION_INDEPENDENT_CODE ON)
+    set_property(TARGET llvm_codegen PROPERTY POSITION_INDEPENDENT_CODE ON)
+    set_property(TARGET llvm_benchmark PROPERTY POSITION_INDEPENDENT_CODE ON)
+    set_property(TARGET benchmark_data PROPERTY POSITION_INDEPENDENT_CODE ON)
     target_link_libraries(_nmodl PRIVATE codegen llvm_codegen llvm_benchmark benchmark_data ${LLVM_LIBS_TO_LINK})
   endif()
   # in case of wheel, python module shouldn't link to wrapper library

--- a/src/pybind/pynmodl.cpp
+++ b/src/pybind/pynmodl.cpp
@@ -166,10 +166,10 @@ class JitDriver  {
     }
 
 
-    benchmark::BenchmarkResults run(nmodl::ast::Program node, std::string& modname, int num_experiments, int instance_size ) {
+    benchmark::BenchmarkResults run(std::shared_ptr<nmodl::ast::Program> node, std::string& modname, int num_experiments, int instance_size ) {
         cg_driver.prepare_mod(node);
         nmodl::codegen::CodegenLLVMVisitor visitor(modname,cfg.output_dir ,platform, 0);
-        visitor.visit_program(node);
+        visitor.visit_program(*node);
         nmodl::benchmark::LLVMBenchmark benchmark(visitor, modname, cfg.output_dir, cfg.shared_lib_paths,
                                                   num_experiments, instance_size, cfg.llvm_cpu_name,
                                                   cfg.llvm_opt_level_ir, cfg.llvm_opt_level_codegen);

--- a/src/pybind/pynmodl.cpp
+++ b/src/pybind/pynmodl.cpp
@@ -8,19 +8,14 @@
 #include <memory>
 #include <set>
 
-#include <pybind11/iostream.h>
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
 
 #include "ast/program.hpp"
 #include "codegen/llvm/codegen_llvm_visitor.hpp"
 #include "config/config.h"
 #include "parser/nmodl_driver.hpp"
 #include "pybind/pybind_utils.hpp"
-#include "visitors/semantic_analysis_visitor.hpp"
-#include "visitors/symtab_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
-#include "visitors/after_cvode_to_cnexp_visitor.hpp"
 #include "codegen/codegen_driver.hpp"
 #include "test/benchmark/llvm_benchmark.hpp"
 

--- a/src/pybind/pynmodl.cpp
+++ b/src/pybind/pynmodl.cpp
@@ -164,7 +164,7 @@ class JitDriver  {
         init_platform();
     }
 
-    explicit JitDriver(nmodl::codegen::CodeGenConfig& cfg) :
+    explicit JitDriver(const nmodl::codegen::CodeGenConfig& cfg) :
         cfg(cfg),
         cg_driver(cfg) {
         init_platform();
@@ -254,6 +254,7 @@ PYBIND11_MODULE(_nmodl, m_nmodl) {
 
     py::class_<nmodl::JitDriver> jit_driver(m_nmodl, "Jit", nmodl::docstring::jit);
     jit_driver.def(py::init<>())
+        .def(py::init<const nmodl::codegen::CodeGenConfig&>())
         .def("run", &nmodl::JitDriver::run, "node"_a, "modname"_a, "num_experiments"_a, "instance_size"_a);
 
     m_nmodl.def("to_nmodl",

--- a/src/pybind/pynmodl.cpp
+++ b/src/pybind/pynmodl.cpp
@@ -171,14 +171,14 @@ class JitDriver  {
     }
 
 
-    void run(nmodl::ast::Program node, std::string& modname, int num_experiments, int instance_size ) {
+    benchmark::BenchmarkResults run(nmodl::ast::Program node, std::string& modname, int num_experiments, int instance_size ) {
         cg_driver.prepare_mod(node);
         nmodl::codegen::CodegenLLVMVisitor visitor(modname,cfg.output_dir ,platform, 0);
         visitor.visit_program(node);
         nmodl::benchmark::LLVMBenchmark benchmark(visitor, modname, cfg.output_dir, cfg.shared_lib_paths,
                                                   num_experiments, instance_size, cfg.llvm_cpu_name,
                                                   cfg.llvm_opt_level_ir, cfg.llvm_opt_level_codegen);
-        benchmark.run();
+        return benchmark.run();
     }
 };
 

--- a/src/pybind/pynmodl.cpp
+++ b/src/pybind/pynmodl.cpp
@@ -11,13 +11,13 @@
 #include <pybind11/pybind11.h>
 
 #include "ast/program.hpp"
+#include "codegen/codegen_driver.hpp"
 #include "codegen/llvm/codegen_llvm_visitor.hpp"
 #include "config/config.h"
 #include "parser/nmodl_driver.hpp"
 #include "pybind/pybind_utils.hpp"
-#include "visitors/visitor_utils.hpp"
-#include "codegen/codegen_driver.hpp"
 #include "test/benchmark/llvm_benchmark.hpp"
+#include "visitors/visitor_utils.hpp"
 
 /**
  * \dir
@@ -137,7 +137,7 @@ class PyNmodlDriver: public nmodl::parser::NmodlDriver {
     }
 };
 
-class JitDriver  {
+class JitDriver {
   private:
     nmodl::codegen::Platform platform;
 
@@ -146,33 +146,44 @@ class JitDriver  {
 
     void init_platform() {
         // Create platform abstraction.
-        nmodl::codegen::PlatformID pid = cfg.llvm_gpu_name == "default" ? nmodl::codegen::PlatformID::CPU
-                                                                        : nmodl::codegen::PlatformID::GPU;
-        const std::string name =
-            cfg.llvm_gpu_name == "default" ? cfg.llvm_cpu_name : cfg.llvm_gpu_name;
-        platform = nmodl::codegen::Platform(pid, name, cfg.llvm_math_library, cfg.llvm_float_type,
-                                            cfg.llvm_vector_width);
+        nmodl::codegen::PlatformID pid = cfg.llvm_gpu_name == "default"
+                                             ? nmodl::codegen::PlatformID::CPU
+                                             : nmodl::codegen::PlatformID::GPU;
+        const std::string name = cfg.llvm_gpu_name == "default" ? cfg.llvm_cpu_name
+                                                                : cfg.llvm_gpu_name;
+        platform = nmodl::codegen::Platform(
+            pid, name, cfg.llvm_math_library, cfg.llvm_float_type, cfg.llvm_vector_width);
     }
+
   public:
-    JitDriver() :
-        cg_driver(cfg) {
+    JitDriver()
+        : cg_driver(cfg) {
         init_platform();
     }
 
-    explicit JitDriver(const nmodl::codegen::CodeGenConfig& cfg) :
-        cfg(cfg),
-        cg_driver(cfg) {
+    explicit JitDriver(const nmodl::codegen::CodeGenConfig& cfg)
+        : cfg(cfg)
+        , cg_driver(cfg) {
         init_platform();
     }
 
 
-    benchmark::BenchmarkResults run(std::shared_ptr<nmodl::ast::Program> node, std::string& modname, int num_experiments, int instance_size ) {
+    benchmark::BenchmarkResults run(std::shared_ptr<nmodl::ast::Program> node,
+                                    std::string& modname,
+                                    int num_experiments,
+                                    int instance_size) {
         cg_driver.prepare_mod(node);
-        nmodl::codegen::CodegenLLVMVisitor visitor(modname,cfg.output_dir ,platform, 0);
+        nmodl::codegen::CodegenLLVMVisitor visitor(modname, cfg.output_dir, platform, 0);
         visitor.visit_program(*node);
-        nmodl::benchmark::LLVMBenchmark benchmark(visitor, modname, cfg.output_dir, cfg.shared_lib_paths,
-                                                  num_experiments, instance_size, cfg.llvm_cpu_name,
-                                                  cfg.llvm_opt_level_ir, cfg.llvm_opt_level_codegen);
+        nmodl::benchmark::LLVMBenchmark benchmark(visitor,
+                                                  modname,
+                                                  cfg.output_dir,
+                                                  cfg.shared_lib_paths,
+                                                  num_experiments,
+                                                  instance_size,
+                                                  cfg.llvm_cpu_name,
+                                                  cfg.llvm_opt_level_ir,
+                                                  cfg.llvm_opt_level_codegen);
         return benchmark.run();
     }
 };
@@ -210,11 +221,11 @@ PYBIND11_MODULE(_nmodl, m_nmodl) {
 
     py::class_<nmodl::codegen::CodeGenConfig> cfg(m_nmodl, "CodeGenConfig");
     cfg.def(py::init([]() {
-        auto cfg = std::make_unique<nmodl::codegen::CodeGenConfig>();
-        // set to more sensible defaults for python binding
-        cfg->llvm_backend = true;
-        return cfg;
-        }))
+           auto cfg = std::make_unique<nmodl::codegen::CodeGenConfig>();
+           // set to more sensible defaults for python binding
+           cfg->llvm_backend = true;
+           return cfg;
+       }))
         .def_readwrite("sympy_analytic", &nmodl::codegen::CodeGenConfig::sympy_analytic)
         .def_readwrite("sympy_pade", &nmodl::codegen::CodeGenConfig::sympy_pade)
         .def_readwrite("sympy_cse", &nmodl::codegen::CodeGenConfig::sympy_cse)
@@ -223,15 +234,18 @@ PYBIND11_MODULE(_nmodl, m_nmodl) {
         .def_readwrite("nmodl_unroll", &nmodl::codegen::CodeGenConfig::nmodl_unroll)
         .def_readwrite("nmodl_const_folding", &nmodl::codegen::CodeGenConfig::nmodl_const_folding)
         .def_readwrite("nmodl_localize", &nmodl::codegen::CodeGenConfig::nmodl_localize)
-        .def_readwrite("nmodl_global_to_range", &nmodl::codegen::CodeGenConfig::nmodl_global_to_range)
+        .def_readwrite("nmodl_global_to_range",
+                       &nmodl::codegen::CodeGenConfig::nmodl_global_to_range)
         .def_readwrite("nmodl_local_to_range", &nmodl::codegen::CodeGenConfig::nmodl_local_to_range)
         .def_readwrite("localize_verbatim", &nmodl::codegen::CodeGenConfig::localize_verbatim)
         .def_readwrite("local_rename", &nmodl::codegen::CodeGenConfig::local_rename)
         .def_readwrite("verbatim_inline", &nmodl::codegen::CodeGenConfig::verbatim_inline)
         .def_readwrite("verbatim_rename", &nmodl::codegen::CodeGenConfig::verbatim_rename)
         .def_readwrite("force_codegen", &nmodl::codegen::CodeGenConfig::force_codegen)
-        .def_readwrite("only_check_compatibility", &nmodl::codegen::CodeGenConfig::only_check_compatibility)
-        .def_readwrite("optimize_ionvar_copies_codegen", &nmodl::codegen::CodeGenConfig::optimize_ionvar_copies_codegen)
+        .def_readwrite("only_check_compatibility",
+                       &nmodl::codegen::CodeGenConfig::only_check_compatibility)
+        .def_readwrite("optimize_ionvar_copies_codegen",
+                       &nmodl::codegen::CodeGenConfig::optimize_ionvar_copies_codegen)
         .def_readwrite("output_dir", &nmodl::codegen::CodeGenConfig::output_dir)
         .def_readwrite("scratch_dir", &nmodl::codegen::CodeGenConfig::scratch_dir)
         .def_readwrite("data_type", &nmodl::codegen::CodeGenConfig::data_type)
@@ -244,13 +258,19 @@ PYBIND11_MODULE(_nmodl, m_nmodl) {
         .def_readwrite("llvm_cpu_name", &nmodl::codegen::CodeGenConfig::llvm_cpu_name)
         .def_readwrite("llvm_gpu_name", &nmodl::codegen::CodeGenConfig::llvm_gpu_name)
         .def_readwrite("llvm_vector_width", &nmodl::codegen::CodeGenConfig::llvm_vector_width)
-        .def_readwrite("llvm_opt_level_codegen", &nmodl::codegen::CodeGenConfig::llvm_opt_level_codegen)
+        .def_readwrite("llvm_opt_level_codegen",
+                       &nmodl::codegen::CodeGenConfig::llvm_opt_level_codegen)
         .def_readwrite("shared_lib_paths", &nmodl::codegen::CodeGenConfig::shared_lib_paths);
 
     py::class_<nmodl::JitDriver> jit_driver(m_nmodl, "Jit", nmodl::docstring::jit);
     jit_driver.def(py::init<>())
         .def(py::init<const nmodl::codegen::CodeGenConfig&>())
-        .def("run", &nmodl::JitDriver::run, "node"_a, "modname"_a, "num_experiments"_a, "instance_size"_a);
+        .def("run",
+             &nmodl::JitDriver::run,
+             "node"_a,
+             "modname"_a,
+             "num_experiments"_a,
+             "instance_size"_a);
 
     m_nmodl.def("to_nmodl",
                 static_cast<std::string (*)(const nmodl::ast::Ast&,

--- a/src/pybind/pynmodl.cpp
+++ b/src/pybind/pynmodl.cpp
@@ -13,11 +13,16 @@
 #include <pybind11/stl.h>
 
 #include "ast/program.hpp"
+#include "codegen/llvm/codegen_llvm_visitor.hpp"
 #include "config/config.h"
 #include "parser/nmodl_driver.hpp"
 #include "pybind/pybind_utils.hpp"
+#include "visitors/semantic_analysis_visitor.hpp"
+#include "visitors/symtab_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
-
+#include "visitors/after_cvode_to_cnexp_visitor.hpp"
+#include "codegen/codegen_driver.hpp"
+#include "test/benchmark/llvm_benchmark.hpp"
 
 /**
  * \dir
@@ -110,6 +115,10 @@ static const char* to_json = R"(
     '{"Program":[{"NeuronBlock":[{"StatementBlock":[]}]}]}'
 )";
 
+static const char* jit = R"(
+    This is the Jit class documentation
+)";
+
 }  // namespace docstring
 
 
@@ -130,6 +139,46 @@ class PyNmodlDriver: public nmodl::parser::NmodlDriver {
             std::istream istr(&buf);
             return NmodlDriver::parse_stream(istr);
         }
+    }
+};
+
+class JitDriver  {
+  private:
+    nmodl::codegen::Platform platform;
+
+    nmodl::codegen::CodeGenConfig cfg;
+    nmodl::codegen::CodegenDriver cg_driver;
+
+    void init_platform() {
+        // Create platform abstraction.
+        nmodl::codegen::PlatformID pid = cfg.llvm_gpu_name == "default" ? nmodl::codegen::PlatformID::CPU
+                                                                        : nmodl::codegen::PlatformID::GPU;
+        const std::string name =
+            cfg.llvm_gpu_name == "default" ? cfg.llvm_cpu_name : cfg.llvm_gpu_name;
+        platform = nmodl::codegen::Platform(pid, name, cfg.llvm_math_library, cfg.llvm_float_type,
+                                            cfg.llvm_vector_width);
+    }
+  public:
+    JitDriver() :
+        cg_driver(cfg) {
+        init_platform();
+    }
+
+    explicit JitDriver(nmodl::codegen::CodeGenConfig& cfg) :
+        cfg(cfg),
+        cg_driver(cfg) {
+        init_platform();
+    }
+
+
+    void run(nmodl::ast::Program node, std::string& modname, int num_experiments, int instance_size ) {
+        cg_driver.prepare_mod(node);
+        nmodl::codegen::CodegenLLVMVisitor visitor(modname,cfg.output_dir ,platform, 0);
+        visitor.visit_program(node);
+        nmodl::benchmark::LLVMBenchmark benchmark(visitor, modname, cfg.output_dir, cfg.shared_lib_paths,
+                                                  num_experiments, instance_size, cfg.llvm_cpu_name,
+                                                  cfg.llvm_opt_level_ir, cfg.llvm_opt_level_codegen);
+        benchmark.run();
     }
 };
 
@@ -163,6 +212,49 @@ PYBIND11_MODULE(_nmodl, m_nmodl) {
              "in"_a,
              nmodl::docstring::driver_parse_stream)
         .def("get_ast", &nmodl::PyNmodlDriver::get_ast, nmodl::docstring::driver_ast);
+
+    py::class_<nmodl::codegen::CodeGenConfig> cfg(m_nmodl, "CodeGenConfig");
+    cfg.def(py::init([]() {
+        auto cfg = std::make_unique<nmodl::codegen::CodeGenConfig>();
+        // set to more sensible defaults for python binding
+        cfg->llvm_backend = true;
+        return cfg;
+        }))
+        .def_readwrite("sympy_analytic", &nmodl::codegen::CodeGenConfig::sympy_analytic)
+        .def_readwrite("sympy_pade", &nmodl::codegen::CodeGenConfig::sympy_pade)
+        .def_readwrite("sympy_cse", &nmodl::codegen::CodeGenConfig::sympy_cse)
+        .def_readwrite("sympy_conductance", &nmodl::codegen::CodeGenConfig::sympy_conductance)
+        .def_readwrite("nmodl_inline", &nmodl::codegen::CodeGenConfig::nmodl_inline)
+        .def_readwrite("nmodl_unroll", &nmodl::codegen::CodeGenConfig::nmodl_unroll)
+        .def_readwrite("nmodl_const_folding", &nmodl::codegen::CodeGenConfig::nmodl_const_folding)
+        .def_readwrite("nmodl_localize", &nmodl::codegen::CodeGenConfig::nmodl_localize)
+        .def_readwrite("nmodl_global_to_range", &nmodl::codegen::CodeGenConfig::nmodl_global_to_range)
+        .def_readwrite("nmodl_local_to_range", &nmodl::codegen::CodeGenConfig::nmodl_local_to_range)
+        .def_readwrite("localize_verbatim", &nmodl::codegen::CodeGenConfig::localize_verbatim)
+        .def_readwrite("local_rename", &nmodl::codegen::CodeGenConfig::local_rename)
+        .def_readwrite("verbatim_inline", &nmodl::codegen::CodeGenConfig::verbatim_inline)
+        .def_readwrite("verbatim_rename", &nmodl::codegen::CodeGenConfig::verbatim_rename)
+        .def_readwrite("force_codegen", &nmodl::codegen::CodeGenConfig::force_codegen)
+        .def_readwrite("only_check_compatibility", &nmodl::codegen::CodeGenConfig::only_check_compatibility)
+        .def_readwrite("optimize_ionvar_copies_codegen", &nmodl::codegen::CodeGenConfig::optimize_ionvar_copies_codegen)
+        .def_readwrite("output_dir", &nmodl::codegen::CodeGenConfig::output_dir)
+        .def_readwrite("scratch_dir", &nmodl::codegen::CodeGenConfig::scratch_dir)
+        .def_readwrite("data_type", &nmodl::codegen::CodeGenConfig::data_type)
+        .def_readwrite("llvm_ir", &nmodl::codegen::CodeGenConfig::llvm_ir)
+        .def_readwrite("llvm_float_type", &nmodl::codegen::CodeGenConfig::llvm_float_type)
+        .def_readwrite("llvm_opt_level_ir", &nmodl::codegen::CodeGenConfig::llvm_opt_level_ir)
+        .def_readwrite("llvm_math_library", &nmodl::codegen::CodeGenConfig::llvm_math_library)
+        .def_readwrite("llvm_no_debug", &nmodl::codegen::CodeGenConfig::llvm_no_debug)
+        .def_readwrite("llvm_fast_math_flags", &nmodl::codegen::CodeGenConfig::llvm_fast_math_flags)
+        .def_readwrite("llvm_cpu_name", &nmodl::codegen::CodeGenConfig::llvm_cpu_name)
+        .def_readwrite("llvm_gpu_name", &nmodl::codegen::CodeGenConfig::llvm_gpu_name)
+        .def_readwrite("llvm_vector_width", &nmodl::codegen::CodeGenConfig::llvm_vector_width)
+        .def_readwrite("llvm_opt_level_codegen", &nmodl::codegen::CodeGenConfig::llvm_opt_level_codegen)
+        .def_readwrite("shared_lib_paths", &nmodl::codegen::CodeGenConfig::shared_lib_paths);
+
+    py::class_<nmodl::JitDriver> jit_driver(m_nmodl, "Jit", nmodl::docstring::jit);
+    jit_driver.def(py::init<>())
+        .def("run", &nmodl::JitDriver::run, "node"_a, "modname"_a, "num_experiments"_a, "instance_size"_a);
 
     m_nmodl.def("to_nmodl",
                 static_cast<std::string (*)(const nmodl::ast::Ast&,

--- a/test/benchmark/CMakeLists.txt
+++ b/test/benchmark/CMakeLists.txt
@@ -24,9 +24,11 @@ if(NMODL_ENABLE_PYTHON_BINDINGS)
   file(GLOB modfiles "${NMODL_PROJECT_SOURCE_DIR}/test/benchmark/kernels/*.mod")
   foreach(modfile ${modfiles})
     get_filename_component(modfile_name "${modfile}" NAME)
-    add_test(NAME "PyJIT/${modfile_name}" COMMAND ${PYTHON_EXECUTABLE} ${NMODL_PROJECT_SOURCE_DIR}/test/benchmark/benchmark.py ${modfile})
-    set_tests_properties("PyJIT/${modfile_name}" PROPERTIES ENVIRONMENT
-            PYTHONPATH=${PROJECT_BINARY_DIR}/lib:$ENV{PYTHONPATH})
+    add_test(NAME "PyJIT/${modfile_name}"
+             COMMAND ${PYTHON_EXECUTABLE} ${NMODL_PROJECT_SOURCE_DIR}/test/benchmark/benchmark.py
+                     ${modfile})
+    set_tests_properties(
+      "PyJIT/${modfile_name}" PROPERTIES ENVIRONMENT
+                                         PYTHONPATH=${PROJECT_BINARY_DIR}/lib:$ENV{PYTHONPATH})
   endforeach()
 endif()
-

--- a/test/benchmark/CMakeLists.txt
+++ b/test/benchmark/CMakeLists.txt
@@ -15,3 +15,18 @@ add_dependencies(llvm_benchmark lexer util visitor)
 if(NMODL_ENABLE_JIT_EVENT_LISTENERS)
   target_compile_definitions(llvm_benchmark PUBLIC NMODL_HAVE_JIT_EVENT_LISTENERS)
 endif()
+
+# =============================================================================
+# LLVM pyjit
+# =============================================================================
+
+if(NMODL_ENABLE_PYTHON_BINDINGS)
+  file(GLOB modfiles "${NMODL_PROJECT_SOURCE_DIR}/test/benchmark/kernels/*.mod")
+  foreach(modfile ${modfiles})
+    get_filename_component(modfile_name "${modfile}" NAME)
+    add_test(NAME "PyJIT/${modfile_name}" COMMAND ${PYTHON_EXECUTABLE} ${NMODL_PROJECT_SOURCE_DIR}/test/benchmark/benchmark.py ${modfile})
+    set_tests_properties("PyJIT/${modfile_name}" PROPERTIES ENVIRONMENT
+            PYTHONPATH=${PROJECT_BINARY_DIR}/lib:$ENV{PYTHONPATH})
+  endforeach()
+endif()
+

--- a/test/benchmark/benchmark.py
+++ b/test/benchmark/benchmark.py
@@ -1,0 +1,25 @@
+import sys
+
+import nmodl.dsl as nmodl
+from nmodl import ast, visitor
+
+def main():
+    driver = nmodl.NmodlDriver()
+    lookup_visitor = visitor.AstLookupVisitor()
+
+    cfg = nmodl.CodeGenConfig()
+    cfg.llvm_vector_width = 4
+    cfg.llvm_opt_level_ir = 2
+    fname = sys.argv[1]
+    with open(fname) as f:
+        hh = f.read()
+        modast = driver.parse_string(hh)
+        modname = lookup_visitor.lookup(modast, ast.AstNodeType.SUFFIX)[0].get_node_name()
+        jit = nmodl.Jit(cfg)
+
+        res = jit.run(modast, modname, 1000, 1000)
+        print(res)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/benchmark/llvm_benchmark.cpp
+++ b/test/benchmark/llvm_benchmark.cpp
@@ -10,9 +10,9 @@
 #include <numeric>
 
 #include "llvm_benchmark.hpp"
-#include "llvm/Support/Host.h"
 #include "test/benchmark/jit_driver.hpp"
 #include "utils/logger.hpp"
+#include "llvm/Support/Host.h"
 
 #include "test/unit/codegen/codegen_data_helper.hpp"
 
@@ -85,10 +85,14 @@ BenchmarkResults LLVMBenchmark::run_benchmark() {
             times[i] = diff.count();
         }
         // Calculate statistics
-        double time_mean = std::accumulate(times.begin(), times.end(), 0.0)/ num_experiments;
-        double time_var = std::accumulate(times.begin(), times.end(), 0.0,
-                                           [time_mean](const double& pres, const double& e) {
-                                               return (e - time_mean)*(e - time_mean); }) / num_experiments;
+        double time_mean = std::accumulate(times.begin(), times.end(), 0.0) / num_experiments;
+        double time_var = std::accumulate(times.begin(),
+                                          times.end(),
+                                          0.0,
+                                          [time_mean](const double& pres, const double& e) {
+                                              return (e - time_mean) * (e - time_mean);
+                                          }) /
+                          num_experiments;
         double time_stdev = std::sqrt(time_var);
         double time_min = *std::min_element(times.begin(), times.end());
         double time_max = *std::max_element(times.begin(), times.end());

--- a/test/benchmark/llvm_benchmark.cpp
+++ b/test/benchmark/llvm_benchmark.cpp
@@ -9,10 +9,10 @@
 #include <cmath>
 #include <numeric>
 
-#include "codegen/llvm/codegen_llvm_visitor.hpp"
 #include "llvm_benchmark.hpp"
-#include "test/benchmark/jit_driver.hpp"
 #include "llvm/Support/Host.h"
+#include "test/benchmark/jit_driver.hpp"
+#include "utils/logger.hpp"
 
 #include "test/unit/codegen/codegen_data_helper.hpp"
 

--- a/test/benchmark/llvm_benchmark.cpp
+++ b/test/benchmark/llvm_benchmark.cpp
@@ -18,14 +18,14 @@
 namespace nmodl {
 namespace benchmark {
 
-void LLVMBenchmark::run(const std::shared_ptr<ast::Program>& node) {
+void LLVMBenchmark::run() {
     // create functions
-    generate_llvm(node);
+    generate_llvm();
     // Finally, run the benchmark and log the measurements.
-    run_benchmark(node);
+    run_benchmark();
 }
 
-void LLVMBenchmark::generate_llvm(const std::shared_ptr<ast::Program>& node) {
+void LLVMBenchmark::generate_llvm() {
     // First, visit the AST to build the LLVM IR module and wrap the kernel function calls.
     auto start = std::chrono::steady_clock::now();
     llvm_visitor.wrap_kernel_functions();
@@ -36,9 +36,9 @@ void LLVMBenchmark::generate_llvm(const std::shared_ptr<ast::Program>& node) {
     logger->info("Created LLVM IR module from NMODL AST in {} sec", diff.count());
 }
 
-void LLVMBenchmark::run_benchmark(const std::shared_ptr<ast::Program>& node) {
+void LLVMBenchmark::run_benchmark() {
     // Set the codegen data helper and find the kernels.
-    auto codegen_data = codegen::CodegenDataHelper(node, llvm_visitor.get_instance_struct_ptr());
+    auto codegen_data = codegen::CodegenDataHelper(llvm_visitor.get_instance_struct_ptr());
     std::vector<std::string> kernel_names;
     llvm_visitor.find_kernel_names(kernel_names);
 

--- a/test/benchmark/llvm_benchmark.cpp
+++ b/test/benchmark/llvm_benchmark.cpp
@@ -6,6 +6,8 @@
  *************************************************************************/
 
 #include <chrono>
+#include <cmath>
+#include <numeric>
 
 #include "codegen/llvm/codegen_llvm_visitor.hpp"
 #include "llvm_benchmark.hpp"
@@ -18,11 +20,11 @@
 namespace nmodl {
 namespace benchmark {
 
-void LLVMBenchmark::run() {
+BenchmarkResults LLVMBenchmark::run() {
     // create functions
     generate_llvm();
     // Finally, run the benchmark and log the measurements.
-    run_benchmark();
+    return run_benchmark();
 }
 
 void LLVMBenchmark::generate_llvm() {
@@ -36,7 +38,7 @@ void LLVMBenchmark::generate_llvm() {
     logger->info("Created LLVM IR module from NMODL AST in {} sec", diff.count());
 }
 
-void LLVMBenchmark::run_benchmark() {
+BenchmarkResults LLVMBenchmark::run_benchmark() {
     // Set the codegen data helper and find the kernels.
     auto codegen_data = codegen::CodegenDataHelper(llvm_visitor.get_instance_struct_ptr());
     std::vector<std::string> kernel_names;
@@ -55,13 +57,11 @@ void LLVMBenchmark::run_benchmark() {
         std::move(m), filename, output_dir, cpu_name, shared_libs, opt_level_ir, opt_level_codegen);
     runner.initialize_driver();
 
+    BenchmarkResults results{};
     // Benchmark every kernel.
     for (const auto& kernel_name: kernel_names) {
-        // For every kernel run the benchmark `num_experiments` times.
-        double time_min = std::numeric_limits<double>::max();
-        double time_max = 0.0;
-        double time_sum = 0.0;
-        double time_squared_sum = 0.0;
+        // For every kernel run the benchmark `num_experiments` times and collect runtimes.
+        auto times = std::vector<double>(num_experiments, 0.0);
         for (int i = 0; i < num_experiments; ++i) {
             // Initialise the data.
             auto instance_data = codegen_data.create_data(instance_size, /*seed=*/1);
@@ -80,22 +80,26 @@ void LLVMBenchmark::run_benchmark() {
             std::chrono::duration<double> diff = end - start;
 
             // Log the time taken for each run.
-            logger->info("Experiment {} compute time = {:.6f} sec", i, diff.count());
+            logger->debug("Experiment {} compute time = {:.6f} sec", i, diff.count());
 
-            // Update statistics.
-            time_sum += diff.count();
-            time_squared_sum += diff.count() * diff.count();
-            time_min = std::min(time_min, diff.count());
-            time_max = std::max(time_max, diff.count());
+            times[i] = diff.count();
         }
+        // Calculate statistics
+        double time_mean = std::accumulate(times.begin(), times.end(), 0.0)/ num_experiments;
+        double time_var = std::accumulate(times.begin(), times.end(), 0.0,
+                                           [time_mean](const double& pres, const double& e) {
+                                               return (e - time_mean)*(e - time_mean); }) / num_experiments;
+        double time_stdev = std::sqrt(time_var);
+        double time_min = *std::min_element(times.begin(), times.end());
+        double time_max = *std::max_element(times.begin(), times.end());
         // Log the average time taken for the kernel.
-        double time_mean = time_sum / num_experiments;
         logger->info("Average compute time = {:.6f}", time_mean);
-        logger->info("Compute time variance = {:g}",
-                     time_squared_sum / num_experiments - time_mean * time_mean);
+        logger->info("Compute time standard deviation = {:8f}", time_stdev);
         logger->info("Minimum compute time = {:.6f}", time_min);
         logger->info("Maximum compute time = {:.6f}\n", time_max);
+        results[kernel_name] = {time_mean, time_stdev, time_min, time_max};
     }
+    return results;
 }
 
 }  // namespace benchmark

--- a/test/benchmark/llvm_benchmark.hpp
+++ b/test/benchmark/llvm_benchmark.hpp
@@ -13,7 +13,6 @@
 #include <tuple>
 
 #include "codegen/llvm/codegen_llvm_visitor.hpp"
-#include "utils/logger.hpp"
 
 namespace nmodl {
 namespace benchmark {

--- a/test/benchmark/llvm_benchmark.hpp
+++ b/test/benchmark/llvm_benchmark.hpp
@@ -8,13 +8,20 @@
 #pragma once
 
 #include <fstream>
+#include <map>
 #include <string>
+#include <tuple>
 
 #include "codegen/llvm/codegen_llvm_visitor.hpp"
 #include "utils/logger.hpp"
 
 namespace nmodl {
 namespace benchmark {
+
+/**
+ * map of {name: [avg, stdev, min, max]}
+ */
+using BenchmarkResults = std::map<std::string, std::tuple<double, double, double, double>>;
 
 /**
  * \class LLVMBenchmark
@@ -74,14 +81,14 @@ class LLVMBenchmark {
         , opt_level_codegen(opt_level_codegen) {}
 
     /// Runs the benchmark.
-    void run();
+    BenchmarkResults run();
 
   private:
     /// Visits the AST to construct the LLVM IR module.
     void generate_llvm();
 
     /// Runs the main body of the benchmark, executing the compute kernels.
-    void run_benchmark();
+    BenchmarkResults run_benchmark();
 
     /// Sets the log output stream (file or console).
     void set_log_output();

--- a/test/benchmark/llvm_benchmark.hpp
+++ b/test/benchmark/llvm_benchmark.hpp
@@ -74,14 +74,14 @@ class LLVMBenchmark {
         , opt_level_codegen(opt_level_codegen) {}
 
     /// Runs the benchmark.
-    void run(const std::shared_ptr<ast::Program>& node);
+    void run();
 
   private:
     /// Visits the AST to construct the LLVM IR module.
-    void generate_llvm(const std::shared_ptr<ast::Program>& node);
+    void generate_llvm();
 
     /// Runs the main body of the benchmark, executing the compute kernels.
-    void run_benchmark(const std::shared_ptr<ast::Program>& node);
+    void run_benchmark();
 
     /// Sets the log output stream (file or console).
     void set_log_output();

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -157,10 +157,8 @@ endif()
 set(testvisitor_env "PYTHONPATH=${PROJECT_BINARY_DIR}/lib:$ENV{PYTHONPATH}")
 if(NOT LINK_AGAINST_PYTHON)
   list(APPEND testvisitor_env "NMODL_PYLIB=$ENV{NMODL_PYLIB}")
-  list(
-    APPEND
-      testvisitor_env
-      "NMODL_WRAPLIB=${PROJECT_BINARY_DIR}/lib/nmodl/libpywrapper${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  list(APPEND testvisitor_env
+       "NMODL_WRAPLIB=${PROJECT_BINARY_DIR}/lib/nmodl/libpywrapper${CMAKE_SHARED_LIBRARY_SUFFIX}")
 endif()
 
 foreach(

--- a/test/unit/codegen/codegen_data_helper.hpp
+++ b/test/unit/codegen/codegen_data_helper.hpp
@@ -96,15 +96,12 @@ std::vector<T> generate_dummy_data(size_t initial_value, size_t num_elements) {
  * to the MOD file.
  */
 class CodegenDataHelper {
-    std::shared_ptr<ast::Program> program;
     std::shared_ptr<ast::InstanceStruct> instance;
 
   public:
     CodegenDataHelper() = delete;
-    CodegenDataHelper(const std::shared_ptr<ast::Program>& program,
-                      const std::shared_ptr<ast::InstanceStruct>& instance)
-        : program(program)
-        , instance(instance) {}
+    CodegenDataHelper(const std::shared_ptr<ast::InstanceStruct>& instance)
+        : instance(instance) {}
 
     CodegenInstanceData create_data(size_t num_elements, size_t seed);
 };

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -320,7 +320,7 @@ SCENARIO("Simple scalar kernel", "[llvm][runner]") {
         // Create the instance struct data.
         int num_elements = 4;
         const auto& generated_instance_struct = llvm_visitor.get_instance_struct_ptr();
-        auto codegen_data = codegen::CodegenDataHelper(ast, generated_instance_struct);
+        auto codegen_data = codegen::CodegenDataHelper(generated_instance_struct);
         auto instance_data = codegen_data.create_data(num_elements, /*seed=*/1);
 
         // Fill the instance struct data with some values.
@@ -404,7 +404,7 @@ SCENARIO("Simple vectorised kernel", "[llvm][runner]") {
         // Create the instance struct data.
         int num_elements = 10;
         const auto& generated_instance_struct = llvm_visitor.get_instance_struct_ptr();
-        auto codegen_data = codegen::CodegenDataHelper(ast, generated_instance_struct);
+        auto codegen_data = codegen::CodegenDataHelper(generated_instance_struct);
         auto instance_data = codegen_data.create_data(num_elements, /*seed=*/1);
 
         // Fill the instance struct data with some values for unit testing.
@@ -488,7 +488,7 @@ SCENARIO("Vectorised kernel with scatter instruction", "[llvm][runner]") {
         // Create the instance struct data.
         int num_elements = 5;
         const auto& generated_instance_struct = llvm_visitor.get_instance_struct_ptr();
-        auto codegen_data = codegen::CodegenDataHelper(ast, generated_instance_struct);
+        auto codegen_data = codegen::CodegenDataHelper(generated_instance_struct);
         auto instance_data = codegen_data.create_data(num_elements, /*seed=*/1);
 
         // Fill the instance struct data with some values.
@@ -581,7 +581,7 @@ SCENARIO("Vectorised kernel with simple control flow", "[llvm][runner]") {
         // Create the instance struct data.
         int num_elements = 5;
         const auto& generated_instance_struct = llvm_visitor.get_instance_struct_ptr();
-        auto codegen_data = codegen::CodegenDataHelper(ast, generated_instance_struct);
+        auto codegen_data = codegen::CodegenDataHelper(generated_instance_struct);
         auto instance_data = codegen_data.create_data(num_elements, /*seed=*/1);
 
         // Fill the instance struct data with some values.

--- a/test/unit/codegen/codegen_llvm_instance_struct.cpp
+++ b/test/unit/codegen/codegen_llvm_instance_struct.cpp
@@ -47,7 +47,7 @@ codegen::CodegenInstanceData generate_instance_data(const std::string& text,
     llvm_visitor.visit_program(*ast);
     llvm_visitor.dump_module();
     const auto& generated_instance_struct = llvm_visitor.get_instance_struct_ptr();
-    auto codegen_data = codegen::CodegenDataHelper(ast, generated_instance_struct);
+    auto codegen_data = codegen::CodegenDataHelper(generated_instance_struct);
     auto instance_data = codegen_data.create_data(num_elements, seed);
     return instance_data;
 }


### PR DESCRIPTION
- Created CodegenDriver class to factor out ast preparation
- Created pybind wrappers for Jit and Codegen configuration options
- misc small changes to simplify code


Here's a little test for this:

```python
import sys
sys.path.pop(0)
print(sys.path)

import nmodl.dsl as nmodl

driver = nmodl.NmodlDriver()

cfg = nmodl.CodeGenConfig()
cfg.llvm_vector_width = 4
cfg.llvm_opt_level_ir = 2

with open('test/benchmark/kernels/hh.mod') as f:
    hh = f.read()
    ast = driver.parse_string(hh)
    jit = nmodl.Jit(cfg)

    res = jit.run(ast, "hh", 1000, 10000)
    print(res)
```
(updated example)