### PR TITLE
[LLVM] Codegen visitor for printing generating benchmarking kernels

### DIFF
--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -4,6 +4,8 @@
 set(CODEGEN_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_acc_visitor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_acc_visitor.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/codegen_benchmark_visitor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/codegen_benchmark_visitor.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_compatibility_visitor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_compatibility_visitor.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_cuda_visitor.cpp

--- a/src/codegen/codegen_benchmark_visitor.hpp
+++ b/src/codegen/codegen_benchmark_visitor.hpp
@@ -1,0 +1,160 @@
+/*************************************************************************
+ * Copyright (C) 2018-2022 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#pragma once
+
+/**
+ * \file
+ * \brief \copybrief nmodl::codegen::CodegenBenchmarkVisitor
+ */
+
+#include "codegen/codegen_acc_visitor.hpp"
+
+
+namespace nmodl {
+namespace codegen {
+
+/**
+ * @addtogroup codegen_backends
+ * @{
+ */
+
+/**
+ * \class CodegenBenchmarkVisitor
+ * \brief %Visitor for printing C code with OpenACC backend
+ */
+class CodegenBenchmarkVisitor: public CodegenAccVisitor {
+  protected:
+    /// name of the code generation backend
+    std::string backend_name() const override;
+
+
+    /// common includes : standard c/c++, coreneuron and backend specific
+    void print_backend_includes() override;
+
+
+    /// ivdep like annotation for channel iterations
+    void print_channel_iteration_block_parallel_hint(BlockType type) override;
+
+
+    /// atomic update pragma for reduction statements
+    void print_atomic_reduction_pragma() override;
+
+
+    /// memory allocation routine
+    void print_memory_allocation_routine() const override;
+
+
+    /// abort routine
+    void print_abort_routine() const override;
+
+
+    /// annotations like "acc enter data present(...)" for main kernel
+    void print_kernel_data_present_annotation_block_begin() override;
+
+
+    /// end of annotation like "acc enter data"
+    void print_kernel_data_present_annotation_block_end() override;
+
+
+    /// start of annotation "acc kernels" for net_init kernel
+    void print_net_init_acc_serial_annotation_block_begin() override;
+
+
+    /// end of annotation "acc kernels" for net_init kernel
+    void print_net_init_acc_serial_annotation_block_end() override;
+
+
+    /// update to matrix elements with/without shadow vectors
+    void print_nrn_cur_matrix_shadow_update() override;
+
+
+    /// reduction to matrix elements from shadow vectors
+    void print_nrn_cur_matrix_shadow_reduction() override;
+
+    /// fast membrane current calculation
+    void print_fast_imem_calculation() override;
+
+    /// setup method for setting matrix shadow vectors
+    void print_rhs_d_shadow_variables() override;
+
+
+    /// if reduction block in nrn_cur required
+    bool nrn_cur_reduction_loop_required() override;
+
+
+    /// create global variable on the device
+    void print_global_variable_device_create_annotation_pre() override;
+    void print_global_variable_device_create_annotation_post() override;
+
+    /// update global variable from host to the device
+    void print_global_variable_device_update_annotation() override;
+
+    /// transfer newtonspace structure to device
+    void print_newtonspace_transfer_to_device() const override;
+
+    // update instance variable object pointer on the gpu device
+    void print_instance_variable_transfer_to_device() const override;
+
+    // update derivimplicit advance flag on the gpu device
+    void print_deriv_advance_flag_transfer_to_device() const override;
+
+    // update NetSendBuffer_t count from device to host
+    void print_net_send_buf_count_update_to_host() const override;
+
+    // update NetSendBuffer_t from device to host
+    void print_net_send_buf_update_to_host() const override;
+
+    // update NetSendBuffer_t count from host to device
+    virtual void print_net_send_buf_count_update_to_device() const override;
+
+    // update dt from host to device
+    virtual void print_dt_update_to_device() const override;
+
+    // synchronise/wait on stream specific to NrnThread
+    virtual void print_device_stream_wait() const override;
+
+    // print atomic capture pragma
+    void print_device_atomic_capture_annotation() const override;
+
+    std::string get_variable_device_pointer(const std::string& variable,
+                                            const std::string& type) const override;
+
+
+    void print_net_send_buffering_grow() override;
+
+
+    void print_eigen_linear_solver(const std::string& float_type, int N) override;
+
+    void visit_codegen_var_type(const ast::CodegenVarType& node) override;
+    void visit_codegen_atomic_statement(const ast::CodegenAtomicStatement& node) override;
+    void visit_codegen_for_statement(const ast::CodegenForStatement& node) override;
+    void visit_codegen_function(const ast::CodegenFunction& node) override;
+    void visit_codegen_return_statement(const ast::CodegenReturnStatement& node) override;
+    void visit_codegen_var_list_statement(const ast::CodegenVarListStatement& node) override;
+    void visit_codegen_instance_var(const ast::CodegenInstanceVar& node) override;
+
+  public:
+    CodegenBenchmarkVisitor(const std::string& mod_file,
+                      const std::string& output_dir,
+                      const std::string& float_type,
+                      bool optimize_ionvar_copies)
+        : CodegenAccVisitor(mod_file, output_dir, float_type, optimize_ionvar_copies) {}
+
+    CodegenBenchmarkVisitor(const std::string& mod_file,
+                      std::ostream& stream,
+                      const std::string& float_type,
+                      bool optimize_ionvar_copies)
+        : CodegenAccVisitor(mod_file, stream, float_type, optimize_ionvar_copies) {}
+
+    void visit_program(const ast::Program& node) override;
+};
+
+/** @} */  // end of codegen_backends
+
+}  // namespace codegen
+}  // namespace nmodl

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -97,6 +97,7 @@ void CodegenCVisitor::visit_boolean(const Boolean& node) {
 
 
 void CodegenCVisitor::visit_name(const Name& node) {
+
     if (!codegen) {
         return;
     }

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -195,6 +195,8 @@ void CodegenLLVMHelperVisitor::create_function_for_node(ast::Block& node) {
     auto function = std::make_shared<ast::CodegenFunction>(fun_ret_type, name, arguments, block);
     if (node.get_token()) {
         function->set_token(*node.get_token()->clone());
+    } else {
+        function->set_token(ModToken());
     }
     codegen_functions.push_back(function);
 }
@@ -733,6 +735,7 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
     /// finally, create new function
     auto function =
         std::make_shared<ast::CodegenFunction>(return_type, name, code_arguments, function_block);
+    function->set_token(ModToken());
     codegen_functions.push_back(function);
 
     // todo: remove this, temporary
@@ -1098,6 +1101,7 @@ void CodegenLLVMHelperVisitor::visit_breakpoint_block(ast::BreakpointBlock& node
                                                                name,
                                                                code_arguments,
                                                                function_block);
+        function->set_token(ModToken());
         codegen_functions.push_back(function);
 
         // todo: remove this, temporary

--- a/src/language/node_info.py
+++ b/src/language/node_info.py
@@ -93,7 +93,8 @@ SYMBOL_BLOCK_TYPES = {"FunctionBlock",
                       "DiscreteBlock",
                       "PartialBlock",
                       "KineticBlock",
-                      "FunctionTableBlock"
+                      "FunctionTableBlock",
+                      "CodegenFunction"
                       }
 
 # nodes which need extra handling to augument symbol table

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include <CLI/CLI.hpp>
 
 #include "codegen/codegen_acc_visitor.hpp"
+#include "codegen/codegen_benchmark_visitor.hpp"
 #include "codegen/codegen_c_visitor.hpp"
 #include "codegen/codegen_cuda_visitor.hpp"
 #include "codegen/codegen_ispc_visitor.hpp"
@@ -408,6 +409,17 @@ int main(int argc, const char* argv[]) {
                                            !cfg.llvm_no_debug,
                                            cfg.llvm_fast_math_flags);
                 visitor.visit_program(*ast);
+
+                {
+                    logger->info("Running Benchmark code generator");
+                    SymtabVisitor().visit_program(*ast);
+                    CodegenBenchmarkVisitor visitor(modfile + "_kernel",
+                                                    cfg.output_dir,
+                                                    data_type,
+                                                    cfg.optimize_ionvar_copies_codegen);
+                    visitor.visit_program(*ast);
+                }
+
                 if (cfg.nmodl_ast) {
                     NmodlPrintVisitor(filepath("llvm", "mod")).visit_program(*ast);
                     logger->info("AST to NMODL transformation written to {}",

--- a/src/symtab/symbol_properties.cpp
+++ b/src/symtab/symbol_properties.cpp
@@ -166,6 +166,10 @@ std::vector<std::string> to_string_vector(const NmodlType& obj) {
         properties.emplace_back("codegen_var");
     }
 
+    if (has_property(obj, NmodlType::codegen_function)) {
+        properties.emplace_back("codegen_function");
+    }
+
     return properties;
 }
 

--- a/src/symtab/symbol_properties.hpp
+++ b/src/symtab/symbol_properties.hpp
@@ -223,7 +223,10 @@ enum class NmodlType : enum_type {
     define = 1L << 34,
 
     /// Codegen specific variable
-    codegen_var = 1L << 35
+    codegen_var = 1L << 35,
+
+    /// Codegen function
+    codegen_function = 1L << 36
 };
 
 template <typename T>


### PR DESCRIPTION
- [ ]  Generating kernel with `./bin/nmodl hh.mod llvm --ir` but still `InstanceStruct` generation and overall cleaning missing here.