### PR TITLE
[LLVM][refactoring] Builders

### DIFF
--- a/src/codegen/llvm/CMakeLists.txt
+++ b/src/codegen/llvm/CMakeLists.txt
@@ -4,10 +4,14 @@
 set(LLVM_CODEGEN_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/annotation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/annotation.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/base_builder.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/base_builder.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_llvm_visitor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_llvm_visitor.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_llvm_helper_visitor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_llvm_helper_visitor.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gpu_builder.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gpu_builder.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/llvm_debug_builder.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/llvm_debug_builder.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/llvm_ir_builder.cpp
@@ -16,6 +20,8 @@ set(LLVM_CODEGEN_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/llvm_utils.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/replace_with_lib_functions.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/replace_with_lib_functions.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/simd_builder.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/simd_builder.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/target_platform.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/target_platform.hpp)
 

--- a/src/codegen/llvm/CMakeLists.txt
+++ b/src/codegen/llvm/CMakeLists.txt
@@ -2,6 +2,8 @@
 # Codegen sources
 # =============================================================================
 set(LLVM_CODEGEN_SOURCE_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/annotation.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/annotation.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_llvm_visitor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_llvm_visitor.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/codegen_llvm_helper_visitor.cpp

--- a/src/codegen/llvm/annotation.cpp
+++ b/src/codegen/llvm/annotation.cpp
@@ -23,10 +23,10 @@ static constexpr const char nmodl_compute_kernel[] = "nmodl.compute-kernel";
 namespace nmodl {
 namespace custom {
 
-void Annotator::add_nmodl_compute_kernel_annotation(llvm::Function* function) {
-    llvm::LLVMContext& context = function->getContext();
+void Annotator::add_nmodl_compute_kernel_annotation(llvm::Function& function) {
+    llvm::LLVMContext& context = function.getContext();
     llvm::MDNode* node = llvm::MDNode::get(context, llvm::MDString::get(context, nmodl_compute_kernel));
-    function->setMetadata(nmodl_annotations, node);
+    function.setMetadata(nmodl_annotations, node);
 }
 
 bool Annotator::has_nmodl_compute_kernel_annotation(llvm::Function& function) {

--- a/src/codegen/llvm/annotation.cpp
+++ b/src/codegen/llvm/annotation.cpp
@@ -38,7 +38,7 @@ bool Annotator::has_nmodl_compute_kernel_annotation(llvm::Function& function) {
     return type == nmodl_compute_kernel;
 }
 
-void CPUAnnotator::annotate(llvm::Function& function) const {
+void DefaultCPUAnnotator::annotate(llvm::Function& function) const {
     // By convention, the compute kernel does not free memory and does not
     // throw exceptions.
     function.setDoesNotFreeMemory();

--- a/src/codegen/llvm/annotation.cpp
+++ b/src/codegen/llvm/annotation.cpp
@@ -92,4 +92,14 @@ bool AnnotationPass::runOnModule(Module& module) {
 
     return modified;
 }
+
+void AnnotationPass::getAnalysisUsage(AnalysisUsage& au) const {
+    au.setPreservesCFG();
+    au.addPreserved<ScalarEvolutionWrapperPass>();
+    au.addPreserved<AAResultsWrapperPass>();
+    au.addPreserved<LoopAccessLegacyAnalysis>();
+    au.addPreserved<DemandedBitsWrapperPass>();
+    au.addPreserved<OptimizationRemarkEmitterWrapperPass>();
+    au.addPreserved<GlobalsAAWrapperPass>();
+}
 }  // namespace llvm

--- a/src/codegen/llvm/annotation.cpp
+++ b/src/codegen/llvm/annotation.cpp
@@ -1,0 +1,95 @@
+/*************************************************************************
+ * Copyright (C) 2018-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#include "codegen/llvm/annotation.hpp"
+#include "codegen/llvm/target_platform.hpp"
+
+#include "llvm/Analysis/DemandedBits.h"
+#include "llvm/Analysis/GlobalsModRef.h"
+#include "llvm/Analysis/LoopAccessAnalysis.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
+#include "llvm/Analysis/ScalarEvolution.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/IR/Module.h"
+
+static constexpr const char nmodl_annotations[] = "nmodl.annotations";
+static constexpr const char nmodl_compute_kernel[] = "nmodl.compute-kernel";
+
+namespace nmodl {
+namespace custom {
+
+void Annotator::add_nmodl_compute_kernel_annotation(llvm::Function* function) {
+    llvm::LLVMContext& context = function->getContext();
+    llvm::MDNode* node = llvm::MDNode::get(context, llvm::MDString::get(context, nmodl_compute_kernel));
+    function->setMetadata(nmodl_annotations, node);
+}
+
+bool Annotator::has_nmodl_compute_kernel_annotation(llvm::Function& function) {
+    if (!function.hasMetadata(nmodl_annotations))
+        return false;
+    
+    llvm::MDNode* node = function.getMetadata(nmodl_annotations);
+    std::string type = llvm::cast<llvm::MDString>(node->getOperand(0))->getString().str();
+    return type == nmodl_compute_kernel;
+}
+
+void CPUAnnotator::annotate(llvm::Function& function) const {
+    // By convention, the compute kernel does not free memory and does not
+    // throw exceptions.
+    function.setDoesNotFreeMemory();
+    function.setDoesNotThrow();
+
+    // We also want to specify that the pointers that instance struct holds
+    // do not alias, unless specified otherwise. In order to do that, we
+    // add a `noalias` attribute to the argument. As per Clang's
+    // specification:
+    //  > The `noalias` attribute indicates that the only memory accesses
+    //  > inside function are loads and stores from objects pointed to by
+    //  > its pointer-typed arguments, with arbitrary offsets.
+    function.addParamAttr(0, llvm::Attribute::NoAlias);
+
+    // Finally, specify that the mechanism data struct pointer does not
+    // capture and is read-only. 
+    function.addParamAttr(0, llvm::Attribute::NoCapture);
+    function.addParamAttr(0, llvm::Attribute::ReadOnly);
+}
+
+void CUDAAnnotator::annotate(llvm::Function& function) const {    
+    llvm::LLVMContext& context = function.getContext();
+    llvm::Module* m = function.getParent();
+
+    auto one = llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), 1);
+    llvm::Metadata* metadata[] = {llvm::ValueAsMetadata::get(&function),
+                                  llvm::MDString::get(context, "kernel"),
+                                  llvm::ValueAsMetadata::get(one)};
+    llvm::MDNode* node = llvm::MDNode::get(context, metadata);
+
+    m->getOrInsertNamedMetadata("nvvm.annotations")->addOperand(node);
+}
+}  // namespace custom
+}  // namespace nmodl
+
+using nmodl::custom::Annotator;
+namespace llvm {
+
+char AnnotationPass::ID = 0;
+
+bool AnnotationPass::runOnModule(Module& module) {
+    bool modified = false;
+
+    for (auto& function: module.getFunctionList()) {
+        if (!function.isDeclaration() &&
+            Annotator::has_nmodl_compute_kernel_annotation(function)) {
+            annotator->annotate(function);
+            modified = true;
+        }
+    }
+
+    return modified;
+}
+}  // namespace llvm

--- a/src/codegen/llvm/annotation.hpp
+++ b/src/codegen/llvm/annotation.hpp
@@ -23,7 +23,7 @@ class Annotator {
     virtual ~Annotator() = default;
 
     /// Marks LLVM function as NMODL compute kernel. 
-    static void add_nmodl_compute_kernel_annotation(llvm::Function* function);
+    static void add_nmodl_compute_kernel_annotation(llvm::Function& function);
 
     /// Returns true if LLVM function is marked as NMODL compute kernel. 
     static bool has_nmodl_compute_kernel_annotation(llvm::Function& function);
@@ -49,7 +49,6 @@ class CUDAAnnotator: public Annotator {
 };
 }  // namespace custom
 }  // namespace nmodl
-
 
 using nmodl::custom::Annotator;
 namespace llvm {

--- a/src/codegen/llvm/annotation.hpp
+++ b/src/codegen/llvm/annotation.hpp
@@ -30,10 +30,11 @@ class Annotator {
 };
 
 /**
- * \class CPUAnnotator
- * \brief Specifies how LLVM IR functions for CPU platforms are annotated. 
+ * \class DefaultAnnotator
+ * \brief Specifies how LLVM IR functions for CPU platforms are annotated. Used
+ * by default.
  */
-class CPUAnnotator: public Annotator {
+class DefaultCPUAnnotator: public Annotator {
   public:
     void annotate(llvm::Function& function) const override;
 };

--- a/src/codegen/llvm/annotation.hpp
+++ b/src/codegen/llvm/annotation.hpp
@@ -71,5 +71,7 @@ class AnnotationPass: public ModulePass {
         , annotator(annotator) {}
 
     bool runOnModule(Module& module) override;
+
+    void getAnalysisUsage(AnalysisUsage& au) const override;
 };
 }  // namespace llvm

--- a/src/codegen/llvm/annotation.hpp
+++ b/src/codegen/llvm/annotation.hpp
@@ -1,0 +1,75 @@
+/*************************************************************************
+ * Copyright (C) 2018-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#pragma once
+
+#include "llvm/IR/Function.h"
+#include "llvm/Pass.h"
+
+namespace nmodl {
+namespace custom {
+
+/**
+ * \class Annotator
+ * \brief Base class that can be overriden to specify function annotations. 
+ */
+class Annotator {
+  public:
+    virtual void annotate(llvm::Function& function) const = 0;
+    virtual ~Annotator() = default;
+
+    /// Marks LLVM function as NMODL compute kernel. 
+    static void add_nmodl_compute_kernel_annotation(llvm::Function* function);
+
+    /// Returns true if LLVM function is marked as NMODL compute kernel. 
+    static bool has_nmodl_compute_kernel_annotation(llvm::Function& function);
+};
+
+/**
+ * \class CPUAnnotator
+ * \brief Specifies how LLVM IR functions for CPU platforms are annotated. 
+ */
+class CPUAnnotator: public Annotator {
+  public:
+    void annotate(llvm::Function& function) const override;
+};
+
+/**
+ * \class CUDAAnnotator
+ * \brief Specifies how LLVM IR functions for CUDA platforms are annotated. This
+ * includes marking functions with "kernel" or "device" attributes.
+ */
+class CUDAAnnotator: public Annotator {
+  public:
+    void annotate(llvm::Function& function) const override;
+};
+}  // namespace custom
+}  // namespace nmodl
+
+
+using nmodl::custom::Annotator;
+namespace llvm {
+
+/**
+ * \class AnnotationPass
+ * \brief LLVM module pass that annotates NMODL compute kernels.
+ */
+class AnnotationPass: public ModulePass {
+  private:
+    // Underlying annotator that is applied to each LLVM function.
+    const Annotator* annotator;
+
+  public:
+    static char ID;
+
+    AnnotationPass(Annotator* annotator)
+        : ModulePass(ID)
+        , annotator(annotator) {}
+
+    bool runOnModule(Module& module) override;
+};
+}  // namespace llvm

--- a/src/codegen/llvm/base_builder.cpp
+++ b/src/codegen/llvm/base_builder.cpp
@@ -1,0 +1,463 @@
+/*************************************************************************
+ * Copyright (C) 2018-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#include "codegen/llvm/base_builder.hpp"
+#include "ast/all.hpp"
+
+#include "llvm/ADT/StringSwitch.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/ValueSymbolTable.h"
+
+namespace nmodl {
+namespace codegen {
+
+/****************************************************************************************/
+/*                         Value processing utilities                                   */
+/****************************************************************************************/
+
+llvm::Value* BaseBuilder::lookup_value(const std::string& value_name) {
+    auto value = current_function->getValueSymbolTable()->lookup(value_name);
+    if (!value)
+        throw std::runtime_error("Error: variable " + value_name + " is not in the scope\n");
+    return value;
+}
+
+llvm::Value* BaseBuilder::pop_last_value() {
+    // Check if the stack is empty.
+    if (value_stack.empty())
+        throw std::runtime_error("Error: popping a value from the empty stack\n");
+
+    // Return the last added value and delete it from the stack.
+    llvm::Value* last = value_stack.back();
+    value_stack.pop_back();
+    return last;
+}
+
+/****************************************************************************************/
+/*                               Type utilities                                         */
+/****************************************************************************************/
+
+llvm::Type* BaseBuilder::get_boolean_type() {
+    return llvm::Type::getInt1Ty(builder.getContext());
+}
+
+llvm::Type* BaseBuilder::get_i32_type() {
+    return llvm::Type::getInt32Ty(builder.getContext());
+}
+
+llvm::Type* BaseBuilder::get_i64_type() {
+    return llvm::Type::getInt64Ty(builder.getContext());
+}
+
+llvm::Type* BaseBuilder::get_fp_type() {
+    if (single_precision)
+        return llvm::Type::getFloatTy(builder.getContext());
+    return llvm::Type::getDoubleTy(builder.getContext());
+}
+
+llvm::Type* BaseBuilder::get_void_type() {
+    return llvm::Type::getVoidTy(builder.getContext());
+}
+
+llvm::Type* BaseBuilder::get_i8_ptr_type() {
+    return llvm::Type::getInt8PtrTy(builder.getContext());
+}
+
+llvm::Type* BaseBuilder::get_i32_ptr_type() {
+    return llvm::Type::getInt32PtrTy(builder.getContext());
+}
+
+llvm::Type* BaseBuilder::get_fp_ptr_type() {
+    if (single_precision)
+        return llvm::Type::getFloatPtrTy(builder.getContext());
+    return llvm::Type::getDoublePtrTy(builder.getContext());
+}
+
+llvm::Type* BaseBuilder::get_struct_ptr_type(const std::string& struct_type_name,
+                                             TypeVector& member_types) {
+    llvm::StructType* llvm_struct_type = llvm::StructType::getTypeByName(builder.getContext(),
+                                                                         struct_type_name);
+
+    if (!llvm_struct_type) {
+        llvm_struct_type = llvm::StructType::create(builder.getContext(), struct_type_name);
+        llvm_struct_type->setBody(member_types);
+    }
+
+    return llvm::PointerType::get(llvm_struct_type, /*AddressSpace=*/0);
+}
+
+/****************************************************************************************/
+/*                                  Function utilities                                  */
+/****************************************************************************************/
+
+std::string BaseBuilder::get_current_function_name() {
+    return current_function->getName().str();
+}
+
+void BaseBuilder::set_function(llvm::Function* function) {
+    current_function = function;
+}
+
+void BaseBuilder::unset_function() {
+    value_stack.clear();
+    current_function = nullptr;
+    alloca_ip = nullptr;
+}
+
+void BaseBuilder::generate_function_call(llvm::Function* callee,
+                                         ValueVector& arguments,
+                                         bool with_result) {
+    llvm::Value* call_instruction = builder.CreateCall(callee, arguments);
+    if (with_result)
+        value_stack.push_back(call_instruction);
+}
+
+void BaseBuilder::generate_intrinsic(const std::string& name,
+                                     ValueVector& argument_values,
+                                     TypeVector& argument_types) {
+    // Process 'pow' call separately.
+    if (name == "pow") {
+        llvm::Value* pow_intrinsic = builder.CreateIntrinsic(llvm::Intrinsic::pow,
+                                                             {argument_types.front()},
+                                                             argument_values);
+        value_stack.push_back(pow_intrinsic);
+        return;
+    }
+
+    // Create other intrinsics.
+    unsigned intrinsic_id = llvm::StringSwitch<llvm::Intrinsic::ID>(name)
+                                .Case("ceil", llvm::Intrinsic::ceil)
+                                .Case("cos", llvm::Intrinsic::cos)
+                                .Case("exp", llvm::Intrinsic::exp)
+                                .Case("fabs", llvm::Intrinsic::fabs)
+                                .Case("floor", llvm::Intrinsic::floor)
+                                .Case("log", llvm::Intrinsic::log)
+                                .Case("log10", llvm::Intrinsic::log10)
+                                .Case("sin", llvm::Intrinsic::sin)
+                                .Case("sqrt", llvm::Intrinsic::sqrt)
+                                .Default(llvm::Intrinsic::not_intrinsic);
+    if (intrinsic_id) {
+        llvm::Value* intrinsic =
+            builder.CreateIntrinsic(intrinsic_id, argument_types, argument_values);
+        value_stack.push_back(intrinsic);
+    } else {
+        throw std::runtime_error("Error: calls to " + name + " are not valid or not supported\n");
+    }
+}
+
+void BaseBuilder::allocate_function_arguments(llvm::Function* function,
+                                              const ast::CodegenVarWithTypeVector& nmodl_arguments) {
+    unsigned i = 0;
+    for (auto& arg: function->args()) {
+        std::string arg_name = nmodl_arguments[i++].get()->get_node_name();
+        llvm::Type* arg_type = arg.getType();
+        llvm::Value* alloca = create_alloca(arg_name, arg_type);
+        arg.setName(arg_name);
+        builder.CreateStore(&arg, alloca);
+    }
+}
+
+void BaseBuilder::allocate_and_wrap_kernel_arguments(llvm::Function* function,
+                                                     const ast::CodegenVarWithTypeVector& nmodl_arguments,
+                                                     llvm::Type* struct_type) {
+    // In theory, this should never happen but let's guard anyway.
+    if (nmodl_arguments.size() != 1) {
+        throw std::runtime_error("Error: NMODL computer kernel must have a single argument\n");
+    }
+
+    // Bitcast void* pointer provided as compute kernel argument to mechanism data type.
+    llvm::Value* data_ptr = builder.CreateBitCast(function->getArg(0), struct_type);
+
+    std::string arg_name = nmodl_arguments[0].get()->get_node_name();
+    llvm::Value* alloca = create_alloca(arg_name, struct_type);
+    builder.CreateStore(data_ptr, alloca);
+}
+
+/****************************************************************************************/
+/*                                 Basic block utilities                                */
+/****************************************************************************************/
+
+llvm::BasicBlock* BaseBuilder::get_current_block() {
+    return builder.GetInsertBlock();
+}
+
+void BaseBuilder::set_insertion_point(llvm::BasicBlock* block) {
+    builder.SetInsertPoint(block);
+}
+
+llvm::BasicBlock* BaseBuilder::create_block_and_set_insertion_point(llvm::Function* function,
+                                                                    llvm::BasicBlock* insert_before,
+                                                                    std::string name) {
+    llvm::BasicBlock* block =
+        llvm::BasicBlock::Create(builder.getContext(), name, function, insert_before);
+    builder.SetInsertPoint(block);
+    return block;
+}
+
+llvm::BranchInst* BaseBuilder::create_cond_br(llvm::Value* condition,
+                                              llvm::BasicBlock* true_block,
+                                              llvm::BasicBlock* false_block) {
+    return builder.CreateCondBr(condition, true_block, false_block);
+}
+
+void BaseBuilder::generate_br(llvm::BasicBlock* block) {
+    builder.CreateBr(block);
+}
+
+void BaseBuilder::generate_br_and_set_insertion_point(llvm::BasicBlock* block) {
+    builder.CreateBr(block);
+    builder.SetInsertPoint(block);
+}
+
+/****************************************************************************************/
+/*                                Instruction utilities                                 */
+/****************************************************************************************/
+
+llvm::Value* BaseBuilder::create_alloca(const std::string& name, llvm::Type* type) {
+    // If insertion point for `alloca` instructions is not set, then create the instruction in the
+    // entry block and set it to be the insertion point.
+    if (!alloca_ip) {
+        // Get the entry block and insert the `alloca` instruction there.
+        llvm::BasicBlock* current_block = builder.GetInsertBlock();
+        llvm::BasicBlock& entry_block = current_block->getParent()->getEntryBlock();
+        builder.SetInsertPoint(&entry_block);
+        llvm::Value* alloca = builder.CreateAlloca(type, /*ArraySize=*/nullptr, name);
+
+        // Set the `alloca` instruction insertion point and restore the insertion point for the next
+        // set of instructions.
+        alloca_ip = llvm::cast<llvm::AllocaInst>(alloca);
+        builder.SetInsertPoint(current_block);
+        return alloca;
+    }
+
+    // Create `alloca` instruction.
+    llvm::BasicBlock* alloca_block = alloca_ip->getParent();
+    const auto& data_layout = alloca_block->getModule()->getDataLayout();
+    auto* alloca = new llvm::AllocaInst(type,
+                                        data_layout.getAllocaAddrSpace(),
+                                        /*ArraySize=*/nullptr,
+                                        data_layout.getPrefTypeAlign(type),
+                                        name);
+
+    // Insert `alloca` at the specified insertion point and reset it for the next instructions.
+    alloca_block->getInstList().insertAfter(alloca_ip->getIterator(), alloca);
+    alloca_ip = alloca;
+    return alloca;
+}
+
+llvm::Value* BaseBuilder::create_array_alloca(const std::string& name,
+                                              llvm::Type* element_type,
+                                              int num_elements) {
+    llvm::Type* array_type = llvm::ArrayType::get(element_type, num_elements);
+    return create_alloca(name, array_type);
+}
+
+llvm::Value* BaseBuilder::create_global_string(const ast::String& node) {
+    return builder.CreateGlobalStringPtr(node.get_value());
+}
+
+llvm::Value* BaseBuilder::create_inbounds_gep(const std::string& variable_name,
+                                              llvm::Value* index) {
+    llvm::Value* variable_ptr = lookup_value(variable_name);
+
+    // Since we index through the pointer, we need an extra 0 index in the indices list for GEP.
+    ValueVector indices{llvm::ConstantInt::get(get_i64_type(), 0), index};
+    llvm::Type* variable_type = variable_ptr->getType()->getPointerElementType();
+    return builder.CreateInBoundsGEP(variable_type, variable_ptr, indices);
+}
+
+void BaseBuilder::create_return(llvm::Value* return_value) {
+    if (return_value)
+        builder.CreateRet(return_value);
+    else
+        builder.CreateRetVoid();
+}
+
+llvm::Value* BaseBuilder::create_struct_field_ptr(llvm::Value* struct_variable, int offset) {
+    ValueVector indices;
+    indices.push_back(llvm::ConstantInt::get(get_i32_type(), 0));
+    indices.push_back(llvm::ConstantInt::get(get_i32_type(), offset));
+
+    llvm::Type* type = struct_variable->getType()->getPointerElementType();
+    return builder.CreateInBoundsGEP(type, struct_variable, indices);
+}
+
+ast::BinaryOp BaseBuilder::into_atomic_op(ast::BinaryOp op) {
+    switch (op) {
+    case ast::BinaryOp::BOP_SUB_ASSIGN:
+        return ast::BinaryOp::BOP_SUBTRACTION;
+    case ast::BinaryOp::BOP_ADD_ASSIGN:
+        return ast::BinaryOp::BOP_ADDITION;
+    default:
+        throw std::runtime_error("Error: only atomic addition and subtraction is supported\n");
+    }
+}
+
+llvm::Value* BaseBuilder::into_index(llvm::Value* value) {
+    // First, check if the passed value is an integer.
+    llvm::Type* value_type = value->getType();
+    if (!value_type->isIntOrIntVectorTy())
+        throw std::runtime_error("Error: only integer indexing is supported\n");
+
+    // Conventionally, in LLVM array indices are 64 bit.
+    llvm::Type* index_type = get_i64_type();
+
+    // If value is a scalar.
+    if (auto integer_type = llvm::dyn_cast<llvm::IntegerType>(value_type)) {
+        if (integer_type->getBitWidth() == index_type->getIntegerBitWidth())
+            return value;
+        return builder.CreateSExtOrTrunc(value, index_type);
+    }
+
+    // If value is a vector.
+    const auto& vector_type = llvm::cast<llvm::FixedVectorType>(value_type);
+    const auto& element_type = llvm::cast<llvm::IntegerType>(vector_type->getElementType());
+    if (element_type->getBitWidth() == index_type->getIntegerBitWidth())
+        return value;
+    unsigned num_elements = vector_type->getNumElements();
+    return builder.CreateSExtOrTrunc(value, llvm::FixedVectorType::get(index_type, num_elements));
+}
+
+/****************************************************************************************/
+/*                                 Constant utilities                                   */
+/****************************************************************************************/
+
+template <typename C, typename V>
+llvm::Value* BaseBuilder::scalar_constant(llvm::Type* type, V value) {
+    return C::get(type, value);
+}
+
+template <typename C, typename V>
+llvm::Value* BaseBuilder::vector_constant(llvm::Type* type, V value, unsigned num_elements) {
+    ConstantVector constants;
+    for (unsigned i = 0; i < num_elements; ++i) {
+        const auto& element = C::get(type, value);
+        constants.push_back(element);
+    }
+    return llvm::ConstantVector::get(constants);
+}
+
+/****************************************************************************************/
+/*                           Generation virtual functions                               */
+/****************************************************************************************/
+
+void BaseBuilder::generate_atomic_statement(llvm::Value* ptr, llvm::Value* rhs, ast::BinaryOp op) {
+    // TODO: rewrite this!
+}
+
+void BaseBuilder::generate_binary_op(llvm::Value* lhs, llvm::Value* rhs, ast::BinaryOp op) {
+    // Check that both lhs and rhs have the same types.
+    if (lhs->getType() != rhs->getType())
+        throw std::runtime_error(
+            "Error: lhs and rhs of the binary operator have different types\n");
+
+    llvm::Value* result;
+    switch (op) {
+#define DISPATCH(binary_op, fp_instruction, integer_instruction) \
+    case binary_op:                                              \
+        if (lhs->getType()->isIntOrIntVectorTy())                \
+            result = integer_instruction(lhs, rhs);              \
+        else                                                     \
+            result = fp_instruction(lhs, rhs);                   \
+        break;
+
+        // Arithmetic instructions.
+        DISPATCH(ast::BinaryOp::BOP_ADDITION, builder.CreateFAdd, builder.CreateAdd);
+        DISPATCH(ast::BinaryOp::BOP_DIVISION, builder.CreateFDiv, builder.CreateSDiv);
+        DISPATCH(ast::BinaryOp::BOP_MULTIPLICATION, builder.CreateFMul, builder.CreateMul);
+        DISPATCH(ast::BinaryOp::BOP_SUBTRACTION, builder.CreateFSub, builder.CreateSub);
+
+        // Comparison instructions.
+        DISPATCH(ast::BinaryOp::BOP_EXACT_EQUAL, builder.CreateFCmpOEQ, builder.CreateICmpEQ);
+        DISPATCH(ast::BinaryOp::BOP_GREATER, builder.CreateFCmpOGT, builder.CreateICmpSGT);
+        DISPATCH(ast::BinaryOp::BOP_GREATER_EQUAL, builder.CreateFCmpOGE, builder.CreateICmpSGE);
+        DISPATCH(ast::BinaryOp::BOP_LESS, builder.CreateFCmpOLT, builder.CreateICmpSLT);
+        DISPATCH(ast::BinaryOp::BOP_LESS_EQUAL, builder.CreateFCmpOLE, builder.CreateICmpSLE);
+        DISPATCH(ast::BinaryOp::BOP_NOT_EQUAL, builder.CreateFCmpONE, builder.CreateICmpNE);
+
+#undef DISPATCH
+
+    // Separately replace ^ with the `pow` intrinsic.
+    case ast::BinaryOp::BOP_POWER:
+        result = builder.CreateIntrinsic(llvm::Intrinsic::pow, {lhs->getType()}, {lhs, rhs});
+        break;
+
+    // Logical instructions.
+    case ast::BinaryOp::BOP_AND:
+        result = builder.CreateAnd(lhs, rhs);
+        break;
+    case ast::BinaryOp::BOP_OR:
+        result = builder.CreateOr(lhs, rhs);
+        break;
+
+    default:
+        throw std::runtime_error("Error: unsupported binary operator\n");
+    }
+    value_stack.push_back(result);
+}
+
+void BaseBuilder::generate_unary_op(llvm::Value* value, ast::UnaryOp op) {
+    if (op == ast::UOP_NEGATION) {
+        value_stack.push_back(builder.CreateFNeg(value));
+    } else if (op == ast::UOP_NOT) {
+        value_stack.push_back(builder.CreateNot(value));
+    } else {
+        throw std::runtime_error("Error: unsupported unary operator\n");
+    }
+}
+
+void BaseBuilder::generate_boolean_constant(int value) {
+    value_stack.push_back(scalar_constant<llvm::ConstantInt>(get_boolean_type(), value));
+}
+
+void BaseBuilder::generate_i32_constant(int value) {
+    value_stack.push_back(scalar_constant<llvm::ConstantInt>(get_i32_type(), value));
+}
+
+void BaseBuilder::generate_fp_constant(const std::string& value) {
+    value_stack.push_back(scalar_constant<llvm::ConstantFP>(get_fp_type(), value));
+}
+
+void BaseBuilder::generate_load_direct(llvm::Value* ptr) {
+    llvm::Type* loaded_type = ptr->getType()->getPointerElementType();
+    llvm::Value* loaded = builder.CreateLoad(loaded_type, ptr);
+    value_stack.push_back(loaded);
+}
+
+void BaseBuilder::generate_load_indirect(llvm::Value* ptr) {
+    llvm::Type* loaded_type = ptr->getType()->getPointerElementType();
+    llvm::Value* loaded = builder.CreateLoad(loaded_type, ptr);
+    value_stack.push_back(loaded);
+}
+
+void BaseBuilder::generate_store_direct(llvm::Value* ptr, llvm::Value* value) {
+    builder.CreateStore(value, ptr);
+}
+
+void BaseBuilder::generate_store_indirect(llvm::Value* ptr, llvm::Value* value) {
+    builder.CreateStore(value, ptr);
+}
+
+void BaseBuilder::try_generate_broadcast(llvm::Value* value) {
+    // No need to broadcast anything!
+    value_stack.push_back(value);
+}
+
+void BaseBuilder::generate_loop_start() {
+    generate_i32_constant(0);
+}
+
+void BaseBuilder::generate_loop_increment() {
+    generate_i32_constant(1);
+}
+
+void BaseBuilder::generate_loop_end() {
+    // TODO: fix this when an AST node is added.
+}
+
+}  // namespace codegen
+}  // namespace nmodl

--- a/src/codegen/llvm/base_builder.hpp
+++ b/src/codegen/llvm/base_builder.hpp
@@ -1,0 +1,280 @@
+/*************************************************************************
+ * Copyright (C) 2018-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#pragma once
+
+#include <string>
+
+#include "codegen/llvm/codegen_llvm_helper_visitor.hpp"
+
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/LLVMContext.h"
+
+// Floating point bit widths.
+static constexpr const unsigned single_precision = 32;
+static constexpr const unsigned double_precision = 64;
+
+// Some typedefs.
+using ConstantVector = std::vector<llvm::Constant*>;
+using TypeVector = std::vector<llvm::Type*>;
+using ValueVector = std::vector<llvm::Value*>;
+
+/// Transforms the fast math flags provided to the builder into LLVM's representation.
+static llvm::FastMathFlags transform_to_fmf(std::vector<std::string>& flags) {
+    static const std::map<std::string, void (llvm::FastMathFlags::*)(bool)> set_flag = {
+        {"nnan", &llvm::FastMathFlags::setNoNaNs},
+        {"ninf", &llvm::FastMathFlags::setNoInfs},
+        {"nsz", &llvm::FastMathFlags::setNoSignedZeros},
+        {"contract", &llvm::FastMathFlags::setAllowContract},
+        {"afn", &llvm::FastMathFlags::setApproxFunc},
+        {"reassoc", &llvm::FastMathFlags::setAllowReassoc},
+        {"fast", &llvm::FastMathFlags::setFast}};
+    llvm::FastMathFlags fmf;
+    for (const auto& flag: flags) {
+        (fmf.*(set_flag.at(flag)))(true);
+    }
+    return fmf;
+}
+
+namespace nmodl {
+namespace codegen {
+
+/**
+ * \class BaseBuilder
+ * \brief A base class to generate LLVM IR for NMODL AST. Assumes a CPU target
+ * by default.
+ */
+class BaseBuilder {
+  protected:
+    /// Underlying LLVM IR builder.
+    llvm::IRBuilder<> builder;
+
+    /// Stack to hold visited and processed values.
+    ValueVector value_stack;
+
+    /// Pointer to the current function for which the code is generated.
+    llvm::Function* current_function;
+
+    /// Insertion point for `alloca` instructions.
+    llvm::Instruction* alloca_ip;
+
+    /// If single-precision floating point numbers are used. 
+    bool single_precision;
+
+    /// Fast math flags for floating-point IR instructions.
+    std::vector<std::string> fast_math_flags;
+
+    BaseBuilder(llvm::LLVMContext& context,
+                bool single_precision,
+                std::vector<std::string> fast_math_flags = {})
+        : builder(context)
+        , current_function(nullptr)
+        , alloca_ip(nullptr)
+        , single_precision(single_precision) {}
+
+  public:
+    /// Creates a new instance of a base builder.
+    void create(llvm::LLVMContext& context,
+              bool single_precision,
+              std::vector<std::string> fast_math_flags) {
+        // TODO: create class!
+        // if (!fast_math_flags.empty())
+        //     builder.setFastMathFlags(transform_to_fmf(fast_math_flags));
+    }
+
+    /*************************************************************************/
+    /*                       Value processing utilities                      */
+    /*************************************************************************/
+
+    /// Lookups the value by its name in the current function's symbol table.
+    llvm::Value* lookup_value(const std::string& value_name);
+
+    /// Pops the last value from the stack.
+    llvm::Value* pop_last_value();
+
+    /*************************************************************************/
+    /*                            Type utilities                             */
+    /*************************************************************************/
+
+    /// Creates a boolean type.
+    llvm::Type* get_boolean_type();
+
+    /// Creates a 32-bit integer type.
+    llvm::Type* get_i32_type();
+
+    /// Creates a 64-bit integer type.
+    llvm::Type* get_i64_type();
+
+    /// Creates a floating-point type.
+    llvm::Type* get_fp_type();
+
+    /// Creates a void type.
+    llvm::Type* get_void_type();
+
+    /// Creates a pointer to 8-bit integer type.
+    llvm::Type* get_i8_ptr_type();
+
+    /// Creates a pointer to 32-bit integer type.
+    llvm::Type* get_i32_ptr_type();
+
+    /// Creates a pointer to floating-point type.
+    llvm::Type* get_fp_ptr_type();
+
+    /// Creates a pointer to struct type with the given name and given members.
+    llvm::Type* get_struct_ptr_type(const std::string& struct_type_name, TypeVector& member_types);
+
+    /*************************************************************************/
+    /*                           Function utilities                          */
+    /*************************************************************************/
+
+    /// Returns the name of the function for which LLVM IR is generated.
+    std::string get_current_function_name();
+
+    /// Sets the current function for which LLVM IR is generated.
+    void set_function(llvm::Function* function);
+
+    /// Clears the stack of the values and unsets the current function.
+    void unset_function();
+
+    /// Generates LLVM IR for a call to the function.
+    void generate_function_call(llvm::Function* callee,
+                                ValueVector& arguments,
+                                bool with_result = true);
+    
+    /// Generates an intrinsic that corresponds to the given name.
+    void generate_intrinsic(const std::string& name,
+                            ValueVector& argument_values,
+                            TypeVector& argument_types);
+
+    /// Generates LLVM IR to allocate the arguments of the function on the stack.
+    void allocate_function_arguments(llvm::Function* function,
+                                     const ast::CodegenVarWithTypeVector& nmodl_arguments);
+
+    /// Generates LLVM IR to allocate the arguments of the NMODL compute kernel
+    /// on the stack, bitcasting void* pointer to mechanism struct pointer.
+    void allocate_and_wrap_kernel_arguments(llvm::Function* function,
+                                            const ast::CodegenVarWithTypeVector& nmodl_arguments,
+                                            llvm::Type* mechanism_ptr);
+
+    /*************************************************************************/
+    /*                          Basic block utilities                        */
+    /*************************************************************************/
+
+    /// Returns the current basic block.
+    llvm::BasicBlock* get_current_block();
+
+    /// Sets builder's insertion point to the given block.
+    void set_insertion_point(llvm::BasicBlock* block);
+
+    /// Creates a basic block and set the builder's insertion point to it.
+    llvm::BasicBlock* create_block_and_set_insertion_point(llvm::Function* function,
+                                                           llvm::BasicBlock* insert_before,
+                                                           std::string name = "");
+
+    /// Creates LLVM IR conditional branch instruction.
+    llvm::BranchInst* create_cond_br(llvm::Value* condition,
+                                     llvm::BasicBlock* true_block,
+                                     llvm::BasicBlock* false_block);
+
+    /// Generates LLVM IR for unconditional branch.
+    void generate_br(llvm::BasicBlock* block);
+
+    /// Generates LLVM IR for unconditional branch and sets the insertion point to this block.
+    void generate_br_and_set_insertion_point(llvm::BasicBlock* block);
+
+    /*************************************************************************/
+    /*                         Instruction utilities                         */
+    /*************************************************************************/
+
+    /// Creates LLVM IR alloca instruction.
+    llvm::Value* create_alloca(const std::string& name, llvm::Type* type);
+
+    /// Creates LLVM IR alloca instruction for an array.
+    llvm::Value* create_array_alloca(const std::string& name, llvm::Type* element_type, int num_elements);
+
+    /// Creates LLVM IR global string value.
+    llvm::Value* create_global_string(const ast::String& node);
+
+    /// Creates LLVM IR inbounds GEP instruction for the given name and returns the calculated address.
+    llvm::Value* create_inbounds_gep(const std::string& variable_name, llvm::Value* index);
+
+    /// Creates LLVM IR return instructions.
+    void create_return(llvm::Value* return_value = nullptr);
+
+    /// Creates LLVM IR to get the address of the struct's value at given offset. Returns the
+    /// calculated address.
+    llvm::Value* create_struct_field_ptr(llvm::Value* struct_variable, int offset);
+
+    /// Extracts binary operator (+ or -) from atomic update (+= or =-).
+    ast::BinaryOp into_atomic_op(ast::BinaryOp op);
+
+    /// Transforms an integer value into an index.
+    llvm::Value* into_index(llvm::Value* value);
+
+    /*************************************************************************/
+    /*                           Constant utilities                          */
+    /*************************************************************************/
+
+  protected:
+    /// Returns a scalar constant of the provided type.
+    template <typename C, typename V>
+    llvm::Value* scalar_constant(llvm::Type* type, V value);
+
+    /// Returns a vector constant of the provided type.
+    template <typename C, typename V>
+    llvm::Value* vector_constant(llvm::Type* type, V value, unsigned num_elements);
+
+    /*************************************************************************/
+    /*                     Virtual generation methods                        */
+    /*************************************************************************/
+
+    /// Generates LLVM IR to handle atomic updates, e.g. *ptr += rhs.
+    virtual void generate_atomic_statement(llvm::Value* ptr, llvm::Value* rhs, ast::BinaryOp op);
+
+    /// Generates LLVM IR for the binary operator.
+    virtual void generate_binary_op(llvm::Value* lhs, llvm::Value* rhs, ast::BinaryOp op);
+
+    /// Generates LLVM IR for the unary operator.
+    virtual void generate_unary_op(llvm::Value* value, ast::UnaryOp op);
+
+    /// Generates LLVM IR for boolean constants.
+    virtual void generate_boolean_constant(int value);
+
+    /// Generates LLVM IR for integer constants.
+    virtual void generate_i32_constant(int value);
+
+    /// Generates LLVM IR for floating-point constants.
+    virtual void generate_fp_constant(const std::string& value);
+
+    /// Generates LLVM IR for directed data read.
+    virtual void generate_load_direct(llvm::Value* ptr);
+
+    /// Generates LLVM IR for indirected data read.
+    virtual void generate_load_indirect(llvm::Value* ptr);
+
+    /// Generates LLVM IR for directed data write.
+    virtual void generate_store_direct(llvm::Value* ptr, llvm::Value* value);
+
+    /// Generates LLVM IR for indirected data write.
+    virtual void generate_store_indirect(llvm::Value* ptr, llvm::Value* value);
+
+    /// Generates LLVM IR for brodcasting a value, if necessary.
+    virtual void try_generate_broadcast(llvm::Value* ptr);
+
+    /// Generates LLVM IR for loop initialization.
+    virtual void generate_loop_start();
+
+    /// Generates LLVM IR for loop increment.
+    virtual void generate_loop_increment();
+
+    /// Generates LLVM IR for loop termination.
+    /// TODO: should take an AST node!
+    virtual void generate_loop_end();
+};
+
+}  // namespace codegen
+}  // namespace nmodl

--- a/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_helper_visitor.cpp
@@ -192,7 +192,7 @@ void CodegenLLVMHelperVisitor::create_function_for_node(ast::Block& node) {
 
     /// we have all information for code generation function, create a new node
     /// which will be inserted later into AST
-    auto function = std::make_shared<ast::CodegenFunction>(fun_ret_type, name, arguments, block);
+    auto function = std::make_shared<ast::CodegenFunction>(fun_ret_type, name, arguments, block, /*is_kernel=*/0);
     if (node.get_token()) {
         function->set_token(*node.get_token()->clone());
     }
@@ -732,7 +732,7 @@ void CodegenLLVMHelperVisitor::visit_nrn_state_block(ast::NrnStateBlock& node) {
 
     /// finally, create new function
     auto function =
-        std::make_shared<ast::CodegenFunction>(return_type, name, code_arguments, function_block);
+        std::make_shared<ast::CodegenFunction>(return_type, name, code_arguments, function_block, /*is_kernel=*/1);
     codegen_functions.push_back(function);
 
     // todo: remove this, temporary
@@ -1097,7 +1097,8 @@ void CodegenLLVMHelperVisitor::visit_breakpoint_block(ast::BreakpointBlock& node
         auto function = std::make_shared<ast::CodegenFunction>(return_type,
                                                                name,
                                                                code_arguments,
-                                                               function_block);
+                                                               function_block,
+                                                               /*is_kernel=*/1);
         codegen_functions.push_back(function);
 
         // todo: remove this, temporary

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -114,10 +114,10 @@ void CodegenLLVMVisitor::create_function_declaration(const ast::CodegenFunction&
 
     TypeVector arg_types;
     if (wrap_kernel_functions && node.get_is_kernel()) {
-        // We are wrapping NMODL compute kernels as a function taling void*. Thus,
-        // ignore struct pointer argument type and create function signature with
+        // We are wrapping NMODL compute kernels as a function taking void*. Thus,
+        // ignore struct pointer argument type and create a function signature with
         // void* - actual conversion to struct pointer is done when generating
-        // function body!
+        // the function body!
         arg_types.push_back(ir_builder.get_i8_ptr_type());
     } else {
         // Otherwise, process argument types as usual.
@@ -670,7 +670,7 @@ void CodegenLLVMVisitor::visit_codegen_function(const ast::CodegenFunction& node
     // Allocate parameters on the stack and add them to the symbol table.
     if (wrap_kernel_functions && node.get_is_kernel()) {
         // If we wrap NMODL compute kernel, the parameter will be void*! Hence,
-        // get the actual struct pointer type and allocate parameters on the
+        // we get the actual struct pointer type and allocate parameters on the
         // stack with additional bitcast.
         llvm::Type* struct_ty = get_codegen_var_type(*arguments[0]->get_type());
         ir_builder.allocate_and_wrap_kernel_arguments(func, arguments, struct_ty);
@@ -699,7 +699,7 @@ void CodegenLLVMVisitor::visit_codegen_function(const ast::CodegenFunction& node
     // If function is a compute kernel, add a void terminator explicitly, since there is no
     // `CodegenReturnVar` node. Also, set the necessary attributes.
     if (node.get_is_kernel()) {
-        custom::Annotator::add_nmodl_compute_kernel_annotation(func);
+        custom::Annotator::add_nmodl_compute_kernel_annotation(*func);
         ir_builder.create_return();
     }
 

--- a/src/codegen/llvm/codegen_llvm_visitor.cpp
+++ b/src/codegen/llvm/codegen_llvm_visitor.cpp
@@ -627,7 +627,6 @@ void CodegenLLVMVisitor::visit_codegen_for_statement(const ast::CodegenForStatem
     // Extract the condition to decide whether to branch to the loop body or loop exit.
     llvm::Value* cond = accept_and_get(node.get_condition());
     llvm::BranchInst* loop_br = ir_builder.create_cond_br(cond, for_body, exit);
-    ir_builder.set_loop_metadata(loop_br);
     ir_builder.set_insertion_point(for_body);
 
     // If not processing remainder of the loop, start vectorization.
@@ -902,7 +901,6 @@ void CodegenLLVMVisitor::visit_program(const ast::Program& node) {
     }
 
     // Pass 1: replace LLVM math intrinsics with library calls.
-    // TODO: this needs to be done in the same way as Annotator!
     utils::replace_with_lib_functions(platform, *module);
 
     // Pass 2: annotate NMODL compute kernels.

--- a/src/codegen/llvm/gpu_builder.cpp
+++ b/src/codegen/llvm/gpu_builder.cpp
@@ -1,0 +1,65 @@
+/*************************************************************************
+ * Copyright (C) 2018-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#include "codegen/llvm/gpu_builder.hpp"
+#include "ast/all.hpp"
+
+#include "llvm/IR/IntrinsicsNVPTX.h"
+
+namespace nmodl {
+namespace codegen {
+
+/****************************************************************************************/
+/*                           Generation virtual functions                               */
+/****************************************************************************************/
+
+void GPUBuilder::generate_atomic_statement(llvm::Value* ptr, llvm::Value* rhs, ast::BinaryOp op) {
+    if (op == ast::BinaryOp::BOP_SUBTRACTION) {
+        rhs = builder.CreateFNeg(rhs);
+    }
+    builder.CreateAtomicRMW(llvm::AtomicRMWInst::FAdd,
+                            ptr,
+                            rhs,
+                            llvm::MaybeAlign(),
+                            llvm::AtomicOrdering::SequentiallyConsistent);
+}
+
+void GPUBuilder::generate_loop_start() {
+    llvm::Module* m = builder.GetInsertBlock()->getParent()->getParent();
+    auto create_call = [&](llvm::Intrinsic::ID id) {
+        llvm::Function* intrinsic = llvm::Intrinsic::getDeclaration(m, id);
+        return builder.CreateCall(intrinsic, {});
+    };
+
+    // For now, this function only supports NVPTX backend, however it can be easily
+    // adjusted to generate thread id variable for any other platform.
+    llvm::Value* block_id = create_call(llvm::Intrinsic::nvvm_read_ptx_sreg_ctaid_x);
+    llvm::Value* block_dim = create_call(llvm::Intrinsic::nvvm_read_ptx_sreg_ntid_x);
+    llvm::Value* tmp = builder.CreateMul(block_id, block_dim);
+
+    llvm::Value* tid = create_call(llvm::Intrinsic::nvvm_read_ptx_sreg_tid_x);
+    llvm::Value* id = builder.CreateAdd(tmp, tid);
+
+    value_stack.push_back(id);
+}
+
+void GPUBuilder::generate_loop_increment() {
+    llvm::Module* m = builder.GetInsertBlock()->getParent()->getParent();
+    auto create_call = [&](llvm::Intrinsic::ID id) {
+        llvm::Function* intrinsic = llvm::Intrinsic::getDeclaration(m, id);
+        return builder.CreateCall(intrinsic, {});
+    };
+
+    llvm::Value* block_dim = create_call(llvm::Intrinsic::nvvm_read_ptx_sreg_ntid_x);
+    llvm::Value* grid_dim = create_call(llvm::Intrinsic::nvvm_read_ptx_sreg_nctaid_x);
+    llvm::Value* stride = builder.CreateMul(block_dim, grid_dim);
+
+    value_stack.push_back(stride);
+}
+
+}  // namespace codegen
+}  // namespace nmodl

--- a/src/codegen/llvm/gpu_builder.hpp
+++ b/src/codegen/llvm/gpu_builder.hpp
@@ -1,0 +1,46 @@
+/*************************************************************************
+ * Copyright (C) 2018-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#pragma once
+
+#include <string>
+
+#include "codegen/llvm/base_builder.hpp"
+#include "codegen/llvm/codegen_llvm_helper_visitor.hpp"
+
+namespace nmodl {
+namespace codegen {
+
+/**
+ * \class GPUBuilder
+ * \brief A class to generate LLVM IR for NMODL AST targeting GPU platforms.
+ */
+class GPUBuilder: public BaseBuilder {
+  protected:
+     GPUBuilder(llvm::LLVMContext& context,
+                 bool single_precision,
+                 std::vector<std::string> fast_math_flags = {})
+        : BaseBuilder(context, single_precision, fast_math_flags) {}
+
+    /*************************************************************************/
+    /*                     Virtual generation methods                        */
+    /*************************************************************************/
+
+  public:
+    /// Generates LLVM IR to handle atomic updates, e.g. *ptr += rhs.
+    void generate_atomic_statement(llvm::Value* lhs, llvm::Value* rhs, ast::BinaryOp op) override;
+
+    /// Generates LLVM IR for loop initialization.
+    void generate_loop_start() override;
+
+    /// Generates LLVM IR for loop increment.
+    void generate_loop_increment() override;
+
+};
+
+}  // namespace codegen
+}  // namespace nmodl

--- a/src/codegen/llvm/llvm_ir_builder.cpp
+++ b/src/codegen/llvm/llvm_ir_builder.cpp
@@ -220,36 +220,6 @@ void IRBuilder::create_intrinsic(const std::string& name,
 }
 
 /****************************************************************************************/
-/*                                LLVM metadata utilities                               */
-/****************************************************************************************/
-
-void IRBuilder::set_loop_metadata(llvm::BranchInst* branch) {
-    /// TODO: do we really need this?
-    llvm::LLVMContext& context = builder.getContext();
-    MetadataVector loop_metadata;
-
-    // Add nullptr to reserve the first place for loop's metadata self-reference.
-    loop_metadata.push_back(nullptr);
-
-    // If `vector_width` is 1, explicitly disable vectorization for benchmarking purposes.
-    if (platform.is_cpu() && platform.get_instruction_width() == 1) {
-        llvm::MDString* name = llvm::MDString::get(context, "llvm.loop.vectorize.enable");
-        llvm::Value* false_value = llvm::ConstantInt::get(get_boolean_type(), 0);
-        llvm::ValueAsMetadata* value = llvm::ValueAsMetadata::get(false_value);
-        loop_metadata.push_back(llvm::MDNode::get(context, {name, value}));
-    }
-
-    // No metadata to add.
-    if (loop_metadata.size() <= 1)
-        return;
-
-    // Add loop's metadata self-reference and attach it to the branch.
-    llvm::MDNode* metadata = llvm::MDNode::get(context, loop_metadata);
-    metadata->replaceOperandWith(0, metadata);
-    branch->setMetadata(llvm::LLVMContext::MD_loop, metadata);
-}
-
-/****************************************************************************************/
 /*                             LLVM instruction utilities                               */
 /****************************************************************************************/
 

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -153,6 +153,12 @@ class IRBuilder {
     void allocate_function_arguments(llvm::Function* function,
                                      const ast::CodegenVarWithTypeVector& nmodl_arguments);
 
+    /// Generates LLVM IR to allocate the arguments of the NMODL compute kernel
+    /// on the stack, bitcasting void* pointer to mechanism struct pointers.
+    void allocate_and_wrap_kernel_arguments(llvm::Function* function,
+                                            const ast::CodegenVarWithTypeVector& nmodl_arguments,
+                                            llvm::Type* struct_type);
+
     llvm::Value* create_alloca(const std::string& name, llvm::Type* type);
 
     /// Generates IR for allocating an array.
@@ -300,9 +306,6 @@ class IRBuilder {
 
     /// Sets builder's insertion point to the given block.
     void set_insertion_point(llvm::BasicBlock* block);
-
-    /// Sets the necessary attributes for the kernel and its arguments.
-    void set_kernel_attributes();
 
     /// Sets the loop metadata for the given branch from the loop.
     void set_loop_metadata(llvm::BranchInst* branch);

--- a/src/codegen/llvm/llvm_ir_builder.hpp
+++ b/src/codegen/llvm/llvm_ir_builder.hpp
@@ -25,7 +25,6 @@ static constexpr const unsigned double_precision = 64;
 
 /// Some typedefs.
 using ConstantVector = std::vector<llvm::Constant*>;
-using MetadataVector = std::vector<llvm::Metadata*>;
 using TypeVector = std::vector<llvm::Type*>;
 using ValueVector = std::vector<llvm::Value*>;
 
@@ -306,9 +305,6 @@ class IRBuilder {
 
     /// Sets builder's insertion point to the given block.
     void set_insertion_point(llvm::BasicBlock* block);
-
-    /// Sets the loop metadata for the given branch from the loop.
-    void set_loop_metadata(llvm::BranchInst* branch);
 
     /// Pops the last visited value from the value stack.
     llvm::Value* pop_last_value();

--- a/src/codegen/llvm/llvm_utils.cpp
+++ b/src/codegen/llvm/llvm_utils.cpp
@@ -190,7 +190,7 @@ void annotate(codegen::Platform& platform, llvm::Module& module) {
     if (platform.is_CUDA_gpu()) {
         annotator = new custom::CUDAAnnotator();
     } else {
-        annotator = new custom::CPUAnnotator();
+        annotator = new custom::DefaultCPUAnnotator();
     }
     pm.add(new llvm::AnnotationPass(annotator));
     pm.run(module);

--- a/src/codegen/llvm/llvm_utils.cpp
+++ b/src/codegen/llvm/llvm_utils.cpp
@@ -179,8 +179,17 @@ void optimise_module(llvm::Module& module, int opt_level, llvm::TargetMachine* t
 
 void replace_with_lib_functions(codegen::Platform& platform, llvm::Module& module) {
     llvm::legacy::PassManager pm;
-    pm.add(new llvm::ReplaceMathFunctions(platform));
+
+    Replacer *replacer = nullptr;
+    if (platform.is_CUDA_gpu()) {
+        replacer = new custom::CUDAReplacer();
+    } else {
+        replacer = new custom::DefaultCPUReplacer(platform.get_math_library());
+    }
+    pm.add(new llvm::ReplacePass(replacer));
     pm.run(module);
+
+    delete replacer;
 }
 
 void annotate(codegen::Platform& platform, llvm::Module& module) {

--- a/src/codegen/llvm/llvm_utils.cpp
+++ b/src/codegen/llvm/llvm_utils.cpp
@@ -7,6 +7,7 @@
 
 #include "codegen/llvm/llvm_utils.hpp"
 #include "codegen/llvm/replace_with_lib_functions.hpp"
+#include "codegen/llvm/annotation.hpp"
 
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/AssemblyAnnotationWriter.h"
@@ -180,6 +181,21 @@ void replace_with_lib_functions(codegen::Platform& platform, llvm::Module& modul
     llvm::legacy::PassManager pm;
     pm.add(new llvm::ReplaceMathFunctions(platform));
     pm.run(module);
+}
+
+void annotate(codegen::Platform& platform, llvm::Module& module) {
+    llvm::legacy::PassManager pm;
+
+    Annotator *annotator = nullptr;
+    if (platform.is_CUDA_gpu()) {
+        annotator = new custom::CUDAAnnotator();
+    } else {
+        annotator = new custom::CPUAnnotator();
+    }
+    pm.add(new llvm::AnnotationPass(annotator));
+    pm.run(module);
+
+    delete annotator;
 }
 
 /****************************************************************************************/

--- a/src/codegen/llvm/llvm_utils.hpp
+++ b/src/codegen/llvm/llvm_utils.hpp
@@ -31,6 +31,12 @@ std::string get_module_ptx(llvm::TargetMachine& tm, llvm::Module& module);
 /// Replaces calls to LLVM intrinsics with appropriate library calls.
 void replace_with_lib_functions(codegen::Platform& platform, llvm::Module& module);
 
+/// Annotates LLVM module with appropriate metadata.
+/// TODO: this function and replace_with_lib_functions will be chnaged
+/// oncePlatform evolves into PlatformConfig which would be responsible
+/// for platform-dependent pass initialisation.
+void annotate(codegen::Platform& platform, llvm::Module& module);
+
 /// Optimises the given LLVM IR module for NVPTX targets.
 void optimise_module_for_nvptx(const codegen::Platform& platform,
                                llvm::Module& module,

--- a/src/codegen/llvm/replace_with_lib_functions.cpp
+++ b/src/codegen/llvm/replace_with_lib_functions.cpp
@@ -18,17 +18,45 @@
 #include "llvm/IR/IntrinsicsNVPTX.h"
 #include "llvm/IR/LegacyPassManager.h"
 
+namespace nmodl {
+namespace custom {
+
+Patterns DefaultCPUReplacer::patterns() const {
+    throw std::runtime_error("Error: DefaultCPUReplacer has no patterns and uses built-in LLVM passes instead.\n");
+}
+
+std::string DefaultCPUReplacer::get_library_name() {
+    return this->library_name;
+}
+
+Patterns CUDAReplacer::patterns() const {
+    return {
+        {"llvm.exp.f32", "__nv_expf"},
+        {"llvm.exp.f64", "__nv_exp"},
+        {"llvm.pow.f32", "__nv_powf"},
+        {"llvm.pow.f64", "__nv_pow"},
+        {"llvm.log.f32", "__nv_logf"},
+        {"llvm.log.f64", "__nv_log"},
+        {"llvm.fabs.f32", "__nv_fabsf"},
+        {"llvm.fabs.f64", "__nv_fabs"}
+    };
+}
+}  // namespace custom
+}  // namespace nmodl
+
+using nmodl::custom::DefaultCPUReplacer;
 namespace llvm {
 
-char ReplaceMathFunctions::ID = 0;
+char ReplacePass::ID = 0;
 
-bool ReplaceMathFunctions::runOnModule(Module& module) {
-    legacy::FunctionPassManager fpm(&module);
+bool ReplacePass::runOnModule(Module& module) {
     bool modified = false;
 
     // If the platform supports SIMD, replace math intrinsics with library
     // functions.
-    if (platform->is_cpu_with_simd()) {
+    if (dynamic_cast<const DefaultCPUReplacer*>(replacer)) {
+        legacy::FunctionPassManager fpm(&module);
+
         // First, get the target library information and add vectorizable functions for the
         // specified vector library.
         Triple triple(sys::getDefaultTargetTriple());
@@ -38,28 +66,55 @@ bool ReplaceMathFunctions::runOnModule(Module& module) {
         // Add passes that replace math intrinsics with calls.
         fpm.add(new TargetLibraryInfoWrapperPass(tli));
         fpm.add(new ReplaceWithVeclibLegacy);
-    }
 
-    // For CUDA GPUs, replace with calls to libdevice.
-    if (platform->is_CUDA_gpu()) {
-        fpm.add(new ReplaceWithLibdevice);
-    }
+        // Run passes.
+        fpm.doInitialization();
+        for (auto& function: module.getFunctionList()) {
+            if (!function.isDeclaration())
+                modified |= fpm.run(function);
+        }
+        fpm.doFinalization();
+    } else {
+        // Otherwise, the replacer is not default and we need to apply patterns
+        // from it to each function!
+        for (auto& function: module.getFunctionList()) {
+            if (!function.isDeclaration()) {
+                // Try to replace a call instruction.
+                std::vector<CallInst*> replaced_calls;
+                for (auto& instruction: instructions(function)) {
+                    if (auto* call_inst = dyn_cast<CallInst>(&instruction)) {
+                        if (replace_call(*call_inst)) {
+                            replaced_calls.push_back(call_inst);
+                            modified = true;
+                        }
+                    }
+                }
 
-    // Run passes.
-    fpm.doInitialization();
-    for (auto& function: module.getFunctionList()) {
-        if (!function.isDeclaration())
-            modified |= fpm.run(function);
+                // Remove calls to replaced functions.
+                for (auto* call_inst: replaced_calls) {
+                    call_inst->eraseFromParent();
+                }
+            }
+        }
     }
-    fpm.doFinalization();
 
     return modified;
 }
 
-void ReplaceMathFunctions::add_vectorizable_functions_from_vec_lib(TargetLibraryInfoImpl& tli,
-                                                                   Triple& triple) {
+void ReplacePass::getAnalysisUsage(AnalysisUsage& au) const {
+    au.setPreservesCFG();
+    au.addPreserved<ScalarEvolutionWrapperPass>();
+    au.addPreserved<AAResultsWrapperPass>();
+    au.addPreserved<LoopAccessLegacyAnalysis>();
+    au.addPreserved<DemandedBitsWrapperPass>();
+    au.addPreserved<OptimizationRemarkEmitterWrapperPass>();
+    au.addPreserved<GlobalsAAWrapperPass>();
+}
+
+void ReplacePass::add_vectorizable_functions_from_vec_lib(TargetLibraryInfoImpl& tli,
+                                                          Triple& triple) {
     // Since LLVM does not support SLEEF as a vector library yet, process it separately.
-    if (platform->get_math_library() == "SLEEF") {
+    if (((DefaultCPUReplacer*)replacer)->get_library_name() == "SLEEF") {
 // clang-format off
 #define FIXED(w) ElementCount::getFixed(w)
 // clang-format on
@@ -110,10 +165,10 @@ void ReplaceMathFunctions::add_vectorizable_functions_from_vec_lib(TargetLibrary
             {"none", VecLib::NoLibrary},
             {"SVML", VecLib::SVML}};
 
-        const auto& library = llvm_supported_vector_libraries.find(platform->get_math_library());
+        const auto& library = llvm_supported_vector_libraries.find(((DefaultCPUReplacer*)replacer)->get_library_name());
         if (library == llvm_supported_vector_libraries.end())
             throw std::runtime_error("Error: unknown vector library - " +
-                                     platform->get_math_library() + "\n");
+                                     ((DefaultCPUReplacer*)replacer)->get_library_name() + "\n");
 
         // Add vectorizable functions to the target library info.
         if (library->second != VecLib::LIBMVEC_X86 || (triple.isX86() && triple.isArch64Bit())) {
@@ -122,77 +177,27 @@ void ReplaceMathFunctions::add_vectorizable_functions_from_vec_lib(TargetLibrary
     }
 }
 
-void ReplaceWithLibdevice::getAnalysisUsage(AnalysisUsage& au) const {
-    au.setPreservesCFG();
-    au.addPreserved<ScalarEvolutionWrapperPass>();
-    au.addPreserved<AAResultsWrapperPass>();
-    au.addPreserved<LoopAccessLegacyAnalysis>();
-    au.addPreserved<DemandedBitsWrapperPass>();
-    au.addPreserved<OptimizationRemarkEmitterWrapperPass>();
-    au.addPreserved<GlobalsAAWrapperPass>();
-}
-
-bool ReplaceWithLibdevice::runOnFunction(Function& function) {
-    bool modified = false;
-
-    // Try to replace math intrinsics.
-    std::vector<CallInst*> replaced_calls;
-    for (auto& instruction: instructions(function)) {
-        if (auto* call_inst = dyn_cast<CallInst>(&instruction)) {
-            if (replace_call(*call_inst)) {
-                replaced_calls.push_back(call_inst);
-                modified = true;
-            }
-        }
-    }
-
-    // Remove calls to replaced intrinsics.
-    for (auto* call_inst: replaced_calls) {
-        call_inst->eraseFromParent();
-    }
-
-    return modified;
-}
-
-bool ReplaceWithLibdevice::replace_call(CallInst& call_inst) {
+bool ReplacePass::replace_call(CallInst& call_inst) {
     Module* m = call_inst.getModule();
     Function* function = call_inst.getCalledFunction();
 
-    // Replace math intrinsics only!
-    auto id = function->getIntrinsicID();
-    bool is_nvvm_intrinsic = id == Intrinsic::nvvm_read_ptx_sreg_ntid_x ||
-                             id == Intrinsic::nvvm_read_ptx_sreg_nctaid_x ||
-                             id == Intrinsic::nvvm_read_ptx_sreg_ctaid_x ||
-                             id == Intrinsic::nvvm_read_ptx_sreg_tid_x;
-    if (id == Intrinsic::not_intrinsic || is_nvvm_intrinsic)
+    // Get supported replacement patterns.
+    Patterns patterns = replacer->patterns();
+
+    // Check if replacement is not supported.
+    std::string old_name = function->getName().str();
+    auto it = patterns.find(old_name);
+    if (it == patterns.end())
         return false;
 
-    // Map of supported replacements. For now it is only exp and pow.
-    static const std::map<std::string, std::string> libdevice_name = {{"llvm.exp.f32", "__nv_expf"},
-                                                                      {"llvm.exp.f64", "__nv_exp"},
-                                                                      {"llvm.pow.f32", "__nv_powf"},
-                                                                      {"llvm.pow.f64", "__nv_pow"},
-                                                                      {"llvm.log.f32", "__nv_logf"},
-                                                                      {"llvm.log.f64", "__nv_log"},
-                                                                      {"llvm.fabs.f32",
-                                                                       "__nv_fabsf"},
-                                                                      {"llvm.fabs.f64",
-                                                                       "__nv_fabs"}};
-
-    // If replacement is not supported, abort.
-    std::string old_name = function->getName().str();
-    auto it = libdevice_name.find(old_name);
-    if (it == libdevice_name.end())
-        throw std::runtime_error("Error: replacements for " + old_name + " are not supported!\n");
-
-    // Get (or create) libdevice function.
-    Function* libdevice_func = m->getFunction(it->second);
-    if (!libdevice_func) {
-        libdevice_func = Function::Create(function->getFunctionType(),
-                                          Function::ExternalLinkage,
-                                          it->second,
-                                          *m);
-        libdevice_func->copyAttributesFrom(function);
+    // Get (or create) new function.
+    Function* new_func = m->getFunction(it->second);
+    if (!new_func) {
+        new_func = Function::Create(function->getFunctionType(),
+                                    Function::ExternalLinkage,
+                                    it->second,
+                                    *m);
+        new_func->copyAttributesFrom(function);
     }
 
     // Create a call to libdevice function with the same operands.
@@ -200,7 +205,7 @@ bool ReplaceWithLibdevice::replace_call(CallInst& call_inst) {
     std::vector<Value*> args(call_inst.arg_operands().begin(), call_inst.arg_operands().end());
     SmallVector<OperandBundleDef, 1> op_bundles;
     call_inst.getOperandBundlesAsDefs(op_bundles);
-    CallInst* new_call = builder.CreateCall(libdevice_func, args, op_bundles);
+    CallInst* new_call = builder.CreateCall(new_func, args, op_bundles);
 
     // Replace all uses of old instruction with the new one. Also, copy
     // fast math flags if necessary.
@@ -211,11 +216,4 @@ bool ReplaceWithLibdevice::replace_call(CallInst& call_inst) {
 
     return true;
 }
-
-char ReplaceWithLibdevice::ID = 0;
-static RegisterPass<ReplaceWithLibdevice> X("libdevice-replacement",
-                                            "Pass replacing math functions with calls to libdevice",
-                                            false,
-                                            false);
-
 }  // namespace llvm

--- a/src/codegen/llvm/replace_with_lib_functions.hpp
+++ b/src/codegen/llvm/replace_with_lib_functions.hpp
@@ -14,52 +14,82 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/Host.h"
 
-using nmodl::codegen::Platform;
+using Patterns = std::map<std::string, std::string>;
 
+namespace nmodl {
+namespace custom {
+
+/**
+ * \class Replacer
+ * \brief Base class that can be overriden to specify how LLVM math intrinsics
+ * are replaced.
+ */
+class Replacer {
+  public:
+    virtual Patterns patterns() const = 0;
+    virtual ~Replacer() = default;
+};
+
+/**
+ * \class DefaultCPUReplacer
+ * \brief Specifies how LLVM IR math functions are replaced on CPUs by default.
+ * Here we reuse LLVM's API so patterns() has no meaning and throws an error
+ * instead! `DefaultCPUReplacer` threfore cannot be overriden.
+ */
+class DefaultCPUReplacer: public Replacer {
+  private:
+    std::string library_name;
+  public:
+    DefaultCPUReplacer(std::string library_name)
+      : Replacer(), library_name(library_name) {}
+
+    Patterns patterns() const final override;
+
+    /// Returns the name of underlying library for which this default
+    /// replacer is used.
+    std::string get_library_name();
+};
+
+/**
+ * \class CUDAReplacer
+ * \brief Specifies replacement patterns for CUDA platforms.
+ */
+class CUDAReplacer: public Replacer {
+  public:
+    Patterns patterns() const override;
+};
+}  // namespace custom
+}  // namespace nmodl
+
+using nmodl::custom::Replacer;
 namespace llvm {
 
 /**
- * \class ReplaceMathFunctions
+ * \class ReplacePass
  * \brief A module LLVM pass that replaces math intrinsics with
- * SIMD or libdevice library calls.
+ * library calls.
  */
-class ReplaceMathFunctions: public ModulePass {
+class ReplacePass: public ModulePass {
   private:
-    const Platform* platform;
+    // Underlying replacer that provides replacement patterns.
+    const Replacer* replacer;
 
   public:
     static char ID;
 
-    ReplaceMathFunctions(const Platform& platform)
+    ReplacePass(Replacer* replacer)
         : ModulePass(ID)
-        , platform(&platform) {}
+        , replacer(replacer) {}
 
     bool runOnModule(Module& module) override;
 
-  private:
-    /// Populates `tli` with vectorizable function definitions.
-    void add_vectorizable_functions_from_vec_lib(TargetLibraryInfoImpl& tli, Triple& triple);
-};
-
-/**
- * \class ReplaceWithLibdevice
- * \brief A function LLVM pass that replaces math intrinsics with
- * libdevice library calls.
- */
-class ReplaceWithLibdevice: public FunctionPass {
-  public:
-    static char ID;
-
-    ReplaceWithLibdevice()
-        : llvm::FunctionPass(ID) {}
-
     void getAnalysisUsage(AnalysisUsage& au) const override;
 
-    bool runOnFunction(Function& function) override;
-
   private:
-    /// Replaces call instruction to intrinsic with libdevice call.
+    /// Populates `tli` with vectorizable function definitions (hook for default replacements).
+    void add_vectorizable_functions_from_vec_lib(TargetLibraryInfoImpl& tli, Triple& triple);
+
+    /// Replaces call instruction with a new call from Replacer's patterns.
     bool replace_call(CallInst& call_inst);
 };
-
 }  // namespace llvm

--- a/src/codegen/llvm/simd_builder.cpp
+++ b/src/codegen/llvm/simd_builder.cpp
@@ -1,0 +1,250 @@
+/*************************************************************************
+ * Copyright (C) 2018-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#include "codegen/llvm/simd_builder.hpp"
+#include "ast/all.hpp"
+
+namespace nmodl {
+namespace codegen {
+
+/****************************************************************************************/
+/*                           Generation virtual functions                               */
+/****************************************************************************************/
+
+void SIMDBuilder::generate_atomic_statement(llvm::Value* ptr, llvm::Value* rhs, ast::BinaryOp op) {
+    // To handle atomic update over vectors, we will a scalar loop. The overall
+    // structure will be:
+    //
+    //  +---------------------------+
+    //  | <for body code>           |
+    //  | <some initialisation>     |
+    //  | br %atomic                |
+    //  +---------------------------+
+    //                |
+    //                V
+    //  +-----------------------------+
+    //  | <atomic update code>        |
+    //  | %cmp = ...                  |<------+
+    //  | cond_br %cmp, %atomic, %rem |       |
+    //  +-----------------------------+       |
+    //      |                 |               |
+    //      |                 +---------------+
+    //      V
+    //  +---------------------------+
+    //  | <for body remaining code> |
+    //  |                           |
+    //  +---------------------------+
+
+    // Step 1: Create a vector of (replicated) starting addresses of the given member.
+    llvm::Value* start = replicate_data_ptr(ptr);
+
+    // Step 2: Create a vector alloca that will store addresses of data values. Also,
+    // create an array of these addresses (as pointers).
+    llvm::Type* vi64_type = llvm::FixedVectorType::get(get_i64_type(), vector_width);
+    llvm::Type* array_type = llvm::ArrayType::get(get_fp_ptr_type(), vector_width);
+
+    llvm::Value* ptrs_vec = create_alloca(/*name=*/"ptrs", vi64_type);
+    llvm::Value* ptrs_arr = builder.CreateBitCast(ptrs_vec,  llvm::PointerType::get(array_type, /*AddressSpace=*/0));
+
+    // Step 3: Calculate offsets of the values in the member by:
+    //     offset = start + (index * sizeof(fp_type))
+    // Store this vector to a temporary for later reuse.
+    llvm::Value* offsets; // = ir_builder.create_member_offsets(start, i64_index);
+    generate_store_direct(ptrs_vec, offsets);
+
+    // Step 4: Create a new block that  will be used for atomic code generation.
+    llvm::BasicBlock* body_bb = get_current_block();
+    llvm::BasicBlock* cond_bb = body_bb->getNextNode();
+    llvm::Function* func = body_bb->getParent();
+    llvm::BasicBlock* atomic_bb =
+        llvm::BasicBlock::Create(*builder.getContext(), /*Name=*/"atomic.update", func, cond_bb);
+    llvm::BasicBlock* remaining_body_bb =
+        llvm::BasicBlock::Create(*context, /*Name=*/"for.body.remaining", func, cond_bb);
+    create_br_and_set_insertion_point(atomic_bb);
+
+    // Step 5: Generate code for the atomic update: go through each element in the vector
+    // performing the computation.
+    llvm::Value* cmp = create_atomic_loop(ptrs_arr, rhs, op);
+
+    // Create branch to close the loop and restore the insertion point.
+    create_cond_br(cmp, remaining_body_bb, atomic_bb);
+    set_insertion_point(remaining_body_bb);
+}
+
+void SIMDBuilder::generate_boolean_constant(int value) {
+    if (vectorize) {
+        value_stack.push_back(vector_constant<llvm::ConstantInt>(get_boolean_type(), value, vector_width));
+    } else {
+        value_stack.push_back(scalar_constant<llvm::ConstantInt>(get_boolean_type(), value));
+    }
+}
+
+void SIMDBuilder::generate_i32_constant(int value) {
+    if (vectorize) {
+        value_stack.push_back(vector_constant<llvm::ConstantInt>(get_i32_type(), value, vector_width));
+    } else {
+        value_stack.push_back(scalar_constant<llvm::ConstantInt>(get_i32_type(), value));
+    }
+}
+
+void SIMDBuilder::generate_fp_constant(const std::string& value) {
+    if (vectorize) {
+        value_stack.push_back(vector_constant<llvm::ConstantFP>(get_fp_type(), value, vector_width));
+    } else {
+        value_stack.push_back(scalar_constant<llvm::ConstantFP>(get_fp_type(), value));
+    }
+}
+
+void SIMDBuilder::generate_load_direct(llvm::Value* ptr) {
+    llvm::Type* loaded_type = ptr->getType()->getPointerElementType();
+
+    // Check if the generated IR is vectorized and masked.
+    if (vectorize && mask) {
+        builder.CreateMaskedLoad(loaded_type, ptr, llvm::Align(), mask);
+    }
+
+    llvm::Value* loaded = builder.CreateLoad(loaded_type, ptr);
+    value_stack.push_back(loaded);
+}
+
+void SIMDBuilder::generate_load_indirect(llvm::Value* ptr) {
+    // Construct the loaded vector type.
+    auto* ptrs = llvm::cast<llvm::VectorType>(ptr->getType());
+    llvm::ElementCount element_count = ptrs->getElementCount();
+    llvm::Type* element_type = ptrs->getElementType()->getPointerElementType();
+    llvm::Type* loaded_type = llvm::VectorType::get(element_type, element_count);
+
+    builder.CreateMaskedGather(loaded_type, ptr, llvm::Align(), mask);
+}
+
+void SIMDBuilder::generate_store_direct(llvm::Value* ptr, llvm::Value* value) {
+    // Check if the generated IR is vectorized and masked.
+    if (vectorize && mask) {
+        builder.CreateMaskedStore(value, ptr, llvm::Align(), mask);
+        return;
+    }
+    builder.CreateStore(value, ptr);
+}
+
+void SIMDBuilder::generate_store_indirect(llvm::Value* ptr, llvm::Value* value) {
+    builder.CreateMaskedScatter(value, ptr, llvm::Align(), mask);
+}
+
+void SIMDBuilder::try_generate_broadcast(llvm::Value* value) {
+    // If the value should not be vectorised, or it is already a vector, add it to the stack.
+    if (!vectorize || value->getType()->isVectorTy()) {
+        value_stack.push_back(value);
+    } else {
+        // Otherwise, we generate vectorized code, so replicate the value to form a vector.
+        llvm::Value* vector_value = builder.CreateVectorSplat(vector_width, value);
+        value_stack.push_back(vector_value);
+    }
+}
+
+void SIMDBuilder::generate_loop_increment() {
+    generate_i32_constant(vector_width);
+}
+
+void SIMDBuilder::generate_loop_end() {
+    // TODO: fix this when an AST node is added.
+}
+
+/****************************************************************************************/
+/*                                     Helpers                                          */
+/****************************************************************************************/
+
+void SIMDBuilder::invert_mask() {
+    if (!mask)
+        throw std::runtime_error("Error: mask is not set\n");
+
+    // Create the vector with all `true` values.
+    generate_boolean_constant(1);
+    llvm::Value* one = pop_last_value();
+
+    mask = builder.CreateXor(mask, one);
+}
+
+llvm::Value* SIMDBuilder::replicate_data_ptr(llvm::Value* data_ptr) {
+    llvm::Module* m = builder.GetInsertBlock()->getParent()->getParent();
+
+    // Treat this data address as integer values.
+    llvm::Type* int_ptr_type = m->getDataLayout().getIntPtrType(builder.getContext());
+    llvm::Value* ptr_to_int = builder.CreatePtrToInt(data_ptr, int_ptr_type);
+
+    // Create a vector that has an address at 0.
+    llvm::Type* vector_type = llvm::FixedVectorType::get(int_ptr_type, vector_width);
+    llvm::Value* zero = scalar_constant<llvm::ConstantInt>(get_i32_type(), 0);
+    llvm::Value* tmp =
+        builder.CreateInsertElement(llvm::UndefValue::get(vector_type), ptr_to_int, zero);
+
+    // Finally, use `shufflevector` with zeroinitializer to replicate the 0th element.
+    llvm::Value* select = llvm::Constant::getNullValue(vector_type);
+    return builder.CreateShuffleVector(tmp, llvm::UndefValue::get(vector_type), select);
+}
+
+llvm::Value* SIMDBuilder::create_member_offsets(llvm::Value* start, llvm::Value* indices) {
+    llvm::Value* factor = get_vector_constant<llvm::ConstantInt>(get_i64_type(),
+                                                                 platform.get_precision() / 8);
+    llvm::Value* offset = builder.CreateMul(indices, factor);
+    return builder.CreateAdd(start, offset);
+}
+
+llvm::Value* SIMDBuilder::create_atomic_loop(llvm::Value* ptrs_arr,
+                                           llvm::Value* rhs,
+                                           ast::BinaryOp op) {
+    const int vector_width = platform.get_instruction_width();
+    llvm::BasicBlock* curr = get_current_block();
+    llvm::BasicBlock* prev = curr->getPrevNode();
+    llvm::BasicBlock* next = curr->getNextNode();
+
+    // Some constant values.
+    llvm::Value* false_value = get_scalar_constant<llvm::ConstantInt>(get_boolean_type(), 0);
+    llvm::Value* zero = get_scalar_constant<llvm::ConstantInt>(get_i64_type(), 0);
+    llvm::Value* one = get_scalar_constant<llvm::ConstantInt>(get_i64_type(), 1);
+    llvm::Value* minus_one = get_scalar_constant<llvm::ConstantInt>(get_i64_type(), -1);
+
+    // First, we create a PHI node that holds the mask of active vector elements.
+    llvm::PHINode* mask = builder.CreatePHI(get_i64_type(), /*NumReservedValues=*/2);
+
+    // Intially, all elements are active.
+    llvm::Value* init_value = get_scalar_constant<llvm::ConstantInt>(get_i64_type(),
+                                                                     ~((~0) << vector_width));
+
+    // Find the index of the next active element and update the mask. This can be easily computed
+    // with:
+    //     index    = cttz(mask)
+    //     new_mask = mask & ((1 << index) ^ -1)
+    llvm::Value* index =
+        builder.CreateIntrinsic(llvm::Intrinsic::cttz, {get_i64_type()}, {mask, false_value});
+    llvm::Value* new_mask = builder.CreateShl(one, index);
+    new_mask = builder.CreateXor(new_mask, minus_one);
+    new_mask = builder.CreateAnd(mask, new_mask);
+
+    // Update PHI with appropriate values.
+    mask->addIncoming(init_value, prev);
+    mask->addIncoming(new_mask, curr);
+
+    // Get the pointer to the current value, the value itself and the update.b
+    llvm::Value* gep =
+        builder.CreateGEP(ptrs_arr->getType()->getPointerElementType(), ptrs_arr, {zero, index});
+    llvm::Value* ptr = create_load(gep);
+    llvm::Value* source = create_load(ptr);
+    llvm::Value* update = builder.CreateExtractElement(rhs, index);
+
+    // Perform the update and store the result back.
+    //     source = *ptr
+    //     *ptr = source + update
+    create_binary_op(source, update, op);
+    llvm::Value* result = pop_last_value();
+    create_store(ptr, result);
+
+    // Return condition to break out of atomic update loop.
+    return builder.CreateICmpEQ(new_mask, zero);
+}
+
+}  // namespace codegen
+}  // namespace nmodl

--- a/src/codegen/llvm/simd_builder.hpp
+++ b/src/codegen/llvm/simd_builder.hpp
@@ -1,0 +1,104 @@
+/*************************************************************************
+ * Copyright (C) 2018-2020 Blue Brain Project
+ *
+ * This file is part of NMODL distributed under the terms of the GNU
+ * Lesser General Public License. See top-level LICENSE file for details.
+ *************************************************************************/
+
+#pragma once
+
+#include <string>
+
+#include "codegen/llvm/base_builder.hpp"
+#include "codegen/llvm/codegen_llvm_helper_visitor.hpp"
+
+namespace nmodl {
+namespace codegen {
+
+/**
+ * \class SIMDBuilder
+ * \brief A class to generate LLVM IR for NMODL AST targeting SIMD platforms.
+ */
+class SIMDBuilder: public BaseBuilder {
+  private:
+    /// Vectorization width.
+    int vector_width;
+
+    /// Flag to indicate that the generated IR should be vectorized. This flag
+    /// is used to catch cases when non-SIMD code needs to be emitted.
+    bool vectorize;
+
+    /// Masked value used to predicate vector instructions.
+    llvm::Value* mask;
+
+  protected:
+    SIMDBuilder(llvm::LLVMContext& context,
+                bool single_precision,
+                int vector_width,
+                std::vector<std::string> fast_math_flags = {})
+        : BaseBuilder(context, single_precision, fast_math_flags)
+        , vector_width(vector_width) {}
+
+    /*************************************************************************/
+    /*                     Virtual generation methods                        */
+    /*************************************************************************/
+
+  public:
+    /// Generates LLVM IR to handle atomic updates, e.g. *ptr += rhs.
+    void generate_atomic_statement(llvm::Value* lhs, llvm::Value* rhs, ast::BinaryOp op) override;
+
+    /// Generates LLVM IR for boolean constants.
+    void generate_boolean_constant(int value) override;
+
+    /// Generates LLVM IR for integer constants.
+    void generate_i32_constant(int value) override;
+
+    /// Generates LLVM IR for floating-point constants.
+    void generate_fp_constant(const std::string& value) override;
+
+    /// Generates LLVM IR for directed data read.
+    void generate_load_direct(llvm::Value* ptr) override;
+
+    /// Generates LLVM IR for indirected data read.
+    void generate_load_indirect(llvm::Value* ptr) override;
+
+    /// Generates LLVM IR for directed data write.
+    void generate_store_direct(llvm::Value* ptr, llvm::Value* value) override;
+
+    /// Generates LLVM IR for indirected data write.
+    void generate_store_indirect(llvm::Value* ptr, llvm::Value* value) override;
+
+    /// Generates LLVM IR for brodcasting a value, if necessary.
+    void try_generate_broadcast(llvm::Value* ptr) override;
+
+    /// Generates LLVM IR for loop increment.
+    void generate_loop_increment() override;
+
+    /// Generates LLVM IR for loop termination.
+    /// TODO: should take an AST node!
+    void generate_loop_end() override;
+
+    /*************************************************************************/
+    /*                               Helpers                                 */
+    /*************************************************************************/
+
+  private:
+    /// Inverts the mask by xoring it.
+    void invert_mask();
+
+    /// Creates a vector of (replicated) starting addresses of the data.
+    llvm::Value* replicate_data_ptr(llvm::Value* data_ptr);
+
+    /// Creates IR for calculating offest to member values. For more context, see
+    /// `visit_codegen_atomic_statement` in LLVM visitor.
+    llvm::Value* create_member_offsets(llvm::Value* start, llvm::Value* indices);
+
+    /// Creates IR to perform scalar updates to instance member based on `ptrs_arr` for every
+    /// element in a vector by
+    ///     member[*ptrs_arr[i]] = member[*ptrs_arr[i]] op rhs.
+    /// Returns condition (i1 value) to break out of atomic update loop.
+    llvm::Value* create_atomic_loop(llvm::Value* ptrs_arr, llvm::Value* rhs, ast::BinaryOp op);
+};
+
+}  // namespace codegen
+}  // namespace nmodl

--- a/src/language/codegen.yaml
+++ b/src/language/codegen.yaml
@@ -156,6 +156,9 @@
                                   brief: "Body of the function"
                                   type: StatementBlock
                                   getter: {override: true}
+                              - is_kernel:
+                                  brief: "If function is compute kernel"
+                                  type: int
                         - InstanceStruct:
                             nmodl: "INSTANCE_STRUCT "
                             members:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -382,6 +382,9 @@ int main(int argc, const char* argv[]) {
                 // information and not in LLVM visitor.
                 int llvm_opt_level = llvm_benchmark ? 0 : cfg.llvm_opt_level_ir;
 
+                // If benchmarking, kernel functions should be wrapped taking void*.
+                bool wrap_kernel_functions = llvm_benchmark;
+
                 // Create platform abstraction.
                 PlatformID pid = cfg.llvm_gpu_name == "default" ? PlatformID::CPU : PlatformID::GPU;
                 const std::string name = cfg.llvm_gpu_name == "default" ? cfg.llvm_cpu_name
@@ -406,7 +409,8 @@ int main(int argc, const char* argv[]) {
                                            platform,
                                            llvm_opt_level,
                                            !cfg.llvm_no_debug,
-                                           cfg.llvm_fast_math_flags);
+                                           cfg.llvm_fast_math_flags,
+                                           wrap_kernel_functions);
                 visitor.visit_program(*ast);
                 if (cfg.nmodl_ast) {
                     NmodlPrintVisitor(filepath("llvm", "mod")).visit_program(*ast);

--- a/src/pybind/pynmodl.cpp
+++ b/src/pybind/pynmodl.cpp
@@ -200,7 +200,7 @@ class JitDriver {
             utils::make_path(cfg.scratch_dir);
         }
         cg_driver.prepare_mod(node, modname);
-        nmodl::codegen::CodegenLLVMVisitor visitor(modname, cfg.output_dir, platform, 0);
+        nmodl::codegen::CodegenLLVMVisitor visitor(modname, cfg.output_dir, platform, 0, false, {}, true);
         visitor.visit_program(*node);
         const GPUExecutionParameters gpu_execution_parameters{cuda_grid_dim_x, cuda_block_dim_x};
         nmodl::benchmark::LLVMBenchmark benchmark(visitor,

--- a/test/benchmark/llvm_benchmark.hpp
+++ b/test/benchmark/llvm_benchmark.hpp
@@ -120,15 +120,10 @@ class LLVMBenchmark {
         , opt_level_codegen(opt_level_codegen)
         , gpu_execution_parameters(gpu_exec_params) {}
 
-    /// Runs the benchmark.
+    /// Runs the main body of the benchmark, executing the compute kernels.
     BenchmarkResults run();
 
   private:
-    /// Visits the AST to construct the LLVM IR module.
-    void generate_llvm();
-
-    /// Runs the main body of the benchmark, executing the compute kernels.
-    BenchmarkResults run_benchmark();
 
     /// Sets the log output stream (file or console).
     void set_log_output();

--- a/test/unit/codegen/codegen_llvm_execution.cpp
+++ b/test/unit/codegen/codegen_llvm_execution.cpp
@@ -314,9 +314,11 @@ SCENARIO("Simple scalar kernel", "[llvm][runner]") {
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
                                                  cpu_platform,
-                                                 /*opt_level_ir=*/0);
+                                                 /*opt_level_ir=*/0,
+                                                 /*add_debug_information=*/false,
+                                                 /*fast_math_flags=*/{},
+                                                 /*wrap_kernel_functions=*/true);
         llvm_visitor.visit_program(*ast);
-        llvm_visitor.wrap_kernel_functions();
 
         // Create the instance struct data.
         int num_elements = 4;
@@ -342,7 +344,7 @@ SCENARIO("Simple scalar kernel", "[llvm][runner]") {
         runner.initialize_driver();
 
         THEN("Values in struct have changed according to the formula") {
-            runner.run_with_argument<int, void*>("__nrn_state_test_wrapper",
+            runner.run_with_argument<int, void*>("nrn_state_test",
                                                  instance_data.base_ptr);
             std::vector<double> x_expected = {4.0, 3.0, 2.0, 1.0};
             REQUIRE(check_instance_variable(instance_info, x_expected, "x"));
@@ -399,9 +401,11 @@ SCENARIO("Simple vectorised kernel", "[llvm][runner]") {
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
                                                  simd_cpu_platform,
-                                                 /*opt_level_ir=*/3);
+                                                 /*opt_level_ir=*/3,
+                                                 /*add_debug_information=*/false,
+                                                 /*fast_math_flags=*/{},
+                                                 /*wrap_kernel_functions=*/true);
         llvm_visitor.visit_program(*ast);
-        llvm_visitor.wrap_kernel_functions();
 
         // Create the instance struct data.
         int num_elements = 10;
@@ -433,7 +437,7 @@ SCENARIO("Simple vectorised kernel", "[llvm][runner]") {
         runner.initialize_driver();
 
         THEN("Values in struct have changed according to the formula") {
-            runner.run_with_argument<int, void*>("__nrn_state_test_wrapper",
+            runner.run_with_argument<int, void*>("nrn_state_test",
                                                  instance_data.base_ptr);
             // Check that the main and remainder loops correctly change the data stored in x.
             std::vector<float> x_expected = {10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0};
@@ -483,9 +487,11 @@ SCENARIO("Vectorised kernel with scatter instruction", "[llvm][runner]") {
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
                                                  simd_cpu_platform,
-                                                 /*opt_level_ir=*/0);
+                                                 /*opt_level_ir=*/0,
+                                                 /*add_debug_information=*/false,
+                                                 /*fast_math_flags=*/{},
+                                                 /*wrap_kernel_functions=*/true);
         llvm_visitor.visit_program(*ast);
-        llvm_visitor.wrap_kernel_functions();
 
         // Create the instance struct data.
         int num_elements = 5;
@@ -511,7 +517,7 @@ SCENARIO("Vectorised kernel with scatter instruction", "[llvm][runner]") {
         runner.initialize_driver();
 
         THEN("Ion values in struct have been updated correctly") {
-            runner.run_with_argument<int, void*>("__nrn_state_test_wrapper",
+            runner.run_with_argument<int, void*>("nrn_state_test",
                                                  instance_data.base_ptr);
             // cai[id] = ion_cai[ion_cai_index[id]]
             // cai[id] += 1
@@ -576,9 +582,11 @@ SCENARIO("Vectorised kernel with simple control flow", "[llvm][runner]") {
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
                                                  simd_cpu_platform,
-                                                 /*opt_level_ir=*/0);
+                                                 /*opt_level_ir=*/0,
+                                                 /*add_debug_information=*/false,
+                                                 /*fast_math_flags=*/{},
+                                                 /*wrap_kernel_functions=*/true);
         llvm_visitor.visit_program(*ast);
-        llvm_visitor.wrap_kernel_functions();
 
         // Create the instance struct data.
         int num_elements = 5;
@@ -612,7 +620,7 @@ SCENARIO("Vectorised kernel with simple control flow", "[llvm][runner]") {
         runner.initialize_driver();
 
         THEN("Masked instructions are generated") {
-            runner.run_with_argument<int, void*>("__nrn_state_test_wrapper",
+            runner.run_with_argument<int, void*>("nrn_state_test",
                                                  instance_data.base_ptr);
             std::vector<double> w_expected = {20.0, 20.0, 60.0, 40.0, 50.0};
             REQUIRE(check_instance_variable(instance_info, w_expected, "w"));
@@ -675,9 +683,11 @@ SCENARIO("Kernel with atomic updates", "[llvm][runner]") {
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
                                                  simd_cpu_platform,
-                                                 /*opt_level_ir=*/3);
+                                                 /*opt_level_ir=*/3,
+                                                 /*add_debug_information=*/false,
+                                                 /*fast_math_flags=*/{},
+                                                 /*wrap_kernel_functions=*/true);
         llvm_visitor.visit_program(*ast);
-        llvm_visitor.wrap_kernel_functions();
 
         // Create the instance struct data.
         int num_elements = 5;
@@ -715,7 +725,7 @@ SCENARIO("Kernel with atomic updates", "[llvm][runner]") {
         runner.initialize_driver();
 
         THEN("updates are commputed correctly with vector instructions and optimizations on") {
-            runner.run_with_argument<int, void*>("__nrn_cur_test_wrapper", instance_data.base_ptr);
+            runner.run_with_argument<int, void*>("nrn_cur_test", instance_data.base_ptr);
             // Recall:
             //     ion_ina_id = mech->ion_ina_index[id]
             //     ion_ika_id = mech->ion_ika_index[id]
@@ -771,9 +781,11 @@ SCENARIO("Kernel with atomic updates", "[llvm][runner]") {
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
                                                  simd_cpu_platform,
-                                                 /*opt_level_ir=*/0);
+                                                 /*opt_level_ir=*/0,
+                                                 /*add_debug_information=*/false,
+                                                 /*fast_math_flags=*/{},
+                                                 /*wrap_kernel_functions=*/true);
         llvm_visitor.visit_program(*ast);
-        llvm_visitor.wrap_kernel_functions();
 
         // Create the instance struct data.
         int num_elements = 6;
@@ -811,7 +823,7 @@ SCENARIO("Kernel with atomic updates", "[llvm][runner]") {
         runner.initialize_driver();
 
         THEN("Atomic updates are correct without optimizations") {
-            runner.run_with_argument<int, void*>("__nrn_cur_test_wrapper", instance_data.base_ptr);
+            runner.run_with_argument<int, void*>("nrn_cur_test", instance_data.base_ptr);
             // Recall:
             //     ion_ina_id = mech->ion_ina_index[id]
             //     ion_ika_id = mech->ion_ika_index[id]
@@ -866,9 +878,11 @@ SCENARIO("Kernel with atomic updates", "[llvm][runner]") {
         codegen::CodegenLLVMVisitor llvm_visitor(/*mod_filename=*/"unknown",
                                                  /*output_dir=*/".",
                                                  simd_cpu_platform,
-                                                 /*opt_level_ir=*/0);
+                                                 /*opt_level_ir=*/0,
+                                                 /*add_debug_information=*/false,
+                                                 /*fast_math_flags=*/{},
+                                                 /*wrap_kernel_functions=*/true);
         llvm_visitor.visit_program(*ast);
-        llvm_visitor.wrap_kernel_functions();
 
         // Create the instance struct data.
         int num_elements = 6;
@@ -907,7 +921,7 @@ SCENARIO("Kernel with atomic updates", "[llvm][runner]") {
         runner.initialize_driver();
 
         THEN("Atomic updates are correct") {
-            runner.run_with_argument<int, void*>("__nrn_cur_test_wrapper", instance_data.base_ptr);
+            runner.run_with_argument<int, void*>("nrn_cur_test", instance_data.base_ptr);
             // Recall:
             //     node_id = mech->node_index[id]
             //     mech->vec_rhs[node_id] -= rhs

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -1015,15 +1015,6 @@ SCENARIO("Scalar state kernel", "[visitor][llvm]") {
             REQUIRE(std::regex_search(module_string, m, condition));
             REQUIRE(std::regex_search(module_string, m, cond_br));
 
-            // Check that loop metadata is attached to the scalar kernel.
-            std::regex loop_metadata(R"(!llvm\.loop ![0-9]+)");
-            std::regex loop_metadata_self_reference(R"(![0-9]+ = distinct !\{![0-9]+, ![0-9]+\})");
-            std::regex loop_metadata_disable_vectorization(
-                R"(![0-9]+ = !\{!\"llvm\.loop\.vectorize\.enable\", i1 false\})");
-            REQUIRE(std::regex_search(module_string, m, loop_metadata));
-            REQUIRE(std::regex_search(module_string, m, loop_metadata_self_reference));
-            REQUIRE(std::regex_search(module_string, m, loop_metadata_disable_vectorization));
-
             // Check for correct loads from the struct with GEPs.
             std::regex load_from_struct(
                 "  %.* = load %.*__instance_var__type\\*, %.*__instance_var__type\\*\\* %.*\n"

--- a/test/unit/codegen/codegen_llvm_ir.cpp
+++ b/test/unit/codegen/codegen_llvm_ir.cpp
@@ -1016,10 +1016,10 @@ SCENARIO("Scalar state kernel", "[visitor][llvm]") {
             REQUIRE(std::regex_search(module_string, m, cond_br));
 
             // Check that loop metadata is attached to the scalar kernel.
-            std::regex loop_metadata(R"(!llvm\.loop !0)");
-            std::regex loop_metadata_self_reference(R"(!0 = distinct !\{!0, !1\})");
+            std::regex loop_metadata(R"(!llvm\.loop ![0-9]+)");
+            std::regex loop_metadata_self_reference(R"(![0-9]+ = distinct !\{![0-9]+, ![0-9]+\})");
             std::regex loop_metadata_disable_vectorization(
-                R"(!1 = !\{!\"llvm\.loop\.vectorize\.enable\", i1 false\})");
+                R"(![0-9]+ = !\{!\"llvm\.loop\.vectorize\.enable\", i1 false\})");
             REQUIRE(std::regex_search(module_string, m, loop_metadata));
             REQUIRE(std::regex_search(module_string, m, loop_metadata_self_reference));
             REQUIRE(std::regex_search(module_string, m, loop_metadata_disable_vectorization));


### PR DESCRIPTION
WIP to have builders per target.

cc @pramodk @iomaganaris - once I finish putting together atomic updates (it is broken in SIMD and base builders) and reads/writes in general, we can land this while keeping the old `IRBuilder`. And then integrate it another PR.