### PR TITLE
Rearrange vec_rhs and vec_d to allocate memory properly

### DIFF
--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -239,13 +239,6 @@ std::shared_ptr<ast::InstanceStruct> CodegenLLVMHelperVisitor::create_instance_s
     add_var_with_type(VOLTAGE_VAR, FLOAT_TYPE, /*is_pointer=*/1);
     add_var_with_type(NODE_INDEX_VAR, INTEGER_TYPE, /*is_pointer=*/1);
 
-    // add dt, t, celsius
-    add_var_with_type(naming::NTHREAD_T_VARIABLE, FLOAT_TYPE, /*is_pointer=*/0);
-    add_var_with_type(naming::NTHREAD_DT_VARIABLE, FLOAT_TYPE, /*is_pointer=*/0);
-    add_var_with_type(naming::CELSIUS_VARIABLE, FLOAT_TYPE, /*is_pointer=*/0);
-    add_var_with_type(naming::SECOND_ORDER_VARIABLE, INTEGER_TYPE, /*is_pointer=*/0);
-    add_var_with_type(naming::MECH_NODECOUNT_VAR, INTEGER_TYPE, /*is_pointer=*/0);
-
     // As we do not have `NrnThread` object as an argument, we store points to rhs
     // and d to in the instance struct as well. Also need their respective shadow variables
     // in case of point process mechanism.
@@ -255,6 +248,17 @@ std::shared_ptr<ast::InstanceStruct> CodegenLLVMHelperVisitor::create_instance_s
     add_var_with_type(naming::NTHREAD_D, FLOAT_TYPE, /*is_pointer=*/1);
     add_var_with_type(naming::NTHREAD_RHS_SHADOW, FLOAT_TYPE, /*is_pointer=*/1);
     add_var_with_type(naming::NTHREAD_D_SHADOW, FLOAT_TYPE, /*is_pointer=*/1);
