### PR TITLE
Install llvm 13.0.1 in MacOS builds in Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -191,7 +191,7 @@ stages:
         export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
         mkdir -p $(Build.Repository.LocalPath)/build
         cd $(Build.Repository.LocalPath)/build
-        cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DNMODL_ENABLE_PYTHON_BINDINGS=OFF -DLLVM_DIR=$(brew --prefix llvm)/lib/cmake/llvm -DNMODL_ENABLE_LLVM=ON
+        cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DNMODL_ENABLE_PYTHON_BINDINGS=OFF -DLLVM_DIR=$(brew --prefix llvm@13)/lib/cmake/llvm -DNMODL_ENABLE_LLVM=ON
         make -j 2
         if [ $? -ne 0 ]
         then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -183,7 +183,7 @@ stages:
     - checkout: self
       submodules: True
     - script: |
-        brew install flex bison cmake python@3 gcc@8 llvm
+        brew install flex bison cmake python@3 gcc@8 llvm@13
         python3 -m pip install --upgrade pip setuptools
         python3 -m pip install --user 'Jinja2>=2.9.3' 'PyYAML>=3.13' pytest pytest-cov numpy 'sympy>=1.3,<1.9'
       displayName: 'Install Dependencies'


### PR DESCRIPTION
`brew` installs by default `LLVM 14` which has the following bug with CMake https://github.com/llvm/llvm-project/issues/53950
For `llvm` branch we just need `LLVM 13.0.0/13.0.1`