### PR TITLE
[LLVM] Instantiate CodegenLLVMVisitor of PyJIT with fast math and debug symbols options

### DIFF
--- a/src/pybind/pynmodl.cpp
+++ b/src/pybind/pynmodl.cpp
@@ -200,8 +200,13 @@ class JitDriver {
             utils::make_path(cfg.scratch_dir);
         }
         cg_driver.prepare_mod(node, modname);
-        nmodl::codegen::CodegenLLVMVisitor visitor(
-            modname, cfg.output_dir, platform, 0, !cfg.llvm_no_debug, cfg.llvm_fast_math_flags, true);
+        nmodl::codegen::CodegenLLVMVisitor visitor(modname,
+                                                   cfg.output_dir,
+                                                   platform,
+                                                   0,
+                                                   !cfg.llvm_no_debug,
+                                                   cfg.llvm_fast_math_flags,
+                                                   true);
         visitor.visit_program(*node);
         const GPUExecutionParameters gpu_execution_parameters{cuda_grid_dim_x, cuda_block_dim_x};
         nmodl::benchmark::LLVMBenchmark benchmark(visitor,

--- a/src/pybind/pynmodl.cpp
+++ b/src/pybind/pynmodl.cpp
@@ -200,7 +200,8 @@ class JitDriver {
             utils::make_path(cfg.scratch_dir);
         }
         cg_driver.prepare_mod(node, modname);
-        nmodl::codegen::CodegenLLVMVisitor visitor(modname, cfg.output_dir, platform, 0, false, {}, true);
+        nmodl::codegen::CodegenLLVMVisitor visitor(
+            modname, cfg.output_dir, platform, 0, !cfg.llvm_no_debug, cfg.llvm_fast_math_flags, true);
         visitor.visit_program(*node);
         const GPUExecutionParameters gpu_execution_parameters{cuda_grid_dim_x, cuda_block_dim_x};
         nmodl::benchmark::LLVMBenchmark benchmark(visitor,

--- a/test/benchmark/benchmark.py
+++ b/test/benchmark/benchmark.py
@@ -33,6 +33,8 @@ def main():
         cfg.llvm_math_library = "libdevice"
         cfg.llvm_gpu_name = "nvptx64"
         cfg.llvm_gpu_target_architecture = "sm_70"
+        # Disable debug symbols generation for GPU code since the PTX generated is not valid
+        cfg.llvm_no_debug = True
         if not os.environ.get("CUDA_HOME"):
             raise RuntimeError("CUDA_HOME environment variable not set")
         cfg.shared_lib_paths = [os.getenv("CUDA_HOME") + "/nvvm/libdevice/libdevice.10.bc"]

--- a/test/benchmark/benchmark.py
+++ b/test/benchmark/benchmark.py
@@ -25,6 +25,8 @@ def main():
     cfg = nmodl.CodeGenConfig()
     cfg.llvm_vector_width = args.vec
     cfg.llvm_opt_level_ir = 2
+    cfg.llvm_fast_math_flags = ["nnan", "contract", "afn"]
+    cfg.llvm_no_debug = False
     cfg.nmodl_ast = True
     fname = args.file
     if args.gpu:  # GPU enabled


### PR DESCRIPTION
- Set `add_debug_information` and `fast_math_flags` variables when constructing the `CodegenLLVMVisitor` of the PyJIT Driver according to the variables passed to the python object of `CodeGenConfig`
- Added related test