### PR TITLE
Code generation changes for "inline" scopmath solvers.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,16 +6,31 @@ include:
   - project: hpc/gitlab-upload-logs
     file: enable-upload.yml
 
+variables:
+  CVF_BRANCH:
+    description: Branch of the channel validation framework (CVF) to trigger the CI of
+    value: main
+  SPACK_BRANCH:
+    description: Branch of BlueBrain Spack to use for the CI pipeline
+    value: develop
+  SPACK_DEPLOYMENT_SUFFIX:
+    description: Extra path component used when finding deployed software. Set to something like `pulls/1497` use software built for https://github.com/BlueBrain/spack/pull/1497. You probably want to set SPACK_BRANCH to the branch used in the relevant PR if you set this.
+    value: ''
+
 trigger cvf:
+  # Stop the globally-defined CVF_BRANCH above from being set in the child pipeline
+  inherit:
+    variables: false
   needs: [spack_setup] # for SPACK_SETUP_COMMIT_MAPPING_URL
+  stage: .pre
   rules:
     # Don't run on PRs targeting the LLVM development branch
     - if: '$CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME == "llvm"'
       when: never
     # Otherwise always run this
     - when: always
-  stage: .pre
   trigger:
+    branch: ${CVF_BRANCH}
     project: hpc/cvf
     # Make the NMODL CI status depend on the CVF CI status
     strategy: depend
@@ -30,11 +45,18 @@ trigger cvf:
 
 spack_setup:
   extends: .spack_setup_ccache
+  script:
+    - !reference [.spack_setup_ccache, script]
+    # Setting CVF_BRANCH in the PR description will cause it to be set in the
+    # environment of this job, but because we put CVF in
+    # SPACK_SETUP_IGNORE_PACKAGE_VARIABLES then nothing will be done with it.
+    - echo "CVF_BRANCH=${CVF_BRANCH}" >> spack_clone_variables.env
   variables:
     NMODL_COMMIT: ${CI_COMMIT_SHA}
     # Enable fetching GitHub PR descriptions and parsing them to find out what
     # branches to build of other projects.
     PARSE_GITHUB_PR_DESCRIPTIONS: "true"
