### PR TITLE
Relax constraints of GPU nodes to allocate in GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,7 +83,7 @@ test:intel:
     bb5_cpus_per_task: 1
     bb5_memory: 16G
     bb5_exclusive: full
-    bb5_constraint: gpu_32g # CascadeLake CPU & V100 GPU node
+    bb5_constraint: volta # V100 GPU node
 
 .build_allocation:
   variables:


### PR DESCRIPTION
- Instead of trying to allocate a CascadeLake + Volta node which might be allocated/down allocate a Volta node with whatever CPU to run the GPU benchmarking tests