### PR TITLE
Remove VarName

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -117,25 +117,25 @@ void CodegenCVisitor::visit_prime_name(const PrimeName& node) {
 /**
  * \todo : Validate how @ is being handled in neuron implementation
  */
-void CodegenCVisitor::visit_var_name(const VarName& node) {
-    if (!codegen) {
-        return;
-    }
-    const auto& name = node.get_name();
-    const auto& at_index = node.get_at();
-    const auto& index = node.get_index();
-    name->accept(*this);
-    if (at_index) {
-        printer->add_text("@");
-        at_index->accept(*this);
-    }
-    if (index) {
-        printer->add_text("[");
-        printer->add_text("static_cast<int>(");
-        index->accept(*this);
-        printer->add_text(")");
-        printer->add_text("]");
-    }
+void CodegenCVisitor::visit_identifier(const Identifier& node) {
+//     if (!codegen) {
+//         return;
+//     }
+//     const auto& name = node.get_name();
+//     const auto& at_index = node.get_at();
+//     const auto& index = node.get_index();
+//     name->accept(*this);
+//     if (at_index) {
+//         printer->add_text("@");
+//         at_index->accept(*this);
+//     }
+//     if (index) {
+//         printer->add_text("[");
+//         printer->add_text("static_cast<int>(");
+//         index->accept(*this);
+//         printer->add_text(")");
+//         printer->add_text("]");
+//     }
 }
 
 
@@ -1371,7 +1371,7 @@ void CodegenCVisitor::print_function_call(const FunctionCall& node) {
                                      arguments.front()->get_node_type() == AstNodeType::STRING &&
                                      arguments.front()->get_node_type() ==
                                          AstNodeType::CONSTANT_VAR &&
-                                     arguments.front()->get_node_type() == AstNodeType::VAR_NAME &&
+                                     arguments.front()->get_node_type() == AstNodeType::IDENTIFIER &&
                                      arguments.front()->get_node_type() == AstNodeType::LOCAL_VAR;
     }
     if (defined_method(name)) {

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1899,7 +1899,7 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
     void visit_solution_expression(const ast::SolutionExpression& node) override;
     void visit_unary_operator(const ast::UnaryOperator& node) override;
     void visit_unit(const ast::Unit& node) override;
-    void visit_var_name(const ast::VarName& node) override;
+    void visit_identifier(const ast::Identifier& node) override;
     void visit_verbatim(const ast::Verbatim& node) override;
     void visit_watch_statement(const ast::WatchStatement& node) override;
     void visit_while_statement(const ast::WhileStatement& node) override;

--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -615,7 +615,7 @@ void CodegenHelperVisitor::visit_statement_block(const ast::StatementBlock& node
     for (auto& statement: statements) {
         statement->accept(*this);
         if (under_derivative_block && assign_lhs &&
-            (assign_lhs->is_name() || assign_lhs->is_var_name())) {
+            (assign_lhs->is_name() || assign_lhs->is_identifier())) {
             auto name = assign_lhs->get_node_name();
             auto symbol = psymtab->lookup(name);
             if (symbol != nullptr) {

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -62,7 +62,7 @@ void CodegenIspcVisitor::visit_function_call(const ast::FunctionCall& node) {
 /*
  * Rename special global variables
  */
-void CodegenIspcVisitor::visit_var_name(const ast::VarName& node) {
+void CodegenIspcVisitor::visit_identifier(const ast::Identifier& node) {
     if (!codegen) {
         return;
     }
@@ -70,7 +70,7 @@ void CodegenIspcVisitor::visit_var_name(const ast::VarName& node) {
     node.accept(celsius_rename);
     RenameVisitor pi_rename("PI", "ISPC_PI");
     node.accept(pi_rename);
-    CodegenCVisitor::visit_var_name(node);
+    CodegenCVisitor::visit_identifier(node);
 }
 
 void CodegenIspcVisitor::visit_local_list_statement(const ast::LocalListStatement& node) {

--- a/src/codegen/codegen_ispc_visitor.hpp
+++ b/src/codegen/codegen_ispc_visitor.hpp
@@ -235,7 +235,7 @@ class CodegenIspcVisitor: public CodegenCVisitor {
         , fallback_codegen(mod_file, float_type, optimize_ionvar_copies, wrapper_printer) {}
 
     void visit_function_call(const ast::FunctionCall& node) override;
-    void visit_var_name(const ast::VarName& node) override;
+    void visit_identifier(const ast::Identifier& node) override;
     void visit_program(const ast::Program& node) override;
     void visit_local_list_statement(const ast::LocalListStatement& node) override;
 

--- a/src/language/code_generator.cmake
+++ b/src/language/code_generator.cmake
@@ -184,7 +184,6 @@ set(AST_GENERATED_SOURCES
     ${PROJECT_BINARY_DIR}/src/ast/update_dt.hpp
     ${PROJECT_BINARY_DIR}/src/ast/useion.hpp
     ${PROJECT_BINARY_DIR}/src/ast/valence.hpp
-    ${PROJECT_BINARY_DIR}/src/ast/var_name.hpp
     ${PROJECT_BINARY_DIR}/src/ast/verbatim.hpp
     ${PROJECT_BINARY_DIR}/src/ast/watch.hpp
     ${PROJECT_BINARY_DIR}/src/ast/watch_statement.hpp

--- a/src/language/nmodl.yaml
+++ b/src/language/nmodl.yaml
@@ -279,31 +279,6 @@
                                         }
                                     \endcode
 
-                        - VarName:
-                            members:
-                              - name:
-                                  brief: "Name of variable"
-                                  type: Identifier
-                                  node_name: true
-                              - at:
-                                  brief: "Value specified with `@`"
-                                  type: Integer
-                                  optional: true
-                                  prefix: {value: "@"}
-                              - index:
-                                  brief: "index value in case of array"
-                                  type: Expression
-                                  optional: true
-                                  prefix: {value: "["}
-                                  suffix: {value: "]"}
-                            brief: "Represents a variable"
-                            description: |
-                                    This type was introduced to store variables of different types like
-                                    ast::Name or ast::IndexedName in the AST.
-
-                                    \note With ast::Identifier as top level base class, this type can be
-                                    removed in the future refactoring.
-
                         - Argument:
                             members:
                               - name:
@@ -337,7 +312,7 @@
                                   prefix: {value: " "}
                               - name:
                                   brief: "TODO"
-                                  type: VarName
+                                  type: Identifier
                                   node_name: true
 
                         - ReadIonVar:
@@ -1781,7 +1756,7 @@
                       members:
                         - variables:
                             brief: "TODO"
-                            type: VarName
+                            type: Identifier
                             vector: true
                             separator: ", "
                       brief: "Represent SENS statement in NMODL"

--- a/src/visitors/defuse_analyze_visitor.cpp
+++ b/src/visitors/defuse_analyze_visitor.cpp
@@ -318,7 +318,7 @@ void DefUseAnalyzeVisitor::visit_conserve(const ast::Conserve& node) {
     visit_unsupported_node(node);
 }
 
-void DefUseAnalyzeVisitor::visit_var_name(const ast::VarName& node) {
+void DefUseAnalyzeVisitor::visit_Identifier(const ast::Identifier& node) {
     const std::string& variable = to_nmodl(node);
     process_variable(variable);
 }

--- a/src/visitors/defuse_analyze_visitor.hpp
+++ b/src/visitors/defuse_analyze_visitor.hpp
@@ -286,7 +286,7 @@ class DefUseAnalyzeVisitor: protected ConstAstVisitor {
 
     void visit_conserve(const ast::Conserve& node) override;
 
-    void visit_var_name(const ast::VarName& node) override;
+    void visit_identifier(const ast::Identifier& node) override;
 
     void visit_name(const ast::Name& node) override;
 

--- a/src/visitors/sympy_solver_visitor.cpp
+++ b/src/visitors/sympy_solver_visitor.cpp
@@ -368,7 +368,7 @@ void SympySolverVisitor::solve_non_linear_system(
     construct_eigen_solver_block(pre_solve_statements, solutions, false);
 }
 
-void SympySolverVisitor::visit_var_name(ast::VarName& node) {
+void SympySolverVisitor::visit_identifier(ast::Identifier& node) {
     if (collect_state_vars) {
         std::string var_name = node.get_node_name();
         if (node.get_name()->is_indexed_name()) {
@@ -391,7 +391,7 @@ void SympySolverVisitor::visit_var_name(ast::VarName& node) {
 void SympySolverVisitor::visit_diff_eq_expression(ast::DiffEqExpression& node) {
     const auto& lhs = node.get_expression()->get_lhs();
 
-    if (!lhs->is_var_name()) {
+    if (!lhs->is_identifier()) {
         logger->warn("SympySolverVisitor :: LHS of differential equation is not a VariableName");
         return;
     }

--- a/src/visitors/sympy_solver_visitor.hpp
+++ b/src/visitors/sympy_solver_visitor.hpp
@@ -171,7 +171,7 @@ class SympySolverVisitor: public AstVisitor {
         , elimination(elimination)
         , SMALL_LINEAR_SYSTEM_MAX_STATES(SMALL_LINEAR_SYSTEM_MAX_STATES){};
 
-    void visit_var_name(ast::VarName& node) override;
+    void visit_identifier(ast::Identifier& node) override;
     void visit_diff_eq_expression(ast::DiffEqExpression& node) override;
     void visit_conserve(ast::Conserve& node) override;
     void visit_derivative_block(ast::DerivativeBlock& node) override;

--- a/src/visitors/visitor_utils.cpp
+++ b/src/visitors/visitor_utils.cpp
@@ -255,11 +255,11 @@ std::pair<std::string, std::unordered_set<std::string>> statement_dependencies(
         return {key, out};
     }
 
-    const auto& lhs_var_name = std::dynamic_pointer_cast<ast::VarName>(lhs);
+    const auto& lhs_var_name = std::dynamic_pointer_cast<ast::Identifier>(lhs);
     key = get_full_var_name(*lhs_var_name);
 
     visitor::AstLookupVisitor lookup_visitor;
-    lookup_visitor.lookup(*rhs, ast::AstNodeType::VAR_NAME);
+    lookup_visitor.lookup(*rhs, ast::AstNodeType::IDENTIFIER);
     auto rhs_nodes = lookup_visitor.get_nodes();
     std::for_each(rhs_nodes.begin(),
                   rhs_nodes.end(),
@@ -273,7 +273,7 @@ std::string get_indexed_name(const ast::IndexedName& node) {
     return fmt::format("{}[{}]", node.get_node_name(), to_nmodl(node.get_length()));
 }
 
-std::string get_full_var_name(const ast::VarName& node) {
+std::string get_full_var_name(const ast::Identifier& node) {
     std::string full_var_name;
     if (node.get_name()->is_indexed_name()) {
         auto index_name_node = std::dynamic_pointer_cast<ast::IndexedName>(node.get_name());

--- a/src/visitors/visitor_utils.hpp
+++ b/src/visitors/visitor_utils.hpp
@@ -137,6 +137,6 @@ std::pair<std::string, std::unordered_set<std::string>> statement_dependencies(
 std::string get_indexed_name(const ast::IndexedName& node);
 
 /// Given a VarName node, return the full var name including index
-std::string get_full_var_name(const ast::VarName& node);
+std::string get_full_var_name(const ast::Identifier& node);
 
 }  // namespace nmodl


### PR DESCRIPTION
It should be remove with adding of Identifier as a master class of all VarName.

It will reduce duplication of code.