### PR TITLE
Prefer printer->fmt_X(...) in code generation.

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -214,15 +214,15 @@ void CodegenCVisitor::visit_from_statement(const ast::FromStatement& node) {
     const auto& to = node.get_to();
     const auto& inc = node.get_increment();
     const auto& block = node.get_statement_block();
-    printer->add_text(fmt::format("for(int {}=", name));
+    printer->fmt_text("for(int {}=", name);
     from->accept(*this);
-    printer->add_text(fmt::format("; {}<=", name));
+    printer->fmt_text("; {}<=", name);
     to->accept(*this);
     if (inc) {
-        printer->add_text(fmt::format("; {}+=", name));
+        printer->fmt_text("; {}+=", name);
         inc->accept(*this);
     } else {
-        printer->add_text(fmt::format("; {}++", name));
+        printer->fmt_text("; {}++", name);
     }
     printer->add_text(")");
     block->accept(*this);
@@ -1371,7 +1371,7 @@ void CodegenCVisitor::print_function_call(const FunctionCall& node) {
     }
 
     auto arguments = node.get_arguments();
-    printer->add_text(fmt::format("{}(", function_name));
+    printer->fmt_text("{}(", function_name);
 
     if (defined_method(name)) {
         printer->add_text(internal_method_arguments());
@@ -1512,7 +1512,7 @@ void CodegenCVisitor::print_table_check_function(const Block& node) {
             printer->add_line("make_table = false;");
 
             printer->add_indent();
-            printer->add_text(fmt::format("{} = ", tmin_name));
+            printer->fmt_text("{} = ", tmin_name);
             from->accept(*this);
             printer->add_text(";");
             printer->add_newline();
@@ -1817,13 +1817,13 @@ void CodegenCVisitor::visit_eigen_newton_solver_block(const ast::EigenNewtonSolv
     const auto& variable_block = *node.get_variable_block();
     const auto& functor_block = *node.get_functor_block();
 
-    printer->add_text(fmt::format(
+    printer->fmt_text(
         "void operator()(const Eigen::Matrix<{0}, {1}, 1>& nmodl_eigen_xm, Eigen::Matrix<{0}, {1}, "
         "1>& nmodl_eigen_fm, "
         "Eigen::Matrix<{0}, {1}, {1}>& nmodl_eigen_jm) {2}",
         float_type,
         N,
-        is_functor_const(variable_block, functor_block) ? "const " : ""));
+        is_functor_const(variable_block, functor_block) ? "const " : "");
     printer->start_block();
     printer->fmt_line("const {}* nmodl_eigen_x = nmodl_eigen_xm.data();", float_type);
     printer->fmt_line("{}* nmodl_eigen_j = nmodl_eigen_jm.data();", float_type);
@@ -3119,7 +3119,7 @@ void CodegenCVisitor::print_ion_var_constructor(const std::vector<std::string>& 
     printer->add_newline();
     printer->add_line("IonCurVar() : ", 0);
     for (int i = 0; i < members.size(); i++) {
-        printer->add_text(fmt::format("{}(0)", members[i]));
+        printer->fmt_text("{}(0)", members[i]);
         if (i + 1 < members.size()) {
             printer->add_text(", ");
         }
@@ -3594,7 +3594,7 @@ void CodegenCVisitor::print_watch_activate() {
 
         auto varname = get_variable_name(fmt::format("watch{}", i + 1));
         printer->add_indent();
-        printer->add_text(fmt::format("{} = 2 + (", varname));
+        printer->fmt_text("{} = 2 + (", varname);
         auto watch = statement->get_statements().front();
         watch->get_expression()->visit_children(*this);
         printer->add_text(");");
@@ -3750,12 +3750,12 @@ void CodegenCVisitor::print_net_send_call(const FunctionCall& node) {
     // artificial cells don't use spike buffering
     // clang-format off
     if (info.artificial_cell) {
-        printer->add_text(fmt::format("artcell_net_send(&{}, {}, {}, nt->_t+", tqitem, weight_index, pnt));
+        printer->fmt_text("artcell_net_send(&{}, {}, {}, nt->_t+", tqitem, weight_index, pnt);
     } else {
         auto point_process = get_variable_name("point_process");
         std::string t = get_variable_name("t");
         printer->add_text("net_send_buffering(");
-        printer->add_text(fmt::format("ml->_net_send_buffer, 0, {}, {}, {}, {}+", tqitem, weight_index, point_process, t));
+        printer->fmt_text("ml->_net_send_buffer, 0, {}, {}, {}, {}+", tqitem, weight_index, point_process, t);
     }
     // clang-format off
     print_vector_elements(arguments, ", ");
@@ -3777,14 +3777,14 @@ void CodegenCVisitor::print_net_move_call(const FunctionCall& node) {
     // artificial cells don't use spike buffering
     // clang-format off
     if (info.artificial_cell) {
-        printer->add_text(fmt::format("artcell_net_move(&{}, {}, ", tqitem, pnt));
+        printer->fmt_text("artcell_net_move(&{}, {}, ", tqitem, pnt);
         print_vector_elements(arguments, ", ");
         printer->add_text(")");
     } else {
         auto point_process = get_variable_name("point_process");
         std::string t = get_variable_name("t");
         printer->add_text("net_send_buffering(");
-        printer->add_text(fmt::format("ml->_net_send_buffer, 2, {}, {}, {}, ", tqitem, weight_index, point_process));
+        printer->fmt_text("ml->_net_send_buffer, 2, {}, {}, {}, ", tqitem, weight_index, point_process);
         print_vector_elements(arguments, ", ");
         printer->add_text(", 0.0");
         printer->add_text(")");
@@ -3800,7 +3800,7 @@ void CodegenCVisitor::print_net_event_call(const FunctionCall& node) {
     } else {
         auto point_process = get_variable_name("point_process");
         printer->add_text("net_send_buffering(");
-        printer->add_text(fmt::format("ml->_net_send_buffer, 1, -1, -1, {}, ", point_process));
+        printer->fmt_text("ml->_net_send_buffer, 1, -1, -1, {}, ", point_process);
         print_vector_elements(arguments, ", ");
         printer->add_text(", 0.0");
     }
@@ -4019,7 +4019,7 @@ void CodegenCVisitor::visit_for_netcon(const ast::ForNetcon& node) {
             return a.name == naming::FOR_NETCON_SEMANTIC;
         })->index;
 
-    printer->add_text(fmt::format("const size_t offset = {}*pnodecount + id;", index));
+    printer->fmt_text("const size_t offset = {}*pnodecount + id;", index);
     printer->add_newline();
     printer->add_line(
         "const size_t for_netcon_start = nt->_fornetcon_perm_indices[indexes[offset]];");

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1151,8 +1151,8 @@ void CodegenCVisitor::print_channel_iteration_block_end() {
 
 void CodegenCVisitor::print_rhs_d_shadow_variables() {
     if (info.point_process) {
-        printer->add_line(fmt::format("double* shadow_rhs = nt->{};", naming::NTHREAD_RHS_SHADOW));
-        printer->add_line(fmt::format("double* shadow_d = nt->{};", naming::NTHREAD_D_SHADOW));
+        printer->fmt_line("double* shadow_rhs = nt->{};", naming::NTHREAD_RHS_SHADOW);
+        printer->fmt_line("double* shadow_d = nt->{};", naming::NTHREAD_D_SHADOW);
     }
 }
 
@@ -1165,9 +1165,9 @@ void CodegenCVisitor::print_nrn_cur_matrix_shadow_update() {
         auto rhs_op = operator_for_rhs();
         auto d_op = operator_for_d();
         print_atomic_reduction_pragma();
-        printer->add_line(fmt::format("vec_rhs[node_id] {} rhs;", rhs_op));
+        printer->fmt_line("vec_rhs[node_id] {} rhs;", rhs_op);
         print_atomic_reduction_pragma();
-        printer->add_line(fmt::format("vec_d[node_id] {} g;", d_op));
+        printer->fmt_line("vec_d[node_id] {} g;", d_op);
     }
 }
 
@@ -1178,9 +1178,9 @@ void CodegenCVisitor::print_nrn_cur_matrix_shadow_reduction() {
     if (info.point_process) {
         printer->add_line("int node_id = node_index[id];");
         print_atomic_reduction_pragma();
-        printer->add_line(fmt::format("vec_rhs[node_id] {} shadow_rhs[id];", rhs_op));
+        printer->fmt_line("vec_rhs[node_id] {} shadow_rhs[id];", rhs_op);
         print_atomic_reduction_pragma();
-        printer->add_line(fmt::format("vec_d[node_id] {} shadow_d[id];", d_op));
+        printer->fmt_line("vec_d[node_id] {} shadow_d[id];", d_op);
     }
 }
 
@@ -1200,8 +1200,7 @@ void CodegenCVisitor::print_shadow_reduction_statements() {
         print_atomic_reduction_pragma();
         auto lhs = get_variable_name(statement.lhs);
         auto rhs = get_variable_name(shadow_varname(statement.lhs));
-        auto text = fmt::format("{} {} {};", lhs, statement.op, rhs);
-        printer->add_line(text);
+        printer->fmt_line("{} {} {};", lhs, statement.op, rhs);
     }
     shadow_statements.clear();
 }
@@ -1250,25 +1249,25 @@ bool CodegenCVisitor::optimize_ion_variable_copies() const {
 void CodegenCVisitor::print_memory_allocation_routine() const {
     printer->add_newline(2);
     auto args = "size_t num, size_t size, size_t alignment = 16";
-    printer->add_line(fmt::format("static inline void* mem_alloc({}) {}", args, "{"));
-    printer->add_line("    void* ptr;");
-    printer->add_line("    posix_memalign(&ptr, alignment, num*size);");
-    printer->add_line("    memset(ptr, 0, size);");
-    printer->add_line("    return ptr;");
-    printer->add_line("}");
+    printer->fmt_start_block("static inline void* mem_alloc({})", args);
+    printer->add_line("void* ptr;");
+    printer->add_line("posix_memalign(&ptr, alignment, num*size);");
+    printer->add_line("memset(ptr, 0, size);");
+    printer->add_line("return ptr;");
+    printer->end_block(1);
 
     printer->add_newline(2);
-    printer->add_line("static inline void mem_free(void* ptr) {");
-    printer->add_line("    free(ptr);");
-    printer->add_line("}");
+    printer->start_block("static inline void mem_free(void* ptr)");
+    printer->add_line("free(ptr);");
+    printer->end_block(1);
 }
 
 
 void CodegenCVisitor::print_abort_routine() const {
     printer->add_newline(2);
-    printer->add_line("static inline void coreneuron_abort() {");
-    printer->add_line("    abort();");
-    printer->add_line("}");
+    printer->start_block("static inline void coreneuron_abort()");
+    printer->add_line("abort();");
+    printer->end_block(1);
 }
 
 
@@ -1676,13 +1675,13 @@ void CodegenCVisitor::print_function_or_procedure(const ast::Block& node, const 
     // function requires return variable declaration
     if (node.is_function_block()) {
         auto type = default_float_data_type();
-        printer->add_line(fmt::format("{} ret_{} = 0.0;", type, name));
+        printer->fmt_line("{} ret_{} = 0.0;", type, name);
     } else {
-        printer->add_line(fmt::format("int ret_{} = 0;", name));
+        printer->fmt_line("int ret_{} = 0;", name);
     }
 
     print_statement_block(*node.get_statement_block(), false, false);
-    printer->add_line(fmt::format("return ret_{};", name));
+    printer->fmt_line("return ret_{};", name);
     printer->end_block(1);
 }
 
@@ -1783,8 +1782,8 @@ void CodegenCVisitor::visit_eigen_newton_solver_block(const ast::EigenNewtonSolv
 
     auto float_type = default_float_data_type();
     int N = node.get_n_state_vars()->get_value();
-    printer->add_line(fmt::format("Eigen::Matrix<{}, {}, 1> nmodl_eigen_xm;", float_type, N));
-    printer->add_line(fmt::format("{}* nmodl_eigen_x = nmodl_eigen_xm.data();", float_type));
+    printer->fmt_line("Eigen::Matrix<{}, {}, 1> nmodl_eigen_xm;", float_type, N);
+    printer->fmt_line("{}* nmodl_eigen_x = nmodl_eigen_xm.data();", float_type);
 
     print_statement_block(*node.get_setup_x_block(), false, false);
 
@@ -1792,7 +1791,7 @@ void CodegenCVisitor::visit_eigen_newton_solver_block(const ast::EigenNewtonSolv
     // Newton solver
     printer->start_block("struct functor");
     printer->add_line("NrnThread* nt;");
-    printer->add_line(fmt::format("{0}* inst;", instance_struct()));
+    printer->fmt_line("{0}* inst;", instance_struct());
     printer->add_line("int id, pnodecount;");
     printer->add_line("double v;");
     printer->add_line("Datum* indexes;");
@@ -1807,11 +1806,11 @@ void CodegenCVisitor::visit_eigen_newton_solver_block(const ast::EigenNewtonSolv
     print_statement_block(*node.get_initialize_block(), false, false);
     printer->end_block(2);
 
-    printer->add_line(fmt::format(
+    printer->fmt_line(
         "functor(NrnThread* nt, {}* inst, int id, int pnodecount, double v, Datum* indexes) : "
-        "nt(nt), inst(inst), id(id), pnodecount(pnodecount), v(v), indexes(indexes) {}",
-        instance_struct(),
-        "{}"));
+        "nt{{nt}}, inst{{inst}}, id{{id}}, pnodecount{{pnodecount}}, v{{v}}, indexes{{indexes}} "
+        "{{}}",
+        instance_struct());
 
     printer->add_indent();
 
@@ -1826,9 +1825,9 @@ void CodegenCVisitor::visit_eigen_newton_solver_block(const ast::EigenNewtonSolv
         N,
         is_functor_const(variable_block, functor_block) ? "const " : ""));
     printer->start_block();
-    printer->add_line(fmt::format("const {}* nmodl_eigen_x = nmodl_eigen_xm.data();", float_type));
-    printer->add_line(fmt::format("{}* nmodl_eigen_j = nmodl_eigen_jm.data();", float_type));
-    printer->add_line(fmt::format("{}* nmodl_eigen_f = nmodl_eigen_fm.data();", float_type));
+    printer->fmt_line("const {}* nmodl_eigen_x = nmodl_eigen_xm.data();", float_type);
+    printer->fmt_line("{}* nmodl_eigen_j = nmodl_eigen_jm.data();", float_type);
+    printer->fmt_line("{}* nmodl_eigen_f = nmodl_eigen_fm.data();", float_type);
     print_statement_block(functor_block, false, false);
     printer->end_block(2);
 
@@ -1858,12 +1857,11 @@ void CodegenCVisitor::visit_eigen_linear_solver_block(const ast::EigenLinearSolv
 
     const std::string float_type = default_float_data_type();
     int N = node.get_n_state_vars()->get_value();
-    printer->add_line(
-        fmt::format("Eigen::Matrix<{0}, {1}, 1> nmodl_eigen_xm, nmodl_eigen_fm;", float_type, N));
-    printer->add_line(fmt::format("Eigen::Matrix<{0}, {1}, {1}> nmodl_eigen_jm;", float_type, N));
-    printer->add_line(fmt::format("{}* nmodl_eigen_x = nmodl_eigen_xm.data();", float_type));
-    printer->add_line(fmt::format("{}* nmodl_eigen_j = nmodl_eigen_jm.data();", float_type));
-    printer->add_line(fmt::format("{}* nmodl_eigen_f = nmodl_eigen_fm.data();", float_type));
+    printer->fmt_line("Eigen::Matrix<{0}, {1}, 1> nmodl_eigen_xm, nmodl_eigen_fm;", float_type, N);
+    printer->fmt_line("Eigen::Matrix<{0}, {1}, {1}> nmodl_eigen_jm;", float_type, N);
+    printer->fmt_line("{}* nmodl_eigen_x = nmodl_eigen_xm.data();", float_type);
+    printer->fmt_line("{}* nmodl_eigen_j = nmodl_eigen_jm.data();", float_type);
+    printer->fmt_line("{}* nmodl_eigen_f = nmodl_eigen_fm.data();", float_type);
     print_statement_block(*node.get_variable_block(), false, false);
     print_statement_block(*node.get_initialize_block(), false, false);
     print_statement_block(*node.get_setup_x_block(), false, false);
@@ -1881,11 +1879,11 @@ void CodegenCVisitor::print_eigen_linear_solver(const std::string& float_type, i
         // Faster compared to LU, given the template specialization in Eigen.
         printer->add_line("nmodl_eigen_xm = nmodl_eigen_jm.inverse()*nmodl_eigen_fm;");
     } else {
-        printer->add_line(
-            fmt::format("nmodl_eigen_xm = Eigen::PartialPivLU<Eigen::Ref<Eigen::Matrix<{0}, {1}, "
-                        "{1}>>>(nmodl_eigen_jm).solve(nmodl_eigen_fm);",
-                        float_type,
-                        N));
+        printer->fmt_line(
+            "nmodl_eigen_xm = Eigen::PartialPivLU<Eigen::Ref<Eigen::Matrix<{0}, {1}, "
+            "{1}>>>(nmodl_eigen_jm).solve(nmodl_eigen_fm);",
+            float_type,
+            N);
     }
 }
 
@@ -2122,9 +2120,9 @@ void CodegenCVisitor::print_nmodl_constants() {
 #else
             const std::string format_string = "static const double {} = {:.18g};";
 #endif
-            printer->add_line(fmt::format(format_string,
-                                          it->get_node_name(),
-                                          stod(it->get_value()->get_value())));
+            printer->fmt_line(format_string,
+                              it->get_node_name(),
+                              stod(it->get_value()->get_value()));
         }
     }
 }
@@ -2133,24 +2131,24 @@ void CodegenCVisitor::print_nmodl_constants() {
 void CodegenCVisitor::print_first_pointer_var_index_getter() {
     printer->add_newline(2);
     print_device_method_annotation();
-    printer->add_line("static inline int first_pointer_var_index() {");
-    printer->add_line(fmt::format("    return {};", info.first_pointer_var_index));
-    printer->add_line("}");
+    printer->start_block("static inline int first_pointer_var_index()");
+    printer->fmt_line("return {};", info.first_pointer_var_index);
+    printer->end_block(1);
 }
 
 
 void CodegenCVisitor::print_num_variable_getter() {
     printer->add_newline(2);
     print_device_method_annotation();
-    printer->add_line("static inline int float_variables_size() {");
-    printer->add_line(fmt::format("    return {};", float_variables_size()));
-    printer->add_line("}");
+    printer->start_block("static inline int float_variables_size()");
+    printer->fmt_line("return {};", float_variables_size());
+    printer->end_block(1);
 
     printer->add_newline(2);
     print_device_method_annotation();
-    printer->add_line("static inline int int_variables_size() {");
-    printer->add_line(fmt::format("    return {};", int_variables_size()));
-    printer->add_line("}");
+    printer->start_block("static inline int int_variables_size()");
+    printer->fmt_line("return {};", int_variables_size());
+    printer->end_block(1);
 }
 
 
@@ -2160,9 +2158,9 @@ void CodegenCVisitor::print_net_receive_arg_size_getter() {
     }
     printer->add_newline(2);
     print_device_method_annotation();
-    printer->add_line("static inline int num_net_receive_args() {");
-    printer->add_line(fmt::format("    return {};", info.num_net_receive_parameters));
-    printer->add_line("}");
+    printer->start_block("static inline int num_net_receive_args()");
+    printer->fmt_line("return {};", info.num_net_receive_parameters);
+    printer->end_block(1);
 }
 
 
@@ -2179,12 +2177,12 @@ void CodegenCVisitor::print_mech_type_getter() {
 void CodegenCVisitor::print_memb_list_getter() {
     printer->add_newline(2);
     print_device_method_annotation();
-    printer->add_line("static inline Memb_list* get_memb_list(NrnThread* nt) {");
-    printer->add_line("    if (nt->_ml_list == NULL) {");
-    printer->add_line("        return NULL;");
-    printer->add_line("    }");
-    printer->add_line("    return nt->_ml_list[get_mech_type()];");
-    printer->add_line("}");
+    printer->start_block("static inline Memb_list* get_memb_list(NrnThread* nt)");
+    printer->start_block("if (!nt->_ml_list)");
+    printer->add_line("return nullptr;");
+    printer->end_block(1);
+    printer->add_line("return nt->_ml_list[get_mech_type()];");
+    printer->end_block(1);
 }
 
 
@@ -2221,35 +2219,33 @@ void CodegenCVisitor::print_thread_getters() {
         printer->add_line("/** thread specific helper routines for derivimplicit */");
 
         printer->add_newline(1);
-        printer->add_line(fmt::format("static inline int* deriv{}_advance(ThreadDatum* thread) {}", list, "{"));
-        printer->add_line(fmt::format("    return &(thread[{}].i);", tid));
-        printer->add_line("}");
+        printer->fmt_start_block("static inline int* deriv{}_advance(ThreadDatum* thread)", list);
+        printer->fmt_line("return &(thread[{}].i);", tid);
+        printer->end_block(2);
 
-        printer->add_newline(1);
-        printer->add_line(fmt::format("static inline int dith{}() {}", list, "{"));
-        printer->add_line(fmt::format("    return {};", tid+1));
-        printer->add_line("}");
+        printer->fmt_start_block("static inline int dith{}()", list);
+        printer->fmt_line("return {};", tid+1);
+        printer->end_block(2);
 
-        printer->add_newline(1);
-        printer->add_line(fmt::format("static inline void** newtonspace{}(ThreadDatum* thread) {}", list, "{"));
-        printer->add_line(fmt::format("    return &(thread[{}]._pvoid);", tid+2));
-        printer->add_line("}");
+        printer->fmt_start_block("static inline void** newtonspace{}(ThreadDatum* thread)", list);
+        printer->fmt_line("return &(thread[{}]._pvoid);", tid+2);
+        printer->end_block(1);
     }
 
     if (info.vectorize && !info.thread_variables.empty()) {
         printer->add_newline(2);
         printer->add_line("/** tid for thread variables */");
-        printer->add_line("static inline int thread_var_tid() {");
-        printer->add_line(fmt::format("    return {};", info.thread_var_thread_id));
-        printer->add_line("}");
+        printer->start_block("static inline int thread_var_tid()");
+        printer->fmt_line("return {};", info.thread_var_thread_id);
+        printer->end_block(1);
     }
 
     if (info.vectorize && !info.top_local_variables.empty()) {
         printer->add_newline(2);
         printer->add_line("/** tid for top local tread variables */");
-        printer->add_line("static inline int top_local_var_tid() {");
-        printer->add_line(fmt::format("    return {};", info.top_local_thread_id));
-        printer->add_line("}");
+        printer->start_block("static inline int top_local_var_tid()");
+        printer->fmt_line("return {};", info.top_local_thread_id);
+        printer->end_block(1);
     }
     // clang-format on
 }
@@ -2425,14 +2421,14 @@ void CodegenCVisitor::print_backend_info() {
     auto version = nmodl::Version::NMODL_VERSION + " [" + nmodl::Version::GIT_REVISION + "]";
 
     printer->add_line("/*********************************************************");
-    printer->add_line(fmt::format("Model Name      : {}", info.mod_suffix));
-    printer->add_line(fmt::format("Filename        : {}", info.mod_file + ".mod"));
-    printer->add_line(fmt::format("NMODL Version   : {}", nmodl_version()));
-    printer->add_line(fmt::format("Vectorized      : {}", info.vectorize));
-    printer->add_line(fmt::format("Threadsafe      : {}", info.thread_safe));
-    printer->add_line(fmt::format("Created         : {}", stringutils::trim(date)));
-    printer->add_line(fmt::format("Backend         : {}", backend_name()));
-    printer->add_line(fmt::format("NMODL Compiler  : {}", version));
+    printer->fmt_line("Model Name      : {}", info.mod_suffix);
+    printer->fmt_line("Filename        : {}", info.mod_file + ".mod");
+    printer->fmt_line("NMODL Version   : {}", nmodl_version());
+    printer->fmt_line("Vectorized      : {}", info.vectorize);
+    printer->fmt_line("Threadsafe      : {}", info.thread_safe);
+    printer->fmt_line("Created         : {}", stringutils::trim(date));
+    printer->fmt_line("Backend         : {}", backend_name());
+    printer->fmt_line("NMODL Compiler  : {}", version);
     printer->add_line("*********************************************************/");
 }
 
@@ -2838,16 +2834,16 @@ static size_t get_register_type_for_ba_block(const ast::Block* block) {
 void CodegenCVisitor::print_mechanism_register() {
     printer->add_newline(2);
     printer->add_line("/** register channel with the simulator */");
-    printer->start_block(fmt::format("void _{}_reg() ", info.mod_file));
+    printer->fmt_start_block("void _{}_reg() ", info.mod_file);
 
     // type related information
     auto suffix = add_escape_quote(info.mod_suffix);
     printer->add_newline();
     printer->fmt_line("int mech_type = nrn_get_mechtype({});", suffix);
     printer->fmt_line("{} = mech_type;", get_variable_name("mech_type", false));
-    printer->add_line("if (mech_type == -1) {");
-    printer->add_line("    return;");
-    printer->add_line("}");
+    printer->start_block("if (mech_type == -1)");
+    printer->add_line("return;");
+    printer->end_block(1);
 
     printer->add_newline();
     printer->add_line("_nrn_layout_reg(mech_type, 0);");  // 0 for SoA
@@ -2889,7 +2885,7 @@ void CodegenCVisitor::print_mechanism_register() {
     }
 
     if (!info.thread_variables.empty()) {
-        printer->add_line(fmt::format("{} = 0;", get_variable_name("thread_data_in_use")));
+        printer->fmt_line("{} = 0;", get_variable_name("thread_data_in_use"));
     }
 
     if (info.thread_callback_register) {
@@ -2899,7 +2895,7 @@ void CodegenCVisitor::print_mechanism_register() {
 
     if (info.emit_table_thread()) {
         auto name = method_name("check_table_thread");
-        printer->add_line(fmt::format("_nrn_thread_table_reg(mech_type, {});", name));
+        printer->fmt_line("_nrn_thread_table_reg(mech_type, {});", name);
     }
 
     // register read/write callbacks for pointers
@@ -2917,12 +2913,12 @@ void CodegenCVisitor::print_mechanism_register() {
     for (auto& semantic: info.semantics) {
         auto args =
             fmt::format("mech_type, {}, {}", semantic.index, add_escape_quote(semantic.name));
-        printer->add_line(fmt::format("hoc_register_dparam_semantics({});", args));
+        printer->fmt_line("hoc_register_dparam_semantics({});", args);
     }
 
     if (info.is_watch_used()) {
         auto watch_fun = compute_method_name(BlockType::Watch);
-        printer->add_line(fmt::format("hoc_register_watch_check({}, mech_type);", watch_fun));
+        printer->fmt_line("hoc_register_watch_check({}, mech_type);", watch_fun);
     }
 
     if (info.write_concentration) {
@@ -2934,22 +2930,20 @@ void CodegenCVisitor::print_mechanism_register() {
         printer->add_line("add_nrn_has_net_event(mech_type);");
     }
     if (info.artificial_cell) {
-        printer->add_line(fmt::format("add_nrn_artcell(mech_type, {});", info.tqitem_index));
+        printer->fmt_line("add_nrn_artcell(mech_type, {});", info.tqitem_index);
     }
     if (net_receive_buffering_required()) {
-        printer->add_line(fmt::format("hoc_register_net_receive_buffering({}, mech_type);",
-                                      method_name("net_buf_receive")));
+        printer->fmt_line("hoc_register_net_receive_buffering({}, mech_type);",
+                          method_name("net_buf_receive"));
     }
     if (info.num_net_receive_parameters != 0) {
         auto net_recv_init_arg = "nullptr";
         if (info.net_receive_initial_node != nullptr) {
             net_recv_init_arg = "net_init";
         }
-        auto pnt_recline =
-            fmt::format("set_pnt_receive(mech_type, {}, {}, num_net_receive_args());",
-                        method_name("net_receive"),
-                        net_recv_init_arg);
-        printer->add_line(pnt_recline);
+        printer->fmt_line("set_pnt_receive(mech_type, {}, {}, num_net_receive_args());",
+                          method_name("net_receive"),
+                          net_recv_init_arg);
     }
     if (info.for_netcon_used) {
         // index where information about FOR_NETCON is stored in the integer array
@@ -2957,7 +2951,7 @@ void CodegenCVisitor::print_mechanism_register() {
             std::find_if(info.semantics.begin(), info.semantics.end(), [](const IndexSemantics& a) {
                 return a.name == naming::FOR_NETCON_SEMANTIC;
             })->index;
-        printer->add_line(fmt::format("add_nrn_fornetcons(mech_type, {});", index));
+        printer->fmt_line("add_nrn_fornetcons(mech_type, {});", index);
     }
 
     if (info.net_event_used || info.net_send_used) {
@@ -2970,8 +2964,7 @@ void CodegenCVisitor::print_mechanism_register() {
         const auto& block = info.before_after_blocks[i];
         size_t register_type = get_register_type_for_ba_block(block);
         std::string function_name = method_name(fmt::format("nrn_before_after_{}", i));
-        printer->add_line(
-            fmt::format("hoc_reg_ba(mech_type, {}, {});", function_name, register_type));
+        printer->fmt_line("hoc_reg_ba(mech_type, {}, {});", function_name, register_type);
     }
 
     // register variables for hoc
@@ -2991,26 +2984,24 @@ void CodegenCVisitor::print_thread_memory_callbacks() {
     printer->start_block("static void thread_mem_init(ThreadDatum* thread) ");
 
     if (info.vectorize && info.derivimplicit_used()) {
-        printer->add_line(
-            fmt::format("thread[dith{}()].pval = NULL;", info.derivimplicit_list_num));
+        printer->fmt_line("thread[dith{}()].pval = nullptr;", info.derivimplicit_list_num);
     }
     if (info.vectorize && (info.top_local_thread_size != 0)) {
         auto length = info.top_local_thread_size;
         auto allocation = fmt::format("(double*)mem_alloc({}, sizeof(double))", length);
-        auto line = fmt::format("thread[top_local_var_tid()].pval = {};", allocation);
-        printer->add_line(line);
+        printer->fmt_line("thread[top_local_var_tid()].pval = {};", allocation);
     }
     if (info.thread_var_data_size != 0) {
         auto length = info.thread_var_data_size;
         auto thread_data = get_variable_name("thread_data");
         auto thread_data_in_use = get_variable_name("thread_data_in_use");
         auto allocation = fmt::format("(double*)mem_alloc({}, sizeof(double))", length);
-        printer->add_line(fmt::format("if ({}) {}", thread_data_in_use, "{"));
-        printer->add_line(fmt::format("    thread[thread_var_tid()].pval = {};", allocation));
-        printer->add_line("} else {");
-        printer->add_line(fmt::format("    thread[thread_var_tid()].pval = {};", thread_data));
-        printer->add_line(fmt::format("    {} = 1;", thread_data_in_use));
-        printer->add_line("}");
+        printer->fmt_start_block("if ({})", thread_data_in_use);
+        printer->fmt_line("thread[thread_var_tid()].pval = {};", allocation);
+        printer->restart_block("else");
+        printer->fmt_line("thread[thread_var_tid()].pval = {};", thread_data);
+        printer->fmt_line("{} = 1;", thread_data_in_use);
+        printer->end_block(1);
     }
     printer->end_block(3);
 
@@ -3022,8 +3013,8 @@ void CodegenCVisitor::print_thread_memory_callbacks() {
     // clang-format off
     if (info.vectorize && info.derivimplicit_used()) {
         int n = info.derivimplicit_list_num;
-        printer->add_line(fmt::format("free(thread[dith{}()].pval);", n));
-        printer->add_line(fmt::format("nrn_destroy_newtonspace(static_cast<NewtonSpace*>(*newtonspace{}(thread)));", n));
+        printer->fmt_line("free(thread[dith{}()].pval);", n);
+        printer->fmt_line("nrn_destroy_newtonspace(static_cast<NewtonSpace*>(*newtonspace{}(thread)));", n);
     }
     // clang-format on
 
@@ -3034,12 +3025,11 @@ void CodegenCVisitor::print_thread_memory_callbacks() {
     if (info.thread_var_data_size != 0) {
         auto thread_data = get_variable_name("thread_data");
         auto thread_data_in_use = get_variable_name("thread_data_in_use");
-        printer->add_line(
-            fmt::format("if (thread[thread_var_tid()].pval == {}) {}", thread_data, "{"));
-        printer->add_line(fmt::format("    {} = 0;", thread_data_in_use));
-        printer->add_line("} else {");
-        printer->add_line("    free(thread[thread_var_tid()].pval);");
-        printer->add_line("}");
+        printer->fmt_start_block("if (thread[thread_var_tid()].pval == {})", thread_data);
+        printer->fmt_line("{} = 0;", thread_data_in_use);
+        printer->restart_block("else");
+        printer->add_line("free(thread[thread_var_tid()].pval);");
+        printer->end_block(1);
     }
     printer->end_block(1);
 }
@@ -3105,13 +3095,13 @@ void CodegenCVisitor::print_ion_var_structure() {
 
     for (auto& ion: info.ions) {
         for (auto& var: ion.writes) {
-            printer->add_line(fmt::format("{} {};", float_type, var));
+            printer->fmt_line("{} {};", float_type, var);
             members.push_back(var);
         }
     }
     for (auto& var: info.currents) {
         if (!info.is_ion_variable(var)) {
-            printer->add_line(fmt::format("{} {};", float_type, var));
+            printer->fmt_line("{} {};", float_type, var);
             members.push_back(var);
         }
     }
@@ -3153,12 +3143,12 @@ void CodegenCVisitor::print_setup_range_variable() {
     auto type = float_data_type();
     printer->add_newline(2);
     printer->add_line("/** allocate and setup array for range variable */");
-    printer->start_block(
-        fmt::format("static inline {}* setup_range_variable(double* variable, int n) ", type));
-    printer->add_line(fmt::format("{0}* data = ({0}*) mem_alloc(n, sizeof({0}));", type));
-    printer->add_line("for(size_t i = 0; i < n; i++) {");
-    printer->add_line("    data[i] = variable[i];");
-    printer->add_line("}");
+    printer->fmt_start_block("static inline {}* setup_range_variable(double* variable, int n)",
+                             type);
+    printer->fmt_line("{0}* data = ({0}*) mem_alloc(n, sizeof({0}));", type);
+    printer->start_block("for(size_t i = 0; i < n; i++)");
+    printer->add_line("data[i] = variable[i];");
+    printer->end_block(1);
     printer->add_line("return data;");
     printer->end_block(1);
 }
@@ -3364,7 +3354,7 @@ void CodegenCVisitor::print_global_function_common_code(BlockType type,
     }
 
     print_global_method_annotation();
-    printer->start_block(fmt::format("void {}({})", method, args));
+    printer->fmt_start_block("void {}({})", method, args);
     if (type != BlockType::Destructor && type != BlockType::Constructor) {
         // We do not (currently) support DESTRUCTOR and CONSTRUCTOR blocks
         // running anything on the GPU.
@@ -3376,20 +3366,17 @@ void CodegenCVisitor::print_global_function_common_code(BlockType type,
     }
     printer->add_line("int nodecount = ml->nodecount;");
     printer->add_line("int pnodecount = ml->_nodecount_padded;");
-    printer->add_line(
-        fmt::format("const int* {}node_index = ml->nodeindices;", ptr_type_qualifier()));
-    printer->add_line(fmt::format("double* {}data = ml->data;", ptr_type_qualifier()));
-    printer->add_line(
-        fmt::format("const double* {}voltage = nt->_actual_v;", ptr_type_qualifier()));
+    printer->fmt_line("const int* {}node_index = ml->nodeindices;", ptr_type_qualifier());
+    printer->fmt_line("double* {}data = ml->data;", ptr_type_qualifier());
+    printer->fmt_line("const double* {}voltage = nt->_actual_v;", ptr_type_qualifier());
 
     if (type == BlockType::Equation) {
-        printer->add_line(
-            fmt::format("double* {} vec_rhs = nt->_actual_rhs;", ptr_type_qualifier()));
-        printer->add_line(fmt::format("double* {} vec_d = nt->_actual_d;", ptr_type_qualifier()));
+        printer->fmt_line("double* {} vec_rhs = nt->_actual_rhs;", ptr_type_qualifier());
+        printer->fmt_line("double* {} vec_d = nt->_actual_d;", ptr_type_qualifier());
         print_rhs_d_shadow_variables();
     }
-    printer->add_line(fmt::format("Datum* {}indexes = ml->pdata;", ptr_type_qualifier()));
-    printer->add_line(fmt::format("ThreadDatum* {}thread = ml->_thread;", ptr_type_qualifier()));
+    printer->fmt_line("Datum* {}indexes = ml->pdata;", ptr_type_qualifier());
+    printer->fmt_line("ThreadDatum* {}thread = ml->_thread;", ptr_type_qualifier());
 
     if (type == BlockType::Initial) {
         printer->add_newline();
@@ -3412,16 +3399,16 @@ void CodegenCVisitor::print_nrn_init(bool skip_init_check) {
         int nequation = info.num_equations;
         int list_num = info.derivimplicit_list_num;
         // clang-format off
-        printer->add_line(fmt::format("int& deriv_advance_flag = *deriv{}_advance(thread);", list_num));
+        printer->fmt_line("int& deriv_advance_flag = *deriv{}_advance(thread);", list_num);
         printer->add_line("deriv_advance_flag = 0;");
         print_deriv_advance_flag_transfer_to_device();
-        printer->add_line(fmt::format("auto ns = newtonspace{}(thread);", list_num));
-        printer->add_line(fmt::format("auto& th = thread[dith{}()];", list_num));
+        printer->fmt_line("auto ns = newtonspace{}(thread);", list_num);
+        printer->fmt_line("auto& th = thread[dith{}()];", list_num);
         printer->start_block("if (*ns == nullptr)");
-        printer->add_line(fmt::format("int vec_size = 2*{}*pnodecount*sizeof(double);", nequation));
-        printer->add_line(fmt::format("double* vec = makevector(vec_size);", nequation));
-        printer->add_line(fmt::format("th.pval = vec;", list_num));
-        printer->add_line(fmt::format("*ns = nrn_cons_newtonspace({}, pnodecount);", nequation));
+        printer->fmt_line("int vec_size = 2*{}*pnodecount*sizeof(double);", nequation);
+        printer->fmt_line("double* vec = makevector(vec_size);", nequation);
+        printer->fmt_line("th.pval = vec;", list_num);
+        printer->fmt_line("*ns = nrn_cons_newtonspace({}, pnodecount);", nequation);
         print_newtonspace_transfer_to_device();
         printer->end_block(1);
         // clang-format on
@@ -3437,11 +3424,11 @@ void CodegenCVisitor::print_nrn_init(bool skip_init_check) {
     }
 
     if (!info.changed_dt.empty()) {
-        printer->add_line(fmt::format("double _save_prev_dt = {};",
-                                      get_variable_name(naming::NTHREAD_DT_VARIABLE)));
-        printer->add_line(fmt::format("{} = {};",
-                                      get_variable_name(naming::NTHREAD_DT_VARIABLE),
-                                      info.changed_dt));
+        printer->fmt_line("double _save_prev_dt = {};",
+                          get_variable_name(naming::NTHREAD_DT_VARIABLE));
+        printer->fmt_line("{} = {};",
+                          get_variable_name(naming::NTHREAD_DT_VARIABLE),
+                          info.changed_dt);
         print_dt_update_to_device();
     }
 
@@ -3449,7 +3436,7 @@ void CodegenCVisitor::print_nrn_init(bool skip_init_check) {
     print_channel_iteration_block_begin(BlockType::Initial);
 
     if (info.net_receive_node != nullptr) {
-        printer->add_line(fmt::format("{} = -1e20;", get_variable_name("tsave")));
+        printer->fmt_line("{} = -1e20;", get_variable_name("tsave"));
     }
 
     print_initial_block(info.initial_node);
@@ -3458,8 +3445,7 @@ void CodegenCVisitor::print_nrn_init(bool skip_init_check) {
     print_channel_iteration_tiling_block_end();
 
     if (!info.changed_dt.empty()) {
-        printer->add_line(
-            fmt::format("{} = _save_prev_dt;", get_variable_name(naming::NTHREAD_DT_VARIABLE)));
+        printer->fmt_line("{} = _save_prev_dt;", get_variable_name(naming::NTHREAD_DT_VARIABLE));
         print_dt_update_to_device();
     }
 
@@ -3502,8 +3488,7 @@ void CodegenCVisitor::print_before_after_block(const ast::Block* node, size_t bl
 
     /// print common function code like init/state/current
     printer->add_newline(2);
-    printer->add_line(
-        fmt::format("/** {} of block type {} # {} */", ba_type, ba_block_type, block_id));
+    printer->fmt_line("/** {} of block type {} # {} */", ba_type, ba_block_type, block_id);
     print_global_function_common_code(BlockType::BeforeAfter, function_name);
 
     print_channel_iteration_tiling_block_begin(BlockType::BeforeAfter);
@@ -3567,8 +3552,7 @@ void CodegenCVisitor::print_nrn_destructor() {
 void CodegenCVisitor::print_nrn_alloc() {
     printer->add_newline(2);
     auto method = method_name(naming::NRN_ALLOC_METHOD);
-    printer->start_block(
-        fmt::format("static void {}(double* data, Datum* indexes, int type) ", method));
+    printer->fmt_start_block("static void {}(double* data, Datum* indexes, int type) ", method);
     printer->add_line("// do nothing");
     printer->end_block(1);
 }
@@ -3586,19 +3570,19 @@ void CodegenCVisitor::print_watch_activate() {
     printer->add_newline(2);
     auto inst = fmt::format("{}* inst", instance_struct());
 
-    printer->start_block(
-        fmt::format("static void nrn_watch_activate({}, int id, int pnodecount, int watch_id, "
-                    "double v, bool &watch_remove) ",
-                    inst));
+    printer->fmt_start_block(
+        "static void nrn_watch_activate({}, int id, int pnodecount, int watch_id, "
+        "double v, bool &watch_remove)",
+        inst);
 
     // initialize all variables only during first watch statement
-    printer->add_line("if (watch_remove == false) {");
+    printer->start_block("if (watch_remove == false)");
     for (int i = 0; i < info.watch_count; i++) {
         auto name = get_variable_name(fmt::format("watch{}", i + 1));
-        printer->add_line(fmt::format("    {} = 0;", name));
+        printer->fmt_line("{} = 0;", name);
     }
-    printer->add_line("    watch_remove = true;");
-    printer->add_line("}");
+    printer->add_line("watch_remove = true;");
+    printer->end_block(1);
 
     /**
      * \todo Similar to neuron/coreneuron we are using
@@ -3606,7 +3590,7 @@ void CodegenCVisitor::print_watch_activate() {
      */
     for (int i = 0; i < info.watch_statements.size(); i++) {
         auto statement = info.watch_statements[i];
-        printer->start_block(fmt::format("if (watch_id == {})", i));
+        printer->fmt_start_block("if (watch_id == {})", i);
 
         auto varname = get_variable_name(fmt::format("watch{}", i + 1));
         printer->add_indent();
@@ -3653,7 +3637,7 @@ void CodegenCVisitor::print_watch_check() {
         auto varname = get_variable_name(fmt::format("watch{}", i + 1));
 
         // start block 1
-        printer->start_block(fmt::format("if ({}&2 && watch_untriggered)", varname));
+        printer->fmt_start_block("if ({}&2 && watch_untriggered)", varname);
 
         // start block 2
         printer->add_indent();
@@ -3664,7 +3648,7 @@ void CodegenCVisitor::print_watch_check() {
         printer->increase_indent();
 
         // start block 3
-        printer->start_block(fmt::format("if (({}&1) == 0)", varname));
+        printer->fmt_start_block("if (({}&1) == 0)", varname);
 
         printer->add_line("watch_untriggered = false;");
 
@@ -3680,13 +3664,13 @@ void CodegenCVisitor::print_watch_check() {
         printer->add_newline();
         printer->end_block(1);
 
-        printer->add_line(fmt::format("{} = 3;", varname));
+        printer->fmt_line("{} = 3;", varname);
         // end block 3
 
         // start block 3
         printer->decrease_indent();
         printer->start_block("} else");
-        printer->add_line(fmt::format("{} = 2;", varname));
+        printer->fmt_line("{} = 2;", varname);
         printer->end_block(1);
         // end block 3
 
@@ -3715,9 +3699,8 @@ void CodegenCVisitor::print_net_receive_common_code(const Block& node, bool need
         print_kernel_data_present_annotation_block_begin();
     }
 
-    printer->add_line(fmt::format("{}int nodecount = ml->nodecount;", param_type_qualifier()));
-    printer->add_line(
-        fmt::format("{}int pnodecount = ml->_nodecount_padded;", param_type_qualifier()));
+    printer->fmt_line("{}int nodecount = ml->nodecount;", param_type_qualifier());
+    printer->fmt_line("{}int pnodecount = ml->_nodecount_padded;", param_type_qualifier());
     printer->add_line("double* data = ml->data;");
     printer->add_line("double* weights = nt->weights;");
     printer->add_line("Datum* indexes = ml->pdata;");
@@ -3739,8 +3722,7 @@ void CodegenCVisitor::print_net_receive_common_code(const Block& node, bool need
             auto name = parameter->get_node_name();
             bool var_used = VarUsageVisitor().variable_used(node, "(*" + name + ")");
             if (var_used) {
-                auto statement = fmt::format("double* {} = weights + weight_index + {};", name, i);
-                printer->add_line(statement);
+                printer->fmt_line("double* {} = weights + weight_index + {};", name, i);
                 RenameVisitor vr(name, "*" + name);
                 node.visit_children(vr);
             }
@@ -3875,7 +3857,7 @@ void CodegenCVisitor::print_net_init() {
     auto args = "Point_process* pnt, int weight_index, double flag";
     printer->add_newline(2);
     printer->add_line("/** initialize block for net receive */");
-    printer->start_block(fmt::format("static void net_init({}) ", args));
+    printer->fmt_start_block("static void net_init({}) ", args);
     auto block = node->get_statement_block().get();
     if (block->get_statements().empty()) {
         printer->add_line("// do nothing");
@@ -3898,18 +3880,16 @@ void CodegenCVisitor::print_send_event_move() {
     printer->add_newline();
     printer->add_line("NetSendBuffer_t* nsb = ml->_net_send_buffer;");
     print_net_send_buf_update_to_host();
-    printer->add_line("for (int i=0; i < nsb->_cnt; i++) {");
-    printer->add_line("    int type = nsb->_sendtype[i];");
-    printer->add_line("    int tid = nt->id;");
-    printer->add_line("    double t = nsb->_nsb_t[i];");
-    printer->add_line("    double flag = nsb->_nsb_flag[i];");
-    printer->add_line("    int vdata_index = nsb->_vdata_index[i];");
-    printer->add_line("    int weight_index = nsb->_weight_index[i];");
-    printer->add_line("    int point_index = nsb->_pnt_index[i];");
-    // clang-format off
-    printer->add_line("    net_sem_from_gpu(type, vdata_index, weight_index, tid, point_index, t, flag);");
-    // clang-format on
-    printer->add_line("}");
+    printer->start_block("for (int i=0; i < nsb->_cnt; i++)");
+    printer->add_line("int type = nsb->_sendtype[i];");
+    printer->add_line("int tid = nt->id;");
+    printer->add_line("double t = nsb->_nsb_t[i];");
+    printer->add_line("double flag = nsb->_nsb_flag[i];");
+    printer->add_line("int vdata_index = nsb->_vdata_index[i];");
+    printer->add_line("int weight_index = nsb->_weight_index[i];");
+    printer->add_line("int point_index = nsb->_pnt_index[i];");
+    printer->add_line("net_sem_from_gpu(type, vdata_index, weight_index, tid, point_index, t, flag);");
+    printer->end_block(1);
     printer->add_line("nsb->_cnt = 0;");
     print_net_send_buf_count_update_to_device();
 }
@@ -3922,10 +3902,9 @@ std::string CodegenCVisitor::net_receive_buffering_declaration() {
 
 void CodegenCVisitor::print_get_memb_list() {
     printer->add_line("Memb_list* ml = get_memb_list(nt);");
-    printer->add_line("if (ml == NULL) {");
-    printer->add_line("    return;");
-    printer->add_line("}");
-    printer->add_newline();
+    printer->start_block("if (!ml)");
+    printer->add_line("return;");
+    printer->end_block(2);
 }
 
 
@@ -3954,8 +3933,7 @@ void CodegenCVisitor::print_net_receive_buffering(bool need_mech_inst) {
 
     print_kernel_data_present_annotation_block_begin();
 
-    printer->add_line(
-        fmt::format("NetReceiveBuffer_t* {}nrb = ml->_net_receive_buffer;", ptr_type_qualifier()));
+    printer->fmt_line("NetReceiveBuffer_t* {}nrb = ml->_net_receive_buffer;", ptr_type_qualifier());
     if (need_mech_inst) {
         printer->fmt_line("auto* const inst = static_cast<{0}*>(ml->instance);", instance_struct());
     }
@@ -3969,8 +3947,7 @@ void CodegenCVisitor::print_net_receive_buffering(bool need_mech_inst) {
     printer->add_line("int weight_index = nrb->_weight_index[index];");
     printer->add_line("double flag = nrb->_nrb_flag[index];");
     printer->add_line("Point_process* point_process = nt->pntprocs + offset;");
-    printer->add_line(
-        fmt::format("{}(t, point_process, inst, nt, ml, weight_index, flag);", net_receive));
+    printer->fmt_line("{}(t, point_process, inst, nt, ml, weight_index, flag);", net_receive);
     printer->end_block(1);
     print_net_receive_loop_end();
 
@@ -3988,9 +3965,9 @@ void CodegenCVisitor::print_net_receive_buffering(bool need_mech_inst) {
 }
 
 void CodegenCVisitor::print_net_send_buffering_grow() {
-    printer->add_line("if(i >= nsb->_size) {");
-    printer->add_line("    nsb->grow();");
-    printer->add_line("}");
+    printer->start_block("if(i >= nsb->_size)");
+    printer->add_line("nsb->grow();");
+    printer->end_block(1);
 }
 
 void CodegenCVisitor::print_net_send_buffering() {
@@ -4003,19 +3980,19 @@ void CodegenCVisitor::print_net_send_buffering() {
     auto args =
         "NetSendBuffer_t* nsb, int type, int vdata_index, "
         "int weight_index, int point_index, double t, double flag";
-    printer->start_block(fmt::format("static inline void net_send_buffering({}) ", args));
+    printer->fmt_start_block("static inline void net_send_buffering({}) ", args);
     printer->add_line("int i = 0;");
     print_device_atomic_capture_annotation();
     printer->add_line("i = nsb->_cnt++;");
     print_net_send_buffering_grow();
-    printer->add_line("if(i < nsb->_size) {");
-    printer->add_line("    nsb->_sendtype[i] = type;");
-    printer->add_line("    nsb->_vdata_index[i] = vdata_index;");
-    printer->add_line("    nsb->_weight_index[i] = weight_index;");
-    printer->add_line("    nsb->_pnt_index[i] = point_index;");
-    printer->add_line("    nsb->_nsb_t[i] = t;");
-    printer->add_line("    nsb->_nsb_flag[i] = flag;");
-    printer->add_line("}");
+    printer->start_block("if(i < nsb->_size)");
+    printer->add_line("nsb->_sendtype[i] = type;");
+    printer->add_line("nsb->_vdata_index[i] = vdata_index;");
+    printer->add_line("nsb->_weight_index[i] = weight_index;");
+    printer->add_line("nsb->_pnt_index[i] = point_index;");
+    printer->add_line("nsb->_nsb_t[i] = t;");
+    printer->add_line("nsb->_nsb_flag[i] = flag;");
+    printer->end_block(1);
     printer->end_block(1);
 }
 
@@ -4090,8 +4067,7 @@ void CodegenCVisitor::print_net_receive_kernel() {
     }
 
     printer->add_newline(2);
-    printer->start_block(
-        fmt::format("static inline void {}({}) ", name, get_parameter_str(params)));
+    printer->fmt_start_block("static inline void {}({}) ", name, get_parameter_str(params));
     print_net_receive_common_code(*node, info.artificial_cell);
     if (info.artificial_cell) {
         printer->add_line("double t = nt->_t;");
@@ -4104,7 +4080,7 @@ void CodegenCVisitor::print_net_receive_kernel() {
         printer->add_line("v = nt->_actual_v[node_id];");
     }
 
-    printer->add_line(fmt::format("{} = t;", get_variable_name("tsave")));
+    printer->fmt_line("{} = t;", get_variable_name("tsave"));
 
     if (info.is_watch_used()) {
         printer->add_line("bool watch_remove = false;");
@@ -4134,13 +4110,13 @@ void CodegenCVisitor::print_net_receive() {
         params.emplace_back("", "int", "", "weight_index");
         params.emplace_back("", "double", "", "flag");
         printer->add_newline(2);
-        printer->start_block(fmt::format("static void {}({}) ", name, get_parameter_str(params)));
+        printer->fmt_start_block("static void {}({}) ", name, get_parameter_str(params));
         printer->add_line("NrnThread* nt = nrn_threads + pnt->_tid;");
         printer->add_line("Memb_list* ml = get_memb_list(nt);");
         printer->add_line("NetReceiveBuffer_t* nrb = ml->_net_receive_buffer;");
-        printer->add_line("if (nrb->_cnt >= nrb->_size) {");
-        printer->add_line("    realloc_net_receive_buffer(nt, ml);");
-        printer->add_line("}");
+        printer->start_block("if (nrb->_cnt >= nrb->_size)");
+        printer->add_line("realloc_net_receive_buffer(nt, ml);");
+        printer->end_block(1);
         printer->add_line("int id = nrb->_cnt;");
         printer->add_line("nrb->_pnt_index[id] = pnt-nt->pntprocs;");
         printer->add_line("nrb->_weight_index[id] = weight_index;");
@@ -4348,13 +4324,14 @@ void CodegenCVisitor::print_nrn_current(const BreakpointBlock& node) {
     const auto& block = node.get_statement_block();
     printer->add_newline(2);
     print_device_method_annotation();
-    printer->start_block(
-        fmt::format("inline double nrn_current_{}({})", info.mod_suffix, get_parameter_str(args)));
+    printer->fmt_start_block("inline double nrn_current_{}({})",
+                             info.mod_suffix,
+                             get_parameter_str(args));
     printer->add_line("double current = 0.0;");
     print_statement_block(*block, false, false);
     for (auto& current: info.currents) {
         auto name = get_variable_name(current);
-        printer->add_line(fmt::format("current += {};", name));
+        printer->fmt_line("current += {};", name);
     }
     printer->add_line("return current;");
     printer->end_block(1);
@@ -4373,7 +4350,7 @@ void CodegenCVisitor::print_nrn_cur_conductance_kernel(const BreakpointBlock& no
                 sum += "+";
             }
         }
-        printer->add_line(fmt::format("double rhs = {};", sum));
+        printer->fmt_line("double rhs = {};", sum);
     }
 
     std::string sum;
@@ -4384,7 +4361,7 @@ void CodegenCVisitor::print_nrn_cur_conductance_kernel(const BreakpointBlock& no
             sum += "+";
         }
     }
-    printer->add_line(fmt::format("double g = {};", sum));
+    printer->fmt_line("double g = {};", sum);
 
     for (const auto& conductance: info.conductances) {
         if (!conductance.ion.empty()) {
@@ -4399,20 +4376,20 @@ void CodegenCVisitor::print_nrn_cur_conductance_kernel(const BreakpointBlock& no
 
 
 void CodegenCVisitor::print_nrn_cur_non_conductance_kernel() {
-    printer->add_line(fmt::format("double g = nrn_current_{}({}+0.001);",
+    printer->fmt_line("double g = nrn_current_{}({}+0.001);",
                                   info.mod_suffix,
-                                  internal_method_arguments()));
+                                  internal_method_arguments());
     for (auto& ion: info.ions) {
         for (auto& var: ion.writes) {
             if (ion.is_ionic_current(var)) {
                 auto name = get_variable_name(var);
-                printer->add_line(fmt::format("double di{} = {};", ion.name, name));
+                printer->fmt_line("double di{} = {};", ion.name, name);
             }
         }
     }
-    printer->add_line(fmt::format("double rhs = nrn_current_{}({});",
+    printer->fmt_line("double rhs = nrn_current_{}({});",
                                   info.mod_suffix,
-                                  internal_method_arguments()));
+                                  internal_method_arguments());
     printer->add_line("g = (g-rhs)/0.001;");
     for (auto& ion: info.ions) {
         for (auto& var: ion.writes) {
@@ -4459,7 +4436,7 @@ void CodegenCVisitor::print_nrn_cur_kernel(const BreakpointBlock& node) {
 
     if (info.point_process) {
         auto area = get_variable_name(naming::NODE_AREA_VARIABLE);
-        printer->add_line(fmt::format("double mfactor = 1.e2/{};", area));
+        printer->fmt_line("double mfactor = 1.e2/{};", area);
         printer->add_line("g = g*mfactor;");
         printer->add_line("rhs = rhs*mfactor;");
     }
@@ -4488,9 +4465,9 @@ void CodegenCVisitor::print_fast_imem_calculation() {
         printer->add_line("int node_id = node_index[id];");
     }
     print_atomic_reduction_pragma();
-    printer->add_line(fmt::format("nt->nrn_fast_imem->nrn_sav_rhs[node_id] {} {};", rhs_op, rhs));
+    printer->fmt_line("nt->nrn_fast_imem->nrn_sav_rhs[node_id] {} {};", rhs_op, rhs);
     print_atomic_reduction_pragma();
-    printer->add_line(fmt::format("nt->nrn_fast_imem->nrn_sav_d[node_id] {} {};", d_op, d));
+    printer->fmt_line("nt->nrn_fast_imem->nrn_sav_d[node_id] {} {};", d_op, d);
     if (nrn_cur_reduction_loop_required()) {
         print_shadow_reduction_block_end();
     }

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1836,9 +1836,7 @@ void CodegenCVisitor::visit_eigen_newton_solver_block(const ast::EigenNewtonSolv
     print_statement_block(*node.get_finalize_block(), false, false);
     printer->end_block(1);
 
-    printer->end_block(0);
-    printer->add_text(";");
-    printer->add_newline();
+    printer->end_block(";");
 
     // call newton solver with functor and X matrix that contains state vars
     printer->add_line("// call newton solver");
@@ -3108,9 +3106,7 @@ void CodegenCVisitor::print_ion_var_structure() {
 
     print_ion_var_constructor(members);
 
-    printer->end_block();
-    printer->add_text(";");
-    printer->add_newline();
+    printer->end_block(";");
 }
 
 
@@ -4198,9 +4194,7 @@ void CodegenCVisitor::print_derivimplicit_kernel(Block* block) {
     printer->end_block(1);
     printer->add_line("return 0;");
     printer->end_block(1);  // operator()
-    printer->end_block();   // struct
-    printer->add_text(";");
-    printer->add_newline();
+    printer->end_block(";");   // struct
     printer->end_block(2);  // namespace
     printer->fmt_start_block("int {}_{}({})", block_name, suffix, ext_params);
     printer->add_line(instance);

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1971,8 +1971,10 @@ void CodegenCVisitor::print_function_declaration(const T& node, const std::strin
 
     print_device_method_annotation();
     printer->add_indent();
-    printer->add_text(fmt::format(
-        "inline {} {}({})", return_type, method_name(name), get_parameter_str(internal_params)));
+    printer->fmt_text("inline {} {}({})",
+                      return_type,
+                      method_name(name),
+                      get_parameter_str(internal_params));
 
     enable_variable_name_lookup = true;
 }

--- a/src/codegen/codegen_cuda_visitor.cpp
+++ b/src/codegen/codegen_cuda_visitor.cpp
@@ -69,7 +69,7 @@ void CodegenCudaVisitor::print_atomic_op(const std::string& lhs,
     } else {
         throw std::runtime_error(fmt::format("CUDA backend error : {} not supported", op));
     }
-    printer->add_line(fmt::format("{}(&{}, {});", function, lhs, rhs));
+    printer->fmt_line("{}(&{}, {});", function, lhs, rhs);
 }
 
 
@@ -190,11 +190,11 @@ void CodegenCudaVisitor::print_wrapper_routine(std::string wrapper_function, Blo
     auto compute_function = compute_method_name(type);
 
     printer->add_newline(2);
-    printer->start_block(fmt::format("void {}({})", wrapper_function, args));
+    printer->fmt_start_block("void {}({})", wrapper_function, args);
     printer->add_line("int nodecount = ml->nodecount;");
     printer->add_line("int nthread = 256;");
     printer->add_line("int nblock = (nodecount+nthread-1)/nthread;");
-    printer->add_line(fmt::format("{}<<<nblock, nthread>>>(nt, ml, type);", compute_function));
+    printer->fmt_line("{}<<<nblock, nthread>>>(nt, ml, type);", compute_function);
     printer->add_line("cudaDeviceSynchronize();");
     printer->end_block();
     printer->add_newline();

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -240,7 +240,7 @@ void CodegenIspcVisitor::print_atomic_op(const std::string& lhs,
     } else {
         throw std::runtime_error(fmt::format("ISPC backend error : {} not supported", op));
     }
-    printer->add_line(fmt::format("{}(&{}, {});", function, lhs, rhs));
+    printer->fmt_line("{}(&{}, {});", function, lhs, rhs);
 }
 
 
@@ -249,8 +249,9 @@ void CodegenIspcVisitor::print_nrn_cur_matrix_shadow_reduction() {
     auto d_op = operator_for_d();
     if (info.point_process) {
         printer->add_line("uniform int node_id = node_index[id];");
-        printer->add_line(fmt::format("vec_rhs[node_id] {} shadow_rhs[id];", rhs_op));
-        printer->add_line(fmt::format("vec_d[node_id] {} shadow_d[id];", d_op));
+        printer->fmt_line("vec_rhs[node_id] {} shadow_rhs[id];", rhs_op);
+        printer->fmt_line("vec_rhs[node_id] {} shadow_rhs[id];", rhs_op);
+        printer->fmt_line("vec_d[node_id] {} shadow_d[id];", d_op);
     }
 }
 
@@ -271,10 +272,8 @@ void CodegenIspcVisitor::print_shadow_reduction_block_end() {
 
 void CodegenIspcVisitor::print_rhs_d_shadow_variables() {
     if (info.point_process) {
-        printer->add_line(
-            fmt::format("double* uniform shadow_rhs = nt->{};", naming::NTHREAD_RHS_SHADOW));
-        printer->add_line(
-            fmt::format("double* uniform shadow_d = nt->{};", naming::NTHREAD_D_SHADOW));
+        printer->fmt_line("double* uniform shadow_rhs = nt->{};", naming::NTHREAD_RHS_SHADOW);
+        printer->fmt_line("double* uniform shadow_d = nt->{};", naming::NTHREAD_D_SHADOW);
     }
 }
 
@@ -374,25 +373,22 @@ void CodegenIspcVisitor::print_global_function_common_code(BlockType type,
 
     auto params = get_global_function_parms(ptr_type_qualifier());
     print_global_method_annotation();
-    printer->start_block(fmt::format("export void {}({})", method, get_parameter_str(params)));
+    printer->fmt_start_block("export void {}({})", method, get_parameter_str(params));
 
     print_kernel_data_present_annotation_block_begin();
     printer->add_line("uniform int nodecount = ml->nodecount;");
     printer->add_line("uniform int pnodecount = ml->_nodecount_padded;");
-    printer->add_line(
-        fmt::format("const int* {}node_index = ml->nodeindices;", ptr_type_qualifier()));
-    printer->add_line(fmt::format("double* {}data = ml->data;", ptr_type_qualifier()));
-    printer->add_line(
-        fmt::format("const double* {}voltage = nt->_actual_v;", ptr_type_qualifier()));
+    printer->fmt_line("const int* {}node_index = ml->nodeindices;", ptr_type_qualifier());
+    printer->fmt_line("double* {}data = ml->data;", ptr_type_qualifier());
+    printer->fmt_line("const double* {}voltage = nt->_actual_v;", ptr_type_qualifier());
 
     if (type == BlockType::Equation) {
-        printer->add_line(
-            fmt::format("double* {}vec_rhs = nt->_actual_rhs;", ptr_type_qualifier()));
-        printer->add_line(fmt::format("double* {}vec_d = nt->_actual_d;", ptr_type_qualifier()));
+        printer->fmt_line("double* {}vec_rhs = nt->_actual_rhs;", ptr_type_qualifier());
+        printer->fmt_line("double* {}vec_d = nt->_actual_d;", ptr_type_qualifier());
         print_rhs_d_shadow_variables();
     }
-    printer->add_line(fmt::format("Datum* {}indexes = ml->pdata;", ptr_type_qualifier()));
-    printer->add_line(fmt::format("ThreadDatum* {}thread = ml->_thread;", ptr_type_qualifier()));
+    printer->fmt_line("Datum* {}indexes = ml->pdata;", ptr_type_qualifier());
+    printer->fmt_line("ThreadDatum* {}thread = ml->_thread;", ptr_type_qualifier());
     printer->add_newline(1);
 }
 
@@ -444,7 +440,7 @@ void CodegenIspcVisitor::print_net_receive_buffering_wrapper() {
         return;
     }
     printer->add_newline(2);
-    printer->start_block(fmt::format("void {}(NrnThread* nt)", method_name("net_buf_receive")));
+    printer->fmt_start_block("void {}(NrnThread* nt)", method_name("net_buf_receive"));
     printer->add_line("Memb_list* ml = get_memb_list(nt);");
     printer->start_block("if (ml == NULL)");
     printer->add_line("return;");
@@ -453,7 +449,7 @@ void CodegenIspcVisitor::print_net_receive_buffering_wrapper() {
                       instance_struct(),
                       ptr_type_qualifier());
 
-    printer->add_line(fmt::format("{}(inst, nt, ml);", method_name("ispc_net_buf_receive")));
+    printer->fmt_line("{}(inst, nt, ml);", method_name("ispc_net_buf_receive"));
 
     printer->end_block(1);
 }
@@ -470,7 +466,7 @@ void CodegenIspcVisitor::print_nmodl_constants() {
         for (auto& it: info.factor_definitions) {
             const std::string name = it->get_node_name() == "PI" ? "ISPC_PI" : it->get_node_name();
             const std::string value = format_double_string(it->get_value()->get_value());
-            printer->add_line(fmt::format("static const uniform double {} = {};", name, value));
+            printer->fmt_line("static const uniform double {} = {};", name, value);
         }
     }
 }
@@ -488,7 +484,7 @@ void CodegenIspcVisitor::print_wrapper_routine(const std::string& wrapper_functi
     auto compute_function = compute_method_name(type);
 
     printer->add_newline(2);
-    printer->start_block(fmt::format("void {}({})", function_name, args));
+    printer->fmt_start_block("void {}({})", function_name, args);
     printer->add_line("int nodecount = ml->nodecount;");
     printer->fmt_line("auto* const {1}inst = static_cast<{0}*>(ml->instance);",
                       instance_struct(),
@@ -511,20 +507,17 @@ void CodegenIspcVisitor::print_backend_compute_routine_decl() {
     auto params = get_global_function_parms("");
     auto compute_function = compute_method_name(BlockType::Initial);
     if (!emit_fallback[BlockType::Initial]) {
-        printer->add_line(
-            fmt::format("extern \"C\" void {}({});", compute_function, get_parameter_str(params)));
+        printer->fmt_line("extern \"C\" void {}({});", compute_function, get_parameter_str(params));
     }
 
     if (nrn_cur_required() && !emit_fallback[BlockType::Equation]) {
         compute_function = compute_method_name(BlockType::Equation);
-        printer->add_line(
-            fmt::format("extern \"C\" void {}({});", compute_function, get_parameter_str(params)));
+        printer->fmt_line("extern \"C\" void {}({});", compute_function, get_parameter_str(params));
     }
 
     if (nrn_state_required() && !emit_fallback[BlockType::State]) {
         compute_function = compute_method_name(BlockType::State);
-        printer->add_line(
-            fmt::format("extern \"C\" void {}({});", compute_function, get_parameter_str(params)));
+        printer->fmt_line("extern \"C\" void {}({});", compute_function, get_parameter_str(params));
     }
 
     if (net_receive_required()) {
@@ -532,9 +525,9 @@ void CodegenIspcVisitor::print_backend_compute_routine_decl() {
         net_recv_params.emplace_back("", fmt::format("{}*", instance_struct()), "", "inst");
         net_recv_params.emplace_back("", "NrnThread*", "", "nt");
         net_recv_params.emplace_back("", "Memb_list*", "", "ml");
-        printer->add_line(fmt::format("extern \"C\" void {}({});",
-                                      method_name("ispc_net_buf_receive"),
-                                      get_parameter_str(net_recv_params)));
+        printer->fmt_line("extern \"C\" void {}({});",
+                          method_name("ispc_net_buf_receive"),
+                          get_parameter_str(net_recv_params));
     }
 }
 

--- a/src/codegen/codegen_ispc_visitor.cpp
+++ b/src/codegen/codegen_ispc_visitor.cpp
@@ -250,7 +250,6 @@ void CodegenIspcVisitor::print_nrn_cur_matrix_shadow_reduction() {
     if (info.point_process) {
         printer->add_line("uniform int node_id = node_index[id];");
         printer->fmt_line("vec_rhs[node_id] {} shadow_rhs[id];", rhs_op);
-        printer->fmt_line("vec_rhs[node_id] {} shadow_rhs[id];", rhs_op);
         printer->fmt_line("vec_d[node_id] {} shadow_d[id];", d_op);
     }
 }

--- a/src/printer/code_printer.hpp
+++ b/src/printer/code_printer.hpp
@@ -82,9 +82,16 @@ class CodePrinter {
         add_line(fmt::format(std::forward<Args>(args)...));
     }
 
+    /// fmt_start_block(args...) is just shorthand for start_block(fmt::format(args...))
     template <typename... Args>
     void fmt_start_block(Args&&... args) {
         start_block(fmt::format(std::forward<Args>(args)...));
+    }
+
+    /// fmt_text(args...) is just shorthand for add_text(fmt::format(args...))
+    template <typename... Args>
+    void fmt_text(Args&&... args) {
+        add_text(fmt::format(std::forward<Args>(args)...));
     }
 
     void add_multi_line(const std::string&);


### PR DESCRIPTION
There are various wrapper functions that can be used in the code generation:
- `add_line(fmt::format(...))` -> `fmt_line(...)`
- `add_text(fmt::format(...))` -> `fmt_text(...)`
- `start_block(fmt::format(...))` -> `fmt_start_block(...)`
- `printer->end_block(); printer->add_text(...); printer->add_newline();` -> `printer->end_block(...)`
- `printer->restart_block("else");`

which make the code generation source code less verbose. Use them.
Also: prefer using `start_block` and `end_block` to manage code indentation.