### PR TITLE
Fix use of array with floating variables

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -2244,9 +2244,9 @@ std::string CodegenCVisitor::float_variable_name(const SymbolType& symbol,
     // clang-format off
     if (symbol->is_array()) {
         if (use_instance) {
-            return fmt::format("(inst->{}+id*{})", name, dimension);
+            return fmt::format("inst->{}[id*{}]", name, dimension);
         }
-        return fmt::format("(data + {}*pnodecount + id*{})", position, dimension);
+        return fmt::format("data[{}*pnodecount + id*{}]", position, dimension);
     }
     if (use_instance) {
         return fmt::format("inst->{}[id]", name);


### PR DESCRIPTION
When using an array we want the value and not the pointer on the value.

Generated code move from `inst->var + size * index` to `inst->var[size * index]` with `double* inst->var`