+    SPACK_SETUP_IGNORE_PACKAGE_VARIABLES: CVF
 
 build:intel:
   extends:

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -4259,8 +4259,8 @@ void CodegenCVisitor::print_derivimplicit_kernel(Block* block) {
     printer->add_newline(2);
 
     printer->start_block("namespace");
-    printer->start_block(fmt::format("struct _newton_{}_{}", block_name, info.mod_suffix));
-    printer->start_block(fmt::format("int operator()({}) const", external_method_parameters()));
+    printer->fmt_start_block("struct _newton_{}_{}", block_name, info.mod_suffix);
+    printer->fmt_start_block("int operator()({}) const", external_method_parameters());
     auto const instance = fmt::format("{0}* inst = ({0}*)get_memb_list(nt)->instance;",
                                       instance_struct());
     auto const slist1 = fmt::format("int* slist{} = {};",
@@ -4281,8 +4281,7 @@ void CodegenCVisitor::print_derivimplicit_kernel(Block* block) {
     if (ion_variable_struct_required()) {
         print_ion_variable();
     }
-    printer->add_line(
-        fmt::format("double* savstate{} = (double*) thread[dith{}()].pval;", list_num, list_num));
+    printer->fmt_line("double* savstate{} = (double*) thread[dith{}()].pval;", list_num, list_num);
     printer->add_line(slist1);
     printer->add_line(dlist1);
     printer->add_line(dlist2);
@@ -4290,51 +4289,46 @@ void CodegenCVisitor::print_derivimplicit_kernel(Block* block) {
     print_statement_block(*block->get_statement_block(), false, false);
     codegen = false;
     printer->add_line("int counter = -1;");
-    printer->start_block(fmt::format("for (int i=0; i<{}; i++)", info.num_primes));
-    printer->start_block(fmt::format("if (*deriv{}_advance(thread))", list_num));
-    printer->add_line(
-        fmt::format("dlist{0}[(++counter){1}] = "
-                    "data[dlist{2}[i]{1}]-(data[slist{2}[i]{1}]-savstate{2}[i{1}])/nt->_dt;",
-                    list_num + 1,
-                    stride,
-                    list_num));
+    printer->fmt_start_block("for (int i=0; i<{}; i++)", info.num_primes);
+    printer->fmt_start_block("if (*deriv{}_advance(thread))", list_num);
+    printer->fmt_line(
+        "dlist{0}[(++counter){1}] = "
+        "data[dlist{2}[i]{1}]-(data[slist{2}[i]{1}]-savstate{2}[i{1}])/nt->_dt;",
+        list_num + 1,
+        stride,
+        list_num);
     printer->restart_block("else");
-    printer->add_line(
-        fmt::format("dlist{0}[(++counter){1}] = data[slist{2}[i]{1}]-savstate{2}[i{1}];",
-                    list_num + 1,
-                    stride,
-                    list_num));
+    printer->fmt_line("dlist{0}[(++counter){1}] = data[slist{2}[i]{1}]-savstate{2}[i{1}];",
+                      list_num + 1,
+                      stride,
+                      list_num);
     printer->end_block(1);
     printer->end_block(1);
     printer->add_line("return 0;");
-    printer->end_block(1);
-    printer->end_block();
+    printer->end_block(1);  // operator()
+    printer->end_block();   // struct
     printer->add_text(";");
     printer->add_newline();
-    printer->end_block(2);
-    printer->start_block(fmt::format("int {}_{}({})", block_name, suffix, ext_params));
+    printer->end_block(2);  // namespace
+    printer->fmt_start_block("int {}_{}({})", block_name, suffix, ext_params);
     printer->add_line(instance);
-    printer->add_line(
-        fmt::format("double* savstate{} = (double*) thread[dith{}()].pval;", list_num, list_num));
+    printer->fmt_line("double* savstate{} = (double*) thread[dith{}()].pval;", list_num, list_num);
     printer->add_line(slist1);
     printer->add_line(slist2);
     printer->add_line(dlist2);
-    printer->start_block(fmt::format("for (int i=0; i<{}; i++)", info.num_primes));
-    printer->add_line(
-        fmt::format("savstate{}[i{}] = data[slist{}[i]{}];", list_num, stride, list_num, stride));
+    printer->fmt_start_block("for (int i=0; i<{}; i++)", info.num_primes);
+    printer->fmt_line("savstate{}[i{}] = data[slist{}[i]{}];", list_num, stride, list_num, stride);
     printer->end_block(1);
-    auto const argument = fmt::format("{}, slist{}, _newton_{}_{}{{}}, dlist{}, {}",
-                                      primes_size,
-                                      list_num + 1,
-                                      block_name,
-                                      suffix,
-                                      list_num + 1,
-                                      ext_args);
-    printer->add_line(fmt::format(
-        "int reset = nrn_newton_thread(static_cast<NewtonSpace*>(*newtonspace{}(thread)), "
-        "{});",
+    printer->fmt_line(
+        "int reset = nrn_newton_thread(static_cast<NewtonSpace*>(*newtonspace{}(thread)), {}, "
+        "slist{}, _newton_{}_{}{{}}, dlist{}, {});",
         list_num,
-        argument));
+        primes_size,
+        list_num + 1,
+        block_name,
+        suffix,
+        list_num + 1,
+        ext_args);
     printer->add_line("return reset;");
     printer->end_block(3);
 }
@@ -4349,10 +4343,10 @@ void CodegenCVisitor::visit_derivimplicit_callback(const ast::DerivimplicitCallb
     if (!codegen) {
         return;
     }
-    printer->add_line(fmt::format("{}_{}({});",
-                                  node.get_node_to_solve()->get_node_name(),
-                                  info.mod_suffix,
-                                  external_method_arguments()));
+    printer->fmt_line("{}_{}({});",
+                      node.get_node_to_solve()->get_node_name(),
+                      info.mod_suffix,
+                      external_method_arguments());
 }
 
 void CodegenCVisitor::visit_solution_expression(const SolutionExpression& node) {

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -2459,7 +2459,6 @@ void CodegenCVisitor::print_standard_includes() {
 
 void CodegenCVisitor::print_coreneuron_includes() {
     printer->add_newline();
-    printer->add_line("#include <coreneuron/mechanism/mech/cfile/scoplib.h>");
     printer->add_line("#include <coreneuron/nrnconf.h>");
     printer->add_line("#include <coreneuron/sim/multicore.hpp>");
     printer->add_line("#include <coreneuron/mechanism/register_mech.hpp>");
@@ -2469,8 +2468,7 @@ void CodegenCVisitor::print_coreneuron_includes() {
     printer->add_line("#include <coreneuron/utils/ivocvect.hpp>");
     printer->add_line("#include <coreneuron/utils/nrnoc_aux.hpp>");
     printer->add_line("#include <coreneuron/mechanism/mech/mod2c_core_thread.hpp>");
-    printer->add_line("#include <coreneuron/sim/scopmath/newton_struct.h>");
-    printer->add_line("#include \"_kinderiv.h\"");
+    printer->add_line("#include <coreneuron/sim/scopmath/newton_thread.hpp>");
     if (info.eigen_newton_solver_exist) {
         printer->add_line("#include <newton/newton.hpp>");
     }
@@ -4260,42 +4258,31 @@ void CodegenCVisitor::print_derivimplicit_kernel(Block* block) {
 
     printer->add_newline(2);
 
-    // clang-format off
-    printer->start_block(fmt::format("int {}_{}({})", block_name, suffix, ext_params));
-    auto instance = fmt::format("{0}* inst = ({0}*)get_memb_list(nt)->instance;", instance_struct());
-    auto slist1 = fmt::format("int* slist{} = {};", list_num, get_variable_name(fmt::format("slist{}", list_num)));
-    auto slist2 = fmt::format("int* slist{} = {};", list_num+1, get_variable_name(fmt::format("slist{}", list_num+1)));
-    auto dlist1 = fmt::format("int* dlist{} = {};", list_num, get_variable_name(fmt::format("dlist{}", list_num)));
-    auto dlist2 = fmt::format("double* dlist{} = (double*) thread[dith{}()].pval + ({}*pnodecount);", list_num + 1, list_num, info.primes_size);
-
-    printer->add_line(instance);
-    printer->add_line(fmt::format("double* savstate{} = (double*) thread[dith{}()].pval;", list_num, list_num));
-    printer->add_line(slist1);
-    printer->add_line(slist2);
-    printer->add_line(dlist2);
-    printer->add_line(fmt::format("for (int i=0; i<{}; i++) {}", info.num_primes, "{"));
-    printer->add_line(fmt::format("    savstate{}[i{}] = data[slist{}[i]{}];", list_num, stride, list_num, stride));
-    printer->add_line("}");
-
-    auto argument = fmt::format("{}, slist{}, _derivimplicit_{}_{}, dlist{}, {}", primes_size, list_num+1, block_name, suffix, list_num + 1, ext_args);
-    printer->add_line(fmt::format("int reset = nrn_newton_thread(static_cast<NewtonSpace*>(*newtonspace{}(thread)), {});", list_num, argument));
-    printer->add_line("return reset;");
-    printer->end_block(3);
-
-    /**
-     * \todo To be backward compatible with mod2c we have to generate below
-     * comment marker in the generated cpp file for kinderiv.py to
-     * process it and generate correct _kinderiv.h
-     */
-    printer->add_line(fmt::format("/* _derivimplicit_ {} _{} */", block_name, info.mod_suffix));
-    printer->add_newline(1);
-
-    printer->start_block(fmt::format("int _newton_{}_{}({}) ", block_name, info.mod_suffix, external_method_parameters()));
+    printer->start_block("namespace");
+    printer->start_block(fmt::format("struct _newton_{}_{}", block_name, info.mod_suffix));
+    printer->start_block(fmt::format("int operator()({}) const", external_method_parameters()));
+    auto const instance = fmt::format("{0}* inst = ({0}*)get_memb_list(nt)->instance;",
+                                      instance_struct());
+    auto const slist1 = fmt::format("int* slist{} = {};",
+                                    list_num,
+                                    get_variable_name(fmt::format("slist{}", list_num)));
+    auto const slist2 = fmt::format("int* slist{} = {};",
+                                    list_num + 1,
+                                    get_variable_name(fmt::format("slist{}", list_num + 1)));
+    auto const dlist1 = fmt::format("int* dlist{} = {};",
+                                    list_num,
+                                    get_variable_name(fmt::format("dlist{}", list_num)));
+    auto const dlist2 =
+        fmt::format("double* dlist{} = (double*) thread[dith{}()].pval + ({}*pnodecount);",
+                    list_num + 1,
+                    list_num,
+                    info.primes_size);
     printer->add_line(instance);
     if (ion_variable_struct_required()) {
         print_ion_variable();
     }
-    printer->add_line(fmt::format("double* savstate{} = (double*) thread[dith{}()].pval;", list_num, list_num));
+    printer->add_line(
+        fmt::format("double* savstate{} = (double*) thread[dith{}()].pval;", list_num, list_num));
     printer->add_line(slist1);
     printer->add_line(dlist1);
     printer->add_line(dlist2);
@@ -4303,17 +4290,53 @@ void CodegenCVisitor::print_derivimplicit_kernel(Block* block) {
     print_statement_block(*block->get_statement_block(), false, false);
     codegen = false;
     printer->add_line("int counter = -1;");
-    printer->add_line(fmt::format("for (int i=0; i<{}; i++) {}", info.num_primes, "{"));
-    printer->add_line(fmt::format("    if (*deriv{}_advance(thread)) {}", list_num, "{"));
-    printer->add_line(fmt::format("        dlist{0}[(++counter){1}] = data[dlist{2}[i]{1}]-(data[slist{2}[i]{1}]-savstate{2}[i{1}])/nt->_dt;", list_num + 1, stride, list_num));
-    printer->add_line("    }");
-    printer->add_line("    else {");
-    printer->add_line(fmt::format("        dlist{0}[(++counter){1}] = data[slist{2}[i]{1}]-savstate{2}[i{1}];", list_num + 1, stride, list_num));
-    printer->add_line("    }");
-    printer->add_line("}");
+    printer->start_block(fmt::format("for (int i=0; i<{}; i++)", info.num_primes));
+    printer->start_block(fmt::format("if (*deriv{}_advance(thread))", list_num));
+    printer->add_line(
+        fmt::format("dlist{0}[(++counter){1}] = "
+                    "data[dlist{2}[i]{1}]-(data[slist{2}[i]{1}]-savstate{2}[i{1}])/nt->_dt;",
+                    list_num + 1,
+                    stride,
+                    list_num));
+    printer->restart_block("else");
+    printer->add_line(
+        fmt::format("dlist{0}[(++counter){1}] = data[slist{2}[i]{1}]-savstate{2}[i{1}];",
+                    list_num + 1,
+                    stride,
+                    list_num));
+    printer->end_block(1);
+    printer->end_block(1);
     printer->add_line("return 0;");
+    printer->end_block(1);
     printer->end_block();
-    // clang-format on
+    printer->add_text(";");
+    printer->add_newline();
+    printer->end_block(2);
+    printer->start_block(fmt::format("int {}_{}({})", block_name, suffix, ext_params));
+    printer->add_line(instance);
+    printer->add_line(
+        fmt::format("double* savstate{} = (double*) thread[dith{}()].pval;", list_num, list_num));
+    printer->add_line(slist1);
+    printer->add_line(slist2);
+    printer->add_line(dlist2);
+    printer->start_block(fmt::format("for (int i=0; i<{}; i++)", info.num_primes));
+    printer->add_line(
+        fmt::format("savstate{}[i{}] = data[slist{}[i]{}];", list_num, stride, list_num, stride));
+    printer->end_block(1);
+    auto const argument = fmt::format("{}, slist{}, _newton_{}_{}{{}}, dlist{}, {}",
+                                      primes_size,
+                                      list_num + 1,
+                                      block_name,
+                                      suffix,
+                                      list_num + 1,
+                                      ext_args);
+    printer->add_line(fmt::format(
+        "int reset = nrn_newton_thread(static_cast<NewtonSpace*>(*newtonspace{}(thread)), "
+        "{});",
+        list_num,
+        argument));
+    printer->add_line("return reset;");
+    printer->end_block(3);
 }
 
 
@@ -4326,23 +4349,10 @@ void CodegenCVisitor::visit_derivimplicit_callback(const ast::DerivimplicitCallb
     if (!codegen) {
         return;
     }
-    auto thread_args = external_method_arguments();
-    auto num_primes = info.num_primes;
-    auto suffix = info.mod_suffix;
-    int num = info.derivimplicit_list_num;
-    auto slist = get_variable_name(fmt::format("slist{}", num));
-    auto dlist = get_variable_name(fmt::format("dlist{}", num));
-    auto block_name = node.get_node_to_solve()->get_node_name();
-
-    auto args = fmt::format("{}, {}, {}, _derivimplicit_{}_{}, {}",
-                            num_primes,
-                            slist,
-                            dlist,
-                            block_name,
-                            suffix,
-                            thread_args);
-    auto statement = fmt::format("derivimplicit_thread({});", args);
-    printer->add_line(statement);
+    printer->add_line(fmt::format("{}_{}({});",
+                                  node.get_node_to_solve()->get_node_name(),
+                                  info.mod_suffix,
+                                  external_method_arguments()));
 }
 
 void CodegenCVisitor::visit_solution_expression(const SolutionExpression& node) {

--- a/src/printer/code_printer.cpp
+++ b/src/printer/code_printer.cpp
@@ -40,6 +40,14 @@ void CodePrinter::start_block(std::string&& text) {
     indent_level++;
 }
 
+void CodePrinter::restart_block(std::string const& expression) {
+    --indent_level;
+    add_indent();
+    *result << "} " << expression << " {";
+    add_newline();
+    ++indent_level;
+}
+
 void CodePrinter::add_indent() {
     *result << std::string(indent_level * NUM_SPACES, ' ');
 }

--- a/src/printer/code_printer.hpp
+++ b/src/printer/code_printer.hpp
@@ -14,6 +14,7 @@
  * \file
  * \brief \copybrief nmodl::printer::CodePrinter
  */
+#include <spdlog/spdlog.h>  // want fmt but <submodule rant>
 
 #include <fstream>
 #include <iostream>
@@ -73,6 +74,17 @@ class CodePrinter {
     void add_text(const std::string&);
 
     void add_line(const std::string&, int num_new_lines = 1);
+
+    /// fmt_line(x, y, z) is just shorthand for add_line(fmt::format(x, y, z))
+    template <typename... Args>
+    void fmt_line(Args&&... args) {
+        add_line(fmt::format(std::forward<Args>(args)...));
+    }
+
+    template <typename... Args>
+    void fmt_start_block(Args&&... args) {
+        start_block(fmt::format(std::forward<Args>(args)...));
+    }
 
     void add_multi_line(const std::string&);
 

--- a/src/printer/code_printer.hpp
+++ b/src/printer/code_printer.hpp
@@ -61,10 +61,14 @@ class CodePrinter {
     /// print whitespaces for indentation
     void add_indent();
 
-    /// start a block scope (i.e. start with "{")
+    /// start a block scope without indentation (i.e. "{\n")
     void start_block();
 
-    void start_block(std::string&&);
+    /// start a block scope with an expression (i.e. "[indent][expression] {\n")
+    void start_block(std::string&& expression);
+
+    /// end a block and immediately start a new one (i.e. "[indent-1]} [expression] {\n")
+    void restart_block(std::string const& expression);
 
     void add_text(const std::string&);
 


### PR DESCRIPTION
Analogue of https://github.com/BlueBrain/mod2c/pull/81, goes with https://github.com/BlueBrain/CoreNeuron/pull/809.

Also:
- Support setting the `CVF_BRANCH` variable via `CI_BRANCHES` syntax in a PR description or explicitly when launching the pipeline from GitLab
-  Add `restart_block`, `fmt_line` and `fmt_start_block` methods for code generation.

CI_BRANCHES:CORENEURON_BRANCH=olupton/scopmath-inline,SPACK_BRANCH=develop