### PR TITLE
[LLVM][FIX] Float generation fix in LLVM helper visitor

### DIFF
--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -135,8 +135,9 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
 
     CodegenLLVMHelperVisitor(Platform& platform)
         : platform(platform) {
-        fp_type = platform.is_single_precision() ? ast::AstNodeType::FLOAT : ast::AstNodeType::DOUBLE;
-        }
+        fp_type = platform.is_single_precision() ? ast::AstNodeType::FLOAT
+                                                 : ast::AstNodeType::DOUBLE;
+    }
 
     const InstanceVarHelper& get_instance_var_helper() {
         return instance_var_helper;

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.hpp
@@ -120,10 +120,13 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
     /// create new InstanceStruct
     std::shared_ptr<ast::InstanceStruct> create_instance_struct();
 
+  private:
+    /// floating-point type
+    ast::AstNodeType fp_type;
+
   public:
-    /// default integer and float node type
+    /// default integer type
     static const ast::AstNodeType INTEGER_TYPE;
-    static const ast::AstNodeType FLOAT_TYPE;
 
     // node count, voltage and node index variables
     static const std::string NODECOUNT_VAR;
@@ -131,7 +134,9 @@ class CodegenLLVMHelperVisitor: public visitor::AstVisitor {
     static const std::string NODE_INDEX_VAR;
 
     CodegenLLVMHelperVisitor(Platform& platform)
-        : platform(platform) {}
+        : platform(platform) {
+        fp_type = platform.is_single_precision() ? ast::AstNodeType::FLOAT : ast::AstNodeType::DOUBLE;
+        }
 
     const InstanceVarHelper& get_instance_var_helper() {
         return instance_var_helper;

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -225,6 +225,7 @@ llvm::Type* CodegenLLVMVisitor::get_codegen_var_type(const ast::CodegenVarType& 
     switch (node.get_type()) {
     case ast::AstNodeType::BOOLEAN:
         return ir_builder.get_boolean_type();
+    case ast::AstNodeType::FLOAT:
     case ast::AstNodeType::DOUBLE:
         return ir_builder.get_fp_type();
     case ast::AstNodeType::INSTANCE_STRUCT:
@@ -255,6 +256,7 @@ llvm::Type* CodegenLLVMVisitor::get_instance_struct_type() {
 
         // Create the corresponding LLVM type.
         switch (nmodl_type) {
+        case ast::AstNodeType::FLOAT:
         case ast::AstNodeType::DOUBLE:
             member_types.push_back(is_pointer ? ir_builder.get_fp_ptr_type()
                                               : ir_builder.get_fp_type());
@@ -756,6 +758,10 @@ void CodegenLLVMVisitor::visit_double(const ast::Double& node) {
     ir_builder.create_fp_constant(node.get_value());
 }
 
+void CodegenLLVMVisitor::visit_float(const ast::Float& node) {
+    ir_builder.create_fp_constant(node.get_value());
+}
+
 void CodegenLLVMVisitor::visit_function_block(const ast::FunctionBlock& node) {
     // do nothing. \todo: remove old function blocks from ast.
 }
@@ -952,6 +958,7 @@ void CodegenLLVMVisitor::print_mechanism_range_var_structure() {
                                       var_name));                             \
         break;
 
+            DISPATCH(ast::AstNodeType::FLOAT, "float");
             DISPATCH(ast::AstNodeType::DOUBLE, "double");
             DISPATCH(ast::AstNodeType::INTEGER, "int");
 

--- a/src/codegen/llvm/codegen_llvm_visitor.hpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.hpp
@@ -173,6 +173,7 @@ class CodegenLLVMVisitor: public CodegenCVisitor {
     void visit_codegen_thread_id(const ast::CodegenThreadId& node) override;
     void visit_codegen_var_list_statement(const ast::CodegenVarListStatement& node) override;
     void visit_double(const ast::Double& node) override;
+    void visit_float(const ast::Float& node) override;
     void visit_function_block(const ast::FunctionBlock& node) override;
     void visit_function_call(const ast::FunctionCall& node) override;
     void visit_if_statement(const ast::IfStatement& node) override;
@@ -196,9 +197,6 @@ class CodegenLLVMVisitor: public CodegenCVisitor {
     }
     void visit_else_statement(const ast::ElseStatement& node) override {
         visitor::ConstAstVisitor::visit_else_statement(node);
-    }
-    void visit_float(const ast::Float& node) override {
-        visitor::ConstAstVisitor::visit_float(node);
     }
     void visit_from_statement(const ast::FromStatement& node) override {
         visitor::ConstAstVisitor::visit_from_statement(node);

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -394,7 +394,7 @@ SCENARIO("Simple vectorised kernel", "[llvm][runner]") {
         NeuronSolveVisitor().visit_program(*ast);
         SolveBlockVisitor().visit_program(*ast);
 
-        codegen::Platform simd_cpu_platform(/*use_single_precision=*/false,
+        codegen::Platform simd_cpu_platform(/*use_single_precision=*/true,
                                             /*instruction_width=*/4);
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
@@ -410,21 +410,21 @@ SCENARIO("Simple vectorised kernel", "[llvm][runner]") {
         auto instance_data = codegen_data.create_data(num_elements, /*seed=*/1);
 
         // Fill the instance struct data with some values for unit testing.
-        std::vector<double> x = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
-        std::vector<double> x0 = {11.0, 11.0, 11.0, 11.0, 11.0, 11.0, 11.0, 11.0, 11.0, 11.0};
-        std::vector<double> x1 = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+        std::vector<float> x = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+        std::vector<float> x0 = {11.0, 11.0, 11.0, 11.0, 11.0, 11.0, 11.0, 11.0, 11.0, 11.0};
+        std::vector<float> x1 = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
 
-        std::vector<double> voltage = {3.0, 4.0, 7.0, 1.0, 2.0, 5.0, 8.0, 6.0, 10.0, 9.0};
+        std::vector<float> voltage = {3.0, 4.0, 7.0, 1.0, 2.0, 5.0, 8.0, 6.0, 10.0, 9.0};
         std::vector<int> node_index = {3, 4, 0, 1, 5, 7, 2, 6, 9, 8};
 
         InstanceTestInfo instance_info{&instance_data,
                                        llvm_visitor.get_instance_var_helper(),
                                        num_elements};
-        initialise_instance_variable<double>(instance_info, x, "x");
-        initialise_instance_variable<double>(instance_info, x0, "x0");
-        initialise_instance_variable<double>(instance_info, x1, "x1");
+        initialise_instance_variable<float>(instance_info, x, "x");
+        initialise_instance_variable<float>(instance_info, x0, "x0");
+        initialise_instance_variable<float>(instance_info, x1, "x1");
 
-        initialise_instance_variable<double>(instance_info, voltage, "voltage");
+        initialise_instance_variable<float>(instance_info, voltage, "voltage");
         initialise_instance_variable<int>(instance_info, node_index, "node_index");
 
         // Set up the JIT runner.
@@ -436,13 +436,13 @@ SCENARIO("Simple vectorised kernel", "[llvm][runner]") {
             runner.run_with_argument<int, void*>("__nrn_state_test_wrapper",
                                                  instance_data.base_ptr);
             // Check that the main and remainder loops correctly change the data stored in x.
-            std::vector<double> x_expected = {10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0};
-            REQUIRE(check_instance_variable<double>(instance_info, x_expected, "x"));
+            std::vector<float> x_expected = {10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0};
+            REQUIRE(check_instance_variable<float>(instance_info, x_expected, "x"));
 
             // Check that the gather load produces correct results in y:
             //   y[id] = voltage[node_index[id]]
-            std::vector<double> y_expected = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
-            REQUIRE(check_instance_variable<double>(instance_info, y_expected, "y"));
+            std::vector<float> y_expected = {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0};
+            REQUIRE(check_instance_variable<float>(instance_info, y_expected, "y"));
         }
     }
 }

--- a/test/unit/codegen/codegen_llvm_instance_struct.cpp
+++ b/test/unit/codegen/codegen_llvm_instance_struct.cpp
@@ -131,51 +131,51 @@ SCENARIO("Instance Struct creation", "[visitor][llvm][instance_struct]") {
             size_t node_count_index = 19;
             // Check if the various instance struct fields are properly initialized
             REQUIRE(compare(instance_data.members[minf_index],
-                            generate_dummy_data<double>(minf_index, num_elements)));
+                            generate_dummy_data<float>(minf_index, num_elements)));
             REQUIRE(compare(instance_data.members[ena_index],
-                            generate_dummy_data<double>(ena_index, num_elements)));
+                            generate_dummy_data<float>(ena_index, num_elements)));
             REQUIRE(compare(instance_data.members[ion_ena_index],
-                            generate_dummy_data<double>(ion_ena_index, num_elements)));
+                            generate_dummy_data<float>(ion_ena_index, num_elements)));
             // index variables are offsets, they start from 0
             REQUIRE(compare(instance_data.members[ion_ena_index_index],
                             generate_dummy_data<int>(0, num_elements)));
             REQUIRE(compare(instance_data.members[node_index_index],
                             generate_dummy_data<int>(0, num_elements)));
 
-            REQUIRE(*static_cast<double*>(instance_data.members[t_index]) ==
+            REQUIRE(*static_cast<float*>(instance_data.members[t_index]) ==
                     default_nthread_t_value);
             REQUIRE(*static_cast<int*>(instance_data.members[node_count_index]) == num_elements);
 
             // Hard code TestInstanceType struct
             struct TestInstanceType {
-                double* minf;
-                double* mtau;
-                double* m;
-                double* Dm;
-                double* ena;
-                double* v_unused;
-                double* g_unused;
-                double* ion_ena;
+                float* minf;
+                float* mtau;
+                float* m;
+                float* Dm;
+                float* ena;
+                float* v_unused;
+                float* g_unused;
+                float* ion_ena;
                 int* ion_ena_index;
-                double* voltage;
+                float* voltage;
                 int* node_index;
-                double* vec_rhs;
-                double* vec_d;
-                double* _shadow_rhs;
-                double* _shadow_d;
-                double t;
-                double dt;
-                double celsius;
+                float* vec_rhs;
+                float* vec_d;
+                float* _shadow_rhs;
+                float* _shadow_d;
+                float t;
+                float dt;
+                float celsius;
                 int secondorder;
                 int node_count;
             };
             // Test if TestInstanceType struct is properly initialized
             // Cast void ptr instance_data.base_ptr to TestInstanceType*
             TestInstanceType* instance = (TestInstanceType*) instance_data.base_ptr;
-            REQUIRE(compare(instance->minf, generate_dummy_data<double>(minf_index, num_elements)));
-            REQUIRE(compare(instance->ena, generate_dummy_data<double>(ena_index, num_elements)));
+            REQUIRE(compare(instance->minf, generate_dummy_data<float>(minf_index, num_elements)));
+            REQUIRE(compare(instance->ena, generate_dummy_data<float>(ena_index, num_elements)));
             REQUIRE(compare(instance->ion_ena,
-                            generate_dummy_data<double>(ion_ena_index, num_elements)));
+                            generate_dummy_data<float>(ion_ena_index, num_elements)));
             REQUIRE(compare(instance->node_index, generate_dummy_data<int>(0, num_elements)));
             REQUIRE(instance->t == default_nthread_t_value);
             REQUIRE(instance->celsius == default_celsius_value);

--- a/test/unit/codegen/codegen_llvm_instance_struct.cpp
+++ b/test/unit/codegen/codegen_llvm_instance_struct.cpp
@@ -105,7 +105,7 @@ SCENARIO("Instance Struct creation", "[visitor][llvm][instance_struct]") {
             constexpr static double seed = 42;
             auto instance_data = generate_instance_data(nmodl_text,
                                                         /*opt_level=*/0,
-                                                        /*use_single_precision=*/true,
+                                                        /*use_single_precision=*/false,
                                                         /*vector_width*/ 1,
                                                         num_elements,
                                                         seed);
@@ -131,51 +131,51 @@ SCENARIO("Instance Struct creation", "[visitor][llvm][instance_struct]") {
             size_t node_count_index = 19;
             // Check if the various instance struct fields are properly initialized
             REQUIRE(compare(instance_data.members[minf_index],
-                            generate_dummy_data<float>(minf_index, num_elements)));
+                            generate_dummy_data<double>(minf_index, num_elements)));
             REQUIRE(compare(instance_data.members[ena_index],
-                            generate_dummy_data<float>(ena_index, num_elements)));
+                            generate_dummy_data<double>(ena_index, num_elements)));
             REQUIRE(compare(instance_data.members[ion_ena_index],
-                            generate_dummy_data<float>(ion_ena_index, num_elements)));
+                            generate_dummy_data<double>(ion_ena_index, num_elements)));
             // index variables are offsets, they start from 0
             REQUIRE(compare(instance_data.members[ion_ena_index_index],
                             generate_dummy_data<int>(0, num_elements)));
             REQUIRE(compare(instance_data.members[node_index_index],
                             generate_dummy_data<int>(0, num_elements)));
 
