### PR TITLE
[LLVM][SIMD] Atomic updates support

### DIFF
--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -556,8 +556,7 @@ void CodegenLLVMVisitor::visit_codegen_atomic_statement(const ast::CodegenAtomic
         // Some sanity checks.
         auto codegen_var_with_type = instance_var_helper.get_variable(member_name);
         if (!codegen_var_with_type->get_is_pointer())
-            throw std::runtime_error(
-                "Error: atomic updates are allowed on pointer variables only\n");
+            throw std::runtime_error("Error: atomic updates are allowed on pointer variables only\n");
         const auto& member_var_name = std::dynamic_pointer_cast<ast::VarName>(member_node);
         if (!member_var_name->get_name()->is_indexed_name())
             throw std::runtime_error("Error: " + member_name + " is not an IndexedName\n");

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -531,8 +531,105 @@ void CodegenLLVMVisitor::visit_codegen_atomic_statement(const ast::CodegenAtomic
     ast::BinaryOp op = ir_builder.extract_atomic_op(atomic_op);
 
     // For different platforms, we handle atomic updates differently!
-    if (platform.is_cpu_with_simd()) {
-        throw std::runtime_error("Error: no atomic update support for SIMD CPUs\n");
+    if (platform.is_cpu_with_simd() && ir_builder.vectorizing()) {
+        const auto& identifier = var->get_name();
+
+        // Some duplication :)
+        if (!identifier->is_codegen_instance_var())
+            throw std::runtime_error("Error: atomic updates for non-instance variable\n");
+        
+        const auto& node = std::dynamic_pointer_cast<ast::CodegenInstanceVar>(identifier);
+        const auto& instance_name = node->get_instance_var()->get_node_name();
+        const auto& member_node = node->get_member_var();
+        const auto& member_name = member_node->get_node_name();
+
+        if (!instance_var_helper.is_an_instance_variable(member_name))
+            throw std::runtime_error("Error: " + member_name +
+                                     " is not a member of the instance variable\n");
+
+        const int vector_width = platform.get_instruction_width();
+        // Step 1: insert at alloca's entry point:
+        // %p = gep to struct.result
+        // %pi = ptrtoint %p to i64
+        // broadcast (insert element) to <vector>
+        // replicate value (shufflevector)
+        // res = %start
+        
+        llvm::Value* instance_ptr = ir_builder.create_load(instance_name);
+        int member_index = instance_var_helper.get_variable_index(member_name);
+        llvm::Value* member_ptr = ir_builder.get_struct_member_ptr(instance_ptr, member_index); 
+        llvm::Value* instance_member = ir_builder.create_load(member_ptr);
+        llvm::Value* starts = ir_builder.create_member_addresses(instance_member);
+
+        // Also have: (aka type punning)
+        // %ptr.i    = < vec_length x i64 >*
+        // %tmp.cast = [array of vec_length x (fp_type)*]*
+        llvm::Type* i64_type = ir_builder.get_i64_type();
+        llvm::Type* vi64_type = llvm::FixedVectorType::get(i64_type, vector_width);
+        llvm::Value* vec_ptr = ir_builder.create_alloca(/*name=*/"ptrs", vi64_type);
+
+        llvm::Type* array_type = llvm::ArrayType::get(ir_builder.get_fp_ptr_type(), vector_width);
+        llvm::Value* ptrs_arr = ir_builder.create_bitcast(vec_ptr, llvm::PointerType::get(array_type, /*AddressSpace=*/0));
+
+        // some more duplication :(
+        auto codegen_var_with_type = instance_var_helper.get_variable(member_name);
+        if (!codegen_var_with_type->get_is_pointer())
+            throw std::runtime_error(
+                "Error: atomic updates are allowed on pointer variables only\n");
+        const auto& member_var_name = std::dynamic_pointer_cast<ast::VarName>(member_node);
+        if (!member_var_name->get_name()->is_indexed_name())
+            throw std::runtime_error("Error: " + member_name + " is not an IndexedName\n");
+        const auto& member_indexed_name = std::dynamic_pointer_cast<ast::IndexedName>(
+            member_var_name->get_name());
+        if (!member_indexed_name->get_length()->is_name())
+            throw std::runtime_error("Error: " + member_name + " must be indexed with a variable!");
+
+        // Step 2: in current block:
+        // get index as vector: %ind = < .. >
+        // calculate address: %addr = %start + %(i64)(%ind * sizeof(fp_type))
+        // store to %ptr.i (store addresses/ptrs basically)
+        llvm::Value* i64_index = get_index(*member_indexed_name);
+        llvm::Value* offsets = ir_builder.create_member_offsets(starts, i64_index);
+        ir_builder.create_store(vec_ptr, offsets);
+
+        // Step 3: create a new block by splitting it in 2, generating code, and then
+        // resetting insertion point.
+        //    [ body ]      [ body ]
+        //              ->  [scalar]
+        //                  [body]
+        llvm::BasicBlock* body_bb = ir_builder.get_current_block();
+        llvm::BasicBlock* cond_bb = body_bb->getNextNode();
+        llvm::Function* func = body_bb->getParent();
+        llvm::BasicBlock* atomic_bb = 
+            llvm::BasicBlock::Create(*context, /*Name=*/"atomic.update", func, cond_bb);
+        llvm::BasicBlock* remaining_body_bb = 
+            llvm::BasicBlock::Create(*context, /*Name=*/"for.body.remaining", func, cond_bb);
+
+        ir_builder.create_br_and_set_insertion_point(atomic_bb);
+
+        // Step 4: find next active element
+        // %mask = phi [%body, 255 (or vector length)] [%this, %new_mask]
+        // %ci = cttz %mask
+        // %tmp = shl 1, %ci
+        // %not.tmp = xor -1, %tmp
+        // %new_mask = and %mask, %not.tmp
+        llvm::Value* cmp = ir_builder.create_atomic_loop(ptrs_arr, rhs, op);
+
+        // %ptr_offsets.addr = gep %tmp_cast, 0, %ci
+        // %ptr = load from %ptr_offsets.addr
+        // %val = load from %ptr
+
+        // extract element using extractelement %update (i32)%ci
+        // perform atomic operation
+        // store result at %ptr
+
+        // icmp new_mask with 0
+        // branch based on cmp
+
+        // Restore insertion point
+        ir_builder.create_cond_br(cmp, remaining_body_bb, atomic_bb);
+        ir_builder.set_insertion_point(remaining_body_bb);
+
     } else if (platform.is_gpu()) {
         const auto& identifier = var->get_name();
 
@@ -572,7 +669,7 @@ void CodegenLLVMVisitor::visit_codegen_atomic_statement(const ast::CodegenAtomic
 
         ir_builder.create_atomic_op(ptr, rhs, op);
     } else {
-        // For non-SIMD CPUs, updates don't have to be atomic at all!
+        // For non-SIMD CPUs (or any scalar code), updates don't have to be atomic at all!
         llvm::Value* lhs = accept_and_get(node.get_lhs());
         ir_builder.create_binary_op(lhs, rhs, op);
         llvm::Value* result = ir_builder.pop_last_value();

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -556,7 +556,8 @@ void CodegenLLVMVisitor::visit_codegen_atomic_statement(const ast::CodegenAtomic
         // Some sanity checks.
         auto codegen_var_with_type = instance_var_helper.get_variable(member_name);
         if (!codegen_var_with_type->get_is_pointer())
-            throw std::runtime_error("Error: atomic updates are allowed on pointer variables only\n");
+            throw std::runtime_error(
+                "Error: atomic updates are allowed on pointer variables only\n");
         const auto& member_var_name = std::dynamic_pointer_cast<ast::VarName>(member_node);
         if (!member_var_name->get_name()->is_indexed_name())
             throw std::runtime_error("Error: " + member_name + " is not an IndexedName\n");

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -315,15 +315,16 @@ void IRBuilder::create_atomic_op(llvm::Value* ptr, llvm::Value* update, ast::Bin
                             llvm::AtomicOrdering::SequentiallyConsistent);
 }
 
-llvm::Value*  IRBuilder::create_member_addresses(llvm::Value* member_ptr) {
+llvm::Value* IRBuilder::create_member_addresses(llvm::Value* member_ptr) {
     llvm::Module* m = builder.GetInsertBlock()->getParent()->getParent();
 
-    // Treat this member address as integer value. 
+    // Treat this member address as integer value.
     llvm::Type* int_ptr_type = m->getDataLayout().getIntPtrType(builder.getContext());
     llvm::Value* ptr_to_int = builder.CreatePtrToInt(member_ptr, int_ptr_type);
 
     // Create a vector that has address at 0.
-    llvm::Type* vector_type = llvm::FixedVectorType::get(int_ptr_type, platform.get_instruction_width());
+    llvm::Type* vector_type = llvm::FixedVectorType::get(int_ptr_type,
+                                                         platform.get_instruction_width());
     llvm::Value* zero = get_scalar_constant<llvm::ConstantInt>(get_i32_type(), 0);
     llvm::Value* tmp =
         builder.CreateInsertElement(llvm::UndefValue::get(vector_type), ptr_to_int, zero);
@@ -334,12 +335,15 @@ llvm::Value*  IRBuilder::create_member_addresses(llvm::Value* member_ptr) {
 }
 
 llvm::Value* IRBuilder::create_member_offsets(llvm::Value* start, llvm::Value* indices) {
-    llvm::Value* factor = get_vector_constant<llvm::ConstantInt>(get_i64_type(), platform.get_precision() / 8);
+    llvm::Value* factor = get_vector_constant<llvm::ConstantInt>(get_i64_type(),
+                                                                 platform.get_precision() / 8);
     llvm::Value* offset = builder.CreateMul(indices, factor);
     return builder.CreateAdd(start, offset);
 }
 
-llvm::Value* IRBuilder::create_atomic_loop(llvm::Value* ptrs_arr, llvm::Value* rhs, ast::BinaryOp op) {
+llvm::Value* IRBuilder::create_atomic_loop(llvm::Value* ptrs_arr,
+                                           llvm::Value* rhs,
+                                           ast::BinaryOp op) {
     const int vector_width = platform.get_instruction_width();
     llvm::BasicBlock* curr = get_current_block();
     llvm::BasicBlock* prev = curr->getPrevNode();
@@ -355,13 +359,16 @@ llvm::Value* IRBuilder::create_atomic_loop(llvm::Value* ptrs_arr, llvm::Value* r
     llvm::PHINode* mask = builder.CreatePHI(get_i64_type(), /*NumReservedValues=*/2);
 
     // Intially, all elements are active.
-    llvm::Value* init_value = get_scalar_constant<llvm::ConstantInt>(get_i64_type(), ~((~0) << vector_width));
+    llvm::Value* init_value = get_scalar_constant<llvm::ConstantInt>(get_i64_type(),
+                                                                     ~((~0) << vector_width));
 
-    // Find the index of the next active element and update the mask. This can be easily computed with:
+    // Find the index of the next active element and update the mask. This can be easily computed
+    // with:
     //     index    = cttz(mask)
     //     new_mask = mask & ((1 << index) ^ -1)
-    llvm::Value* index = builder.CreateIntrinsic(llvm::Intrinsic::cttz, {get_i64_type()}, {mask, false_value});
-    llvm::Value* new_mask= builder.CreateShl(one, index);
+    llvm::Value* index =
+        builder.CreateIntrinsic(llvm::Intrinsic::cttz, {get_i64_type()}, {mask, false_value});
+    llvm::Value* new_mask = builder.CreateShl(one, index);
     new_mask = builder.CreateXor(new_mask, minus_one);
     new_mask = builder.CreateAnd(mask, new_mask);
 
@@ -370,7 +377,8 @@ llvm::Value* IRBuilder::create_atomic_loop(llvm::Value* ptrs_arr, llvm::Value* r
     mask->addIncoming(new_mask, curr);
 
     // Get the pointer to the current value, the value itself and the update.b
-    llvm::Value* gep = builder.CreateGEP(ptrs_arr->getType()->getPointerElementType(), ptrs_arr, {zero, index});
+    llvm::Value* gep =
+        builder.CreateGEP(ptrs_arr->getType()->getPointerElementType(), ptrs_arr, {zero, index});
     llvm::Value* ptr = create_load(gep);
     llvm::Value* source = create_load(ptr);
     llvm::Value* update = builder.CreateExtractElement(rhs, index);
@@ -381,7 +389,7 @@ llvm::Value* IRBuilder::create_atomic_loop(llvm::Value* ptrs_arr, llvm::Value* r
     create_binary_op(source, update, op);
     llvm::Value* result = pop_last_value();
     create_store(ptr, result);
-    
+
     // Return condition to break out of atomic update loop.
     return builder.CreateICmpEQ(new_mask, zero);
 }

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -294,24 +294,22 @@ void IRBuilder::create_array_alloca(const std::string& name,
 }
 
 ast::BinaryOp IRBuilder::extract_atomic_op(ast::BinaryOp op) {
-    switch (op) {
-    case ast::BinaryOp::BOP_SUB_ASSIGN:
-        return ast::BinaryOp::BOP_SUBTRACTION;
-    case ast::BinaryOp::BOP_ADD_ASSIGN:
-        return ast::BinaryOp::BOP_ADDITION;
-    default:
-        throw std::runtime_error("Error: only atomic addition and subtraction is supported\n");
+    switch(op) {
+        case ast::BinaryOp::BOP_SUB_ASSIGN:
+            return  ast::BinaryOp::BOP_SUBTRACTION;
+        case ast::BinaryOp::BOP_ADD_ASSIGN:
+            return ast::BinaryOp::BOP_ADDITION;
+        default:
+            throw std::runtime_error(
+                "Error: only atomic addition and subtraction is supported\n");
     }
 }
 
 void IRBuilder::create_atomic_op(llvm::Value* ptr, llvm::Value* update, ast::BinaryOp op) {
-    if (op == ast::BinaryOp::BOP_SUBTRACTION) {
-        update = builder.CreateFNeg(update);
+    if (op == ast::BinaryOp::BOP_SUBTRACTION)  {
+       update = builder.CreateFNeg(update);
     }
-    builder.CreateAtomicRMW(llvm::AtomicRMWInst::FAdd,
-                            ptr,
-                            update,
-                            llvm::MaybeAlign(),
+    builder.CreateAtomicRMW(llvm::AtomicRMWInst::FAdd, ptr, update, llvm::MaybeAlign(),
                             llvm::AtomicOrdering::SequentiallyConsistent);
 }
 

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -294,22 +294,24 @@ void IRBuilder::create_array_alloca(const std::string& name,
 }
 
 ast::BinaryOp IRBuilder::extract_atomic_op(ast::BinaryOp op) {
-    switch(op) {
-        case ast::BinaryOp::BOP_SUB_ASSIGN:
-            return  ast::BinaryOp::BOP_SUBTRACTION;
-        case ast::BinaryOp::BOP_ADD_ASSIGN:
-            return ast::BinaryOp::BOP_ADDITION;
-        default:
-            throw std::runtime_error(
-                "Error: only atomic addition and subtraction is supported\n");
+    switch (op) {
+    case ast::BinaryOp::BOP_SUB_ASSIGN:
+        return ast::BinaryOp::BOP_SUBTRACTION;
+    case ast::BinaryOp::BOP_ADD_ASSIGN:
+        return ast::BinaryOp::BOP_ADDITION;
+    default:
+        throw std::runtime_error("Error: only atomic addition and subtraction is supported\n");
     }
 }
 
 void IRBuilder::create_atomic_op(llvm::Value* ptr, llvm::Value* update, ast::BinaryOp op) {
-    if (op == ast::BinaryOp::BOP_SUBTRACTION)  {
-       update = builder.CreateFNeg(update);
+    if (op == ast::BinaryOp::BOP_SUBTRACTION) {
+        update = builder.CreateFNeg(update);
     }
-    builder.CreateAtomicRMW(llvm::AtomicRMWInst::FAdd, ptr, update, llvm::MaybeAlign(),
+    builder.CreateAtomicRMW(llvm::AtomicRMWInst::FAdd,
+                            ptr,
+                            update,
+                            llvm::MaybeAlign(),
                             llvm::AtomicOrdering::SequentiallyConsistent);
 }
 

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -315,6 +315,75 @@ void IRBuilder::create_atomic_op(llvm::Value* ptr, llvm::Value* update, ast::Bin
                             llvm::AtomicOrdering::SequentiallyConsistent);
 }
 
+llvm::Value*  IRBuilder::create_member_addresses(llvm::Value* member_ptr) {
+    llvm::BasicBlock* bb = builder.GetInsertBlock();
+    llvm::Module* m = bb->getParent()->getParent();
+    const int vector_width = platform.get_instruction_width();
+
+    llvm::Type* int_ptr_type = m->getDataLayout().getIntPtrType(builder.getContext());
+    llvm::Value* ptr_to_int = builder.CreatePtrToInt(member_ptr, int_ptr_type);
+
+    llvm::Type* vector_type = llvm::FixedVectorType::get(int_ptr_type, vector_width);
+    llvm::Value* zero = get_scalar_constant<llvm::ConstantInt>(get_i32_type(), 0);
+    llvm::Value* tmp =
+        builder.CreateInsertElement(llvm::UndefValue::get(vector_type), ptr_to_int, zero);
+
+    // Then, use `shufflevector` with zeroinitializer to select only 0th element.
+    llvm::Value* select = llvm::Constant::getNullValue(vector_type);
+    llvm::Value* res = builder.CreateShuffleVector(tmp, llvm::UndefValue::get(vector_type), select);
+
+    builder.SetInsertPoint(bb);
+
+    return res;
+}
+
+llvm::Value* IRBuilder::create_member_offsets(llvm::Value* start, llvm::Value* indices) {
+    llvm::Value* factor = get_vector_constant<llvm::ConstantInt>(get_i64_type(), platform.get_precision() / 8);
+    llvm::Value* offset = builder.CreateMul(indices, factor);
+    return builder.CreateAdd(start, offset);
+}
+
+llvm::Value* IRBuilder::create_atomic_loop(llvm::Value* ptrs_arr, llvm::Value* rhs, ast::BinaryOp op) {
+    const int vector_width = platform.get_instruction_width();
+    llvm::BasicBlock* curr = get_current_block();
+    llvm::BasicBlock* prev = curr->getPrevNode();
+    llvm::BasicBlock* next = curr->getNextNode();
+
+    llvm::PHINode* mask = builder.CreatePHI(get_i64_type(), /*NumReservedValues=*/2);
+    // TODO: use proper mask instead of 255!
+    llvm::Value* init_value = get_scalar_constant<llvm::ConstantInt>(get_i64_type(), ~((~0) << vector_width));
+    mask->addIncoming(init_value, prev);
+
+    llvm::Value* zero = get_scalar_constant<llvm::ConstantInt>(get_i64_type(), 0);
+    
+
+    llvm::Value* false_value = get_scalar_constant<llvm::ConstantInt>(get_boolean_type(), 0);
+    llvm::Value* count = builder.CreateIntrinsic(llvm::Intrinsic::cttz, {get_i64_type()}, {mask, false_value});
+
+    llvm::Value* one = get_scalar_constant<llvm::ConstantInt>(get_i64_type(), 1);
+    llvm::Value* minus_one = get_scalar_constant<llvm::ConstantInt>(get_i64_type(), -1);
+    llvm::Value* new_mask= builder.CreateShl(one, count);
+    new_mask = builder.CreateXor(new_mask, minus_one);
+    new_mask = builder.CreateAnd(mask, new_mask);
+
+    mask->addIncoming(new_mask, curr);
+
+    // compute!
+
+    ValueVector indices{zero, count};
+    llvm::Type* ptrs_arr_type = ptrs_arr->getType()->getPointerElementType();
+    llvm::Value* gep = builder.CreateGEP(ptrs_arr_type, ptrs_arr, indices);
+    llvm::Value* ptr = create_load(gep);
+    llvm::Value* source = create_load(ptr);
+    llvm::Value* update = builder.CreateExtractElement(rhs, count);
+
+    create_binary_op(source, update, op);
+    llvm::Value* result = pop_last_value();
+    create_store(ptr, result);
+    
+    return builder.CreateICmpEQ(new_mask, zero);
+}
+
 void IRBuilder::create_binary_op(llvm::Value* lhs, llvm::Value* rhs, ast::BinaryOp op) {
     // Check that both lhs and rhs have the same types.
     if (lhs->getType() != rhs->getType())

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -313,6 +313,10 @@ class IRBuilder {
     /// Generates an inbounds GEP instruction for the given value and returns calculated address.
     llvm::Value* create_inbounds_gep(llvm::Value* variable, llvm::Value* index);
 
+    llvm::Value* create_member_addresses(llvm::Value* member_ptr);
+    llvm::Value* create_member_offsets(llvm::Value* start, llvm::Value* indices);
+    llvm::Value* create_atomic_loop(llvm::Value* ptrs_arr, llvm::Value* rhs, ast::BinaryOp op);
+
   private:
     /// Generates an inbounds GEP instruction for the given name and returns calculated address.
     llvm::Value* create_inbounds_gep(const std::string& variable_name, llvm::Value* index);

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -313,8 +313,15 @@ class IRBuilder {
     /// Generates an inbounds GEP instruction for the given value and returns calculated address.
     llvm::Value* create_inbounds_gep(llvm::Value* variable, llvm::Value* index);
 
+    /// Creates a vector splat of starting addresses of the given member. 
     llvm::Value* create_member_addresses(llvm::Value* member_ptr);
+
+    /// Creates IR for calculating offest to member values. For more context, see `visit_codegen_atomic_statement` in LLVM visitor.
     llvm::Value* create_member_offsets(llvm::Value* start, llvm::Value* indices);
+
+    /// Creates IR to perform scalar updates to instance member based on `ptrs_arr` for every element in a vector by
+    ///     member[*ptrs_arr[i]] = member[*ptrs_arr[i]] op rhs.
+    /// Returns condition (i1 value) to break out of atomic update loop.
     llvm::Value* create_atomic_loop(llvm::Value* ptrs_arr, llvm::Value* rhs, ast::BinaryOp op);
 
   private:

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -313,13 +313,15 @@ class IRBuilder {
     /// Generates an inbounds GEP instruction for the given value and returns calculated address.
     llvm::Value* create_inbounds_gep(llvm::Value* variable, llvm::Value* index);
 
-    /// Creates a vector splat of starting addresses of the given member. 
+    /// Creates a vector splat of starting addresses of the given member.
     llvm::Value* create_member_addresses(llvm::Value* member_ptr);
 
-    /// Creates IR for calculating offest to member values. For more context, see `visit_codegen_atomic_statement` in LLVM visitor.
+    /// Creates IR for calculating offest to member values. For more context, see
+    /// `visit_codegen_atomic_statement` in LLVM visitor.
     llvm::Value* create_member_offsets(llvm::Value* start, llvm::Value* indices);
 
-    /// Creates IR to perform scalar updates to instance member based on `ptrs_arr` for every element in a vector by
+    /// Creates IR to perform scalar updates to instance member based on `ptrs_arr` for every
+    /// element in a vector by
     ///     member[*ptrs_arr[i]] = member[*ptrs_arr[i]] op rhs.
     /// Returns condition (i1 value) to break out of atomic update loop.
     llvm::Value* create_atomic_loop(llvm::Value* ptrs_arr, llvm::Value* rhs, ast::BinaryOp op);

--- a/test/benchmark/CMakeLists.txt
+++ b/test/benchmark/CMakeLists.txt
@@ -32,11 +32,6 @@ if(NMODL_ENABLE_PYTHON_BINDINGS)
   file(GLOB modfiles "${NMODL_PROJECT_SOURCE_DIR}/test/benchmark/kernels/*.mod")
   list(APPEND modfiles "${NMODL_PROJECT_SOURCE_DIR}/test/integration/mod/test_math.mod")
   foreach(modfile ${modfiles})
-    # For expsyn.mod set the vector width to 1 since atomic operations are not supported for vector
-    # widths > 1. See https://github.com/BlueBrain/nmodl/issues/857
-    if(${modfile} STREQUAL "${NMODL_PROJECT_SOURCE_DIR}/test/benchmark/kernels/expsyn.mod")
-      set(extra_args "--vec 1")
-    endif()
     get_filename_component(modfile_name "${modfile}" NAME)
     add_test(NAME "PyJIT/${modfile_name}"
              COMMAND ${PYTHON_EXECUTABLE} ${NMODL_PROJECT_SOURCE_DIR}/test/benchmark/benchmark.py

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -146,7 +146,7 @@ if(NMODL_ENABLE_LLVM)
     printer
     ${NMODL_WRAPPER_LIBS}
     ${LLVM_LIBS_TO_LINK})
-  set(CODEGEN_TEST testllvm)
+  set(CODEGEN_TEST "testllvm;test_llvm_runner")
 endif()
 
 # =============================================================================

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -46,7 +46,6 @@ bool check_instance_variable(InstanceTestInfo& instance_info,
 
     // While we are comparing double types as well, for simplicity the test cases are hand-crafted
     // so that no floating-point arithmetic is really involved.
-    std::cout << fmt::format("[{}]: {}", variable_name, fmt::join(actual, ", "));
     return actual == expected;
 }
 

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -46,6 +46,7 @@ bool check_instance_variable(InstanceTestInfo& instance_info,
 
     // While we are comparing double types as well, for simplicity the test cases are hand-crafted
     // so that no floating-point arithmetic is really involved.
+    std::cout << fmt::format("[{}]: {}", variable_name, fmt::join(actual, ", "));
     return actual == expected;
 }
 
@@ -822,6 +823,102 @@ SCENARIO("Kernel with atomic updates", "[llvm][runner]") {
 
             std::vector<double> ion_ika_expected = {0.0, 12.0, 27.0, -5.0, 0.0, 0.0};
             REQUIRE(check_instance_variable(instance_info, ion_ika_expected, "ion_ika"));
+        }
+    }
+
+    GIVEN("Atomic updates of rhs and d") {
+        std::string nmodl_text = R"(
+            NEURON {
+                POINT_PROCESS test
+                USEION na READ ena WRITE ina
+                USEION ka READ eka WRITE ika
+            }
+
+            STATE { }
+
+            ASSIGNED {
+                v (mV)
+                ena (mV)
+                ina (mA/cm2)
+            }
+
+            BREAKPOINT { }
+
+            DERIVATIVE states { }
+
+            : The atomic update that we want to check is again:
+            :
+            :     node_id = mech->node_index[id]
+            :     mech->vec_rhs[node_id] -= rhs
+            :     mech->vec_d[node_id] -= g
+        )";
+
+
+        NmodlDriver driver;
+        const auto& ast = driver.parse_string(nmodl_text);
+
+        // Run passes on the AST to generate LLVM.
+        SymtabVisitor().visit_program(*ast);
+        NeuronSolveVisitor().visit_program(*ast);
+        SolveBlockVisitor().visit_program(*ast);
+
+        codegen::Platform simd_cpu_platform(/*use_single_precision=*/false,
+                                            /*instruction_width=*/2);
+        codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
+                                                 /*output_dir=*/".",
+                                                 simd_cpu_platform,
+                                                 /*opt_level_ir=*/0);
+        llvm_visitor.visit_program(*ast);
+        llvm_visitor.wrap_kernel_functions();
+
+        // Create the instance struct data.
+        int num_elements = 6;
+        const auto& generated_instance_struct = llvm_visitor.get_instance_struct_ptr();
+        auto codegen_data = codegen::CodegenDataHelper(generated_instance_struct);
+        auto instance_data = codegen_data.create_data(num_elements, /*seed=*/1);
+
+        // With these indices vec_rhs[1] = -0.2-1.e2/1.5*2-1.e2/3.4*6-1.e2/5.2*10 =
+        // -502.3116138763197.
+        // With these indices vec_rhs[4] =
+        // -0.54-1.e2/2.3*22.0-1.e2/4.1*8.0-1.e2/6.0*12.0 = -1351.103690349947.
+        // vec_d remains the same because the contribution of g each time is 0.0.
+        std::vector<int> node_index = {1, 4, 1, 4, 1, 4};
+        std::vector<double> ina = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0};
+        std::vector<double> ika = {1.0, 20.0, 3.0, 4.0, 5.0, 6.0};
+        std::vector<double> vec_rhs = {0.64, -0.2, 1.1, 0.42, 0.54, -0.36};
+        std::vector<double> vec_d = {1.6, 2.5, 3.4, 4.3, 5.2, 6.1};
+        std::vector<int> node_area_index = {0, 1, 2, 3, 4, 5};
+        std::vector<double> node_area = {1.5, 2.3, 3.4, 4.1, 5.2, 6.0};
+
+        InstanceTestInfo instance_info{&instance_data,
+                                       llvm_visitor.get_instance_var_helper(),
+                                       num_elements};
+
+        initialise_instance_variable(instance_info, node_index, "node_index");
+        initialise_instance_variable(instance_info, ina, "ina");
+        initialise_instance_variable(instance_info, ika, "ika");
+        initialise_instance_variable(instance_info, vec_rhs, "vec_rhs");
+        initialise_instance_variable(instance_info, vec_d, "vec_d");
+        initialise_instance_variable(instance_info, node_area_index, "node_area_index");
+        initialise_instance_variable(instance_info, node_area, "node_area");
+
+        // Set up the JIT runner.
+        std::unique_ptr<llvm::Module> module = llvm_visitor.get_module();
+        TestRunner runner(std::move(module));
+        runner.initialize_driver();
+
+        THEN("Atomic updates are correct") {
+            runner.run_with_argument<int, void*>("__nrn_cur_test_wrapper", instance_data.base_ptr);
+            // Recall:
+            //     node_id = mech->node_index[id]
+            //     mech->vec_rhs[node_id] -= rhs
+            //     mech->vec_d[node_id] -= g
+            std::vector<double> vec_rhs_expected = {
+                0.64, -502.3116138763197, 1.1, 0.42, -1351.103690349947, -0.36};
+            REQUIRE(check_instance_variable(instance_info, vec_rhs_expected, "vec_rhs"));
+
+            std::vector<double> vec_d_expected = {1.6, 2.5, 3.4, 4.3, 5.2, 6.1};
+            REQUIRE(check_instance_variable(instance_info, vec_d_expected, "vec_d"));
         }
     }
 }

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -715,8 +715,7 @@ SCENARIO("Kernel with atomic updates", "[llvm][runner]") {
         runner.initialize_driver();
 
         THEN("updates are commputed correctly with vector instructions and optimizations on") {
-            runner.run_with_argument<int, void*>("__nrn_cur_test_wrapper",
-                                                 instance_data.base_ptr);
+            runner.run_with_argument<int, void*>("__nrn_cur_test_wrapper", instance_data.base_ptr);
             // Recall:
             //     ion_ina_id = mech->ion_ina_index[id]
             //     ion_ika_id = mech->ion_ika_index[id]
@@ -812,8 +811,7 @@ SCENARIO("Kernel with atomic updates", "[llvm][runner]") {
         runner.initialize_driver();
 
         THEN("Atomic updates are correct without optimizations") {
-            runner.run_with_argument<int, void*>("__nrn_cur_test_wrapper",
-                                                 instance_data.base_ptr);
+            runner.run_with_argument<int, void*>("__nrn_cur_test_wrapper", instance_data.base_ptr);
             // Recall:
             //     ion_ina_id = mech->ion_ina_index[id]
             //     ion_ika_id = mech->ion_ika_index[id]

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -1912,7 +1912,8 @@ SCENARIO("A simple kernel with atomic current updates", "[visitor][llvm]") {
             // Check for correct %ptrs calculation and bitcast to an array.
             std::regex ptrtoint(R"(ptrtoint float\* %.* to i64)");
             std::regex insertelement(R"(insertelement <4 x i64> undef, i64 %.*, i32 0)");
-            std::regex shufflevector(R"(shufflevector <4 x i64> %.*, <4 x i64> undef, <4 x i32> zeroinitializer)");
+            std::regex shufflevector(
+                R"(shufflevector <4 x i64> %.*, <4 x i64> undef, <4 x i32> zeroinitializer)");
             std::regex bitcast(R"(bitcast <4 x i64>\* %ptrs to \[4 x float\*\]\*)");
             REQUIRE(std::regex_search(module_string, m, ptrtoint));
             REQUIRE(std::regex_search(module_string, m, insertelement));
@@ -1932,14 +1933,16 @@ SCENARIO("A simple kernel with atomic current updates", "[visitor][llvm]") {
                 "  %.* = shl i64 1, %.*\n"
                 "  %.* = xor i64 %.*, -1\n"
                 "  %.* = and i64 %.*, %.*\n"
-                "  %.* = getelementptr \\[4 x float\\*\\], \\[4 x float\\*\\]\\* %.*, i64 0, i64 %.*\n"
+                "  %.* = getelementptr \\[4 x float\\*\\], \\[4 x float\\*\\]\\* %.*, i64 0, i64 "
+                "%.*\n"
                 "  %.* = load float\\*, float\\*\\* %.*, align 8\n"
                 "  %.* = load float, float\\* %.*, align 4\n"
                 "  %.* = extractelement <4 x float> %.*, i64 %.*\n"
                 "  %.* = fadd float %.*, %.*\n"
                 "  store float %.*, float\\* %.*, align 4\n"
                 "  %.* = icmp eq i64 %.*, 0\n");
-            std::regex remaining(R"(br i1 %.*, label %for\.body\.remaining, label %atomic\.update)");
+            std::regex remaining(
+                R"(br i1 %.*, label %for\.body\.remaining, label %atomic\.update)");
             REQUIRE(std::regex_search(module_string, m, atomic_update));
             REQUIRE(std::regex_search(module_string, m, remaining));
         }

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -1876,3 +1876,72 @@ SCENARIO("GPU kernel body IR generation", "[visitor][llvm][gpu]") {
         }
     }
 }
+
+//=============================================================================
+// Atomics for vectorised kernel
+//=============================================================================
+
+SCENARIO("A simple kernel with atomic current updates", "[visitor][llvm]") {
+    GIVEN("A simple atomic update") {
+        std::string nmodl_text = R"(
+            NEURON {
+                SUFFIX test
+                USEION na READ ena WRITE ina
+            }
+
+            STATE { }
+
+            ASSIGNED {
+                v (mV)
+                ena (mV)
+                ina (mA/cm2)
+            }
+
+            BREAKPOINT { }
+
+            DERIVATIVE states { }
+        )";
+
+        THEN("an atomic loop is created") {
+            std::string module_string = run_llvm_visitor(nmodl_text,
+                                                         /*opt_level=*/0,
+                                                         /*use_single_precision=*/true,
+                                                         /*vector_width=*/4);
+            std::smatch m;
+
+            // Check for correct %ptrs calculation and bitcast to an array.
+            std::regex ptrtoint(R"(ptrtoint float\* %.* to i64)");
+            std::regex insertelement(R"(insertelement <4 x i64> undef, i64 %.*, i32 0)");
+            std::regex shufflevector(R"(shufflevector <4 x i64> %.*, <4 x i64> undef, <4 x i32> zeroinitializer)");
+            std::regex bitcast(R"(bitcast <4 x i64>\* %ptrs to \[4 x float\*\]\*)");
+            REQUIRE(std::regex_search(module_string, m, ptrtoint));
+            REQUIRE(std::regex_search(module_string, m, insertelement));
+            REQUIRE(std::regex_search(module_string, m, shufflevector));
+            REQUIRE(std::regex_search(module_string, m, bitcast));
+
+            // Check for %ptrs store and branch to atomic update block.
+            std::regex ptrs_store(R"(store <4 x i64> %.*, <4 x i64>\* %ptrs)");
+            std::regex atomic_branch(R"(br label %atomic\.update)");
+            REQUIRE(std::regex_search(module_string, m, ptrs_store));
+            REQUIRE(std::regex_search(module_string, m, atomic_branch));
+
+            // Check the scalar loop for atomic update mis implemented correctly.
+            std::regex atomic_update(
+                "  %.* = phi i64 \\[ 15, %for\\.body \\], \\[ %.*, %atomic\\.update \\]\n"
+                "  %.* = call i64 @llvm\\.cttz\\.i64\\(i64 %.*, i1 false\\)\n"
+                "  %.* = shl i64 1, %.*\n"
+                "  %.* = xor i64 %.*, -1\n"
+                "  %.* = and i64 %.*, %.*\n"
+                "  %.* = getelementptr \\[4 x float\\*\\], \\[4 x float\\*\\]\\* %.*, i64 0, i64 %.*\n"
+                "  %.* = load float\\*, float\\*\\* %.*, align 8\n"
+                "  %.* = load float, float\\* %.*, align 4\n"
+                "  %.* = extractelement <4 x float> %.*, i64 %.*\n"
+                "  %.* = fadd float %.*, %.*\n"
+                "  store float %.*, float\\* %.*, align 4\n"
+                "  %.* = icmp eq i64 %.*, 0\n");
+            std::regex remaining(R"(br i1 %.*, label %for\.body\.remaining, label %atomic\.update)");
+            REQUIRE(std::regex_search(module_string, m, atomic_update));
+            REQUIRE(std::regex_search(module_string, m, remaining));
+        }
+    }
+}

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -1841,4 +1841,38 @@ SCENARIO("GPU kernel body IR generation", "[visitor][llvm][gpu]") {
             REQUIRE(std::regex_search(module_string, m, add));
         }
     }
+
+    GIVEN("For current update with atomic addition ") {
+        std::string nmodl_text = R"(
+            NEURON {
+                SUFFIX test
+                USEION na READ ena WRITE ina
+            }
+
+            STATE { }
+
+            ASSIGNED {
+                v (mV)
+                ena (mV)
+                ina (mA/cm2)
+            }
+
+            BREAKPOINT {
+                SOLVE states METHOD cnexp
+            }
+
+            DERIVATIVE states { }
+        )";
+
+        THEN("corresponding LLVM atomic instruction is generated") {
+            std::string module_string = run_gpu_llvm_visitor(nmodl_text,
+                                                             /*opt_level=*/0,
+                                                             /*use_single_precision=*/false);
+            std::smatch m;
+
+            // Check for atomic addition.
+            std::regex add(R"(atomicrmw fadd double\* %.*, double %.* seq_cst)");
+            REQUIRE(std::regex_search(module_string, m, add));
+        }
+    }
 }


### PR DESCRIPTION
This PR introduces atomic write support for SIMD code generation.

Current  update kernels sometimes require atomic updates, usually in the form of
```
index = indices[id]
data[index] += update[id]
```
Since it is not possible to generate atomics with SIMD, we insert a scalar loop
that updates every element of the vector one by one.

In particular, this PR:
- Adds code generation functionality for atomic writes on SIMD platforms
- Adds both execution and IR tests
- Refactors common GPU/SIMD atomics code