### PR TITLE
[LLVM] Fixes compilation with LLVM codegen disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,9 @@ set(MEMORYCHECK_COMMAND_OPTIONS
 # do not enable tests if nmodl is used as submodule
 if(NOT NMODL_AS_SUBPROJECT)
   include(CTest)
-  add_subdirectory(test/benchmark)
+  if(NMODL_ENABLE_LLVM)
+    add_subdirectory(test/benchmark)
+  endif()
   add_subdirectory(test/unit)
   add_subdirectory(test/integration)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,8 +27,8 @@ set(NMODL_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 add_executable(nmodl ${NMODL_SOURCE_FILES})
 target_link_libraries(
   nmodl
-  printer
   codegen
+  printer
   visitor
   symtab
   util

--- a/src/codegen/codegen_driver.cpp
+++ b/src/codegen/codegen_driver.cpp
@@ -181,7 +181,11 @@ bool CodegenDriver::prepare_mod(std::shared_ptr<ast::Program> node, const std::s
     /// that old symbols (e.g. prime variables) are not lost
     update_symtab = true;
 
+#ifdef NMODL_LLVM_BACKEND
     if (cfg.nmodl_inline || cfg.llvm_ir) {
+#else
+    if (cfg.nmodl_inline) {
+#endif
         logger->info("Running nmodl inline visitor");
         InlineVisitor().visit_program(*node);
         ast_to_nmodl(*node, filepath("inline", "mod"));

--- a/src/pybind/pynmodl.cpp
+++ b/src/pybind/pynmodl.cpp
@@ -12,12 +12,15 @@
 
 #include "ast/program.hpp"
 #include "codegen/codegen_driver.hpp"
-#include "codegen/llvm/codegen_llvm_visitor.hpp"
 #include "config/config.h"
 #include "parser/nmodl_driver.hpp"
 #include "pybind/pybind_utils.hpp"
-#include "test/benchmark/llvm_benchmark.hpp"
 #include "visitors/visitor_utils.hpp"
+
+#ifdef NMODL_LLVM_BACKEND
+#include "codegen/llvm/codegen_llvm_visitor.hpp"
+#include "test/benchmark/llvm_benchmark.hpp"
+#endif
 
 /**
  * \dir
@@ -110,9 +113,11 @@ static const char* to_json = R"(
     '{"Program":[{"NeuronBlock":[{"StatementBlock":[]}]}]}'
 )";
 
+#ifdef NMODL_LLVM_BACKEND
 static const char* jit = R"(
     This is the Jit class documentation
 )";
+#endif
 
 }  // namespace docstring
 
@@ -137,6 +142,7 @@ class PyNmodlDriver: public nmodl::parser::NmodlDriver {
     }
 };
 
+#ifdef NMODL_LLVM_BACKEND
 class JitDriver {
   private:
     nmodl::codegen::Platform platform;
@@ -210,6 +216,7 @@ class JitDriver {
         return benchmark.run();
     }
 };
+#endif
 
 }  // namespace nmodl
 
@@ -245,8 +252,10 @@ PYBIND11_MODULE(_nmodl, m_nmodl) {
     py::class_<nmodl::codegen::CodeGenConfig> cfg(m_nmodl, "CodeGenConfig");
     cfg.def(py::init([]() {
            auto cfg = std::make_unique<nmodl::codegen::CodeGenConfig>();
+#ifdef NMODL_LLVM_BACKEND
            // set to more sensible defaults for python binding
            cfg->llvm_ir = true;
+#endif
            return cfg;
        }))
         .def_readwrite("sympy_analytic", &nmodl::codegen::CodeGenConfig::sympy_analytic)
@@ -275,6 +284,7 @@ PYBIND11_MODULE(_nmodl, m_nmodl) {
         .def_readwrite("nmodl_ast", &nmodl::codegen::CodeGenConfig::nmodl_ast)
         .def_readwrite("json_ast", &nmodl::codegen::CodeGenConfig::json_ast)
         .def_readwrite("json_perfstat", &nmodl::codegen::CodeGenConfig::json_perfstat)
+#ifdef NMODL_LLVM_BACKEND
         .def_readwrite("llvm_ir", &nmodl::codegen::CodeGenConfig::llvm_ir)
         .def_readwrite("llvm_float_type", &nmodl::codegen::CodeGenConfig::llvm_float_type)
         .def_readwrite("llvm_opt_level_ir", &nmodl::codegen::CodeGenConfig::llvm_opt_level_ir)
@@ -301,6 +311,9 @@ PYBIND11_MODULE(_nmodl, m_nmodl) {
              "instance_size"_a,
              "cuda_grid_dim_x"_a = 1,
              "cuda_block_dim_x"_a = 1);
+#else
+        ;
+#endif
 
     m_nmodl.def("to_nmodl",
                 static_cast<std::string (*)(const nmodl::ast::Ast&,


### PR DESCRIPTION
- Makes sure that `llvm` branch compiles with `LLVM` codegen and `Python bindings` disabled or enabled
- Selectively enables options of Python Codegen and Python JIT Driver
- Fixes the order of linkage of static variables for the generation of `nmodl` binary