### PR TITLE
Fix for instance struct type creation

### DIFF
--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -59,9 +59,13 @@ llvm::Type* IRBuilder::get_void_type() {
 
 llvm::Type* IRBuilder::get_struct_ptr_type(const std::string& struct_type_name,
                                            TypeVector& member_types) {
-    llvm::StructType* llvm_struct_type = llvm::StructType::create(builder.getContext(),
-                                                                  struct_type_name);
-    llvm_struct_type->setBody(member_types);
+    llvm::StructType* llvm_struct_type = llvm::StructType::getTypeByName(builder.getContext(), struct_type_name);
+
+    if (!llvm_struct_type) {
+        llvm_struct_type = llvm::StructType::create(builder.getContext(), struct_type_name);
+        llvm_struct_type->setBody(member_types);
+    }
+
     return llvm::PointerType::get(llvm_struct_type, /*AddressSpace=*/0);
 }
 

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -59,7 +59,8 @@ llvm::Type* IRBuilder::get_void_type() {
 
 llvm::Type* IRBuilder::get_struct_ptr_type(const std::string& struct_type_name,
                                            TypeVector& member_types) {
-    llvm::StructType* llvm_struct_type = llvm::StructType::getTypeByName(builder.getContext(), struct_type_name);
+    llvm::StructType* llvm_struct_type = llvm::StructType::getTypeByName(builder.getContext(),
+                                                                         struct_type_name);
 
     if (!llvm_struct_type) {
         llvm_struct_type = llvm::StructType::create(builder.getContext(), struct_type_name);

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -983,7 +983,7 @@ SCENARIO("Scalar state kernel", "[visitor][llvm]") {
                 "double\\*, double\\*, double\\*, double\\*, double\\*, double\\*, i32\\*, double, "
                 "double, double, i32, i32, double\\*, double\\*, double\\*, double\\* \\}");
             std::regex kernel_declaration(
-                R"(define void @nrn_state_hh\(%.*__instance_var__type.0\* noalias nocapture readonly .*\) #0)");
+                R"(define void @nrn_state_hh\(%.*__instance_var__type\* noalias nocapture readonly .*\) #0)");
             REQUIRE(std::regex_search(module_string, m, struct_type));
             REQUIRE(std::regex_search(module_string, m, kernel_declaration));
 


### PR DESCRIPTION
This is a small fix to make sure that the named struct
type (instance struct) is created only once.