### PR TITLE
azure: fix non-PR execution.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,10 @@ stages:
     steps:
     - checkout: none
     - script: |
+        if [[ -z ${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER+x} ]]; then
+        echo "Not running on a PR."
+        exit 0
+        fi
         cat > parse_description.py << END_SCRIPT
         import os
         import re


### PR DESCRIPTION
Do not try to fetch the GitHub pull request description when the
pipeline is not running on a pull request.