### PR TITLE
CI: Bump to macos-11

### DIFF
--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -32,8 +32,6 @@ jobs:
               flag_warnings: ON
               os: ubuntu-22.04
           - config:
-              os: macos-10.15
-          - config:
               os: macos-11
           # TODO: might be interesting to add the thread sanitizer too
           - config:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -177,8 +177,8 @@ stages:
       displayName: 'Build CoreNEURON and Run Integration Tests with ISPC compiler'
   - job: 'osx1015'
     pool:
-      vmImage: 'macOS-10.15'
-    displayName: 'MacOS (10.15), AppleClang 12.0'
+      vmImage: 'macOS-11'
+    displayName: 'MacOS (11), AppleClang 12.0'
     steps:
     - checkout: self
       submodules: True
@@ -289,7 +289,7 @@ stages:
   - job: 'macos_wheels'
     timeoutInMinutes: 45
     pool:
-      vmImage: 'macOS-10.15'
+      vmImage: 'macOS-11'
     strategy:
       matrix:
         ${{ if eq(variables.buildWheel, True) }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,7 @@ variables:
   #- ReleaseWheelBuild: False
   #- UploadWheel: False
   buildWheel: ${{ or(in(variables['Build.Reason'], 'Schedule'), in(variables['Build.Reason'], 'Manual')) }}
+  MACOSX_DEPLOYMENT_TARGET: 10.14
 
 # Nightly build master for pypi upload
 schedules:
@@ -175,7 +176,7 @@ stages:
       env:
         CMAKE_PKG: 'cmake-3.15.0-Linux-x86_64'
       displayName: 'Build CoreNEURON and Run Integration Tests with ISPC compiler'
-  - job: 'osx1015'
+  - job: 'osx11'
     pool:
       vmImage: 'macOS-11'
     displayName: 'MacOS (11), AppleClang 12.0'
@@ -332,7 +333,6 @@ stages:
       condition: succeeded()
       displayName: 'Install Python from python.org'
     - script: |
-        export MACOSX_DEPLOYMENT_TARGET=10.14
         export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH
         export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
         if [[ "$(RELEASEWHEELBUILD)" != "True" ]]; then


### PR DESCRIPTION
NMODL CI: .github#L1The macOS-10.15 environment is deprecated, consider switching to macos-11(macos-latest), macos-12 instead. For more details see https://github.com/actions/virtual-environments/issues/5583