+
+    // NOTE: All the pointer variables should be declared before the scalar variables otherwise
+    // the allocation of memory for the variables in the InstanceStruct and their offsets will be
+    // wrong
+
+    // add dt, t, celsius
+    add_var_with_type(naming::NTHREAD_T_VARIABLE, FLOAT_TYPE, /*is_pointer=*/0);
+    add_var_with_type(naming::NTHREAD_DT_VARIABLE, FLOAT_TYPE, /*is_pointer=*/0);
+    add_var_with_type(naming::CELSIUS_VARIABLE, FLOAT_TYPE, /*is_pointer=*/0);
+    add_var_with_type(naming::SECOND_ORDER_VARIABLE, INTEGER_TYPE, /*is_pointer=*/0);
+    add_var_with_type(naming::MECH_NODECOUNT_VAR, INTEGER_TYPE, /*is_pointer=*/0);
 
     return std::make_shared<ast::InstanceStruct>(codegen_vars);
 }

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -998,6 +998,12 @@ void CodegenLLVMVisitor::print_instance_variable_setup() {
     // Pass ml->nodeindices pointer to node_index
     printer->add_line("inst->node_index = ml->nodeindices;");
 
+    // Setup rhs, d and their shadow vectors
+    printer->add_line(fmt::format("inst->{} = nt->_actual_rhs;", naming::NTHREAD_RHS));
+    printer->add_line(fmt::format("inst->{} = nt->_actual_d;", naming::NTHREAD_D));
+    printer->add_line(fmt::format("inst->{} = nt->_shadow_rhs;", naming::NTHREAD_RHS_SHADOW));
+    printer->add_line(fmt::format("inst->{} = nt->_shadow_d;", naming::NTHREAD_D_SHADOW));
+
     // Setup global variables
     printer->add_line("inst->{0} = nt->{0};"_format(naming::NTHREAD_T_VARIABLE));
     printer->add_line("inst->{0} = nt->{0};"_format(naming::NTHREAD_DT_VARIABLE));

--- a/test/unit/codegen/codegen_llvm_instance_struct.cpp
+++ b/test/unit/codegen/codegen_llvm_instance_struct.cpp
@@ -120,11 +120,15 @@ SCENARIO("Instance Struct creation", "[visitor][llvm][instance_struct]") {
             size_t ion_ena_index_index = 8;
             size_t voltage_index = 9;
             size_t node_index_index = 10;
-            size_t t_index = 11;
-            size_t dt_index = 12;
-            size_t celsius_index = 13;
-            size_t secondorder_index = 14;
-            size_t node_count_index = 15;
+            size_t rhs_index = 11;
+            size_t d_index = 12;
+            size_t rhs_shadow_index = 13;
+            size_t d_shadow_index = 14;
+            size_t t_index = 15;
+            size_t dt_index = 16;
+            size_t celsius_index = 17;
+            size_t secondorder_index = 18;
+            size_t node_count_index = 19;
             // Check if the various instance struct fields are properly initialized
             REQUIRE(compare(instance_data.members[minf_index],
                             generate_dummy_data<double>(minf_index, num_elements)));
@@ -155,6 +159,10 @@ SCENARIO("Instance Struct creation", "[visitor][llvm][instance_struct]") {
                 int* ion_ena_index;
                 double* voltage;
                 int* node_index;
+                double* vec_rhs;
+                double* vec_d;
+                double* _shadow_rhs;
+                double* _shadow_d;
                 double t;
                 double dt;
                 double celsius;

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -980,8 +980,8 @@ SCENARIO("Scalar state kernel", "[visitor][llvm]") {
             // Check the struct type with correct attributes and the kernel declaration.
             std::regex struct_type(
                 "%.*__instance_var__type = type \\{ double\\*, double\\*, double\\*, double\\*, "
-                "double\\*, double\\*, double\\*, double\\*, double\\*, double\\*, i32\\*, double, "
-                "double, double, i32, i32, double\\*, double\\*, double\\*, double\\* \\}");
+                "double\\*, double\\*, double\\*, double\\*, double\\*, double\\*, i32\\*, "
+                "double\\*, double\\*, double\\*, double\\*, double, double, double, i32, i32 \\}");
             std::regex kernel_declaration(
                 R"(define void @nrn_state_hh\(%.*__instance_var__type\* noalias nocapture readonly .*\) #0)");
             REQUIRE(std::regex_search(module_string, m, struct_type));

--- a/test/unit/codegen/codegen_llvm_visitor.cpp
+++ b/test/unit/codegen/codegen_llvm_visitor.cpp
@@ -171,15 +171,15 @@ SCENARIO("Check instance struct declaration and setup in wrapper",
                 int* __restrict__ ion_dikdv_index;
                 double* __restrict__ voltage;
                 int* __restrict__ node_index;
+                double* __restrict__ vec_rhs;
+                double* __restrict__ vec_d;
+                double* __restrict__ _shadow_rhs;
+                double* __restrict__ _shadow_d;
                 double t;
                 double dt;
                 double celsius;
                 int secondorder;
                 int node_count;
-                double* __restrict__ vec_rhs;
-                double* __restrict__ vec_d;
-                double* __restrict__ _shadow_rhs;
-                double* __restrict__ _shadow_d;
             };
         )";
         std::string generated_instance_struct_setup = R"(

--- a/test/unit/codegen/codegen_llvm_visitor.cpp
+++ b/test/unit/codegen/codegen_llvm_visitor.cpp
@@ -226,6 +226,10 @@ SCENARIO("Check instance struct declaration and setup in wrapper",
                 inst->ion_dikdv_index = indexes+5*pnodecount;
                 inst->voltage = nt->_actual_v;
                 inst->node_index = ml->nodeindices;
+                inst->vec_rhs = nt->_actual_rhs;
+                inst->vec_d = nt->_actual_d;
+                inst->_shadow_rhs = nt->_shadow_rhs;
+                inst->_shadow_d = nt->_shadow_d;
                 inst->t = nt->t;
                 inst->dt = nt->dt;
                 inst->celsius = celsius;


### PR DESCRIPTION
TODO:

- [x] Fix `setup_instance()` function for `vec_rhs`, `vec_d`, `_shadow_rhs` and `_shadow_d`