### PR TITLE
Use [CORE]NEURON_BRANCH from PR descriptions in Azure CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,261 +21,320 @@ trigger:
 - llvm
 - releases/*
 
-jobs:
-- job: 'ubuntu1804'
-  pool:
-    vmImage: 'ubuntu-18.04'
-  displayName: 'Ubuntu (18.04), GCC 8.4'
-  steps:
-  - checkout: self
-    submodules: False
-  - script: |
-      sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-      sudo apt-add-repository -y ppa:deadsnakes/ppa
-      sudo apt-get update
-      sudo apt-get install -y g++-8 flex bison libfl-dev cython libx11-dev libxcomposite-dev libncurses-dev mpich
-      sudo apt-get install -y python3.7 python3.7-dev python3.7-venv ninja-build
-      python3.7 -m pip install --upgrade pip setuptools
-      python3.7 -m pip install --user 'Jinja2>=2.9.3' 'PyYAML>=3.13' pytest pytest-cov 'sympy>=1.3,<1.6' numpy
-      # we manually get version 3.15.0 to make sure that changes in the cmake
-      # files do not require unsupported versions of cmake in our package.
-      wget --quiet --output-document=- "https://github.com/Kitware/CMake/releases/download/$CMAKE_VER/$CMAKE_PKG.tar.gz" | tar xzpf -
-      # install ISPC compiler for integration testing
-      ispc_version="v1.12.0";
-      url_os="linux";
-      ispc_version_suffix="b";
-      url="https://github.com/ispc/ispc/releases/download/${ispc_version}/ispc-${ispc_version}${ispc_version_suffix}-${url_os}.tar.gz";
-      mkdir $(pwd)/$CMAKE_PKG/ispc
-      wget --quiet --output-document=- $url | tar -xvzf - -C $(pwd)/$CMAKE_PKG/ispc --strip 1;
-    env:
-      CMAKE_VER: 'v3.15.0'
-      CMAKE_PKG: 'cmake-3.15.0-Linux-x86_64'
-    displayName: 'Install Dependencies'
-  - script: |
-      export PATH=$(pwd)/$CMAKE_PKG/bin:/home/vsts/.local/bin:$PATH
-      export CXX='g++-8'
-      mkdir -p $(Build.Repository.LocalPath)/build
-      cd $(Build.Repository.LocalPath)/build
-      cmake --version
-      cmake .. -DPYTHON_EXECUTABLE=$(which python3.7) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=Release
-      make -j 2
-      if [ $? -ne 0 ]
-      then
-        make VERBOSE=1
-        exit 1
-      fi
-      make install #this is needed for the integration tests
-      env CTEST_OUTPUT_ON_FAILURE=1 make test
-    env:
-      CMAKE_PKG: 'cmake-3.15.0-Linux-x86_64'
-    displayName: 'Build and Run Unit Tests'
-  - script: |
-      export PATH=$(pwd)/$CMAKE_PKG/bin:/home/vsts/.local/bin:$PATH
-      export CXX='g++-8'
-      git clone --recursive --single-branch --shallow-submodules https://github.com/neuronsimulator/nrn.git
-      mkdir nrn/build
-      cd nrn/build
-      cmake --version
-      cmake .. -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_INTERVIEWS=OFF -DNRN_ENABLE_RX3D=OFF -DNRN_ENABLE_MPI=ON -DNRN_ENABLE_TESTS=ON -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_DIR=$HOME/nmodl -Dnmodl_PYTHONPATH=$HOME/nmodl/lib -DPYTHON_EXECUTABLE=$(which python3.7) -DCORENRN_NMODL_FLAGS="sympy --analytic"
-      make -j 2
-      if [ $? -ne 0 ]
-      then
-        make VERBOSE=1
-        exit 1
-      fi
-      ctest --output-on-failure
-      if [ $? -ne 0 ]
-      then
-        exit 1
-      fi
-      ./bin/nrnivmodl-core $(Build.Repository.LocalPath)/test/integration/mod
-    env:
-      CMAKE_PKG: 'cmake-3.15.0-Linux-x86_64'
-      SHELL: 'bash'
-    displayName: 'Build Neuron and Run Integration Tests'
-  - script: |
-      export PATH=$(pwd)/$CMAKE_PKG/bin:/home/vsts/.local/bin:$PATH
-      export CXX='g++-8'
-      git clone --recursive https://github.com/BlueBrain/CoreNeuron.git
-      mkdir CoreNeuron/build_ispc
-      cd CoreNeuron/build_ispc
-      cmake --version
-      cmake .. -DCORENRN_ENABLE_MPI=OFF -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_DIR=$HOME/nmodl -DPYTHON_EXECUTABLE=$(which python3.7) -DCORENRN_NMODL_FLAGS="sympy --analytic" -DCORENRN_ENABLE_ISPC=ON -DCMAKE_ISPC_COMPILER=$(Build.Repository.LocalPath)/$CMAKE_PKG/ispc/bin/ispc
-      make -j 2
-      if [ $? -ne 0 ]
-      then
-        make VERBOSE=1
-        exit 1
-      fi
-      ctest --output-on-failure
-      if [ $? -ne 0 ]
-      then
-        exit 1
-      fi
-      ./bin/nrnivmodl-core $(Build.Repository.LocalPath)/test/integration/mod
-    env:
-      CMAKE_PKG: 'cmake-3.15.0-Linux-x86_64'
-    displayName: 'Build CoreNEURON and Run Integration Tests with ISPC compiler'
-- job: 'osx1015'
-  pool:
-    vmImage: 'macOS-10.15'
-  displayName: 'MacOS (10.15), AppleClang 12.0'
-  steps:
-  - checkout: self
-    submodules: True
-  - script: |
-      brew install flex bison cmake python@3 gcc@8
-      python3 -m pip install --upgrade pip setuptools
-      python3 -m pip install --user 'Jinja2>=2.9.3' 'PyYAML>=3.13' pytest pytest-cov numpy 'sympy>=1.3,<1.9'
-    displayName: 'Install Dependencies'
-  - script: |
-      export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
-      mkdir -p $(Build.Repository.LocalPath)/build
-      cd $(Build.Repository.LocalPath)/build
-      cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DNMODL_ENABLE_PYTHON_BINDINGS=OFF
-      make -j 2
-      if [ $? -ne 0 ]
-      then
-        make VERBOSE=1
-        exit 1
-      fi
-      ctest --output-on-failure
-      if [ $? -ne 0 ]
-      then
-        exit 1
-      fi
-      make install
-    displayName: 'Build and Run Tests'
-  - script: |
-      export PATH=$(pwd)/$CMAKE_PKG/bin:/home/vsts/.local/bin:$PATH
-      export CXX='g++-8'
-      git clone --single-branch --recursive --shallow-submodules https://github.com/neuronsimulator/nrn.git
-      mkdir nrn/build
-      cd nrn/build
-      cmake --version
-      cmake .. -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_INTERVIEWS=OFF -DNRN_ENABLE_RX3D=OFF -DNRN_ENABLE_BINARY_SPECIAL=ON -DNRN_ENABLE_MPI=OFF -DNRN_ENABLE_TESTS=ON -DCORENRN_ENABLE_MPI=OFF -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_DIR=$HOME/nmodl -Dnmodl_PYTHONPATH=$HOME/nmodl/lib -DPYTHON_EXECUTABLE=$(which python3) -DCORENRN_NMODL_FLAGS="sympy --analytic"
-      make -j 2
-      if [ $? -ne 0 ]
-      then
-        make VERBOSE=1
-        exit 1
-      fi
-      ctest --output-on-failure
-      if [ $? -ne 0 ]
-      then
-        exit 1
-      fi
-      ./bin/nrnivmodl-core $(Build.Repository.LocalPath)/test/integration/mod
-    env:
-      SHELL: 'bash'
-    displayName: 'Build Neuron and Run Integration Tests'
-- job: 'manylinux_wheels'
-  timeoutInMinutes: 45
-  pool:
-    vmImage: 'ubuntu-18.04'
-  strategy:
-    matrix:
-      ${{ if eq(variables.buildWheel, True) }}:
-        Python36:
-          python.version: '3.6'
-        Python37:
-          python.version: '3.7'
-        Python38:
-          python.version: '3.8'
-        Python39:
-          python.version: '3.9'
-      ${{ if eq(variables.buildWheel, False) }}:
-        Python39:
-          python.version: '3.9'
-  steps:
-  - checkout: self
-    submodules: True
-    condition: succeeded()
-  - script: |
-      if [[ "$(RELEASEWHEELBUILD)" != "True" ]]; then
-        export TAG="-nightly"
-      else
-        export TAG=""
-      fi
-      docker run --rm \
-        -w /root/nmodl \
-        -v $PWD:/root/nmodl \
-        -e NMODL_NIGHTLY_TAG=$TAG \
-        'bluebrain/nmodl:wheel' \
-        packaging/build_wheels.bash linux $(python.version)
-    condition: succeeded()
-    displayName: 'Building ManyLinux Wheel'
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathToPublish: '$(Build.SourcesDirectory)/wheelhouse'
-    condition: succeeded()
-    displayName: 'Publish wheel as build artifact'
-  - script: |
-      sudo apt-add-repository -y ppa:deadsnakes/ppa
-      sudo apt-get update
-      sudo apt-get install -y python$(python.version) python$(python.version)-dev python$(python.version)-venv
-      packaging/test_wheel.bash python$(python.version) wheelhouse/*.whl
-    condition: succeeded()
-    displayName: 'Test ManyLinux Wheel with Python $(python.version)'
-  - template: ci/upload-wheels.yml
-- job: 'macos_wheels'
-  timeoutInMinutes: 45
-  pool:
-    vmImage: 'macOS-10.15'
-  strategy:
-    matrix:
-      ${{ if eq(variables.buildWheel, True) }}:
-        Python36:
-          python.version: '3.6'
-          python.org.version: '3.6.8'
-        Python37:
-          python.version: '3.7'
-          python.org.version: '3.7.7'
-        Python38:
-          python.version: '3.8'
-          python.org.version: '3.8.2'
-        Python39:
-          python.version: '3.9'
-          python.org.version: '3.9.0'
-      ${{ if eq(variables.buildWheel, False) }}:
-        Python39:
-          python.version: '3.9'
-          python.org.version: '3.9.0'
-  steps:
-  - checkout: self
-    submodules: True
-    condition: succeeded()
-  - script: |
-      brew install flex bison cmake ninja
-      export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
-    condition: succeeded()
-    displayName: 'Install Dependencies'
-  - script: |
-      installer=python-$(python.org.version)-macosx10.9.pkg
-      url=https://www.python.org/ftp/python/$(python.org.version)/$installer
-      curl $url -o $installer
-      sudo installer -pkg $installer -target /
-    condition: succeeded()
-    displayName: 'Install Python from python.org'
-  - script: |
-      export MACOSX_DEPLOYMENT_TARGET=10.9
-      export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH
-      export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
-      if [[ "$(RELEASEWHEELBUILD)" != "True" ]]; then
-        export NMODL_NIGHTLY_TAG="-nightly"
-      else
-        export NMODL_NIGHTLY_TAG=""
-      fi
-      packaging/build_wheels.bash osx $(python.version)
-    condition: succeeded()
-    displayName: 'Build macos Wheel'
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathToPublish: '$(Build.SourcesDirectory)/wheelhouse'
-    condition: succeeded()
-    displayName: 'Publish wheel as build artifact'
-  - script: |
-      packaging/test_wheel.bash python$(python.version) wheelhouse/*.whl
-    condition: succeeded()
-    displayName: 'Test macos Wheel with Python $(python.version)'
-  - template: ci/upload-wheels.yml
+stages:
+- stage: fetch_config
+  jobs:
+  - job: github
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+    - checkout: none
+    - script: |
+        cat > parse_description.py << END_SCRIPT
+        import os
+        import re
+        import requests
+        pr_info = requests.get("https://api.github.com/repos/{}/pulls/{}".format(
+                                os.environ['BUILD_REPOSITORY_NAME'],
+                                os.environ['SYSTEM_PULLREQUEST_PULLREQUESTNUMBER']),
+                               headers={'Accept': 'application/vnd.github.v3+json'})
+        pr_body = pr_info.json()["body"]
+        # match something like NEURON_BRANCH=foo/bar
+        pat = re.compile('^([A-Z0-9_]+)_([A-Z]+)=([A-Z0-9\-\_\/\+]+)$', re.IGNORECASE)
+        def parse_term(m):
+          ref_type = m.group(2).lower()
+          if ref_type not in {'branch', 'tag', 'ref'}: return
+          variable = m.group(1).upper() + '_' + ref_type.upper()
+          value = m.group(3)
+          print('{}={}'.format(variable, value))
+          print('#{}[task.setvariable variable={};isOutput=true]{}'.format('#vso', variable, value))
+        if pr_body is not None:
+          for pr_body_line in pr_body.splitlines():
+            if not pr_body_line.startswith('CI_BRANCHES:'): continue
+            for config_term in pr_body_line[12:].split(','):
+              pat.sub(parse_term, config_term)
+        END_SCRIPT
+        echo '----'
+        cat parse_description.py
+        echo '----'
+        python parse_description.py
+      name: prdesc
+- stage: build
+  dependsOn: fetch_config
+  variables:
+    NEURON_BRANCH: $[stageDependencies.fetch_config.github.outputs['prdesc.NEURON_BRANCH']]
+    CORENEURON_BRANCH: $[stageDependencies.fetch_config.github.outputs['prdesc.CORENEURON_BRANCH']]
+  jobs:
+  - job: 'ubuntu1804'
+    pool:
+      vmImage: 'ubuntu-18.04'
+    displayName: 'Ubuntu (18.04), GCC 8.4'
+    steps:
+    - checkout: self
+      submodules: False
+    - script: |
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        sudo apt-add-repository -y ppa:deadsnakes/ppa
+        sudo apt-get update
+        sudo apt-get install -y g++-8 flex bison libfl-dev cython libx11-dev libxcomposite-dev libncurses-dev mpich
+        sudo apt-get install -y python3.7 python3.7-dev python3.7-venv ninja-build
+        python3.7 -m pip install --upgrade pip setuptools
+        python3.7 -m pip install --user 'Jinja2>=2.9.3' 'PyYAML>=3.13' pytest pytest-cov 'sympy>=1.3,<1.6' numpy
+        # we manually get version 3.15.0 to make sure that changes in the cmake
+        # files do not require unsupported versions of cmake in our package.
+        wget --quiet --output-document=- "https://github.com/Kitware/CMake/releases/download/$CMAKE_VER/$CMAKE_PKG.tar.gz" | tar xzpf -
+        # install ISPC compiler for integration testing
+        ispc_version="v1.12.0";
+        url_os="linux";
+        ispc_version_suffix="b";
+        url="https://github.com/ispc/ispc/releases/download/${ispc_version}/ispc-${ispc_version}${ispc_version_suffix}-${url_os}.tar.gz";
+        mkdir $(pwd)/$CMAKE_PKG/ispc
+        wget --quiet --output-document=- $url | tar -xvzf - -C $(pwd)/$CMAKE_PKG/ispc --strip 1;
+      env:
+        CMAKE_VER: 'v3.15.0'
+        CMAKE_PKG: 'cmake-3.15.0-Linux-x86_64'
+      displayName: 'Install Dependencies'
+    - script: |
+        export PATH=$(pwd)/$CMAKE_PKG/bin:/home/vsts/.local/bin:$PATH
+        export CXX='g++-8'
+        mkdir -p $(Build.Repository.LocalPath)/build
+        cd $(Build.Repository.LocalPath)/build
+        cmake --version
+        cmake .. -DPYTHON_EXECUTABLE=$(which python3.7) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=Release
+        make -j 2
+        if [ $? -ne 0 ]
+        then
+          make VERBOSE=1
+          exit 1
+        fi
+        make install #this is needed for the integration tests
+        env CTEST_OUTPUT_ON_FAILURE=1 make test
+      env:
+        CMAKE_PKG: 'cmake-3.15.0-Linux-x86_64'
+      displayName: 'Build and Run Unit Tests'
+    - script: |
+        export PATH=$(pwd)/$CMAKE_PKG/bin:/home/vsts/.local/bin:$PATH
+        export CC='gcc-8'
+        export CXX='g++-8'
+        git clone${NEURON_BRANCH:+ --branch }${NEURON_BRANCH} --single-branch https://github.com/neuronsimulator/nrn.git
+        if [[ -n "${CORENEURON_BRANCH}" ]]; then
+          pushd nrn
+          git submodule update --init external/coreneuron
+          cd external/coreneuron
+          git checkout ${CORENEURON_BRANCH}
+          popd
+        fi
+        mkdir nrn/build
+        cd nrn/build
+        cmake --version
+        cmake .. -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_INTERVIEWS=OFF -DNRN_ENABLE_RX3D=OFF -DNRN_ENABLE_MPI=ON -DNRN_ENABLE_TESTS=ON -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_DIR=$HOME/nmodl -Dnmodl_PYTHONPATH=$HOME/nmodl/lib -DPYTHON_EXECUTABLE=$(which python3.7) -DCORENRN_NMODL_FLAGS="sympy --analytic"
+        make -j 2
+        if [ $? -ne 0 ]
+        then
+          make VERBOSE=1
+          exit 1
+        fi
+        ctest --output-on-failure
+        if [ $? -ne 0 ]
+        then
+          exit 1
+        fi
+        ./bin/nrnivmodl-core $(Build.Repository.LocalPath)/test/integration/mod
+      env:
+        CMAKE_PKG: 'cmake-3.15.0-Linux-x86_64'
+        SHELL: 'bash'
+      displayName: 'Build Neuron and Run Integration Tests'
+    - script: |
+        export PATH=$(pwd)/$CMAKE_PKG/bin:/home/vsts/.local/bin:$PATH
+        export CXX='g++-8'
+        git clone${CORENEURON_BRANCH:+ --branch }${CORENEURON_BRANCH} https://github.com/BlueBrain/CoreNeuron.git
+        mkdir CoreNeuron/build_ispc
+        cd CoreNeuron/build_ispc
+        cmake --version
+        cmake .. -DCORENRN_ENABLE_MPI=OFF -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_DIR=$HOME/nmodl -DPYTHON_EXECUTABLE=$(which python3.7) -DCORENRN_NMODL_FLAGS="sympy --analytic" -DCORENRN_ENABLE_ISPC=ON -DCMAKE_ISPC_COMPILER=$(Build.Repository.LocalPath)/$CMAKE_PKG/ispc/bin/ispc
+        make -j 2
+        if [ $? -ne 0 ]
+        then
+          make VERBOSE=1
+          exit 1
+        fi
+        ctest --output-on-failure
+        if [ $? -ne 0 ]
+        then
+          exit 1
+        fi
+        ./bin/nrnivmodl-core $(Build.Repository.LocalPath)/test/integration/mod
+      env:
+        CMAKE_PKG: 'cmake-3.15.0-Linux-x86_64'
+      displayName: 'Build CoreNEURON and Run Integration Tests with ISPC compiler'
+  - job: 'osx1015'
+    pool:
+      vmImage: 'macOS-10.15'
+    displayName: 'MacOS (10.15), AppleClang 12.0'
+    steps:
+    - checkout: self
+      submodules: True
+    - script: |
+        brew install flex bison cmake python@3 gcc@8
+        python3 -m pip install --upgrade pip setuptools
+        python3 -m pip install --user 'Jinja2>=2.9.3' 'PyYAML>=3.13' pytest pytest-cov numpy 'sympy>=1.3,<1.9'
+      displayName: 'Install Dependencies'
+    - script: |
+        export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
+        mkdir -p $(Build.Repository.LocalPath)/build
+        cd $(Build.Repository.LocalPath)/build
+        cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DNMODL_ENABLE_PYTHON_BINDINGS=OFF
+        make -j 2
+        if [ $? -ne 0 ]
+        then
+          make VERBOSE=1
+          exit 1
+        fi
+        ctest --output-on-failure
+        if [ $? -ne 0 ]
+        then
+          exit 1
+        fi
+        make install
+      displayName: 'Build and Run Tests'
+    - script: |
+        export PATH=$(pwd)/$CMAKE_PKG/bin:/home/vsts/.local/bin:$PATH
+        export CC='gcc-8'
+        export CXX='g++-8'
+        git clone${NEURON_BRANCH:+ --branch }${NEURON_BRANCH} --single-branch https://github.com/neuronsimulator/nrn.git
+        if [[ -n "${CORENEURON_BRANCH}" ]]; then
+          pushd nrn
+          git submodule update --init external/coreneuron
+          cd external/coreneuron
+          git checkout ${CORENEURON_BRANCH}
+          popd
+        fi
+        mkdir nrn/build
+        cd nrn/build
+        cmake --version
+        cmake .. -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_INTERVIEWS=OFF -DNRN_ENABLE_RX3D=OFF -DNRN_ENABLE_BINARY_SPECIAL=ON -DNRN_ENABLE_MPI=OFF -DNRN_ENABLE_TESTS=ON -DCORENRN_ENABLE_MPI=OFF -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_DIR=$HOME/nmodl -Dnmodl_PYTHONPATH=$HOME/nmodl/lib -DPYTHON_EXECUTABLE=$(which python3) -DCORENRN_NMODL_FLAGS="sympy --analytic"
+        make -j 2
+        if [ $? -ne 0 ]
+        then
+          make VERBOSE=1
+          exit 1
+        fi
+        ctest --output-on-failure
+        if [ $? -ne 0 ]
+        then
+          exit 1
+        fi
+        ./bin/nrnivmodl-core $(Build.Repository.LocalPath)/test/integration/mod
+      env:
+        SHELL: 'bash'
+      displayName: 'Build Neuron and Run Integration Tests'
+  - job: 'manylinux_wheels'
+    timeoutInMinutes: 45
+    pool:
+      vmImage: 'ubuntu-18.04'
+    strategy:
+      matrix:
+        ${{ if eq(variables.buildWheel, True) }}:
+          Python36:
+            python.version: '3.6'
+          Python37:
+            python.version: '3.7'
+          Python38:
+            python.version: '3.8'
+          Python39:
+            python.version: '3.9'
+        ${{ if eq(variables.buildWheel, False) }}:
+          Python39:
+            python.version: '3.9'
+    steps:
+    - checkout: self
+      submodules: True
+      condition: succeeded()
+    - script: |
+        if [[ "$(RELEASEWHEELBUILD)" != "True" ]]; then
+          export TAG="-nightly"
+        else
+          export TAG=""
+        fi
+        docker run --rm \
+          -w /root/nmodl \
+          -v $PWD:/root/nmodl \
+          -e NMODL_NIGHTLY_TAG=$TAG \
+          'bluebrain/nmodl:wheel' \
+          packaging/build_wheels.bash linux $(python.version)
+      condition: succeeded()
+      displayName: 'Building ManyLinux Wheel'
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: '$(Build.SourcesDirectory)/wheelhouse'
+      condition: succeeded()
+      displayName: 'Publish wheel as build artifact'
+    - script: |
+        sudo apt-add-repository -y ppa:deadsnakes/ppa
+        sudo apt-get update
+        sudo apt-get install -y python$(python.version) python$(python.version)-dev python$(python.version)-venv
+        packaging/test_wheel.bash python$(python.version) wheelhouse/*.whl
+      condition: succeeded()
+      displayName: 'Test ManyLinux Wheel with Python $(python.version)'
+    - template: ci/upload-wheels.yml
+  - job: 'macos_wheels'
+    timeoutInMinutes: 45
+    pool:
+      vmImage: 'macOS-10.15'
+    strategy:
+      matrix:
+        ${{ if eq(variables.buildWheel, True) }}:
+          Python36:
+            python.version: '3.6'
+            python.org.version: '3.6.8'
+          Python37:
+            python.version: '3.7'
+            python.org.version: '3.7.7'
+          Python38:
+            python.version: '3.8'
+            python.org.version: '3.8.2'
+          Python39:
+            python.version: '3.9'
+            python.org.version: '3.9.0'
+        ${{ if eq(variables.buildWheel, False) }}:
+          Python39:
+            python.version: '3.9'
+            python.org.version: '3.9.0'
+    steps:
+    - checkout: self
+      submodules: True
+      condition: succeeded()
+    - script: |
+        brew install flex bison cmake ninja
+        export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
+      condition: succeeded()
+      displayName: 'Install Dependencies'
+    - script: |
+        installer=python-$(python.org.version)-macosx10.9.pkg
+        url=https://www.python.org/ftp/python/$(python.org.version)/$installer
+        curl $url -o $installer
+        sudo installer -pkg $installer -target /
+      condition: succeeded()
+      displayName: 'Install Python from python.org'
+    - script: |
+        export MACOSX_DEPLOYMENT_TARGET=10.9
+        export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH
+        export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+        if [[ "$(RELEASEWHEELBUILD)" != "True" ]]; then
+          export NMODL_NIGHTLY_TAG="-nightly"
+        else
+          export NMODL_NIGHTLY_TAG=""
+        fi
+        packaging/build_wheels.bash osx $(python.version)
+      condition: succeeded()
+      displayName: 'Build macos Wheel'
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: '$(Build.SourcesDirectory)/wheelhouse'
+      condition: succeeded()
+      displayName: 'Publish wheel as build artifact'
+    - script: |
+        packaging/test_wheel.bash python$(python.version) wheelhouse/*.whl
+      condition: succeeded()
+      displayName: 'Test macos Wheel with Python $(python.version)'
+    - template: ci/upload-wheels.yml


### PR DESCRIPTION
- Update NEURON submodule commit of CoreNEURON using `CORENEURON_BRANCH`.
- Use `gcc-8` when we're using `g++-8`.

CI_BRANCHES:CORENEURON_BRANCH=olupton/canary