### PR TITLE
[LLVM][refactoring] Annotations pass and no more wrappers

### DIFF
--- a/src/codegen/llvm/CMakeLists.txt
+++ b/src/codegen/llvm/CMakeLists.txt
@@ -2,6 +2,8 @@
 # Codegen sources
 # =============================================================================
 set(LLVM_CODEGEN_SOURCE_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/annotation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/annotation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_llvm_visitor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_llvm_visitor.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_llvm_helper_visitor.cpp

--- a/src/codegen/llvm/annotation.cpp
+++ b/src/codegen/llvm/annotation.cpp
@@ -23,10 +23,10 @@ static constexpr const char nmodl_compute_kernel[] = "nmodl.compute-kernel";
 namespace nmodl {
 namespace custom {
 
-void Annotator::add_nmodl_compute_kernel_annotation(llvm::Function* function) {
-    llvm::LLVMContext& context = function->getContext();
+void Annotator::add_nmodl_compute_kernel_annotation(llvm::Function& function) {
+    llvm::LLVMContext& context = function.getContext();
     llvm::MDNode* node = llvm::MDNode::get(context, llvm::MDString::get(context, nmodl_compute_kernel));
-    function->setMetadata(nmodl_annotations, node);
+    function.setMetadata(nmodl_annotations, node);
 }
 
 bool Annotator::has_nmodl_compute_kernel_annotation(llvm::Function& function) {

--- a/src/codegen/llvm/annotation.cpp
+++ b/src/codegen/llvm/annotation.cpp
@@ -38,7 +38,7 @@ bool Annotator::has_nmodl_compute_kernel_annotation(llvm::Function& function) {
     return type == nmodl_compute_kernel;
 }
 
-void CPUAnnotator::annotate(llvm::Function& function) const {
+void DefaultCPUAnnotator::annotate(llvm::Function& function) const {
     // By convention, the compute kernel does not free memory and does not
     // throw exceptions.
     function.setDoesNotFreeMemory();

--- a/src/codegen/llvm/annotation.cpp
+++ b/src/codegen/llvm/annotation.cpp
@@ -92,4 +92,14 @@ bool AnnotationPass::runOnModule(Module& module) {
 
     return modified;
 }
+
+void AnnotationPass::getAnalysisUsage(AnalysisUsage& au) const {
+    au.setPreservesCFG();
+    au.addPreserved<ScalarEvolutionWrapperPass>();
+    au.addPreserved<AAResultsWrapperPass>();
+    au.addPreserved<LoopAccessLegacyAnalysis>();
+    au.addPreserved<DemandedBitsWrapperPass>();
+    au.addPreserved<OptimizationRemarkEmitterWrapperPass>();
+    au.addPreserved<GlobalsAAWrapperPass>();
+}
 }  // namespace llvm

--- a/src/codegen/llvm/annotation.cpp
+++ b/src/codegen/llvm/annotation.cpp
@@ -1,0 +1,95 @@
+/*************************************************************************
+ * Copyright (C) 2018-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#include "codegen/llvm/annotation.hpp"
+#include "codegen/llvm/target_platform.hpp"
+
+#include "llvm/Analysis/DemandedBits.h"
+#include "llvm/Analysis/GlobalsModRef.h"
+#include "llvm/Analysis/LoopAccessAnalysis.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
+#include "llvm/Analysis/ScalarEvolution.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/IR/Module.h"
+
+static constexpr const char nmodl_annotations[] = "nmodl.annotations";
+static constexpr const char nmodl_compute_kernel[] = "nmodl.compute-kernel";
+
+namespace nmodl {
+namespace custom {
+
+void Annotator::add_nmodl_compute_kernel_annotation(llvm::Function* function) {
+    llvm::LLVMContext& context = function->getContext();
+    llvm::MDNode* node = llvm::MDNode::get(context, llvm::MDString::get(context, nmodl_compute_kernel));
+    function->setMetadata(nmodl_annotations, node);
+}
+
+bool Annotator::has_nmodl_compute_kernel_annotation(llvm::Function& function) {
+    if (!function.hasMetadata(nmodl_annotations))
+        return false;
+    
+    llvm::MDNode* node = function.getMetadata(nmodl_annotations);
+    std::string type = llvm::cast<llvm::MDString>(node->getOperand(0))->getString().str();
+    return type == nmodl_compute_kernel;
+}
+
+void CPUAnnotator::annotate(llvm::Function& function) const {
+    // By convention, the compute kernel does not free memory and does not
+    // throw exceptions.
+    function.setDoesNotFreeMemory();
+    function.setDoesNotThrow();
+
+    // We also want to specify that the pointers that instance struct holds
+    // do not alias, unless specified otherwise. In order to do that, we
+    // add a `noalias` attribute to the argument. As per Clang's
+    // specification:
+    //  > The `noalias` attribute indicates that the only memory accesses
+    //  > inside function are loads and stores from objects pointed to by
+    //  > its pointer-typed arguments, with arbitrary offsets.
+    function.addParamAttr(0, llvm::Attribute::NoAlias);
+
+    // Finally, specify that the mechanism data struct pointer does not
+    // capture and is read-only. 
+    function.addParamAttr(0, llvm::Attribute::NoCapture);
+    function.addParamAttr(0, llvm::Attribute::ReadOnly);
+}
+
+void CUDAAnnotator::annotate(llvm::Function& function) const {    
+    llvm::LLVMContext& context = function.getContext();
+    llvm::Module* m = function.getParent();
+
+    auto one = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 1);
+    llvm::Metadata* metadata[] = {llvm::ValueAsMetadata::get(&function),
+                                  llvm::MDString::get(context, "kernel"),
+                                  llvm::ValueAsMetadata::get(one)};
+    llvm::MDNode* node = llvm::MDNode::get(context, metadata);
+
+    m->getOrInsertNamedMetadata("nvvm.annotations")->addOperand(node);
+}
+}  // namespace custom
+}  // namespace nmodl
+
+using nmodl::custom::Annotator;
+namespace llvm {
+
+char AnnotationPass::ID = 0;
+
+bool AnnotationPass::runOnModule(Module& module) {
+    bool modified = false;
+
+    for (auto& function: module.getFunctionList()) {
+        if (!function.isDeclaration() &&
+            Annotator::has_nmodl_compute_kernel_annotation(function)) {
+            annotator->annotate(function);
+            modified = true;
+        }
+    }
+
+    return modified;
+}
+}  // namespace llvm

--- a/src/codegen/llvm/annotation.hpp
+++ b/src/codegen/llvm/annotation.hpp
@@ -23,7 +23,7 @@ class Annotator {
     virtual ~Annotator() = default;
 
     /// Marks LLVM function as NMODL compute kernel. 
-    static void add_nmodl_compute_kernel_annotation(llvm::Function* function);
+    static void add_nmodl_compute_kernel_annotation(llvm::Function& function);
 
     /// Returns true if LLVM function is marked as NMODL compute kernel. 
     static bool has_nmodl_compute_kernel_annotation(llvm::Function& function);
@@ -49,7 +49,6 @@ class CUDAAnnotator: public Annotator {
 };
 }  // namespace custom
 }  // namespace nmodl
-
 
 using nmodl::custom::Annotator;
 namespace llvm {

--- a/src/codegen/llvm/annotation.hpp
+++ b/src/codegen/llvm/annotation.hpp
@@ -30,10 +30,11 @@ class Annotator {
 };
 
 /**
- * \class CPUAnnotator
- * \brief Specifies how LLVM IR functions for CPU platforms are annotated. 
+ * \class DefaultAnnotator
+ * \brief Specifies how LLVM IR functions for CPU platforms are annotated. Used
+ * by default.
  */
-class CPUAnnotator: public Annotator {
+class DefaultCPUAnnotator: public Annotator {
   public:
     void annotate(llvm::Function& function) const override;
 };

--- a/src/codegen/llvm/annotation.hpp
+++ b/src/codegen/llvm/annotation.hpp
@@ -71,5 +71,7 @@ class AnnotationPass: public ModulePass {
         , annotator(annotator) {}
 
     bool runOnModule(Module& module) override;
+
+    void getAnalysisUsage(AnalysisUsage& au) const override;
 };
 }  // namespace llvm

--- a/src/codegen/llvm/annotation.hpp
+++ b/src/codegen/llvm/annotation.hpp
@@ -1,0 +1,75 @@
+/*************************************************************************
+ * Copyright (C) 2018-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#pragma once
+
+#include "llvm/IR/Function.h"
+#include "llvm/Pass.h"
+
+namespace nmodl {
+namespace custom {
+
+/**
+ * \class Annotator
+ * \brief Base class that can be overriden to specify function annotations. 
+ */
+class Annotator {
+  public:
+    virtual void annotate(llvm::Function& function) const = 0;
+    virtual ~Annotator() = default;
+
+    /// Marks LLVM function as NMODL compute kernel. 
+    static void add_nmodl_compute_kernel_annotation(llvm::Function* function);
+
+    /// Returns true if LLVM function is marked as NMODL compute kernel. 
+    static bool has_nmodl_compute_kernel_annotation(llvm::Function& function);
+};
+
+/**
+ * \class CPUAnnotator
+ * \brief Specifies how LLVM IR functions for CPU platforms are annotated. 
+ */
+class CPUAnnotator: public Annotator {
+  public:
+    void annotate(llvm::Function& function) const override;
+};
+
+/**
+ * \class CUDAAnnotator
+ * \brief Specifies how LLVM IR functions for CUDA platforms are annotated. This
+ * includes marking functions with "kernel" or "device" attributes.
+ */
+class CUDAAnnotator: public Annotator {
+  public:
+    void annotate(llvm::Function& function) const override;
+};
+}  // namespace custom
+}  // namespace nmodl
+
+
+using nmodl::custom::Annotator;
+namespace llvm {
+
+/**
+ * \class AnnotationPass
+ * \brief LLVM module pass that annotates NMODL compute kernels.
+ */
+class AnnotationPass: public ModulePass {
+  private:
+    // Underlying annotator that is applied to each LLVM function.
+    const Annotator* annotator;
+
+  public:
+    static char ID;
+
+    AnnotationPass(Annotator* annotator)
+        : ModulePass(ID)
+        , annotator(annotator) {}
+
+    bool runOnModule(Module& module) override;
+};
+}  // namespace llvm

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -192,7 +192,7 @@ void CodegenLLVMHelperVisitor::create_function_for_node(ast::Block& node) {
 
     /// we have all information for code generation function, create a new node
     /// which will be inserted later into AST
-    auto function = std::make_shared<ast::CodegenFunction>(fun_ret_type, name, arguments, block);
+    auto function = std::make_shared<ast::CodegenFunction>(fun_ret_type, name, arguments, block, /*is_kernel=*/0);
     if (node.get_token()) {
         function->set_token(*node.get_token()->clone());
     }
@@ -732,7 +732,7 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
 
     /// finally, create new function
     auto function =
-        std::make_shared<ast::CodegenFunction>(return_type, name, code_arguments, function_block);
+        std::make_shared<ast::CodegenFunction>(return_type, name, code_arguments, function_block, /*is_kernel=*/1);
     codegen_functions.push_back(function);
 
     // todo: remove this, temporary
@@ -1097,7 +1097,8 @@ void CodegenLLVMHelperVisitor::visit_breakpoint_block(ast::BreakpointBlock& node
         auto function = std::make_shared<ast::CodegenFunction>(return_type,
                                                                name,
                                                                code_arguments,
-                                                               function_block);
+                                                               function_block,
+                                                               /*is_kernel=*/1);
         codegen_functions.push_back(function);
 
         // todo: remove this, temporary

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -114,10 +114,10 @@ void CodegenLLVMVisitor::create_function_declaration(const ast::CodegenFunction&
 
     TypeVector arg_types;
     if (wrap_kernel_functions && node.get_is_kernel()) {
-        // We are wrapping NMODL compute kernels as a function taling void*. Thus,
-        // ignore struct pointer argument type and create function signature with
+        // We are wrapping NMODL compute kernels as a function taking void*. Thus,
+        // ignore struct pointer argument type and create a function signature with
         // void* - actual conversion to struct pointer is done when generating
-        // function body!
+        // the function body!
         arg_types.push_back(ir_builder.get_i8_ptr_type());
     } else {
         // Otherwise, process argument types as usual.
@@ -670,7 +670,7 @@ void CodegenLLVMVisitor::visit_codegen_function(const ast::CodegenFunction& node
     // Allocate parameters on the stack and add them to the symbol table.
     if (wrap_kernel_functions && node.get_is_kernel()) {
         // If we wrap NMODL compute kernel, the parameter will be void*! Hence,
-        // get the actual struct pointer type and allocate parameters on the
+        // we get the actual struct pointer type and allocate parameters on the
         // stack with additional bitcast.
         llvm::Type* struct_ty = get_codegen_var_type(*arguments[0]->get_type());
         ir_builder.allocate_and_wrap_kernel_arguments(func, arguments, struct_ty);
@@ -699,7 +699,7 @@ void CodegenLLVMVisitor::visit_codegen_function(const ast::CodegenFunction& node
     // If function is a compute kernel, add a void terminator explicitly, since there is no
     // `CodegenReturnVar` node. Also, set the necessary attributes.
     if (node.get_is_kernel()) {
-        custom::Annotator::add_nmodl_compute_kernel_annotation(func);
+        custom::Annotator::add_nmodl_compute_kernel_annotation(*func);
         ir_builder.create_return();
     }
 

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -627,7 +627,6 @@ void CodegenLLVMVisitor::visit_codegen_for_statement(const ast::CodegenForStatem
     // Extract the condition to decide whether to branch to the loop body or loop exit.
     llvm::Value* cond = accept_and_get(node.get_condition());
     llvm::BranchInst* loop_br = ir_builder.create_cond_br(cond, for_body, exit);
-    ir_builder.set_loop_metadata(loop_br);
     ir_builder.set_insertion_point(for_body);
 
     // If not processing remainder of the loop, start vectorization.
@@ -902,7 +901,6 @@ void CodegenLLVMVisitor::visit_program(const ast::Program& node) {
     }
 
     // Pass 1: replace LLVM math intrinsics with library calls.
-    // TODO: this needs to be done in the same way as Annotator!
     utils::replace_with_lib_functions(platform, *module);
 
     // Pass 2: annotate NMODL compute kernels.

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -220,36 +220,6 @@ void IRBuilder::create_intrinsic(const std::string& name,
 }
 
 /****************************************************************************************/
-/*                                LLVM metadata utilities                               */
-/****************************************************************************************/
-
-void IRBuilder::set_loop_metadata(llvm::BranchInst* branch) {
-    /// TODO: do we really need this?
-    llvm::LLVMContext& context = builder.getContext();
-    MetadataVector loop_metadata;
-
-    // Add nullptr to reserve the first place for loop's metadata self-reference.
-    loop_metadata.push_back(nullptr);
-
-    // If `vector_width` is 1, explicitly disable vectorization for benchmarking purposes.
-    if (platform.is_cpu() && platform.get_instruction_width() == 1) {
-        llvm::MDString* name = llvm::MDString::get(context, "llvm.loop.vectorize.enable");
-        llvm::Value* false_value = llvm::ConstantInt::get(get_boolean_type(), 0);
-        llvm::ValueAsMetadata* value = llvm::ValueAsMetadata::get(false_value);
-        loop_metadata.push_back(llvm::MDNode::get(context, {name, value}));
-    }
-
-    // No metadata to add.
-    if (loop_metadata.size() <= 1)
-        return;
-
-    // Add loop's metadata self-reference and attach it to the branch.
-    llvm::MDNode* metadata = llvm::MDNode::get(context, loop_metadata);
-    metadata->replaceOperandWith(0, metadata);
-    branch->setMetadata(llvm::LLVMContext::MD_loop, metadata);
-}
-
-/****************************************************************************************/
 /*                             LLVM instruction utilities                               */
 /****************************************************************************************/
 

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -153,6 +153,12 @@ class IRBuilder {
     void allocate_function_arguments(llvm::Function* function,
                                      const ast::CodegenVarWithTypeVector& nmodl_arguments);
 
+    /// Generates LLVM IR to allocate the arguments of the NMODL compute kernel
+    /// on the stack, bitcasting void* pointer to mechanism struct pointers.
+    void allocate_and_wrap_kernel_arguments(llvm::Function* function,
+                                            const ast::CodegenVarWithTypeVector& nmodl_arguments,
+                                            llvm::Type* struct_type);
+
     llvm::Value* create_alloca(const std::string& name, llvm::Type* type);
 
     /// Generates IR for allocating an array.
@@ -300,9 +306,6 @@ class IRBuilder {
 
     /// Sets builder's insertion point to the given block.
     void set_insertion_point(llvm::BasicBlock* block);
-
-    /// Sets the necessary attributes for the kernel and its arguments.
-    void set_kernel_attributes();
 
     /// Sets the loop metadata for the given branch from the loop.
     void set_loop_metadata(llvm::BranchInst* branch);

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -25,7 +25,6 @@ static constexpr const unsigned double_precision = 64;
 
 /// Some typedefs.
 using ConstantVector = std::vector<llvm::Constant*>;
-using MetadataVector = std::vector<llvm::Metadata*>;
 using TypeVector = std::vector<llvm::Type*>;
 using ValueVector = std::vector<llvm::Value*>;
 
@@ -306,9 +305,6 @@ class IRBuilder {
 
     /// Sets builder's insertion point to the given block.
     void set_insertion_point(llvm::BasicBlock* block);
-
-    /// Sets the loop metadata for the given branch from the loop.
-    void set_loop_metadata(llvm::BranchInst* branch);
 
     /// Pops the last visited value from the value stack.
     llvm::Value* pop_last_value();

--- a/src/codegen/llvm/llvm_utils.cpp
+++ b/src/codegen/llvm/llvm_utils.cpp
@@ -190,7 +190,7 @@ void annotate(codegen::Platform& platform, llvm::Module& module) {
     if (platform.is_CUDA_gpu()) {
         annotator = new custom::CUDAAnnotator();
     } else {
-        annotator = new custom::CPUAnnotator();
+        annotator = new custom::DefaultCPUAnnotator();
     }
     pm.add(new llvm::AnnotationPass(annotator));
     pm.run(module);

--- a/src/codegen/llvm/llvm_utils.cpp
+++ b/src/codegen/llvm/llvm_utils.cpp
@@ -179,8 +179,17 @@ void optimise_module(llvm::Module& module, int opt_level, llvm::TargetMachine* t
 
 void replace_with_lib_functions(codegen::Platform& platform, llvm::Module& module) {
     llvm::legacy::PassManager pm;
-    pm.add(new llvm::ReplaceMathFunctions(platform));
+
+    Replacer *replacer = nullptr;
+    if (platform.is_CUDA_gpu()) {
+        replacer = new custom::CUDAReplacer();
+    } else {
+        replacer = new custom::DefaultCPUReplacer(platform.get_math_library());
+    }
+    pm.add(new llvm::ReplacePass(replacer));
     pm.run(module);
+
+    delete replacer;
 }
 
 void annotate(codegen::Platform& platform, llvm::Module& module) {

--- a/src/codegen/llvm/llvm_utils.cpp
+++ b/src/codegen/llvm/llvm_utils.cpp
@@ -7,6 +7,7 @@
 
 #include "codegen/llvm/llvm_utils.hpp"
 #include "codegen/llvm/replace_with_lib_functions.hpp"
+#include "codegen/llvm/annotation.hpp"
 
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/AssemblyAnnotationWriter.h"
@@ -180,6 +181,21 @@ void replace_with_lib_functions(codegen::Platform& platform, llvm::Module& modul
     llvm::legacy::PassManager pm;
     pm.add(new llvm::ReplaceMathFunctions(platform));
     pm.run(module);
+}
+
+void annotate(codegen::Platform& platform, llvm::Module& module) {
+    llvm::legacy::PassManager pm;
+
+    Annotator *annotator = nullptr;
+    if (platform.is_CUDA_gpu()) {
+        annotator = new custom::CUDAAnnotator();
+    } else {
+        annotator = new custom::CPUAnnotator();
+    }
+    pm.add(new llvm::AnnotationPass(annotator));
+    pm.run(module);
+
+    delete annotator;
 }
 
 /****************************************************************************************/

--- a/src/codegen/llvm/llvm_utils.hpp
+++ b/src/codegen/llvm/llvm_utils.hpp
@@ -31,6 +31,12 @@ std::string get_module_ptx(llvm::TargetMachine& tm, llvm::Module& module);
 /// Replaces calls to LLVM intrinsics with appropriate library calls.
 void replace_with_lib_functions(codegen::Platform& platform, llvm::Module& module);
 
+/// Annotates LLVM module with appropriate metadata.
+/// TODO: this function and replace_with_lib_functions will be chnaged
+/// oncePlatform evolves into PlatformConfig which would be responsible
+/// for platform-dependent pass initialisation.
+void annotate(codegen::Platform& platform, llvm::Module& module);
+
 /// Optimises the given LLVM IR module for NVPTX targets.
 void optimise_module_for_nvptx(const codegen::Platform& platform,
                                llvm::Module& module,

--- a/src/codegen/llvm/replace_with_lib_functions.cpp
+++ b/src/codegen/llvm/replace_with_lib_functions.cpp
@@ -18,17 +18,45 @@
 #include "llvm/IR/IntrinsicsNVPTX.h"
 #include "llvm/IR/LegacyPassManager.h"
 
+namespace nmodl {
+namespace custom {
+
+Patterns DefaultCPUReplacer::patterns() const {
+    throw std::runtime_error("Error: DefaultCPUReplacer has no patterns and uses built-in LLVM passes instead.\n");
+}
+
+std::string DefaultCPUReplacer::get_library_name() {
+    return this->library_name;
+}
+
+Patterns CUDAReplacer::patterns() const {
+    return {
+        {"llvm.exp.f32", "__nv_expf"},
+        {"llvm.exp.f64", "__nv_exp"},
+        {"llvm.pow.f32", "__nv_powf"},
+        {"llvm.pow.f64", "__nv_pow"},
+        {"llvm.log.f32", "__nv_logf"},
+        {"llvm.log.f64", "__nv_log"},
+        {"llvm.fabs.f32", "__nv_fabsf"},
+        {"llvm.fabs.f64", "__nv_fabs"}
+    };
+}
+}  // namespace custom
+}  // namespace nmodl
+
+using nmodl::custom::DefaultCPUReplacer;
 namespace llvm {
 
-char ReplaceMathFunctions::ID = 0;
+char ReplacePass::ID = 0;
 
-bool ReplaceMathFunctions::runOnModule(Module& module) {
-    legacy::FunctionPassManager fpm(&module);
+bool ReplacePass::runOnModule(Module& module) {
     bool modified = false;
 
     // If the platform supports SIMD, replace math intrinsics with library
     // functions.
-    if (platform->is_cpu_with_simd()) {
+    if (dynamic_cast<const DefaultCPUReplacer*>(replacer)) {
+        legacy::FunctionPassManager fpm(&module);
+
         // First, get the target library information and add vectorizable functions for the
         // specified vector library.
         Triple triple(sys::getDefaultTargetTriple());
@@ -38,28 +66,55 @@ bool ReplaceMathFunctions::runOnModule(Module& module) {
         // Add passes that replace math intrinsics with calls.
         fpm.add(new TargetLibraryInfoWrapperPass(tli));
         fpm.add(new ReplaceWithVeclibLegacy);
-    }
 
-    // For CUDA GPUs, replace with calls to libdevice.
-    if (platform->is_CUDA_gpu()) {
-        fpm.add(new ReplaceWithLibdevice);
-    }
+        // Run passes.
+        fpm.doInitialization();
+        for (auto& function: module.getFunctionList()) {
+            if (!function.isDeclaration())
+                modified |= fpm.run(function);
+        }
+        fpm.doFinalization();
+    } else {
+        // Otherwise, the replacer is not default and we need to apply patterns
+        // from it to each function!
+        for (auto& function: module.getFunctionList()) {
+            if (!function.isDeclaration()) {
+                // Try to replace a call instruction.
+                std::vector<CallInst*> replaced_calls;
+                for (auto& instruction: instructions(function)) {
+                    if (auto* call_inst = dyn_cast<CallInst>(&instruction)) {
+                        if (replace_call(*call_inst)) {
+                            replaced_calls.push_back(call_inst);
+                            modified = true;
+                        }
+                    }
+                }
 
-    // Run passes.
-    fpm.doInitialization();
-    for (auto& function: module.getFunctionList()) {
-        if (!function.isDeclaration())
-            modified |= fpm.run(function);
+                // Remove calls to replaced functions.
+                for (auto* call_inst: replaced_calls) {
+                    call_inst->eraseFromParent();
+                }
+            }
+        }
     }
-    fpm.doFinalization();
 
     return modified;
 }
 
-void ReplaceMathFunctions::add_vectorizable_functions_from_vec_lib(TargetLibraryInfoImpl& tli,
-                                                                   Triple& triple) {
+void ReplacePass::getAnalysisUsage(AnalysisUsage& au) const {
+    au.setPreservesCFG();
+    au.addPreserved<ScalarEvolutionWrapperPass>();
+    au.addPreserved<AAResultsWrapperPass>();
+    au.addPreserved<LoopAccessLegacyAnalysis>();
+    au.addPreserved<DemandedBitsWrapperPass>();
+    au.addPreserved<OptimizationRemarkEmitterWrapperPass>();
+    au.addPreserved<GlobalsAAWrapperPass>();
+}
+
+void ReplacePass::add_vectorizable_functions_from_vec_lib(TargetLibraryInfoImpl& tli,
+                                                          Triple& triple) {
     // Since LLVM does not support SLEEF as a vector library yet, process it separately.
-    if (platform->get_math_library() == "SLEEF") {
+    if (((DefaultCPUReplacer*)replacer)->get_library_name() == "SLEEF") {
 // clang-format off
 #define FIXED(w) ElementCount::getFixed(w)
 // clang-format on
@@ -110,10 +165,10 @@ void ReplaceMathFunctions::add_vectorizable_functions_from_vec_lib(TargetLibrary
             {"none", VecLib::NoLibrary},
             {"SVML", VecLib::SVML}};
 
-        const auto& library = llvm_supported_vector_libraries.find(platform->get_math_library());
+        const auto& library = llvm_supported_vector_libraries.find(((DefaultCPUReplacer*)replacer)->get_library_name());
         if (library == llvm_supported_vector_libraries.end())
             throw std::runtime_error("Error: unknown vector library - " +
-                                     platform->get_math_library() + "\n");
+                                     ((DefaultCPUReplacer*)replacer)->get_library_name() + "\n");
 
         // Add vectorizable functions to the target library info.
         if (library->second != VecLib::LIBMVEC_X86 || (triple.isX86() && triple.isArch64Bit())) {
@@ -122,77 +177,27 @@ void ReplaceMathFunctions::add_vectorizable_functions_from_vec_lib(TargetLibrary
     }
 }
 
-void ReplaceWithLibdevice::getAnalysisUsage(AnalysisUsage& au) const {
-    au.setPreservesCFG();
-    au.addPreserved<ScalarEvolutionWrapperPass>();
-    au.addPreserved<AAResultsWrapperPass>();
-    au.addPreserved<LoopAccessLegacyAnalysis>();
-    au.addPreserved<DemandedBitsWrapperPass>();
-    au.addPreserved<OptimizationRemarkEmitterWrapperPass>();
-    au.addPreserved<GlobalsAAWrapperPass>();
-}
-
-bool ReplaceWithLibdevice::runOnFunction(Function& function) {
-    bool modified = false;
-
-    // Try to replace math intrinsics.
-    std::vector<CallInst*> replaced_calls;
-    for (auto& instruction: instructions(function)) {
-        if (auto* call_inst = dyn_cast<CallInst>(&instruction)) {
-            if (replace_call(*call_inst)) {
-                replaced_calls.push_back(call_inst);
-                modified = true;
-            }
-        }
-    }
-
-    // Remove calls to replaced intrinsics.
-    for (auto* call_inst: replaced_calls) {
-        call_inst->eraseFromParent();
-    }
-
-    return modified;
-}
-
-bool ReplaceWithLibdevice::replace_call(CallInst& call_inst) {
+bool ReplacePass::replace_call(CallInst& call_inst) {
     Module* m = call_inst.getModule();
     Function* function = call_inst.getCalledFunction();
 
-    // Replace math intrinsics only!
-    auto id = function->getIntrinsicID();
-    bool is_nvvm_intrinsic = id == Intrinsic::nvvm_read_ptx_sreg_ntid_x ||
-                             id == Intrinsic::nvvm_read_ptx_sreg_nctaid_x ||
-                             id == Intrinsic::nvvm_read_ptx_sreg_ctaid_x ||
-                             id == Intrinsic::nvvm_read_ptx_sreg_tid_x;
-    if (id == Intrinsic::not_intrinsic || is_nvvm_intrinsic)
+    // Get supported replacement patterns.
+    Patterns patterns = replacer->patterns();
+
+    // Check if replacement is not supported.
+    std::string old_name = function->getName().str();
+    auto it = patterns.find(old_name);
+    if (it == patterns.end())
         return false;
 
-    // Map of supported replacements. For now it is only exp and pow.
-    static const std::map<std::string, std::string> libdevice_name = {{"llvm.exp.f32", "__nv_expf"},
-                                                                      {"llvm.exp.f64", "__nv_exp"},
-                                                                      {"llvm.pow.f32", "__nv_powf"},
-                                                                      {"llvm.pow.f64", "__nv_pow"},
-                                                                      {"llvm.log.f32", "__nv_logf"},
-                                                                      {"llvm.log.f64", "__nv_log"},
-                                                                      {"llvm.fabs.f32",
-                                                                       "__nv_fabsf"},
-                                                                      {"llvm.fabs.f64",
-                                                                       "__nv_fabs"}};
-
-    // If replacement is not supported, abort.
-    std::string old_name = function->getName().str();
-    auto it = libdevice_name.find(old_name);
-    if (it == libdevice_name.end())
-        throw std::runtime_error("Error: replacements for " + old_name + " are not supported!\n");
-
-    // Get (or create) libdevice function.
-    Function* libdevice_func = m->getFunction(it->second);
-    if (!libdevice_func) {
-        libdevice_func = Function::Create(function->getFunctionType(),
-                                          Function::ExternalLinkage,
-                                          it->second,
-                                          *m);
-        libdevice_func->copyAttributesFrom(function);
+    // Get (or create) new function.
+    Function* new_func = m->getFunction(it->second);
+    if (!new_func) {
+        new_func = Function::Create(function->getFunctionType(),
+                                    Function::ExternalLinkage,
+                                    it->second,
+                                    *m);
+        new_func->copyAttributesFrom(function);
     }
 
     // Create a call to libdevice function with the same operands.
@@ -200,7 +205,7 @@ bool ReplaceWithLibdevice::replace_call(CallInst& call_inst) {
     std::vector<Value*> args(call_inst.arg_operands().begin(), call_inst.arg_operands().end());
     SmallVector<OperandBundleDef, 1> op_bundles;
     call_inst.getOperandBundlesAsDefs(op_bundles);
-    CallInst* new_call = builder.CreateCall(libdevice_func, args, op_bundles);
+    CallInst* new_call = builder.CreateCall(new_func, args, op_bundles);
 
     // Replace all uses of old instruction with the new one. Also, copy
     // fast math flags if necessary.
@@ -211,11 +216,4 @@ bool ReplaceWithLibdevice::replace_call(CallInst& call_inst) {
 
     return true;
 }
-
-char ReplaceWithLibdevice::ID = 0;
-static RegisterPass<ReplaceWithLibdevice> X("libdevice-replacement",
-                                            "Pass replacing math functions with calls to libdevice",
-                                            false,
-                                            false);
-
 }  // namespace llvm

--- a/src/codegen/llvm/replace_with_lib_functions.hpp
+++ b/src/codegen/llvm/replace_with_lib_functions.hpp
@@ -14,52 +14,82 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/Host.h"
 
-using nmodl::codegen::Platform;
+using Patterns = std::map<std::string, std::string>;
 
+namespace nmodl {
+namespace custom {
+
+/**
+ * \class Replacer
+ * \brief Base class that can be overriden to specify how LLVM math intrinsics
+ * are replaced.
+ */
+class Replacer {
+  public:
+    virtual Patterns patterns() const = 0;
+    virtual ~Replacer() = default;
+};
+
+/**
+ * \class DefaultCPUReplacer
+ * \brief Specifies how LLVM IR math functions are replaced on CPUs by default.
+ * Here we reuse LLVM's API so patterns() has no meaning and throws an error
+ * instead! `DefaultCPUReplacer` threfore cannot be overriden.
+ */
+class DefaultCPUReplacer: public Replacer {
+  private:
+    std::string library_name;
+  public:
+    DefaultCPUReplacer(std::string library_name)
+      : Replacer(), library_name(library_name) {}
+
+    Patterns patterns() const final override;
+
+    /// Returns the name of underlying library for which this default
+    /// replacer is used.
+    std::string get_library_name();
+};
+
+/**
+ * \class CUDAReplacer
+ * \brief Specifies replacement patterns for CUDA platforms.
+ */
+class CUDAReplacer: public Replacer {
+  public:
+    Patterns patterns() const override;
+};
+}  // namespace custom
+}  // namespace nmodl
+
+using nmodl::custom::Replacer;
 namespace llvm {
 
 /**
- * \class ReplaceMathFunctions
+ * \class ReplacePass
  * \brief A module LLVM pass that replaces math intrinsics with
- * SIMD or libdevice library calls.
+ * library calls.
  */
-class ReplaceMathFunctions: public ModulePass {
+class ReplacePass: public ModulePass {
   private:
-    const Platform* platform;
+    // Underlying replacer that provides replacement patterns.
+    const Replacer* replacer;
 
   public:
     static char ID;
 
-    ReplaceMathFunctions(const Platform& platform)
+    ReplacePass(Replacer* replacer)
         : ModulePass(ID)
-        , platform(&platform) {}
+        , replacer(replacer) {}
 
     bool runOnModule(Module& module) override;
 
-  private:
-    /// Populates `tli` with vectorizable function definitions.
-    void add_vectorizable_functions_from_vec_lib(TargetLibraryInfoImpl& tli, Triple& triple);
-};
-
-/**
- * \class ReplaceWithLibdevice
- * \brief A function LLVM pass that replaces math intrinsics with
- * libdevice library calls.
- */
-class ReplaceWithLibdevice: public FunctionPass {
-  public:
-    static char ID;
-
-    ReplaceWithLibdevice()
-        : llvm::FunctionPass(ID) {}
-
     void getAnalysisUsage(AnalysisUsage& au) const override;
 
-    bool runOnFunction(Function& function) override;
-
   private:
-    /// Replaces call instruction to intrinsic with libdevice call.
+    /// Populates `tli` with vectorizable function definitions (hook for default replacements).
+    void add_vectorizable_functions_from_vec_lib(TargetLibraryInfoImpl& tli, Triple& triple);
+
+    /// Replaces call instruction with a new call from Replacer's patterns.
     bool replace_call(CallInst& call_inst);
 };
-
 }  // namespace llvm

--- a/src/language/codegen.yaml
+++ b/src/language/codegen.yaml
@@ -156,6 +156,9 @@
                                   brief: "Body of the function"
                                   type: StatementBlock
                                   getter: {override: true}
+                              - is_kernel:
+                                  brief: "If function is compute kernel"
+                                  type: int
                         - InstanceStruct:
                             nmodl: "INSTANCE_STRUCT "
                             members:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -382,6 +382,9 @@ int main(int argc, const char* argv[]) {
                 // information and not in LLVM visitor.
                 int llvm_opt_level = llvm_benchmark ? 0 : cfg.llvm_opt_level_ir;
 
+                // If benchmarking, kernel functions should be wrapped taking void*.
+                bool wrap_kernel_functions = llvm_benchmark;
+
                 // Create platform abstraction.
                 PlatformID pid = cfg.llvm_gpu_name == "default" ? PlatformID::CPU : PlatformID::GPU;
                 const std::string name = cfg.llvm_gpu_name == "default" ? cfg.llvm_cpu_name
@@ -406,7 +409,8 @@ int main(int argc, const char* argv[]) {
                                            platform,
                                            llvm_opt_level,
                                            !cfg.llvm_no_debug,
-                                           cfg.llvm_fast_math_flags);
+                                           cfg.llvm_fast_math_flags,
+                                           wrap_kernel_functions);
                 visitor.visit_program(*ast);
                 if (cfg.nmodl_ast) {
                     NmodlPrintVisitor(filepath("llvm", "mod")).visit_program(*ast);

--- a/src/pybind/pynmodl.cpp
+++ b/src/pybind/pynmodl.cpp
@@ -200,7 +200,7 @@ class JitDriver {
             utils::make_path(cfg.scratch_dir);
         }
         cg_driver.prepare_mod(node, modname);
-        nmodl::codegen::CodegenLLVMVisitor visitor(modname, cfg.output_dir, platform, 0);
+        nmodl::codegen::CodegenLLVMVisitor visitor(modname, cfg.output_dir, platform, 0, false, {}, true);
         visitor.visit_program(*node);
         const GPUExecutionParameters gpu_execution_parameters{cuda_grid_dim_x, cuda_block_dim_x};
         nmodl::benchmark::LLVMBenchmark benchmark(visitor,

--- a/test/benchmark/llvm_benchmark.hpp
+++ b/test/benchmark/llvm_benchmark.hpp
@@ -120,15 +120,10 @@ class LLVMBenchmark {
         , opt_level_codegen(opt_level_codegen)
         , gpu_execution_parameters(gpu_exec_params) {}
 
-    /// Runs the benchmark.
+    /// Runs the main body of the benchmark, executing the compute kernels.
     BenchmarkResults run();
 
   private:
-    /// Visits the AST to construct the LLVM IR module.
-    void generate_llvm();
-
-    /// Runs the main body of the benchmark, executing the compute kernels.
-    BenchmarkResults run_benchmark();
 
     /// Sets the log output stream (file or console).
     void set_log_output();

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -314,9 +314,11 @@ SCENARIO("Simple scalar kernel", "[llvm][runner]") {
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
                                                  cpu_platform,
-                                                 /*opt_level_ir=*/0);
+                                                 /*opt_level_ir=*/0,
+                                                 /*add_debug_information=*/false,
+                                                 /*fast_math_flags=*/{},
+                                                 /*wrap_kernel_functions=*/true);
         llvm_visitor.visit_program(*ast);
-        llvm_visitor.wrap_kernel_functions();
 
         // Create the instance struct data.
         int num_elements = 4;
@@ -342,7 +344,7 @@ SCENARIO("Simple scalar kernel", "[llvm][runner]") {
         runner.initialize_driver();
 
         THEN("Values in struct have changed according to the formula") {
-            runner.run_with_argument<int, void*>("__nrn_state_test_wrapper",
+            runner.run_with_argument<int, void*>("nrn_state_test",
                                                  instance_data.base_ptr);
             std::vector<double> x_expected = {4.0, 3.0, 2.0, 1.0};
             REQUIRE(check_instance_variable(instance_info, x_expected, "x"));
@@ -399,9 +401,11 @@ SCENARIO("Simple vectorised kernel", "[llvm][runner]") {
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
                                                  simd_cpu_platform,
-                                                 /*opt_level_ir=*/3);
+                                                 /*opt_level_ir=*/3,
+                                                 /*add_debug_information=*/false,
+                                                 /*fast_math_flags=*/{},
+                                                 /*wrap_kernel_functions=*/true);
         llvm_visitor.visit_program(*ast);
-        llvm_visitor.wrap_kernel_functions();
 
         // Create the instance struct data.
         int num_elements = 10;
@@ -433,7 +437,7 @@ SCENARIO("Simple vectorised kernel", "[llvm][runner]") {
         runner.initialize_driver();
 
         THEN("Values in struct have changed according to the formula") {
-            runner.run_with_argument<int, void*>("__nrn_state_test_wrapper",
+            runner.run_with_argument<int, void*>("nrn_state_test",
                                                  instance_data.base_ptr);
             // Check that the main and remainder loops correctly change the data stored in x.
             std::vector<float> x_expected = {10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0};
@@ -483,9 +487,11 @@ SCENARIO("Vectorised kernel with scatter instruction", "[llvm][runner]") {
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
                                                  simd_cpu_platform,
-                                                 /*opt_level_ir=*/0);
+                                                 /*opt_level_ir=*/0,
+                                                 /*add_debug_information=*/false,
+                                                 /*fast_math_flags=*/{},
+                                                 /*wrap_kernel_functions=*/true);
         llvm_visitor.visit_program(*ast);
-        llvm_visitor.wrap_kernel_functions();
 
         // Create the instance struct data.
         int num_elements = 5;
@@ -511,7 +517,7 @@ SCENARIO("Vectorised kernel with scatter instruction", "[llvm][runner]") {
         runner.initialize_driver();
 
         THEN("Ion values in struct have been updated correctly") {
-            runner.run_with_argument<int, void*>("__nrn_state_test_wrapper",
+            runner.run_with_argument<int, void*>("nrn_state_test",
                                                  instance_data.base_ptr);
             // cai[id] = ion_cai[ion_cai_index[id]]
             // cai[id] += 1
@@ -576,9 +582,11 @@ SCENARIO("Vectorised kernel with simple control flow", "[llvm][runner]") {
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
                                                  simd_cpu_platform,
-                                                 /*opt_level_ir=*/0);
+                                                 /*opt_level_ir=*/0,
+                                                 /*add_debug_information=*/false,
+                                                 /*fast_math_flags=*/{},
+                                                 /*wrap_kernel_functions=*/true);
         llvm_visitor.visit_program(*ast);
-        llvm_visitor.wrap_kernel_functions();
 
         // Create the instance struct data.
         int num_elements = 5;
@@ -612,7 +620,7 @@ SCENARIO("Vectorised kernel with simple control flow", "[llvm][runner]") {
         runner.initialize_driver();
 
         THEN("Masked instructions are generated") {
-            runner.run_with_argument<int, void*>("__nrn_state_test_wrapper",
+            runner.run_with_argument<int, void*>("nrn_state_test",
                                                  instance_data.base_ptr);
             std::vector<double> w_expected = {20.0, 20.0, 60.0, 40.0, 50.0};
             REQUIRE(check_instance_variable(instance_info, w_expected, "w"));
@@ -675,9 +683,11 @@ SCENARIO("Kernel with atomic updates", "[llvm][runner]") {
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
                                                  simd_cpu_platform,
-                                                 /*opt_level_ir=*/3);
+                                                 /*opt_level_ir=*/3,
+                                                 /*add_debug_information=*/false,
+                                                 /*fast_math_flags=*/{},
+                                                 /*wrap_kernel_functions=*/true);
         llvm_visitor.visit_program(*ast);
-        llvm_visitor.wrap_kernel_functions();
 
         // Create the instance struct data.
         int num_elements = 5;
@@ -715,7 +725,7 @@ SCENARIO("Kernel with atomic updates", "[llvm][runner]") {
         runner.initialize_driver();
 
         THEN("updates are commputed correctly with vector instructions and optimizations on") {
-            runner.run_with_argument<int, void*>("__nrn_cur_test_wrapper", instance_data.base_ptr);
+            runner.run_with_argument<int, void*>("nrn_cur_test", instance_data.base_ptr);
             // Recall:
             //     ion_ina_id = mech->ion_ina_index[id]
             //     ion_ika_id = mech->ion_ika_index[id]
@@ -771,9 +781,11 @@ SCENARIO("Kernel with atomic updates", "[llvm][runner]") {
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
                                                  simd_cpu_platform,
-                                                 /*opt_level_ir=*/0);
+                                                 /*opt_level_ir=*/0,
+                                                 /*add_debug_information=*/false,
+                                                 /*fast_math_flags=*/{},
+                                                 /*wrap_kernel_functions=*/true);
         llvm_visitor.visit_program(*ast);
-        llvm_visitor.wrap_kernel_functions();
 
         // Create the instance struct data.
         int num_elements = 6;
@@ -811,7 +823,7 @@ SCENARIO("Kernel with atomic updates", "[llvm][runner]") {
         runner.initialize_driver();
 
         THEN("Atomic updates are correct without optimizations") {
-            runner.run_with_argument<int, void*>("__nrn_cur_test_wrapper", instance_data.base_ptr);
+            runner.run_with_argument<int, void*>("nrn_cur_test", instance_data.base_ptr);
             // Recall:
             //     ion_ina_id = mech->ion_ina_index[id]
             //     ion_ika_id = mech->ion_ika_index[id]
@@ -866,9 +878,11 @@ SCENARIO("Kernel with atomic updates", "[llvm][runner]") {
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
                                                  simd_cpu_platform,
-                                                 /*opt_level_ir=*/0);
+                                                 /*opt_level_ir=*/0,
+                                                 /*add_debug_information=*/false,
+                                                 /*fast_math_flags=*/{},
+                                                 /*wrap_kernel_functions=*/true);
         llvm_visitor.visit_program(*ast);
-        llvm_visitor.wrap_kernel_functions();
 
         // Create the instance struct data.
         int num_elements = 6;
@@ -907,7 +921,7 @@ SCENARIO("Kernel with atomic updates", "[llvm][runner]") {
         runner.initialize_driver();
 
         THEN("Atomic updates are correct") {
-            runner.run_with_argument<int, void*>("__nrn_cur_test_wrapper", instance_data.base_ptr);
+            runner.run_with_argument<int, void*>("nrn_cur_test", instance_data.base_ptr);
             // Recall:
             //     node_id = mech->node_index[id]
             //     mech->vec_rhs[node_id] -= rhs

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -1015,15 +1015,6 @@ SCENARIO("Scalar state kernel", "[visitor][llvm]") {
             REQUIRE(std::regex_search(module_string, m, condition));
             REQUIRE(std::regex_search(module_string, m, cond_br));
 
-            // Check that loop metadata is attached to the scalar kernel.
-            std::regex loop_metadata(R"(!llvm\.loop ![0-9]+)");
-            std::regex loop_metadata_self_reference(R"(![0-9]+ = distinct !\{![0-9]+, ![0-9]+\})");
-            std::regex loop_metadata_disable_vectorization(
-                R"(![0-9]+ = !\{!\"llvm\.loop\.vectorize\.enable\", i1 false\})");
-            REQUIRE(std::regex_search(module_string, m, loop_metadata));
-            REQUIRE(std::regex_search(module_string, m, loop_metadata_self_reference));
-            REQUIRE(std::regex_search(module_string, m, loop_metadata_disable_vectorization));
-
             // Check for correct loads from the struct with GEPs.
             std::regex load_from_struct(
                 "  %.* = load %.*__instance_var__type\\*, %.*__instance_var__type\\*\\* %.*\n"

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -1016,10 +1016,10 @@ SCENARIO("Scalar state kernel", "[visitor][llvm]") {
             REQUIRE(std::regex_search(module_string, m, cond_br));
 
             // Check that loop metadata is attached to the scalar kernel.
-            std::regex loop_metadata(R"(!llvm\.loop !0)");
-            std::regex loop_metadata_self_reference(R"(!0 = distinct !\{!0, !1\})");
+            std::regex loop_metadata(R"(!llvm\.loop ![0-9]+)");
+            std::regex loop_metadata_self_reference(R"(![0-9]+ = distinct !\{![0-9]+, ![0-9]+\})");
             std::regex loop_metadata_disable_vectorization(
-                R"(!1 = !\{!\"llvm\.loop\.vectorize\.enable\", i1 false\})");
+                R"(![0-9]+ = !\{!\"llvm\.loop\.vectorize\.enable\", i1 false\})");
             REQUIRE(std::regex_search(module_string, m, loop_metadata));
             REQUIRE(std::regex_search(module_string, m, loop_metadata_self_reference));
             REQUIRE(std::regex_search(module_string, m, loop_metadata_disable_vectorization));


### PR DESCRIPTION
This PR fixes two things:

1. A new `Annotator` class is added with an abstract `annotate()` method. The users of MOD2IR can override this method (see `CUDAAnnotator` for example) to specialise how NMODL compute kernels (`llvm::Function`s) are annotated. This includes a helper LLVM module pass as well. Ideally, we want some config class (`Platform`?) to set up the right `Annotator`, but since there is no such class yet it is done in `nmodl::utils` similarly to MathFunctionReplacement.

2. It turns out that NVPTX backend infers address spaces only for "kernel"s and not for "device" functions. One of the reasons why the current GPU code generation was working was inlining of the compute kernel ("device") functions into wrapper ("kernel") functions. This PR fixes this issue by removing wrapping altogether, instead providing a new flag `wrap_kernel_functions` to visitor. If flag is set, compute kernel is generated with `void*` ptr and additional `bitcast`, otherwise struct pointer type is used directly.

```llvm
;; wrap_kernel_functions = false
define void @nrn_state_hh(%__instance_var__type* noalias nocapture readonly %mech1)

;; wrap_kernel_functions = true
define void @nrn_state_hh(%i8* noalias nocapture readonly %mech1)
```

3. Finally, to identify compute kernels `CodegenFunction` has a new `is_kernel` flag. Hence, LLVM visitor knows straight away if the function is a kernel or not. No more type checks (single argument, struct pointer, etc.) needed. `is_kernel` is mapped to LLVM metadata node `nmodl.compute-kernel` that allows any to easily identify compute kernels in LLVM IR. This metadata handling is part of `Annotator`s API.

```llvm
define void @nrn_state_hh(%__instance_var__type* %mech1) #0 !nmodl.annotations !0 {
  ;; some code
}

;; This says that `nrn_state_hh` is a kernel!
!0 = !{!"nmodl.compute-kernel"}
```