### PR TITLE
Fix for WATCH statement weight vector index for net_send (copy from BlueBrain/mod2c/pull/82)

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3663,7 +3663,7 @@ void CodegenCVisitor::print_watch_check() {
         printer->add_text("net_send_buffering(");
         auto t = get_variable_name("t");
         printer->add_text(
-            fmt::format("ml->_net_send_buffer, 0, {}, 0, {}, {}+0.0, ", tqitem, point_process, t));
+            fmt::format("ml->_net_send_buffer, 0, {}, -1, {}, {}+0.0, ", tqitem, point_process, t));
         watch->get_value()->accept(*this);
         printer->add_text(");");
         printer->add_newline();


### PR DESCRIPTION
See https://github.com/BlueBrain/mod2c/pull/82