### PR TITLE
Not prepend argument with t+ in net_move

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,8 +134,8 @@ setup(
         "jupyter-client",
         "jupyter",
         "myst_parser",
-        "mistune<2",  # prevents a version conflict with nbconvert
-        "nbconvert<3",
+        "mistune<3",  # prevents a version conflict with nbconvert
+        "nbconvert",
         "nbsphinx>=0.3.2",
         "pytest>=3.7.2",
         "sphinx<5", # myst_parser requires <5 and pip falls over

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ setup(
         "jupyter",
         "myst_parser",
         "mistune<2",  # prevents a version conflict with nbconvert
-        "nbconvert",
+        "nbconvert<3",
         "nbsphinx>=0.3.2",
         "pytest>=3.7.2",
         "sphinx<5", # myst_parser requires <5 and pip falls over

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -3794,7 +3794,7 @@ void CodegenCVisitor::print_net_move_call(const FunctionCall& node) {
     // artificial cells don't use spike buffering
     // clang-format off
     if (info.artificial_cell) {
-        printer->add_text(fmt::format("artcell_net_move(&{}, {}, nt->_t+", tqitem, pnt));
+        printer->add_text(fmt::format("artcell_net_move(&{}, {}, ", tqitem, pnt));
         print_vector_elements(arguments, ", ");
         printer->add_text(")");
     } else {


### PR DESCRIPTION
In mod2c call from net_send are prepend with t+ but not net_move