### PR TITLE
Fixes issue with debug printing of visitors

### DIFF
--- a/src/codegen/codegen_driver.cpp
+++ b/src/codegen/codegen_driver.cpp
@@ -37,13 +37,12 @@ using namespace nmodl;
 using namespace codegen;
 using namespace visitor;
 
-bool CodegenDriver::prepare_mod(std::shared_ptr<ast::Program> node) {
+bool CodegenDriver::prepare_mod(std::shared_ptr<ast::Program> node, const std::string& modfile) {
     /// whether to update existing symbol table or create new
     /// one whenever we run symtab visitor.
     bool update_symtab = false;
 
-    std::string modfile;
-    std::string scratch_dir = "tmp";
+    const auto scratch_dir = cfg.scratch_dir;
     auto filepath = [scratch_dir, modfile](const std::string& suffix, const std::string& ext) {
         static int count = 0;
         return "{}/{}.{}.{}.{}"_format(scratch_dir, modfile, std::to_string(count++), suffix, ext);

--- a/src/codegen/codegen_driver.hpp
+++ b/src/codegen/codegen_driver.hpp
@@ -153,7 +153,7 @@ class CodegenDriver {
     explicit CodegenDriver(CodeGenConfig _cfg)
         : cfg(std::move(_cfg)) {}
 
-    bool prepare_mod(std::shared_ptr<nmodl::ast::Program> node);
+    bool prepare_mod(std::shared_ptr<nmodl::ast::Program> node, const std::string& modfile);
 
   private:
     CodeGenConfig cfg;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -299,7 +299,7 @@ int main(int argc, const char* argv[]) {
         const auto& ast = nmodl_driver.parse_file(file);
 
         auto cg_driver = CodegenDriver(cfg);
-        auto success = cg_driver.prepare_mod(ast);
+        auto success = cg_driver.prepare_mod(ast, modfile);
 
         if (show_symtab) {
             logger->info("Printing symbol table");

--- a/src/pybind/pynmodl.cpp
+++ b/src/pybind/pynmodl.cpp
@@ -172,7 +172,12 @@ class JitDriver {
                                     std::string& modname,
                                     int num_experiments,
                                     int instance_size) {
-        cg_driver.prepare_mod(node);
+        // create "tmp" directory if nmodl_ast is set
+        if (!utils::is_dir_exist(cfg.scratch_dir) && cfg.nmodl_ast || cfg.json_ast ||
+            cfg.json_perfstat) {
+            utils::make_path(cfg.scratch_dir);
+        }
+        cg_driver.prepare_mod(node, modname);
         nmodl::codegen::CodegenLLVMVisitor visitor(modname, cfg.output_dir, platform, 0);
         visitor.visit_program(*node);
         nmodl::benchmark::LLVMBenchmark benchmark(visitor,
@@ -249,6 +254,9 @@ PYBIND11_MODULE(_nmodl, m_nmodl) {
         .def_readwrite("output_dir", &nmodl::codegen::CodeGenConfig::output_dir)
         .def_readwrite("scratch_dir", &nmodl::codegen::CodeGenConfig::scratch_dir)
         .def_readwrite("data_type", &nmodl::codegen::CodeGenConfig::data_type)
+        .def_readwrite("nmodl_ast", &nmodl::codegen::CodeGenConfig::nmodl_ast)
+        .def_readwrite("json_ast", &nmodl::codegen::CodeGenConfig::json_ast)
+        .def_readwrite("json_perfstat", &nmodl::codegen::CodeGenConfig::json_perfstat)
         .def_readwrite("llvm_ir", &nmodl::codegen::CodeGenConfig::llvm_ir)
         .def_readwrite("llvm_float_type", &nmodl::codegen::CodeGenConfig::llvm_float_type)
         .def_readwrite("llvm_opt_level_ir", &nmodl::codegen::CodeGenConfig::llvm_opt_level_ir)

--- a/src/pybind/pynmodl.cpp
+++ b/src/pybind/pynmodl.cpp
@@ -172,9 +172,9 @@ class JitDriver {
                                     std::string& modname,
                                     int num_experiments,
                                     int instance_size) {
-        // create "tmp" directory if nmodl_ast is set
-        if (!utils::is_dir_exist(cfg.scratch_dir) && cfg.nmodl_ast || cfg.json_ast ||
-            cfg.json_perfstat) {
+        // New directory is needed to be created otherwise the directory cannot be created
+        // automatically through python
+        if (cfg.nmodl_ast || cfg.json_ast || cfg.json_perfstat) {
             utils::make_path(cfg.scratch_dir);
         }
         cg_driver.prepare_mod(node, modname);

--- a/test/benchmark/benchmark.py
+++ b/test/benchmark/benchmark.py
@@ -10,6 +10,7 @@ def main():
     cfg = nmodl.CodeGenConfig()
     cfg.llvm_vector_width = 4
     cfg.llvm_opt_level_ir = 2
+    cfg.nmodl_ast = True
     fname = sys.argv[1]
     with open(fname) as f:
         hh = f.read()

--- a/test/benchmark/jit_driver.hpp
+++ b/test/benchmark/jit_driver.hpp
@@ -76,7 +76,7 @@ class JITDriver {
         if (!expected_symbol)
             throw std::runtime_error("Error: entry-point symbol not found in JIT\n");
 
-        auto (*res)() = (ReturnType(*)())(intptr_t) expected_symbol->getAddress();
+        auto(*res)() = (ReturnType(*)())(intptr_t) expected_symbol->getAddress();
         ReturnType result = res();
         return result;
     }
@@ -88,7 +88,7 @@ class JITDriver {
         if (!expected_symbol)
             throw std::runtime_error("Error: entry-point symbol not found in JIT\n");
 
-        auto (*res)(ArgType) = (ReturnType(*)(ArgType))(intptr_t) expected_symbol->getAddress();
+        auto(*res)(ArgType) = (ReturnType(*)(ArgType))(intptr_t) expected_symbol->getAddress();
         ReturnType result = res(arg);
         return result;
     }


### PR DESCRIPTION
After the refactoring of the codegen configuration the intermediate files being generated with `nmodl_ast` option were not printed properly with the correct name.
This PR prints them with the proper name and in the correct place.
Same for `json_ast` and `json_perfstat`.