### PR TITLE
Update GitHub Actions CI, minor CMake fixes.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,37 +16,37 @@ on:
       - release/**
 
 env:
-  BUILD_TYPE: Release
-  CTEST_PARALLEL_LEVEL: 1
   CMAKE_BUILD_PARALLEL_LEVEL: 3
-  DEFAULT_PY_VERSION: 3.8
+  CTEST_PARALLEL_LEVEL: 1
   DESIRED_CMAKE_VERSION: 3.15.0
+  PYTHON_VERSION: 3.8
 
 jobs:
   coverage:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     name: "Coverage Test"
     steps:
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1
+        with:
+          cmake-version: ${{ env.DESIRED_CMAKE_VERSION }}
       - name: Install packages
         run: |
           sudo apt-get install bison ccache flex lcov libfl-dev ninja-build \
             python3-dev python3-pip
         shell: bash
       - name: Set up Python3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-        env:
-          PYTHON_VERSION:  ${{ env.DEFAULT_PY_VERSION }}
       - name: Install Python3 dependencies
         run: |
-          pip3 install -U pip setuptools scikit-build Jinja2 PyYAML pytest \
-            'sympy>=1.3,<1.9'
-      - uses: actions/checkout@v2
+          pip3 install -U pip setuptools scikit-build Jinja2 PyYAML pytest sympy
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - name: Restore compiler cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{runner.workspace}}/ccache
@@ -62,7 +62,8 @@ jobs:
           mkdir build && cd build
           cmake .. -G Ninja \
             -DPYTHON_EXECUTABLE=$(which python3) \
-            -DCMAKE_CXX_FLAGS="-coverage -O0" \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_FLAGS="-coverage" \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           ccache -z
           ccache -s

--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   CTEST_PARALLEL_LEVEL: 1
-  DEFAULT_PY_VERSION: 3.8
+  PYTHON_VERSION: 3.8
   DESIRED_CMAKE_VERSION: 3.15.0
 
 jobs:
@@ -27,9 +27,9 @@ jobs:
       matrix:
         # Core counts taken from https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
         include:
-          - os: ubuntu-18.04
-            cores: 2
           - os: ubuntu-20.04
+            cores: 2
+          - os: ubuntu-22.04
             cores: 2
           - os: macos-10.15
             cores: 3
@@ -40,7 +40,7 @@ jobs:
       CMAKE_BUILD_PARALLEL_LEVEL: ${{matrix.cores}}
     steps:
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.4
+        uses: jwlawson/actions-setup-cmake@v1
         with:
           cmake-version: ${{ env.DESIRED_CMAKE_VERSION }}
 
@@ -58,18 +58,16 @@ jobs:
         shell: bash
 
       - name: Set up Python3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-        env:
-          PYTHON_VERSION:  ${{ env.DEFAULT_PY_VERSION }}
 
       - name: Install Python3 dependencies
         run: |
           pip3 install -U pip setuptools scikit-build Jinja2 PyYAML pytest \
-            'sympy>=1.3,<1.9' 'cmake-format==0.6.13'
+            sympy 'cmake-format==0.6.13'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Configure
         shell: bash
@@ -98,7 +96,7 @@ jobs:
           exit ${status}
 
       - name: Restore compiler cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{runner.workspace}}/ccache
@@ -137,7 +135,7 @@ jobs:
           echo "------- Installing -------"
           cmake --build . --target install
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ctest-results-${{matrix.os}}
           path: ${{runner.workspace}}/nmodl/build/Testing/*/Test.xml
@@ -164,7 +162,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.11
+        uses: jwlawson/actions-setup-cmake@v1
 
       - name: Install apt packages
         run: |
@@ -180,16 +178,16 @@ jobs:
         shell: bash
 
       - name: Set up Python3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Python3 dependencies
         run: |
           pip3 install -U pip setuptools scikit-build Jinja2 PyYAML pytest \
             'sympy>=1.3,<1.9'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Configure
         shell: bash
@@ -241,7 +239,7 @@ jobs:
           INSTALL_DIR: ${{ runner.workspace }}/install
 
       - name: Restore compiler cache
-        uses: pat-s/always-upload-cache@v2
+        uses: pat-s/always-upload-cache@v3
         with:
           path: |
             ${{runner.workspace}}/ccache
