### PR TITLE
Use new formatting utility

### DIFF
--- a/.bbp-project.yaml
+++ b/.bbp-project.yaml
@@ -1,0 +1,13 @@
+tools:
+  ClangFormat:
+    enable: True
+    exclude:
+      match:
+      - ext/.*
+      - src/language/templates/*
+  CMakeFormat:
+    enable: True
+    exclude:
+      match:
+      - ext/.*
+      - src/language/templates/*

--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install homebrew packages
         if: startsWith(matrix.config.os, 'macOS')
         run: |
-          brew install ccache coreutils bison boost clang-format flex ninja
+          brew install ccache coreutils bison boost flex ninja
           echo /usr/local/opt/flex/bin:/usr/local/opt/bison/bin >> $GITHUB_PATH
           # Taken from https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
           echo CMAKE_BUILD_PARALLEL_LEVEL=3 >> $GITHUB_ENV
@@ -77,7 +77,7 @@ jobs:
       - name: Install Python3 dependencies
         run: |
           python3 -m pip install -U pip setuptools scikit-build Jinja2 PyYAML \
-            pytest sympy 'cmake-format==0.6.13'
+            pytest sympy
 
       - uses: actions/checkout@v3
 
@@ -97,8 +97,7 @@ jobs:
           mkdir build && pushd build
           cmake_args=(-G Ninja
                       -DPYTHON_EXECUTABLE=$(which python3) \
-                      -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR \
-                      -DNMODL_FORMATTING:BOOL=ON)
+                      -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR)
           if [[ -n "${{matrix.config.flag_warnings}}" ]]; then
             cmake_args+=(-DNMODL_EXTRA_CXX_FLAGS="-Wall \
                           -Wno-reorder \
@@ -122,13 +121,10 @@ jobs:
 
       - name: Formatting
         shell: bash
-        working-directory: ${{runner.workspace}}/nmodl/build
+        working-directory: ${{runner.workspace}}/nmodl
         run:  |
           echo "------- Check formatting -------"
-          status=0 # Check both clang and cmake formatting before exiting.
-          if ! cmake --build . --target check-cmake-format; then status=1; fi
-          if ! cmake --build . --target check-clang-format; then status=1; fi
-          exit ${status}
+          cmake/hpc-coding-conventions/bin/format -v --dry-run
 
       - name: Dump config dictionary
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ venv.bak/
 .cmake-format.yaml
 .pre-commit-config.yaml
 .ipynb_checkpoints
+.bbp-project-venv/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,20 +81,12 @@ project(
 # =============================================================================
 # HPC Coding Conventions
 # =============================================================================
-set(NMODL_ClangFormat_EXCLUDES_RE
-    "ext/.*$$" "src/language/templates/.*$$"
-    CACHE STRING "list of regular expressions to exclude C/C++ files from formatting" FORCE)
-set(NMODL_CMakeFormat_EXCLUDES_RE
-    "ext/.*$$" "src/language/templates/.*$$"
-    CACHE STRING "list of regular expressions to exclude CMake files from formatting" FORCE)
-
 # initialize submodule of coding conventions under cmake
 if(NOT EXISTS "${PROJECT_SOURCE_DIR}/cmake/hpc-coding-conventions/cpp/CMakeLists.txt")
   initialize_submodule("${PROJECT_SOURCE_DIR}/cmake/hpc-coding-conventions")
 endif()
 set(CODING_CONV_PREFIX NMODL)
 add_subdirectory(cmake/hpc-coding-conventions/cpp)
-include(cmake/hpc-coding-conventions/cpp/cmake/FindClangFormat.cmake)
 
 # =============================================================================
 # Enable sanitizer support if the NMODL_SANITIZERS variable is set
@@ -271,12 +263,6 @@ message(STATUS "Python Bindings     | ${NMODL_ENABLE_PYTHON_BINDINGS}")
 message(STATUS "Flex                | ${FLEX_EXECUTABLE}")
 message(STATUS "Bison               | ${BISON_EXECUTABLE}")
 message(STATUS "Python              | ${PYTHON_EXECUTABLE}")
-if(NMODL_CLANG_FORMAT)
-  message(STATUS "Clang Format        | ${ClangFormat_EXECUTABLE}")
-endif()
-if(NMODL_CMAKE_FORMAT)
-  message(STATUS "Cmake Format        | ${CMakeFormat_EXECUTABLE}")
-endif()
 message(STATUS "--------------+--------------------------------------------------------------")
 message(STATUS " See documentation : https://github.com/BlueBrain/nmodl/")
 message(STATUS "--------------+--------------------------------------------------------------")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,13 @@ When you wish to contribute to the code base, please consider the following guid
      git checkout -b my-fix-branch master
      ```
 * Create your patch, **including appropriate test cases**.
-* Enable `NMODL_FORMATTING` and `NMODL_PRECOMMIT` CMake variables
-  to ensure that your change follows coding conventions of this project.
-  Please see [README.md](./README.md) for more information.
+* Enable `NMODL_TEST_FORMATTING` CMake variable
+  to ensure that your change follows the coding conventions of this project when running the tests.
+  The formatting utility can also be used directly:
+  * to format CMake and C++ files: `cmake/hpc-coding-conventions/bin/format`
+  * to format only the C++ files: `cmake/hpc-coding-conventions/bin/format --lang c++`
+  * to format a subset of files or directories: `cmake/hpc-coding-conventions/bin/format src/codegen/ src/main.cpp`
+  * to check the formatting of CMake files: `cmake/hpc-coding-conventions/bin/format --dry-run --lang cmake`
 * Run the full test suite, and ensure that all tests pass.
 * Commit your changes using a descriptive commit message.
 


### PR DESCRIPTION
Bump hpc-coding-conventions submodule providing a new way to
format the code. It is not required to run CMake anymore.
Just use `cmake/hpc-coding-conventions/bin/format` utility.