### PR TITLE
Avoid using raw pointers in InlineVisitor

### DIFF
--- a/src/visitors/inline_visitor.cpp
+++ b/src/visitors/inline_visitor.cpp
@@ -159,7 +159,7 @@ bool InlineVisitor::inline_function_call(ast::Block& callee,
     }
 
     /// get a copy of function/procedure body
-    auto inlined_block = callee.get_statement_block()->clone();
+    auto inlined_block = std::make_unique<ast::StatementBlock>(*(callee.get_statement_block()->clone()));
 
     /// function definition has function name as return value. we have to rename
     /// it with new variable name
@@ -177,7 +177,7 @@ bool InlineVisitor::inline_function_call(ast::Block& callee,
         add_return_variable(*inlined_block, new_varname);
     }
 
-    auto statement = new ast::ExpressionStatement(inlined_block);
+    auto statement = new ast::ExpressionStatement(std::move(inlined_block));
 
     if (to_replace) {
         replaced_statements[caller_statement] = statement;

--- a/src/visitors/inline_visitor.cpp
+++ b/src/visitors/inline_visitor.cpp
@@ -159,7 +159,8 @@ bool InlineVisitor::inline_function_call(ast::Block& callee,
     }
 
     /// get a copy of function/procedure body
-    auto inlined_block = std::make_unique<ast::StatementBlock>(*(callee.get_statement_block()->clone()));
+    auto inlined_block = std::make_unique<ast::StatementBlock>(
+        *(callee.get_statement_block()->clone()));
 
     /// function definition has function name as return value. we have to rename
     /// it with new variable name

--- a/src/visitors/inline_visitor.cpp
+++ b/src/visitors/inline_visitor.cpp
@@ -159,8 +159,8 @@ bool InlineVisitor::inline_function_call(ast::Block& callee,
     }
 
     /// get a copy of function/procedure body
-    auto inlined_block = std::make_unique<ast::StatementBlock>(
-        *(callee.get_statement_block()->clone()));
+    auto inlined_block = std::unique_ptr<ast::StatementBlock>(
+        callee.get_statement_block()->clone());
 
     /// function definition has function name as return value. we have to rename
     /// it with new variable name


### PR DESCRIPTION
Usage of raw pointers in InlineVisitor seems like it generated bugs when running on the Apple M1 processor. Instead of using raw pointers handle cloning statements in need of replacing using `unique_ptr`.

Fixes #809 

Note: Unfortunately I couldn't validate this in any way apart from running `NMODL` multiple times since valgrind is not working on mac. Before this change rerunning `NMODL` with certain mod file would randomly crash with issues similar to the ones on mentioned on the above issue.