### PR TITLE
[LLVM] Code formatting changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ trigger cvf:
 .spack_nmodl:
   variables:
     SPACK_PACKAGE: nmodl
-    SPACK_PACKAGE_SPEC: ~legacy-unit+python
+    SPACK_PACKAGE_SPEC: ~legacy-unit+python+llvm
     SPACK_EXTRA_MODULES: llvm
     SPACK_INSTALL_EXTRA_FLAGS: -v
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,14 +105,11 @@ include_directories(
 # HPC Coding Conventions
 # =============================================================================
 set(NMODL_ClangFormat_EXCLUDES_RE
-    ".*/ext/.*$$"
+    "ext/.*$$" "src/language/templates/.*$$"
     CACHE STRING "list of regular expressions to exclude C/C++ files from formatting" FORCE)
 set(NMODL_CMakeFormat_EXCLUDES_RE
-    ".*/ext/.*$$" ".*/src/language/templates/.*$$"
+    "ext/.*$$" "src/language/templates/.*$$"
     CACHE STRING "list of regular expressions to exclude CMake files from formatting" FORCE)
-set(NMODL_ClangFormat_DEPENDENCIES
-    pyastgen parser-gen
-    CACHE STRING "list of CMake targets to build before formatting C++ code" FORCE)
 
 # initialize submodule of coding conventions under cmake
 set(THIRD_PARTY_DIRECTORY "${PROJECT_SOURCE_DIR}/cmake")

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -171,8 +171,9 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
 
   private:
     /// Methods to create target-specific loop constructs.
-    std::shared_ptr<ast::Expression> loop_initialization_expression(const std::string& induction_var,
-                                                                    bool is_remainder_loop);
+    std::shared_ptr<ast::Expression> loop_initialization_expression(
+        const std::string& induction_var,
+        bool is_remainder_loop);
     std::shared_ptr<ast::Expression> loop_count_expression(const std::string& induction_var,
                                                            const std::string& node_count,
                                                            bool is_remainder_loop);

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -62,11 +62,10 @@ static bool can_vectorize(const ast::CodegenForStatement& statement, symtab::Sym
 }
 
 void CodegenLLVMVisitor::annotate_kernel_with_nvvm(llvm::Function* kernel) {
-    llvm::Metadata* metadata[] = {
-        llvm::ValueAsMetadata::get(kernel),
-        llvm::MDString::get(*context, "kernel"),
-        llvm::ValueAsMetadata::get(
-            llvm::ConstantInt::get(llvm::Type::getInt32Ty(*context), 1))};
+    llvm::Metadata* metadata[] = {llvm::ValueAsMetadata::get(kernel),
+                                  llvm::MDString::get(*context, "kernel"),
+                                  llvm::ValueAsMetadata::get(
+                                      llvm::ConstantInt::get(llvm::Type::getInt32Ty(*context), 1))};
     llvm::MDNode* node = llvm::MDNode::get(*context, metadata);
     module->getOrInsertNamedMetadata("nvvm.annotations")->addOperand(node);
 }
@@ -121,7 +120,8 @@ void CodegenLLVMVisitor::add_vectorizable_functions_from_vec_lib(llvm::TargetLib
             {"SVML", VecLib::SVML}};
         const auto& library = llvm_supported_vector_libraries.find(platform.get_math_library());
         if (library == llvm_supported_vector_libraries.end())
-            throw std::runtime_error("Error: unknown vector library - " + platform.get_math_library() + "\n");
+            throw std::runtime_error("Error: unknown vector library - " +
+                                     platform.get_math_library() + "\n");
 
         // Add vectorizable functions to the target library info.
         switch (library->second) {
@@ -682,7 +682,7 @@ void CodegenLLVMVisitor::visit_codegen_function(const ast::CodegenFunction& node
         } else if (platform.is_gpu()) {
             block->accept(*this);
             annotate_kernel_with_nvvm(func);
-        } else { // scalar
+        } else {  // scalar
             block->accept(*this);
         }
     } else {

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -451,7 +451,8 @@ void IRBuilder::create_scalar_or_vector_alloca(const std::string& name,
     // Even if generating vectorised code, some variables still need to be scalar. Particularly, the
     // induction variable "id" and remainder loop variables (that start with "epilogue" prefix).
     llvm::Type* type;
-    if (platform.is_cpu_with_simd() && vectorize && name != kernel_id && name.rfind("epilogue", 0)) {
+    if (platform.is_cpu_with_simd() && vectorize && name != kernel_id &&
+        name.rfind("epilogue", 0)) {
         int vector_width = platform.get_instruction_width();
         type = llvm::FixedVectorType::get(element_or_scalar_type, vector_width);
     } else {
@@ -558,8 +559,8 @@ void IRBuilder::maybe_replicate_value(llvm::Value* value) {
 void IRBuilder::create_grid_stride() {
     llvm::Module* m = builder.GetInsertBlock()->getParent()->getParent();
     auto create_call = [&](llvm::Intrinsic::ID id) {
-      llvm::Function* intrinsic = llvm::Intrinsic::getDeclaration(m, id);
-      return builder.CreateCall(intrinsic, {});
+        llvm::Function* intrinsic = llvm::Intrinsic::getDeclaration(m, id);
+        return builder.CreateCall(intrinsic, {});
     };
 
     llvm::Value* block_dim = create_call(llvm::Intrinsic::nvvm_read_ptx_sreg_ntid_x);
@@ -572,8 +573,8 @@ void IRBuilder::create_grid_stride() {
 void IRBuilder::create_thread_id() {
     llvm::Module* m = builder.GetInsertBlock()->getParent()->getParent();
     auto create_call = [&](llvm::Intrinsic::ID id) {
-      llvm::Function* intrinsic = llvm::Intrinsic::getDeclaration(m, id);
-      return builder.CreateCall(intrinsic, {});
+        llvm::Function* intrinsic = llvm::Intrinsic::getDeclaration(m, id);
+        return builder.CreateCall(intrinsic, {});
     };
 
     // For now, this function only supports NVPTX backend, however it can be easily

--- a/src/codegen/llvm/llvm_utils.cpp
+++ b/src/codegen/llvm/llvm_utils.cpp
@@ -83,16 +83,18 @@ void optimise_module_for_nvptx(codegen::Platform& platform,
     std::string platform_name = platform.get_name();
 
     // Target and layout information.
-    static const std::map<std::string, std::string> triple_str = {
-            {"nvptx", "nvptx-nvidia-cuda"},
-            {"nvptx64", "nvptx64-nvidia-cuda"}};
+    static const std::map<std::string, std::string> triple_str = {{"nvptx", "nvptx-nvidia-cuda"},
+                                                                  {"nvptx64",
+                                                                   "nvptx64-nvidia-cuda"}};
     static const std::map<std::string, std::string> data_layout_str = {
-            {"nvptx", "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32"
-                      "-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32"
-                      "-v64:64:64-v128:128:128-n16:32:64"},
-            {"nvptx64", "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32"
-                        "-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32"
-                        "-v64:64:64-v128:128:128-n16:32:64"}};
+        {"nvptx",
+         "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32"
+         "-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32"
+         "-v64:64:64-v128:128:128-n16:32:64"},
+        {"nvptx64",
+         "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32"
+         "-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32"
+         "-v64:64:64-v128:128:128-n16:32:64"}};
 
     // Set data layout and target triple information for the module.
     auto triple = triple_str.at(platform_name);

--- a/src/codegen/llvm/main.cpp
+++ b/src/codegen/llvm/main.cpp
@@ -51,7 +51,10 @@ int main(int argc, const char* argv[]) {
     codegen::Platform platform;
 
     logger->info("Running LLVM Visitor");
-    codegen::CodegenLLVMVisitor llvm_visitor(filename, /*output_dir=*/".", platform, /*opt_level_ir=*/0);
+    codegen::CodegenLLVMVisitor llvm_visitor(filename,
+                                             /*output_dir=*/".",
+                                             platform,
+                                             /*opt_level_ir=*/0);
     llvm_visitor.visit_program(*ast);
     std::unique_ptr<llvm::Module> module = llvm_visitor.get_module();
 

--- a/src/codegen/llvm/target_platform.cpp
+++ b/src/codegen/llvm/target_platform.cpp
@@ -17,7 +17,7 @@ const std::string Platform::DEFAULT_MATH_LIBRARY = "none";
 
 bool Platform::is_default_platform() {
     // Default platform is a CPU.
-    return platform_id == PlatformID::CPU &&  name == Platform::DEFAULT_PLATFORM_NAME;
+    return platform_id == PlatformID::CPU && name == Platform::DEFAULT_PLATFORM_NAME;
 }
 
 bool Platform::is_cpu() {
@@ -33,11 +33,11 @@ bool Platform::is_gpu() {
 }
 
 bool Platform::is_CUDA_gpu() {
-  return platform_id == PlatformID::GPU && (name == "nvptx" || name == "nvptx64");
+    return platform_id == PlatformID::GPU && (name == "nvptx" || name == "nvptx64");
 }
 
 bool Platform::is_single_precision() {
-  return use_single_precision;
+    return use_single_precision;
 }
 
 std::string Platform::get_name() const {
@@ -59,7 +59,7 @@ int Platform::get_instruction_width() const {
 }
 
 int Platform::get_precision() const {
-    return use_single_precision? 32 : 64;
+    return use_single_precision ? 32 : 64;
 }
 
 }  // namespace codegen

--- a/src/codegen/llvm/target_platform.hpp
+++ b/src/codegen/llvm/target_platform.hpp
@@ -12,10 +12,7 @@
 namespace nmodl {
 namespace codegen {
 
-enum PlatformID {
-    CPU,
-    GPU
-};
+enum PlatformID { CPU, GPU };
 
 /**
  * \class Platform
@@ -57,31 +54,31 @@ class Platform {
              std::string& math_library,
              bool use_single_precision = false,
              int instruction_width = 1)
-              : platform_id(platform_id)
-              , name(name)
-              , subtarget_name(subtarget_name)
-              , math_library(math_library)
-              , use_single_precision(use_single_precision)
-              , instruction_width(instruction_width) {}
+        : platform_id(platform_id)
+        , name(name)
+        , subtarget_name(subtarget_name)
+        , math_library(math_library)
+        , use_single_precision(use_single_precision)
+        , instruction_width(instruction_width) {}
 
     Platform(PlatformID platform_id,
              const std::string& name,
              std::string& math_library,
              bool use_single_precision = false,
              int instruction_width = 1)
-              : platform_id(platform_id)
-              , name(name)
-              , math_library(math_library)
-              , use_single_precision(use_single_precision)
-              , instruction_width(instruction_width) {}
+        : platform_id(platform_id)
+        , name(name)
+        , math_library(math_library)
+        , use_single_precision(use_single_precision)
+        , instruction_width(instruction_width) {}
 
-    Platform(bool use_single_precision,
-             int instruction_width)
-            : platform_id(PlatformID::CPU)
-            , use_single_precision(use_single_precision)
-            , instruction_width(instruction_width) {}
+    Platform(bool use_single_precision, int instruction_width)
+        : platform_id(PlatformID::CPU)
+        , use_single_precision(use_single_precision)
+        , instruction_width(instruction_width) {}
 
-    Platform() : platform_id(PlatformID::CPU) {}
+    Platform()
+        : platform_id(PlatformID::CPU) {}
 
     /// Checks if this platform is a default platform.
     bool is_default_platform();

--- a/src/parser/verbatim_driver.hpp
+++ b/src/parser/verbatim_driver.hpp
@@ -23,7 +23,6 @@ namespace parser {
  * \brief Class that binds lexer and parser together for parsing VERBATIM block
  */
 class VerbatimDriver {
-
   protected:
     void init_scanner();
     void destroy_scanner();
@@ -53,4 +52,3 @@ class VerbatimDriver {
 
 
 int Verbatim_parse(nmodl::parser::VerbatimDriver*);
-

--- a/src/visitors/nmodl_visitor_helper.ipp
+++ b/src/visitors/nmodl_visitor_helper.ipp
@@ -69,4 +69,3 @@ void NmodlPrintVisitor::visit_element(const std::vector<T>& elements,
 
 }  // namespace visitor
 }  // namespace nmodl
-

--- a/src/visitors/symtab_visitor_helper.hpp
+++ b/src/visitors/symtab_visitor_helper.hpp
@@ -164,13 +164,13 @@ void SymtabVisitor::add_model_symbol_with_property(ast::Node* node, NmodlType pr
 static void add_external_symbols(symtab::ModelSymbolTable* symtab) {
     ModToken tok(true);
     auto variables = nmodl::get_external_variables();
-    for (auto variable : variables) {
+    for (auto variable: variables) {
         auto symbol = std::make_shared<Symbol>(variable, nullptr, tok);
         symbol->add_property(NmodlType::extern_neuron_variable);
         symtab->insert(symbol);
     }
     auto methods = nmodl::get_external_functions();
-    for (auto method : methods) {
+    for (auto method: methods) {
         auto symbol = std::make_shared<Symbol>(method, nullptr, tok);
         symbol->add_property(NmodlType::extern_method);
         symtab->insert(symbol);
@@ -241,16 +241,17 @@ void SymtabVisitor::setup_symbol_table_for_scoped_block(ast::Node* node, const s
  * @todo we assume table statement follows variable declaration
  */
 void SymtabVisitor::visit_table_statement(ast::TableStatement& node) {
-    auto update_symbol = [this](const ast::NameVector& variables, NmodlType property, int num_values) {
-        for (auto& var : variables) {
-            auto name = var->get_node_name();
-            auto symbol = modsymtab->lookup(name);
-            if (symbol) {
-                symbol->add_property(property);
-                symbol->set_num_values(num_values);
+    auto update_symbol =
+        [this](const ast::NameVector& variables, NmodlType property, int num_values) {
+            for (auto& var: variables) {
+                auto name = var->get_node_name();
+                auto symbol = modsymtab->lookup(name);
+                if (symbol) {
+                    symbol->add_property(property);
+                    symbol->set_num_values(num_values);
+                }
             }
-        }
-    };
+        };
     int num_values = node.get_with()->eval() + 1;
     update_symbol(node.get_table_vars(), NmodlType::table_statement_var, num_values);
     update_symbol(node.get_depend_vars(), NmodlType::table_assigned_var, num_values);

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -49,11 +49,13 @@ std::string run_gpu_llvm_visitor(const std::string& text,
     NeuronSolveVisitor().visit_program(*ast);
     SolveBlockVisitor().visit_program(*ast);
 
-    codegen::Platform gpu_platform(codegen::PlatformID::GPU, /*name=*/"nvptx64",
-                                   math_library, use_single_precision, 1);
+    codegen::Platform gpu_platform(
+        codegen::PlatformID::GPU, /*name=*/"nvptx64", math_library, use_single_precision, 1);
     codegen::CodegenLLVMVisitor llvm_visitor(
         /*mod_filename=*/"unknown",
-        /*output_dir=*/".", gpu_platform, opt_level,
+        /*output_dir=*/".",
+        gpu_platform,
+        opt_level,
         /*add_debug_information=*/false);
 
     llvm_visitor.visit_program(*ast);
@@ -77,12 +79,15 @@ std::string run_llvm_visitor(const std::string& text,
     NeuronSolveVisitor().visit_program(*ast);
     SolveBlockVisitor().visit_program(*ast);
 
-    codegen::Platform cpu_platform(codegen::PlatformID::CPU, /*name=*/"default",
-                                   vec_lib, use_single_precision, vector_width);
+    codegen::Platform cpu_platform(
+        codegen::PlatformID::CPU, /*name=*/"default", vec_lib, use_single_precision, vector_width);
     codegen::CodegenLLVMVisitor llvm_visitor(
         /*mod_filename=*/"unknown",
-        /*output_dir=*/".", cpu_platform, opt_level,
-        /*add_debug_information=*/false, fast_math_flags);
+        /*output_dir=*/".",
+        cpu_platform,
+        opt_level,
+        /*add_debug_information=*/false,
+        fast_math_flags);
 
     llvm_visitor.visit_program(*ast);
     return llvm_visitor.dump_module();
@@ -1306,7 +1311,8 @@ SCENARIO("Vectorised derivative block", "[visitor][llvm][derivative]") {
 
 
         THEN("vector and epilogue scalar loops are constructed") {
-            codegen::Platform simd_platform(/*use_single_precision=*/false, /*instruction_width=*/8);
+            codegen::Platform simd_platform(/*use_single_precision=*/false,
+                                            /*instruction_width=*/8);
             auto result = run_llvm_visitor_helper(nmodl_text,
                                                   simd_platform,
                                                   {ast::AstNodeType::CODEGEN_FOR_STATEMENT});
@@ -1633,7 +1639,8 @@ SCENARIO("GPU kernel body IR generation", "[visitor][llvm][gpu]") {
 
             // Check kernel annotations are correclty created.
             std::regex annotations(R"(!nvvm\.annotations = !\{!0\})");
-            std::regex kernel_data(R"(!0 = !\{void \(%.*__instance_var__type\*\)\* @nrn_state_.*, !\"kernel\", i32 1\})");
+            std::regex kernel_data(
+                R"(!0 = !\{void \(%.*__instance_var__type\*\)\* @nrn_state_.*, !\"kernel\", i32 1\})");
             REQUIRE(std::regex_search(module_string, m, annotations));
             REQUIRE(std::regex_search(module_string, m, kernel_data));
 
@@ -1677,14 +1684,17 @@ SCENARIO("GPU kernel body IR generation", "[visitor][llvm][gpu]") {
 
             // Check target information.
             // TODO: this may change when more platforms are supported.
-            std::regex data_layout(R"(target datalayout = \"e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64\")");
+            std::regex data_layout(
+                R"(target datalayout = \"e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64\")");
             std::regex triple(R"(nvptx64-nvidia-cuda)");
             REQUIRE(std::regex_search(module_string, m, data_layout));
             REQUIRE(std::regex_search(module_string, m, triple));
 
             // Check for address space casts and address spaces in general when loading data.
-            std::regex as_cast(R"(addrspacecast %.*__instance_var__type\* %.* to %.*__instance_var__type addrspace\(1\)\*)");
-            std::regex gep_as1(R"(getelementptr inbounds %.*__instance_var__type, %.*__instance_var__type addrspace\(1\)\* %.*, i64 0, i32 .*)");
+            std::regex as_cast(
+                R"(addrspacecast %.*__instance_var__type\* %.* to %.*__instance_var__type addrspace\(1\)\*)");
+            std::regex gep_as1(
+                R"(getelementptr inbounds %.*__instance_var__type, %.*__instance_var__type addrspace\(1\)\* %.*, i64 0, i32 .*)");
             std::regex load_as1(R"(load double\*, double\* addrspace\(1\)\* %.*)");
             REQUIRE(std::regex_search(module_string, m, as_cast));
             REQUIRE(std::regex_search(module_string, m, gep_as1));


### PR DESCRIPTION
- Cherry-pick update of hpc-coding-conventions from `master`
- Run clang-format with clang-format-13 (part of llvm 13 we are using)

Please let me know if there is any issue with these changes and the clang-format version you are using