### PR TITLE
[LLVM][GPU] NVPTX specific passes for code generation

### DIFF
--- a/cmake/LLVMHelper.cmake
+++ b/cmake/LLVMHelper.cmake
@@ -15,6 +15,9 @@ set(NMODL_LLVM_COMPONENTS
     ipo
     mc
     native
+    nvptxcodegen
+    nvptxdesc
+    nvptxinfo
     orcjit
     target
     transformutils

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -917,12 +917,15 @@ void CodegenLLVMVisitor::visit_program(const ast::Program& node) {
     }
 
     // Handle GPU optimizations (CUDA platfroms only for now).
-    if (platform.is_gpu() && opt_level_ir) {
+    if (platform.is_gpu()) {
+        if (!platform.is_CUDA_gpu())
+            throw std::runtime_error("Error: unsupported GPU architecture!\n");
+
         // We only support CUDA backends anyway, so this works for now.
         utils::initialise_nvptx_passes();
 
         std::string target_asm;
-        utils::optimise_module_for_nvptx(*module, opt_level_ir, target_asm);
+        utils::optimise_module_for_nvptx(platform, *module, opt_level_ir, target_asm);
 
         logger->debug("Dumping generated IR...\n" + dump_module());
         logger->debug("Dumping generated PTX...\n" + target_asm);

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -883,8 +883,9 @@ void CodegenLLVMVisitor::visit_program(const ast::Program& node) {
         throw std::runtime_error("Error: incorrect IR has been generated!\n" + ostream.str());
     }
 
-    if (opt_level_ir) {
-        logger->info("Running LLVM optimisation passes");
+    // Handle optimization passes for GPUs separately.
+    if (platform.is_cpu() && opt_level_ir) {
+        logger->info("Running LLVM optimisation passes for CPU platforms");
         utils::initialise_optimisation_passes();
         utils::optimise_module(*module, opt_level_ir);
     }
@@ -915,12 +916,26 @@ void CodegenLLVMVisitor::visit_program(const ast::Program& node) {
 #endif
     }
 
+    // Handle GPU optimizations (CUDA platfroms only for now).
+    if (platform.is_gpu() && opt_level_ir) {
+        // We only support CUDA backends anyway, so this works for now.
+        utils::initialise_nvptx_passes();
+
+        std::string target_asm;
+        utils::optimise_module_for_nvptx(*module, opt_level_ir, target_asm);
+
+        logger->debug("Dumping generated IR...\n" + dump_module());
+        logger->debug("Dumping generated PTX...\n" + target_asm);
+    } else {
+        // Workaround for debug outputs.
+        logger->debug("Dumping generated IR...\n" + dump_module());
+    }
+
     // If the output directory is specified, save the IR to .ll file.
     if (output_dir != ".") {
         utils::save_ir_to_ll_file(*module, output_dir + "/" + mod_filename);
     }
 
-    logger->debug("Dumping generated IR...\n" + dump_module());
     // Setup CodegenHelper for C++ wrapper file
     setup(node);
     print_wrapper_routines();

--- a/src/codegen/llvm/llvm_utils.cpp
+++ b/src/codegen/llvm/llvm_utils.cpp
@@ -96,7 +96,7 @@ void optimise_module_for_nvptx(codegen::Platform& platform,
 
     // Set data layout and target triple information for the module.
     auto triple = triple_str.at(platform_name);
-    module.setDataLayout(data_layout_str.at(platform_name);
+    module.setDataLayout(data_layout_str.at(platform_name));
     module.setTargetTriple(triple);
 
     std::string subtarget = platform.get_subtarget_name();

--- a/src/codegen/llvm/llvm_utils.cpp
+++ b/src/codegen/llvm/llvm_utils.cpp
@@ -74,31 +74,45 @@ void initialise_nvptx_passes() {
     initialise_optimisation_passes();
 }
 
-void optimise_module_for_nvptx(llvm::Module& module, int opt_level, std::string& target_asm) {
+void optimise_module_for_nvptx(codegen::Platform& platform,
+                               llvm::Module& module,
+                               int opt_level,
+                               std::string& target_asm) {
     // CUDA target machine we generating code for.
     std::unique_ptr<llvm::TargetMachine> tm;
+    std::string platform_name = platform.get_name();
 
-    // Hardcode target infromation for now. Change if necessary.
-    llvm::Triple triple("nvptx64-nvidia-cuda");
-    std::string subtarget = "sm_20";
-    std::string features = "+ptx60";
+    // Target and layout information.
+    static const std::map<std::string, std::string> triple_str = {
+            {"nvptx", "nvptx-nvidia-cuda"},
+            {"nvptx64", "nvptx64-nvidia-cuda"}};
+    static const std::map<std::string, std::string> data_layout_str = {
+            {"nvptx", "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32"
+                      "-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32"
+                      "-v64:64:64-v128:128:128-n16:32:64"},
+            {"nvptx64", "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32"
+                        "-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32"
+                        "-v64:64:64-v128:128:128-n16:32:64"}};
+
+    // Set data layout and target triple information for the module.
+    auto triple = triple_str.find(platform_name)->second;
+    module.setDataLayout(data_layout_str.find(platform_name)->second);
+    module.setTargetTriple(triple);
+
+    std::string subtarget = platform.get_subtarget_name();
+    std::string features = "+ptx70";
 
     // Find the specified target in registry.
     std::string error_msg;
-    auto* target = llvm::TargetRegistry::lookupTarget("", triple, error_msg);
+    auto* target = llvm::TargetRegistry::lookupTarget(triple, error_msg);
     if (!target)
         throw std::runtime_error("Error: " + error_msg + "\n");
 
-    tm.reset(target->createTargetMachine(triple.str(), subtarget, features, {}, {}));
+    tm.reset(target->createTargetMachine(triple, subtarget, features, {}, {}));
     if (!tm)
         throw std::runtime_error("Error: creating target machine failed! Aborting.");
 
-    // Set data layout and target triple information for the module. Note
-    // that  we may want to have a more elaborate layout than the one
-    // created by `createDataLayout()`.
-    module.setDataLayout(tm->createDataLayout());
-    module.setTargetTriple("nvptx64-nvidia-cuda");
-
+    // Create pass managers.
     llvm::legacy::FunctionPassManager func_pm(&module);
     llvm::legacy::PassManager module_pm;
     llvm::PassManagerBuilder pm_builder;

--- a/src/codegen/llvm/llvm_utils.cpp
+++ b/src/codegen/llvm/llvm_utils.cpp
@@ -13,8 +13,10 @@
 #include "llvm/IR/Verifier.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Target/TargetMachine.h"
+#include "llvm/Transforms/IPO.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 
 namespace nmodl {
@@ -60,6 +62,71 @@ static void run_optimisation_passes(llvm::Module& module,
 /****************************************************************************************/
 /*                             Optimisation utils                                       */
 /****************************************************************************************/
+
+void initialise_nvptx_passes() {
+    // Register targets.
+    LLVMInitializeNVPTXTarget();
+    LLVMInitializeNVPTXTargetMC();
+    LLVMInitializeNVPTXTargetInfo();
+    LLVMInitializeNVPTXAsmPrinter();
+
+    // Initialize passes.
+    initialise_optimisation_passes();
+}
+
+void optimise_module_for_nvptx(llvm::Module& module, int opt_level, std::string& target_asm) {
+    // CUDA target machine we generating code for.
+    std::unique_ptr<llvm::TargetMachine> tm;
+
+    // Hardcode target infromation for now. Change if necessary.
+    llvm::Triple triple("nvptx64-nvidia-cuda");
+    std::string subtarget = "sm_20";
+    std::string features = "+ptx60";
+
+    // Find the specified target in registry.
+    std::string error_msg;
+    auto* target = llvm::TargetRegistry::lookupTarget("", triple, error_msg);
+    if (!target)
+        throw std::runtime_error("Error: " + error_msg + "\n");
+
+    tm.reset(target->createTargetMachine(triple.str(), subtarget, features, {}, {}));
+    if (!tm)
+        throw std::runtime_error("Error: creating target machine failed! Aborting.");
+
+    // Set data layout and target triple information for the module. Note
+    // that  we may want to have a more elaborate layout than the one
+    // created by `createDataLayout()`.
+    module.setDataLayout(tm->createDataLayout());
+    module.setTargetTriple("nvptx64-nvidia-cuda");
+
+    llvm::legacy::FunctionPassManager func_pm(&module);
+    llvm::legacy::PassManager module_pm;
+    llvm::PassManagerBuilder pm_builder;
+    pm_builder.OptLevel = opt_level;
+    pm_builder.SizeLevel = 0;
+    pm_builder.Inliner = llvm::createFunctionInliningPass();
+
+    // Do not vectorize!
+    pm_builder.LoopVectorize = false;
+
+    // Adjusting pass manager adds target-specific IR transformations, e.g.
+    // inferring address spaces.
+    tm->adjustPassManager(pm_builder);
+    pm_builder.populateFunctionPassManager(func_pm);
+    pm_builder.populateModulePassManager(module_pm);
+
+    // This runs target-indepependent optimizations.
+    run_optimisation_passes(module, func_pm, module_pm);
+
+    // Now, we want to run target-specific (e.g. NVPTX) passes. In LLVM, this
+    // is done via `addPassesToEmitFile`.
+    llvm::raw_string_ostream stream(target_asm);
+    llvm::buffer_ostream pstream(stream);
+    llvm::legacy::PassManager codegen_pm;
+
+    tm->addPassesToEmitFile(codegen_pm, pstream, nullptr, llvm::CGFT_AssemblyFile);
+    codegen_pm.run(module);
+}
 
 void initialise_optimisation_passes() {
     auto& registry = *llvm::PassRegistry::getPassRegistry();

--- a/src/codegen/llvm/llvm_utils.cpp
+++ b/src/codegen/llvm/llvm_utils.cpp
@@ -95,8 +95,8 @@ void optimise_module_for_nvptx(codegen::Platform& platform,
                         "-v64:64:64-v128:128:128-n16:32:64"}};
 
     // Set data layout and target triple information for the module.
-    auto triple = triple_str.find(platform_name)->second;
-    module.setDataLayout(data_layout_str.find(platform_name)->second);
+    auto triple = triple_str.at(platform_name);
+    module.setDataLayout(data_layout_str.at(platform_name);
     module.setTargetTriple(triple);
 
     std::string subtarget = platform.get_subtarget_name();

--- a/src/codegen/llvm/llvm_utils.hpp
+++ b/src/codegen/llvm/llvm_utils.hpp
@@ -16,6 +16,12 @@ namespace utils {
 /// Initialises some LLVM optimisation passes.
 void initialise_optimisation_passes();
 
+/// Initialises NVPTX-specific optimisation passes.
+void initialise_nvptx_passes();
+
+/// Optimises the given LLVM IR module for NVPTX targets.
+void optimise_module_for_nvptx(llvm::Module& module, int opt_level, std::string& target_asm);
+
 /// Optimises the given LLVM IR module.
 void optimise_module(llvm::Module& module, int opt_level, llvm::TargetMachine* tm = nullptr);
 

--- a/src/codegen/llvm/llvm_utils.hpp
+++ b/src/codegen/llvm/llvm_utils.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "codegen/llvm/target_platform.hpp"
+
 #include "llvm/IR/Module.h"
 #include "llvm/Support/TargetRegistry.h"
 
@@ -20,7 +22,10 @@ void initialise_optimisation_passes();
 void initialise_nvptx_passes();
 
 /// Optimises the given LLVM IR module for NVPTX targets.
-void optimise_module_for_nvptx(llvm::Module& module, int opt_level, std::string& target_asm);
+void optimise_module_for_nvptx(codegen::Platform& platform,
+                               llvm::Module& module,
+                               int opt_level,
+                               std::string& target_asm);
 
 /// Optimises the given LLVM IR module.
 void optimise_module(llvm::Module& module, int opt_level, llvm::TargetMachine* tm = nullptr);

--- a/src/codegen/llvm/target_platform.cpp
+++ b/src/codegen/llvm/target_platform.cpp
@@ -30,12 +30,22 @@ bool Platform::is_gpu() {
     return platform_id == PlatformID::GPU;
 }
 
+bool Platform::is_CUDA_gpu() {
+  return platform_id == PlatformID::GPU && (name == "nvptx" || name == "nvptx64");
+}
+
 bool Platform::is_single_precision() {
   return use_single_precision;
 }
 
 std::string Platform::get_name() const {
     return name;
+}
+
+std::string Platform::get_subtarget_name() const {
+    if (platform_id != PlatformID::GPU)
+        throw std::runtime_error("Error: platform must be a GPU to query the subtarget!\n");
+    return subtarget_name;
 }
 
 std::string Platform::get_math_library() const {

--- a/src/codegen/llvm/target_platform.cpp
+++ b/src/codegen/llvm/target_platform.cpp
@@ -7,6 +7,8 @@
 
 #include "codegen/llvm/target_platform.hpp"
 
+#include <stdexcept>
+
 namespace nmodl {
 namespace codegen {
 

--- a/src/codegen/llvm/target_platform.hpp
+++ b/src/codegen/llvm/target_platform.hpp
@@ -35,7 +35,7 @@ class Platform {
     /// Target chip for GPUs.
     /// TODO: this should only be available to GPUs! If we refactor target
     /// classes so that GPUPlatform <: Platform, it will be nicer!
-    const std::string subtarget_name = "sm_35";
+    const std::string subtarget_name = "sm_70";
 
     /// Target-specific id to compare platforms easily.
     PlatformID platform_id;

--- a/src/codegen/llvm/target_platform.hpp
+++ b/src/codegen/llvm/target_platform.hpp
@@ -32,11 +32,16 @@ class Platform {
     /// Name of the platform.
     const std::string name = Platform::DEFAULT_PLATFORM_NAME;
 
+    /// Target chip for GPUs.
+    /// TODO: this should only be available to GPUs! If we refactor target
+    /// classes so that GPUPlatform <: Platform, it will be nicer!
+    const std::string subtarget_name = "sm_35";
+
     /// Target-specific id to compare platforms easily.
     PlatformID platform_id;
 
     /// User-provided width that is used to construct LLVM instructions
-    //  and types.
+    ///  and types.
     int instruction_width = 1;
 
     /// Use single-precision floating-point types.
@@ -46,6 +51,19 @@ class Platform {
     std::string math_library = Platform::DEFAULT_MATH_LIBRARY;
 
   public:
+    Platform(PlatformID platform_id,
+             const std::string& name,
+             const std::string& subtarget_name,
+             std::string& math_library,
+             bool use_single_precision = false,
+             int instruction_width = 1)
+              : platform_id(platform_id)
+              , name(name)
+              , subtarget_name(subtarget_name)
+              , math_library(math_library)
+              , use_single_precision(use_single_precision)
+              , instruction_width(instruction_width) {}
+
     Platform(PlatformID platform_id,
              const std::string& name,
              std::string& math_library,
@@ -77,9 +95,14 @@ class Platform {
     /// Checks if this platform is a GPU.
     bool is_gpu();
 
+    /// Checks if this platform is CUDA platform.
+    bool is_CUDA_gpu();
+
     bool is_single_precision();
 
     std::string get_name() const;
+
+    std::string get_subtarget_name() const;
 
     std::string get_math_library() const;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -356,9 +356,12 @@ int main(int argc, const char* argv[]) {
 
     auto gpu_opt = app.add_subcommand("gpu", "LLVM GPU option")->ignore_case();
     gpu_opt->needs(llvm_opt);
-    gpu_opt->add_option("--name",
+    auto gpu_target_name = gpu_opt->add_option("--name",
         llvm_gpu_name,
         "Name of GPU platform to use")->ignore_case();
+   gpu_opt->add_option("--target-chip",
+        llvm_cpu_name,
+        "Name of target chip to use")->ignore_case();
     auto gpu_math_library_opt = gpu_opt->add_option("--math-library",
         llvm_math_library,
         "Math library for GPU code generation ({})"_format(llvm_math_library));
@@ -701,7 +704,7 @@ int main(int argc, const char* argv[]) {
                                                           : PlatformID::GPU;
               const std::string name =
                   llvm_gpu_name == "default" ? llvm_cpu_name : llvm_gpu_name;
-              Platform platform(pid, name, llvm_math_library, llvm_float_type,
+              Platform platform(pid, name, llvm_cpu_name, llvm_math_library, llvm_float_type,
                                 llvm_vector_width);
 
               logger->info("Running LLVM backend code generator");

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -1648,4 +1648,47 @@ SCENARIO("GPU kernel body IR generation", "[visitor][llvm][gpu]") {
             REQUIRE(std::regex_search(module_string, m, grid_dim));
         }
     }
+
+    GIVEN("When optimizing for GPU platforms") {
+        std::string nmodl_text = R"(
+            NEURON {
+                SUFFIX test
+                RANGE x, y
+            }
+
+            ASSIGNED { x y }
+
+            STATE { m }
+
+            BREAKPOINT {
+                SOLVE states METHOD cnexp
+            }
+
+            DERIVATIVE states {
+              m = y + 2
+            }
+        )";
+
+        THEN("address spaces are inferred and target information added") {
+            std::string module_string = run_gpu_llvm_visitor(nmodl_text,
+                                                             /*opt_level=*/3,
+                                                             /*use_single_precision=*/false);
+            std::smatch m;
+
+            // Check target information.
+            // TODO: this may change when more platforms are supported.
+            std::regex data_layout(R"(target datalayout = \"e-i64:64-i128:128-v16:16-v32:32-n16:32:64\")");
+            std::regex triple(R"(nvptx64-nvidia-cuda)");
+            REQUIRE(std::regex_search(module_string, m, data_layout));
+            REQUIRE(std::regex_search(module_string, m, triple));
+
+            // Check for address space casts and address spaces in general when loading data.
+            std::regex as_cast(R"(addrspacecast %.*__instance_var__type\* %.* to %.*__instance_var__type addrspace\(1\)\*)");
+            std::regex gep_as1(R"(getelementptr inbounds %.*__instance_var__type, %.*__instance_var__type addrspace\(1\)\* %.*, i64 0, i32 .*)");
+            std::regex load_as1(R"(load double\*, double\* addrspace\(1\)\* %.*)");
+            REQUIRE(std::regex_search(module_string, m, as_cast));
+            REQUIRE(std::regex_search(module_string, m, gep_as1));
+            REQUIRE(std::regex_search(module_string, m, load_as1));
+        }
+    }
 }

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -49,7 +49,7 @@ std::string run_gpu_llvm_visitor(const std::string& text,
     NeuronSolveVisitor().visit_program(*ast);
     SolveBlockVisitor().visit_program(*ast);
 
-    codegen::Platform gpu_platform(codegen::PlatformID::GPU, /*name=*/"nvidia",
+    codegen::Platform gpu_platform(codegen::PlatformID::GPU, /*name=*/"nvptx64",
                                    math_library, use_single_precision, 1);
     codegen::CodegenLLVMVisitor llvm_visitor(
         /*mod_filename=*/"unknown",
@@ -1677,7 +1677,7 @@ SCENARIO("GPU kernel body IR generation", "[visitor][llvm][gpu]") {
 
             // Check target information.
             // TODO: this may change when more platforms are supported.
-            std::regex data_layout(R"(target datalayout = \"e-i64:64-i128:128-v16:16-v32:32-n16:32:64\")");
+            std::regex data_layout(R"(target datalayout = \"e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64\")");
             std::regex triple(R"(nvptx64-nvidia-cuda)");
             REQUIRE(std::regex_search(module_string, m, data_layout));
             REQUIRE(std::regex_search(module_string, m, triple));


### PR DESCRIPTION
This PR adds basic functionality to encode codegen (here,
for NVPTX) passes into optimization pipeline for GPUs. In
particular, this allows to infer address spaces and perform
other NVPTX-specific optimizations.

Corresponding tests were also added.