### PR TITLE
Code generation fixes for array variables in TABLE statement

### DIFF
--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1025,6 +1025,12 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      */
     virtual bool is_constant_variable(const std::string& name) const;
 
+    /**
+     * Check if the given name exist in the symbol
+     * \return \c return a tuple <true, array_length> if variable
+     *            is an array otherwise <false, 0>
+     */
+    std::tuple<bool, int> check_if_var_is_array(const std::string& name);
 
     /**
      * Print declaration of macro NRN_PRCELLSTATE for debugging

--- a/test/unit/codegen/codegen_c_visitor.cpp
+++ b/test/unit/codegen/codegen_c_visitor.cpp
@@ -13,7 +13,11 @@
 #include "parser/nmodl_driver.hpp"
 #include "test/unit/utils/test_utils.hpp"
 #include "visitors/implicit_argument_visitor.hpp"
+#include "visitors/inline_visitor.hpp"
+#include "visitors/neuron_solve_visitor.hpp"
 #include "visitors/perf_visitor.hpp"
+#include "visitors/solve_block_visitor.hpp"
+#include "visitors/sympy_solver_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"
 
 using Catch::Matchers::Contains;  // ContainsSubstring in newer Catch2
@@ -32,6 +36,13 @@ std::shared_ptr<CodegenCVisitor> create_c_visitor(const std::shared_ptr<ast::Pro
     /// construct symbol table
     SymtabVisitor().visit_program(*ast);
 
+    /// run all necessary pass
+    InlineVisitor().visit_program(*ast);
+    SympySolverVisitor().visit_program(*ast);
+    SymtabVisitor(true).visit_program(*ast);
+    NeuronSolveVisitor().visit_program(*ast);
+    SolveBlockVisitor().visit_program(*ast);
+
     /// create C code generation visitor
     auto cv = std::make_shared<CodegenCVisitor>("temp.mod", ss, "double", false);
     cv->setup(*ast);
@@ -44,6 +55,15 @@ std::string get_instance_var_setup_function(std::string& nmodl_text) {
     std::stringstream ss;
     auto cvisitor = create_c_visitor(ast, nmodl_text, ss);
     cvisitor->print_instance_variable_setup();
+    return reindent_text(ss.str());
+}
+
+/// print entire code
+std::string get_cpp_code(const std::string& nmodl_text) {
+    const auto& ast = NmodlDriver().parse_string(nmodl_text);
+    std::stringstream ss;
+    auto cvisitor = create_c_visitor(ast, nmodl_text, ss);
+    cvisitor->visit_program(*ast);
     return reindent_text(ss.str());
 }
 
@@ -342,6 +362,60 @@ SCENARIO("Check NEURON globals are added to the instance struct on demand",
             REQUIRE_THAT(generated, !Contains("celsius"));
             REQUIRE_THAT(generated, !Contains("pi"));
             REQUIRE_THAT(generated, !Contains("secondorder"));
+        }
+    }
+}
+
+SCENARIO("Check code generation for TABLE statements", "[codegen][array_variables]") {
+    GIVEN("A MOD file that uses global and array variables in TABLE") {
+        std::string const nmodl_text = R"(
+            NEURON {
+                SUFFIX glia_Cav2_3
+                RANGE inf
+                GLOBAL tau
+            }
+
+            STATE { m }
+
+            PARAMETER {
+                tau = 1
+            }
+
+            ASSIGNED {
+                inf[2]
+            }
+
+            BREAKPOINT {
+                 SOLVE states METHOD cnexp
+            }
+
+            DERIVATIVE states {
+                mhn(v)
+                m' =  (inf[0] - m)/tau
+            }
+
+            PROCEDURE mhn(v (mV)) {
+                TABLE inf, tau DEPEND celsius FROM -100 TO 100 WITH 200
+                FROM i=0 TO 1 {
+                    inf[i] = v + tau
+                }
+            }
+        )";
+        THEN("Array and global variables should be correctly generated") {
+            auto const generated = get_cpp_code(nmodl_text);
+            REQUIRE_THAT(generated, Contains("double t_inf[2][201]{};"));
+            REQUIRE_THAT(generated, Contains("double t_tau[201]{};"));
+
+            REQUIRE_THAT(generated, Contains("inst->global->t_inf[0][i] = (inst->inf+id*2)[0];"));
+            REQUIRE_THAT(generated, Contains("inst->global->t_inf[1][i] = (inst->inf+id*2)[1];"));
+            REQUIRE_THAT(generated, Contains("inst->global->t_tau[i] = inst->global->tau;"));
+
+            REQUIRE_THAT(generated,
+                         Contains("(inst->inf+id*2)[0] = inst->global->t_inf[0][index];"));
+
+            REQUIRE_THAT(generated, Contains("(inst->inf+id*2)[0] = inst->global->t_inf[0][i]"));
+            REQUIRE_THAT(generated, Contains("(inst->inf+id*2)[1] = inst->global->t_inf[1][i]"));
+            REQUIRE_THAT(generated, Contains("inst->global->tau = inst->global->t_tau[i]"));
         }
     }
 }

--- a/test/unit/codegen/codegen_c_visitor.cpp
+++ b/test/unit/codegen/codegen_c_visitor.cpp
@@ -38,8 +38,6 @@ std::shared_ptr<CodegenCVisitor> create_c_visitor(const std::shared_ptr<ast::Pro
 
     /// run all necessary pass
     InlineVisitor().visit_program(*ast);
-    SympySolverVisitor().visit_program(*ast);
-    SymtabVisitor(true).visit_program(*ast);
     NeuronSolveVisitor().visit_program(*ast);
     SolveBlockVisitor().visit_program(*ast);
 


### PR DESCRIPTION
* table statements can have array variables. Until now only
  scalar variables were supported in code generation.
* we can check symbol table to find out if the variable is
  an array and it's length.
* similar to mod2c implementation, generate code for array
  variable assignments:
     https://github.com/BlueBrain/mod2c/blob/469c74dc7d96bbc5a06a42696422154b4cd2ce28/src/mod2c_core/parsact.c#L942
* with this, `glia__dbbs_mod_collection__Cav2_3__0.mod` from #888
  compiles