### PR TITLE
[LLVM][GPU][+refactoring] Replacement of math intrinsics with library calls

### DIFF
--- a/src/codegen/llvm/CMakeLists.txt
+++ b/src/codegen/llvm/CMakeLists.txt
@@ -12,6 +12,8 @@ set(LLVM_CODEGEN_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/llvm_ir_builder.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/llvm_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/llvm_utils.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/replace_with_lib_functions.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/replace_with_lib_functions.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/target_platform.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/target_platform.hpp)
 

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -12,16 +12,9 @@
 #include "visitors/rename_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
 
-#include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Function.h"
-#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Type.h"
-#include "llvm/Support/Host.h"
-
-#if LLVM_VERSION_MAJOR >= 13
-#include "llvm/CodeGen/ReplaceWithVeclib.h"
-#endif
 
 namespace nmodl {
 namespace codegen {
@@ -70,71 +63,6 @@ void CodegenLLVMVisitor::annotate_kernel_with_nvvm(llvm::Function* kernel) {
     llvm::MDNode* node = llvm::MDNode::get(*context, metadata);
     module->getOrInsertNamedMetadata("nvvm.annotations")->addOperand(node);
 }
-
-#if LLVM_VERSION_MAJOR >= 13
-void CodegenLLVMVisitor::add_vectorizable_functions_from_vec_lib(llvm::TargetLibraryInfoImpl& tli,
-                                                                 llvm::Triple& triple) {
-    // Since LLVM does not support SLEEF as a vector library yet, process it separately.
-    if (platform.get_math_library() == "SLEEF") {
-// clang-format off
-#define FIXED(w) llvm::ElementCount::getFixed(w)
-// clang-format on
-#define DISPATCH(func, vec_func, width) {func, vec_func, width},
-
-        // Populate function definitions of only exp and pow (for now)
-        const llvm::VecDesc aarch64_functions[] = {
-            // clang-format off
-            DISPATCH("llvm.exp.f32", "_ZGVnN4v_expf", FIXED(4))
-            DISPATCH("llvm.exp.f64", "_ZGVnN2v_exp", FIXED(2))
-            DISPATCH("llvm.pow.f32", "_ZGVnN4vv_powf", FIXED(4))
-            DISPATCH("llvm.pow.f64", "_ZGVnN2vv_pow", FIXED(2))
-            // clang-format on
-        };
-        const llvm::VecDesc x86_functions[] = {
-            // clang-format off
-            DISPATCH("llvm.exp.f64", "_ZGVbN2v_exp", FIXED(2))
-            DISPATCH("llvm.exp.f64", "_ZGVdN4v_exp", FIXED(4))
-            DISPATCH("llvm.exp.f64", "_ZGVeN8v_exp", FIXED(8))
-            DISPATCH("llvm.pow.f64", "_ZGVbN2vv_pow", FIXED(2))
-            DISPATCH("llvm.pow.f64", "_ZGVdN4vv_pow", FIXED(4))
-            DISPATCH("llvm.pow.f64", "_ZGVeN8vv_pow", FIXED(8))
-            // clang-format on
-        };
-#undef DISPATCH
-
-        if (triple.isAArch64()) {
-            tli.addVectorizableFunctions(aarch64_functions);
-        }
-        if (triple.isX86() && triple.isArch64Bit()) {
-            tli.addVectorizableFunctions(x86_functions);
-        }
-
-    } else {
-        // A map to query vector library by its string value.
-        using VecLib = llvm::TargetLibraryInfoImpl::VectorLibrary;
-        static const std::map<std::string, VecLib> llvm_supported_vector_libraries = {
-            {"Accelerate", VecLib::Accelerate},
-            {"libmvec", VecLib::LIBMVEC_X86},
-            {"libsystem_m", VecLib ::DarwinLibSystemM},
-            {"MASSV", VecLib::MASSV},
-            {"none", VecLib::NoLibrary},
-            {"SVML", VecLib::SVML}};
-        const auto& library = llvm_supported_vector_libraries.find(platform.get_math_library());
-        if (library == llvm_supported_vector_libraries.end())
-            throw std::runtime_error("Error: unknown vector library - " + platform.get_math_library() + "\n");
-
-        // Add vectorizable functions to the target library info.
-        switch (library->second) {
-        case VecLib::LIBMVEC_X86:
-            if (!triple.isX86() || !triple.isArch64Bit())
-                break;
-        default:
-            tli.addVectorizableFunctionsFromVecLib(library->second);
-            break;
-        }
-    }
-}
-#endif
 
 llvm::Value* CodegenLLVMVisitor::accept_and_get(const std::shared_ptr<ast::Node>& node) {
     node->accept(*this);
@@ -890,31 +818,8 @@ void CodegenLLVMVisitor::visit_program(const ast::Program& node) {
         utils::optimise_module(*module, opt_level_ir);
     }
 
-    // Optionally, replace LLVM math intrinsics with vector library calls.
-    if (platform.is_cpu_with_simd()) {
-#if LLVM_VERSION_MAJOR < 13
-        logger->warn(
-            "This version of LLVM does not support replacement of LLVM intrinsics with vector "
-            "library calls");
-#else
-        // First, get the target library information and add vectorizable functions for the
-        // specified vector library.
-        llvm::Triple triple(llvm::sys::getDefaultTargetTriple());
-        llvm::TargetLibraryInfoImpl target_lib_info = llvm::TargetLibraryInfoImpl(triple);
-        add_vectorizable_functions_from_vec_lib(target_lib_info, triple);
-
-        // Run passes that replace math intrinsics.
-        llvm::legacy::FunctionPassManager fpm(module.get());
-        fpm.add(new llvm::TargetLibraryInfoWrapperPass(target_lib_info));
-        fpm.add(new llvm::ReplaceWithVeclibLegacy);
-        fpm.doInitialization();
-        for (auto& function: module->getFunctionList()) {
-            if (!function.isDeclaration())
-                fpm.run(function);
-        }
-        fpm.doFinalization();
-#endif
-    }
+    // Optionally, replace LLVM math intrinsics with library calls.
+    utils::replace_with_lib_functions(platform, *module);
 
     // Handle GPU optimizations (CUDA platfroms only for now).
     if (platform.is_gpu()) {

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -26,7 +26,6 @@
 #include "utils/logger.hpp"
 #include "visitors/ast_visitor.hpp"
 
-#include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
@@ -304,12 +303,6 @@ class CodegenLLVMVisitor: public CodegenCVisitor {
   private:
     // Annotates kernel function with NVVM metadata.
     void annotate_kernel_with_nvvm(llvm::Function* kernel);
-
-#if LLVM_VERSION_MAJOR >= 13
-    /// Populates target library info with the vector library definitions.
-    void add_vectorizable_functions_from_vec_lib(llvm::TargetLibraryInfoImpl& tli,
-                                                 llvm::Triple& triple);
-#endif
 
     /// Accepts the given AST node and returns the processed value.
     llvm::Value* accept_and_get(const std::shared_ptr<ast::Node>& node);

--- a/src/codegen/llvm/llvm_utils.cpp
+++ b/src/codegen/llvm/llvm_utils.cpp
@@ -6,6 +6,7 @@
  *************************************************************************/
 
 #include "codegen/llvm/llvm_utils.hpp"
+#include "codegen/llvm/replace_with_lib_functions.hpp"
 
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/AssemblyAnnotationWriter.h"
@@ -158,6 +159,13 @@ void optimise_module(llvm::Module& module, int opt_level, llvm::TargetMachine* t
     llvm::legacy::PassManager module_pm;
     populate_pms(func_pm, module_pm, opt_level, /*size_level=*/0, tm);
     run_optimisation_passes(module, func_pm, module_pm);
+}
+
+void replace_with_lib_functions(codegen::Platform& platform,
+                                llvm::Module& module) {
+    llvm::legacy::PassManager pm;
+    pm.add(new llvm::ReplaceMathFunctions(platform));
+    pm.run(module);
 }
 
 /****************************************************************************************/

--- a/src/codegen/llvm/llvm_utils.cpp
+++ b/src/codegen/llvm/llvm_utils.cpp
@@ -163,8 +163,7 @@ void optimise_module(llvm::Module& module, int opt_level, llvm::TargetMachine* t
     run_optimisation_passes(module, func_pm, module_pm);
 }
 
-void replace_with_lib_functions(codegen::Platform& platform,
-                                llvm::Module& module) {
+void replace_with_lib_functions(codegen::Platform& platform, llvm::Module& module) {
     llvm::legacy::PassManager pm;
     pm.add(new llvm::ReplaceMathFunctions(platform));
     pm.run(module);

--- a/src/codegen/llvm/llvm_utils.hpp
+++ b/src/codegen/llvm/llvm_utils.hpp
@@ -21,6 +21,10 @@ void initialise_optimisation_passes();
 /// Initialises NVPTX-specific optimisation passes.
 void initialise_nvptx_passes();
 
+/// Replaces calls to LLVM intrinsics with appropriate library calls.
+void replace_with_lib_functions(codegen::Platform& platform,
+                                llvm::Module& module);
+
 /// Optimises the given LLVM IR module for NVPTX targets.
 void optimise_module_for_nvptx(codegen::Platform& platform,
                                llvm::Module& module,
@@ -30,7 +34,7 @@ void optimise_module_for_nvptx(codegen::Platform& platform,
 /// Optimises the given LLVM IR module.
 void optimise_module(llvm::Module& module, int opt_level, llvm::TargetMachine* tm = nullptr);
 
-///
+/// Saves generated IR module to .ll file.
 void save_ir_to_ll_file(llvm::Module& module, const std::string& filename);
 
 }  // namespace utils

--- a/src/codegen/llvm/llvm_utils.hpp
+++ b/src/codegen/llvm/llvm_utils.hpp
@@ -22,8 +22,7 @@ void initialise_optimisation_passes();
 void initialise_nvptx_passes();
 
 /// Replaces calls to LLVM intrinsics with appropriate library calls.
-void replace_with_lib_functions(codegen::Platform& platform,
-                                llvm::Module& module);
+void replace_with_lib_functions(codegen::Platform& platform, llvm::Module& module);
 
 /// Optimises the given LLVM IR module for NVPTX targets.
 void optimise_module_for_nvptx(codegen::Platform& platform,

--- a/src/codegen/llvm/replace_with_lib_functions.cpp
+++ b/src/codegen/llvm/replace_with_lib_functions.cpp
@@ -1,0 +1,109 @@
+/*************************************************************************
+ * Copyright (C) 2018-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#include "codegen/llvm/replace_with_lib_functions.hpp"
+
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/CodeGen/ReplaceWithVeclib.h"
+
+namespace llvm {
+
+char ReplaceMathFunctions::ID = 0;
+
+bool ReplaceMathFunctions::runOnModule(Module &module) {
+    bool modified = false;
+
+    // If the platform supports SIMD, replace math intrinsics with library
+    // functions.
+    if (platform->is_cpu_with_simd()) {
+
+        // First, get the target library information and add vectorizable functions for the
+        // specified vector library.
+        Triple triple(sys::getDefaultTargetTriple());
+        TargetLibraryInfoImpl tli = TargetLibraryInfoImpl(triple);
+        add_vectorizable_functions_from_vec_lib(tli, triple);
+
+        // Run passes that replace math intrinsics.
+        legacy::FunctionPassManager fpm(&module);
+        fpm.add(new TargetLibraryInfoWrapperPass(tli));
+        fpm.add(new ReplaceWithVeclibLegacy);
+        fpm.doInitialization();
+        for (auto& function: module.getFunctionList()) {
+            if (!function.isDeclaration()) 
+                modified |= fpm.run(function);
+        }
+        fpm.doFinalization();
+    }
+
+    return modified;
+}
+
+void
+ReplaceMathFunctions::add_vectorizable_functions_from_vec_lib(TargetLibraryInfoImpl& tli,
+                                                                 Triple& triple) {
+    // Since LLVM does not support SLEEF as a vector library yet, process it separately.
+    if (platform->get_math_library() == "SLEEF") {
+// clang-format off
+#define FIXED(w) ElementCount::getFixed(w)
+// clang-format on
+#define DISPATCH(func, vec_func, width) {func, vec_func, width},
+
+        // Populate function definitions of only exp and pow (for now)
+        const VecDesc aarch64_functions[] = {
+            // clang-format off
+            DISPATCH("llvm.exp.f32", "_ZGVnN4v_expf", FIXED(4))
+            DISPATCH("llvm.exp.f64", "_ZGVnN2v_exp", FIXED(2))
+            DISPATCH("llvm.pow.f32", "_ZGVnN4vv_powf", FIXED(4))
+            DISPATCH("llvm.pow.f64", "_ZGVnN2vv_pow", FIXED(2))
+            // clang-format on
+        };
+        const VecDesc x86_functions[] = {
+            // clang-format off
+            DISPATCH("llvm.exp.f64", "_ZGVbN2v_exp", FIXED(2))
+            DISPATCH("llvm.exp.f64", "_ZGVdN4v_exp", FIXED(4))
+            DISPATCH("llvm.exp.f64", "_ZGVeN8v_exp", FIXED(8))
+            DISPATCH("llvm.pow.f64", "_ZGVbN2vv_pow", FIXED(2))
+            DISPATCH("llvm.pow.f64", "_ZGVdN4vv_pow", FIXED(4))
+            DISPATCH("llvm.pow.f64", "_ZGVeN8vv_pow", FIXED(8))
+            // clang-format on
+        };
+#undef DISPATCH
+
+        if (triple.isAArch64()) {
+            tli.addVectorizableFunctions(aarch64_functions);
+        }
+        if (triple.isX86() && triple.isArch64Bit()) {
+            tli.addVectorizableFunctions(x86_functions);
+        }
+
+    } else {
+        // A map to query vector library by its string value.
+        using VecLib = TargetLibraryInfoImpl::VectorLibrary;
+        static const std::map<std::string, VecLib> llvm_supported_vector_libraries = {
+            {"Accelerate", VecLib::Accelerate},
+            {"libmvec", VecLib::LIBMVEC_X86},
+            {"libsystem_m", VecLib ::DarwinLibSystemM},
+            {"MASSV", VecLib::MASSV},
+            {"none", VecLib::NoLibrary},
+            {"SVML", VecLib::SVML}};
+        const auto& library = llvm_supported_vector_libraries.find(platform->get_math_library());
+        if (library == llvm_supported_vector_libraries.end())
+            throw std::runtime_error("Error: unknown vector library - " + platform->get_math_library() + "\n");
+
+        // Add vectorizable functions to the target library info.
+        switch (library->second) {
+        case VecLib::LIBMVEC_X86:
+            if (!triple.isX86() || !triple.isArch64Bit())
+                break;
+        default:
+            tli.addVectorizableFunctionsFromVecLib(library->second);
+            break;
+        }
+    }
+}
+
+}  // namespace llvm

--- a/src/codegen/llvm/replace_with_lib_functions.hpp
+++ b/src/codegen/llvm/replace_with_lib_functions.hpp
@@ -24,23 +24,43 @@ namespace llvm {
  * SIMD or libdevice library calls.
  */
 class ReplaceMathFunctions : public ModulePass {
-    static char ID;
-
   private:
     const Platform* platform;
 
   public:
+    static char ID;
+
     ReplaceMathFunctions(const Platform& platform)
         : ModulePass(ID)
         , platform(&platform) {}
 
-    bool runOnModule(Module &module) override;
+    bool runOnModule(Module& module) override;
 
   private:
 
     /// Populates `tli` with vectorizable function definitions.
     void add_vectorizable_functions_from_vec_lib(TargetLibraryInfoImpl& tli,
                                                  Triple& triple);
+};
+
+/**
+ * \class ReplaceWithLibdevice
+ * \brief A function LLVM pass that replaces math intrinsics with
+ * libdevice library calls.
+ */
+class ReplaceWithLibdevice : public FunctionPass {
+  public:
+    static char ID;
+
+    ReplaceWithLibdevice() : llvm::FunctionPass(ID) {}
+
+    void getAnalysisUsage(AnalysisUsage& au) const override;
+
+    bool runOnFunction(Function& function) override;
+
+  private:
+    /// Replaces call instruction to intrinsic with libdevice call.
+    bool replace_call(CallInst& call_inst);
 };
 
 }  // namespace llvm

--- a/src/codegen/llvm/replace_with_lib_functions.hpp
+++ b/src/codegen/llvm/replace_with_lib_functions.hpp
@@ -1,0 +1,46 @@
+/*************************************************************************
+ * Copyright (C) 2018-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#pragma once
+
+#include "codegen/llvm/target_platform.hpp"
+
+#include "llvm/ADT/Triple.h"
+#include "llvm/Analysis/TargetLibraryInfo.h"
+#include "llvm/Pass.h"
+#include "llvm/Support/Host.h"
+
+using nmodl::codegen::Platform;
+
+namespace llvm {
+
+/**
+ * \class ReplaceMathFunctions
+ * \brief A module LLVM pass that replaces math intrinsics with
+ * SIMD or libdevice library calls.
+ */
+class ReplaceMathFunctions : public ModulePass {
+    static char ID;
+
+  private:
+    const Platform* platform;
+
+  public:
+    ReplaceMathFunctions(const Platform& platform)
+        : ModulePass(ID)
+        , platform(&platform) {}
+
+    bool runOnModule(Module &module) override;
+
+  private:
+
+    /// Populates `tli` with vectorizable function definitions.
+    void add_vectorizable_functions_from_vec_lib(TargetLibraryInfoImpl& tli,
+                                                 Triple& triple);
+};
+
+}  // namespace llvm

--- a/src/codegen/llvm/replace_with_lib_functions.hpp
+++ b/src/codegen/llvm/replace_with_lib_functions.hpp
@@ -23,7 +23,7 @@ namespace llvm {
  * \brief A module LLVM pass that replaces math intrinsics with
  * SIMD or libdevice library calls.
  */
-class ReplaceMathFunctions : public ModulePass {
+class ReplaceMathFunctions: public ModulePass {
   private:
     const Platform* platform;
 
@@ -37,10 +37,8 @@ class ReplaceMathFunctions : public ModulePass {
     bool runOnModule(Module& module) override;
 
   private:
-
     /// Populates `tli` with vectorizable function definitions.
-    void add_vectorizable_functions_from_vec_lib(TargetLibraryInfoImpl& tli,
-                                                 Triple& triple);
+    void add_vectorizable_functions_from_vec_lib(TargetLibraryInfoImpl& tli, Triple& triple);
 };
 
 /**
@@ -48,11 +46,12 @@ class ReplaceMathFunctions : public ModulePass {
  * \brief A function LLVM pass that replaces math intrinsics with
  * libdevice library calls.
  */
-class ReplaceWithLibdevice : public FunctionPass {
+class ReplaceWithLibdevice: public FunctionPass {
   public:
     static char ID;
 
-    ReplaceWithLibdevice() : llvm::FunctionPass(ID) {}
+    ReplaceWithLibdevice()
+        : llvm::FunctionPass(ID) {}
 
     void getAnalysisUsage(AnalysisUsage& au) const override;
 

--- a/src/codegen/llvm/target_platform.cpp
+++ b/src/codegen/llvm/target_platform.cpp
@@ -32,7 +32,7 @@ bool Platform::is_gpu() const {
     return platform_id == PlatformID::GPU;
 }
 
-bool Platform::is_CUDA_gpu() {
+bool Platform::is_CUDA_gpu() const {
     return platform_id == PlatformID::GPU && (name == "nvptx" || name == "nvptx64");
 }
 

--- a/src/codegen/llvm/target_platform.cpp
+++ b/src/codegen/llvm/target_platform.cpp
@@ -15,24 +15,24 @@ namespace codegen {
 const std::string Platform::DEFAULT_PLATFORM_NAME = "default";
 const std::string Platform::DEFAULT_MATH_LIBRARY = "none";
 
-bool Platform::is_default_platform() {
+bool Platform::is_default_platform() const {
     // Default platform is a CPU.
     return platform_id == PlatformID::CPU &&  name == Platform::DEFAULT_PLATFORM_NAME;
 }
 
-bool Platform::is_cpu() {
+bool Platform::is_cpu() const {
     return platform_id == PlatformID::CPU;
 }
 
-bool Platform::is_cpu_with_simd() {
+bool Platform::is_cpu_with_simd() const {
     return platform_id == PlatformID::CPU && instruction_width > 1;
 }
 
-bool Platform::is_gpu() {
+bool Platform::is_gpu() const {
     return platform_id == PlatformID::GPU;
 }
 
-bool Platform::is_CUDA_gpu() {
+bool Platform::is_CUDA_gpu() const {
   return platform_id == PlatformID::GPU && (name == "nvptx" || name == "nvptx64");
 }
 

--- a/src/codegen/llvm/target_platform.hpp
+++ b/src/codegen/llvm/target_platform.hpp
@@ -84,19 +84,19 @@ class Platform {
     Platform() : platform_id(PlatformID::CPU) {}
 
     /// Checks if this platform is a default platform.
-    bool is_default_platform();
+    bool is_default_platform() const;
 
     /// Checks if this platform is a CPU.
-    bool is_cpu();
+    bool is_cpu() const;
 
     /// Checks if this platform is a CPU with SIMD support.
-    bool is_cpu_with_simd();
+    bool is_cpu_with_simd() const;
 
     /// Checks if this platform is a GPU.
-    bool is_gpu();
+    bool is_gpu() const;
 
     /// Checks if this platform is CUDA platform.
-    bool is_CUDA_gpu();
+    bool is_CUDA_gpu() const;
 
     bool is_single_precision();
 

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -1360,7 +1360,6 @@ SCENARIO("Vector library calls", "[visitor][llvm][vector_lib]") {
             REQUIRE(std::regex_search(no_library_module_str, m, exp_decl));
             REQUIRE(std::regex_search(no_library_module_str, m, exp_call));
 
-#if LLVM_VERSION_MAJOR >= 13
             // Check exponential calls are replaced with calls to SVML library.
             std::string svml_library_module_str = run_llvm_visitor(nmodl_text,
                                                                    /*opt_level=*/0,
@@ -1438,7 +1437,6 @@ SCENARIO("Vector library calls", "[visitor][llvm][vector_lib]") {
             REQUIRE(std::regex_search(libsystem_m_library_module_str, m, libsystem_m_exp_decl));
             REQUIRE(std::regex_search(libsystem_m_library_module_str, m, libsystem_m_exp_call));
             REQUIRE(!std::regex_search(libsystem_m_library_module_str, m, fexp_call));
-#endif
         }
     }
 }

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -1716,7 +1716,7 @@ SCENARIO("GPU kernel body IR generation", "[visitor][llvm][gpu]") {
             }
 
             DERIVATIVE states {
-              m = exp(y) + exp(x)
+              m = exp(y) + x ^ 2
             }
         )";
 
@@ -1727,13 +1727,19 @@ SCENARIO("GPU kernel body IR generation", "[visitor][llvm][gpu]") {
                                                              /*math_library=*/"libdevice");
             std::smatch m;
 
-            // Check if exp intrinsic has been replaced.
-            std::regex declaration(R"(declare double @__nv_exp\(double\))");
-            std::regex new_call(R"(call double @__nv_exp\(double %.*\))");
-            std::regex old_call(R"(call double @llvm\.exp\.f64\(double %.*\))");
-            REQUIRE(std::regex_search(module_string, m, declaration));
-            REQUIRE(std::regex_search(module_string, m, new_call));
-            REQUIRE(!std::regex_search(module_string, m, old_call));
+            // Check if exp and pow intrinsics have been replaced.
+            std::regex exp_declaration(R"(declare double @__nv_exp\(double\))");
+            std::regex exp_new_call(R"(call double @__nv_exp\(double %.*\))");
+            std::regex exp_old_call(R"(call double @llvm\.exp\.f64\(double %.*\))");
+            std::regex pow_declaration(R"(declare double @__nv_pow\(double, double\))");
+            std::regex pow_new_call(R"(call double @__nv_pow\(double %.*, double .*\))");
+            std::regex pow_old_call(R"(call double @llvm\.pow\.f64\(double %.*, double .*\))");
+            REQUIRE(std::regex_search(module_string, m, exp_declaration));
+            REQUIRE(std::regex_search(module_string, m, exp_new_call));
+            REQUIRE(!std::regex_search(module_string, m, exp_old_call));
+            REQUIRE(std::regex_search(module_string, m, pow_declaration));
+            REQUIRE(std::regex_search(module_string, m, pow_new_call));
+            REQUIRE(!std::regex_search(module_string, m, pow_old_call));
         }
     }
 }

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -1689,4 +1689,41 @@ SCENARIO("GPU kernel body IR generation", "[visitor][llvm][gpu]") {
             REQUIRE(std::regex_search(module_string, m, load_as1));
         }
     }
+
+    GIVEN("When using math functions") {
+        std::string nmodl_text = R"(
+            NEURON {
+                SUFFIX test
+                RANGE x, y
+            }
+
+            ASSIGNED { x y }
+
+            STATE { m }
+
+            BREAKPOINT {
+                SOLVE states METHOD cnexp
+            }
+
+            DERIVATIVE states {
+              m = exp(y) + exp(x)
+            }
+        )";
+
+        THEN("calls to libdevice are created") {
+            std::string module_string = run_gpu_llvm_visitor(nmodl_text,
+                                                             /*opt_level=*/3,
+                                                             /*use_single_precision=*/false,
+                                                             /*math_library=*/"libdevice");
+            std::smatch m;
+
+            // Check if exp intrinsic has been replaced.
+            std::regex declaration(R"(declare double @__nv_exp\(double\))");
+            std::regex new_call(R"(call double @__nv_exp\(double %.*\))");
+            std::regex old_call(R"(call double @llvm\.exp\.f64\(double %.*\))");
+            REQUIRE(std::regex_search(module_string, m, declaration));
+            REQUIRE(std::regex_search(module_string, m, new_call));
+            REQUIRE(!std::regex_search(module_string, m, old_call));
+        }
+    }
 }


### PR DESCRIPTION
This PR adds a LLVM pass that replaces math intrinsics
with calls to math library. In particular:

*  Functionality of replacement with SIMD functions is factored
out into a separate file and LLVM version dependencies are
dropped (we use LLVM 13 already anyway).

* A pass to replace intrinsics with libdevice calls when targeting
CUDA platforms has been added. So far only `exp` is supported
(single and double precision)

* Added a test to check the replacement

Note: factoring replacement functionality into a separate file
allows us to completely drop the dependency on target information
inside `LLVMCodegenVisitor`😊