### PR TITLE
Minor changes to improve compiler vectorisation

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1116,6 +1116,7 @@ void CodegenCVisitor::print_net_init_acc_serial_annotation_block_end() {
  */
 void CodegenCVisitor::print_channel_iteration_block_parallel_hint(BlockType type) {
     printer->add_line("#pragma ivdep");
+    printer->add_line("#pragma omp simd");
 }
 
 

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -4337,7 +4337,7 @@ void CodegenCVisitor::print_nrn_current(const BreakpointBlock& node) {
     printer->add_newline(2);
     print_device_method_annotation();
     printer->start_block(
-        fmt::format("static inline double nrn_current({})", get_parameter_str(args)));
+        fmt::format("inline double nrn_current_{}({})", info.mod_suffix, get_parameter_str(args)));
     printer->add_line("double current = 0.0;");
     print_statement_block(*block, false, false);
     for (auto& current: info.currents) {
@@ -4388,7 +4388,7 @@ void CodegenCVisitor::print_nrn_cur_conductance_kernel(const BreakpointBlock& no
 
 void CodegenCVisitor::print_nrn_cur_non_conductance_kernel() {
     printer->add_line(
-        fmt::format("double g = nrn_current({}+0.001);", internal_method_arguments()));
+        fmt::format("double g = nrn_current_{}({}+0.001);", info.mod_suffix, internal_method_arguments()));
     for (auto& ion: info.ions) {
         for (auto& var: ion.writes) {
             if (ion.is_ionic_current(var)) {
@@ -4397,7 +4397,7 @@ void CodegenCVisitor::print_nrn_cur_non_conductance_kernel() {
             }
         }
     }
-    printer->add_line(fmt::format("double rhs = nrn_current({});", internal_method_arguments()));
+    printer->add_line(fmt::format("double rhs = nrn_current_{}({});", info.mod_suffix, internal_method_arguments()));
     printer->add_line("g = (g-rhs)/0.001;");
     for (auto& ion: info.ions) {
         for (auto& var: ion.writes) {


### PR DESCRIPTION
* Similar to `#pragma ivdep`, add `#pragma omp simd` which is now commonly available with OpenMP compilers
* Clang inhibits compiler auto-vectorisation when functions being called are declared `static`
  * as `nrn_current` function doesn't need to be static, we can just add unique suffix like all other functions.
  
![image](https://user-images.githubusercontent.com/666852/175090158-685abba6-b4a8-4838-b1c9-78bd99782658.png)

```
# static inline nrn_current()  

x86_64/corenrn/mod2c/hh.cpp:451:9: remark: loop not vectorized (Force=true) [-Rpass-missed=loop-vectorize]
x86_64/corenrn/mod2c/hh.cpp:451:9: warning: loop not vectorized: the optimizer was unable to perform the requested transformation; the transformation might be disabled or specified as part of an unsupported transformation ordering [-Wpass-failed=transform-warning] 


# inline nrn_current()

x86_64/corenrn/mod2c/hh.cpp:451:9: remark: the cost-model indicates that interleaving is not beneficial [-Rpass-analysis=loop-vectorize]
x86_64/corenrn/mod2c/hh.cpp:451:9: remark: vectorized loop (vectorization width: 8, interleaved count: 1) [-Rpass=loop-vectorize]
```

Note: we can further investigate `static inline` aspects with clang but doesn't hurt to get this PR done as part of hackathon.