-            REQUIRE(*static_cast<float*>(instance_data.members[t_index]) ==
+            REQUIRE(*static_cast<double*>(instance_data.members[t_index]) ==
                     default_nthread_t_value);
             REQUIRE(*static_cast<int*>(instance_data.members[node_count_index]) == num_elements);
 
             // Hard code TestInstanceType struct
             struct TestInstanceType {
-                float* minf;
-                float* mtau;
-                float* m;
-                float* Dm;
-                float* ena;
-                float* v_unused;
-                float* g_unused;
-                float* ion_ena;
+                double* minf;
+                double* mtau;
+                double* m;
+                double* Dm;
+                double* ena;
+                double* v_unused;
+                double* g_unused;
+                double* ion_ena;
                 int* ion_ena_index;
-                float* voltage;
+                double* voltage;
                 int* node_index;
-                float* vec_rhs;
-                float* vec_d;
-                float* _shadow_rhs;
-                float* _shadow_d;
-                float t;
-                float dt;
-                float celsius;
+                double* vec_rhs;
+                double* vec_d;
+                double* _shadow_rhs;
+                double* _shadow_d;
+                double t;
+                double dt;
+                double celsius;
                 int secondorder;
                 int node_count;
             };
             // Test if TestInstanceType struct is properly initialized
             // Cast void ptr instance_data.base_ptr to TestInstanceType*
             TestInstanceType* instance = (TestInstanceType*) instance_data.base_ptr;
-            REQUIRE(compare(instance->minf, generate_dummy_data<float>(minf_index, num_elements)));
-            REQUIRE(compare(instance->ena, generate_dummy_data<float>(ena_index, num_elements)));
+            REQUIRE(compare(instance->minf, generate_dummy_data<double>(minf_index, num_elements)));
+            REQUIRE(compare(instance->ena, generate_dummy_data<double>(ena_index, num_elements)));
             REQUIRE(compare(instance->ion_ena,
-                            generate_dummy_data<float>(ion_ena_index, num_elements)));
+                            generate_dummy_data<double>(ion_ena_index, num_elements)));
             REQUIRE(compare(instance->node_index, generate_dummy_data<int>(0, num_elements)));
             REQUIRE(instance->t == default_nthread_t_value);
             REQUIRE(instance->celsius == default_celsius_value);


### PR DESCRIPTION
This PR fixes how single-precision floats are handles in LLVM
helper visitor. Before, `DOUBLE` was always created which was
not consistent with LLVM visitor (that lowered `DOUBLE` to 32-
or 64-bit types) and instance struct initialisation in testing (which
assumed that for `DOUBLE` it always holds that
`sizeof(double) = 8`).

Now, there is a clear separation between `FLOAT` and `DOUBLE`
values in helper visitor.


Note: this bug was not discovered before since execution tests were
only considering doubles. So, one of the tests was changed to use
floats.