@@ -292,7 +290,7 @@ jobs:
           fi
           ctest -T Test --output-on-failure
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ctest-results-${{matrix.sanitizer}}-sanitizer
           path: ${{runner.workspace}}/nmodl/build/Testing/*/Test.xml

--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -184,8 +184,7 @@ jobs:
 
       - name: Install Python3 dependencies
         run: |
-          pip3 install -U pip setuptools scikit-build Jinja2 PyYAML pytest \
-            'sympy>=1.3,<1.9'
+          pip3 install -U pip setuptools scikit-build Jinja2 PyYAML pytest sympy
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/nmodl-doc.yml
+++ b/.github/workflows/nmodl-doc.yml
@@ -16,12 +16,12 @@ on:
 
 env:
   BUILD_TYPE: Release
-  DEFAULT_PY_VERSION: 3.8
+  PYTHON_VERSION: 3.8
   DESIRED_CMAKE_VERSION: 3.15.0
 
 jobs:
   ci:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     name: documentation
 
@@ -34,7 +34,7 @@ jobs:
     steps:
 
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.4
+        uses: jwlawson/actions-setup-cmake@v1
         with:
           cmake-version: ${{ env.DESIRED_CMAKE_VERSION }}
           
@@ -47,18 +47,16 @@ jobs:
         shell: bash
 
       - name: Set up Python3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-        env:
-          PYTHON_VERSION:  ${{ env.DEFAULT_PY_VERSION }}
        
       - name: Install Python3 dependencies
         run: |
           pip3 install -U pip setuptools scikit-build Jinja2 PyYAML pytest \
-            'sympy>=1.3,<1.9'
+            sympy
           
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         
       # This step will set up an SSH connection on tmate.io for live debugging.
       # To trigger it, simply add 'live-debug-docs' to your last pushed commit message.
@@ -67,7 +65,7 @@ jobs:
         uses: mxschmitt/action-tmate@v3
 
       - name: Restore compiler cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ${{runner.workspace}}/ccache
@@ -94,11 +92,9 @@ jobs:
           CCACHE_DIR: ${{runner.workspace}}/ccache
           
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@v4
         if: steps.documentation.outputs.status == 'done' && startsWith(github.ref, 'refs/heads/master')
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: ${{runner.workspace}}/nmodl/_skbuild/linux-x86_64-3.8/setuptools/sphinx # The folder the action should deploy.
-          CLEAN: false # Automatically remove deleted files from the deploy branch
-
+          branch: gh-pages # The branch the action should deploy to.
+          folder: ${{runner.workspace}}/nmodl/_skbuild/linux-x86_64-3.8/setuptools/sphinx # The folder the action should deploy.
+          clean: false # Automatically remove deleted files from the deploy branch

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,15 +89,17 @@ set(NMODL_CMakeFormat_EXCLUDES_RE
     CACHE STRING "list of regular expressions to exclude CMake files from formatting" FORCE)
 
 # initialize submodule of coding conventions under cmake
-set(THIRD_PARTY_DIRECTORY "${PROJECT_SOURCE_DIR}/cmake")
-add_external_project(hpc-coding-conventions OFF)
+if(NOT EXISTS "${PROJECT_SOURCE_DIR}/cmake/hpc-coding-conventions/cpp/CMakeLists.txt")
+  initialize_submodule("${PROJECT_SOURCE_DIR}/cmake/hpc-coding-conventions")
+endif()
+set(CODING_CONV_PREFIX NMODL)
 add_subdirectory(cmake/hpc-coding-conventions/cpp)
 include(cmake/hpc-coding-conventions/cpp/cmake/FindClangFormat.cmake)
 
 # =============================================================================
-# Initialize external libraries as submodule
+# Initialize external libraries as submodules
 # =============================================================================
-set(NMODL_3RDPARTY_DIR "${PROJECT_SOURCE_DIR}/ext")
+set(NMODL_3RDPARTY_DIR ext)
 include(cmake/hpc-coding-conventions/cpp/cmake/3rdparty.cmake)
 cpp_cc_git_submodule(catch2 BUILD PACKAGE Catch2 REQUIRED)
 if(NMODL_3RDPARTY_USE_CATCH2)
@@ -106,7 +108,11 @@ if(NMODL_3RDPARTY_USE_CATCH2)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/ext/catch2/contrib")
 endif()
 include(Catch)
-cpp_cc_git_submodule(cli11 BUILD PACKAGE CLI11 REQUIRED)
+# If we're being built as a submodule of CoreNEURON then CoreNEURON may have already found/loaded a
+# CLI11 submodule.
+if(NOT TARGET CLI11::CLI11)
+  cpp_cc_git_submodule(cli11 BUILD PACKAGE CLI11 REQUIRED)
+endif()
 # For the moment do not try and use an external Eigen.
 cpp_cc_git_submodule(eigen)
 cpp_cc_git_submodule(fmt BUILD PACKAGE fmt REQUIRED)

--- a/cmake/ExternalProjectHelper.cmake
+++ b/cmake/ExternalProjectHelper.cmake
@@ -10,16 +10,3 @@ function(initialize_submodule path)
   execute_process(COMMAND git submodule update --init -- ${path}
                   WORKING_DIRECTORY ${NMODL_PROJECT_SOURCE_DIR})
 endfunction()
-
-# check for external project and initialize submodule if it is missing
-function(add_external_project name)
-  find_path(
-    ${name}_PATH
-    NAMES CMakeLists.txt
-    PATHS "${THIRD_PARTY_DIRECTORY}/${name}")
-  if(NOT EXISTS ${${name}_PATH})
-    initialize_submodule("${THIRD_PARTY_DIRECTORY}/${name}")
-  else()
-    message(STATUS "Sub-project : using ${name} from \"${THIRD_PARTY_DIRECTORY}/${name}\"")
-  endif()
-endfunction()


### PR DESCRIPTION
- Only pin major versions, update some of those.
  - See https://github.com/JamesIves/github-pages-deploy-action/discussions/592
- Drop sympy version constraints.
- Coverage from a Debug, not Release, build.
- Prefer `ubuntu-20.04` to `ubuntu-18.04`, add `ubuntu-22.04` too.
- Drop `add_external_project` helper that was only used to bootstrap `hpc-coding-conventions`.
- Do not add a CLI11 submodule if the relevant targets already exist, this fixes some combinations of NMODL-as-a-submodule build.
- Fix `NMODL_3RDPARTY_DIR` to avoid the absolute path being prepended twice.