### PR TITLE
Codegen fixes for Eigen solvers with use of PROCEDURE using TABLE statement

### DIFF
--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1848,8 +1848,10 @@ void CodegenCVisitor::visit_eigen_newton_solver_block(const ast::EigenNewtonSolv
     printer->end_block(2);
 
     printer->fmt_line(
-        "functor(NrnThread* nt, {}* inst, int id, int pnodecount, double v, Datum* indexes, double* data, ThreadDatum* thread) : "
-        "nt{{nt}}, inst{{inst}}, id{{id}}, pnodecount{{pnodecount}}, v{{v}}, indexes{{indexes}}, data{{data}}, thread{{thread}} "
+        "functor(NrnThread* nt, {}* inst, int id, int pnodecount, double v, Datum* indexes, "
+        "double* data, ThreadDatum* thread) : "
+        "nt{{nt}}, inst{{inst}}, id{{id}}, pnodecount{{pnodecount}}, v{{v}}, indexes{{indexes}}, "
+        "data{{data}}, thread{{thread}} "
         "{{}}",
         instance_struct());
 
@@ -1881,7 +1883,8 @@ void CodegenCVisitor::visit_eigen_newton_solver_block(const ast::EigenNewtonSolv
 
     // call newton solver with functor and X matrix that contains state vars
     printer->add_line("// call newton solver");
-    printer->add_line("functor newton_functor(nt, inst, id, pnodecount, v, indexes, data, thread);");
+    printer->add_line(
+        "functor newton_functor(nt, inst, id, pnodecount, v, indexes, data, thread);");
     printer->add_line("newton_functor.initialize();");
     printer->add_line(
         "int newton_iterations = nmodl::newton::newton_solver(nmodl_eigen_xm, newton_functor);");

--- a/src/codegen/codegen_c_visitor.cpp
+++ b/src/codegen/codegen_c_visitor.cpp
@@ -1830,6 +1830,9 @@ void CodegenCVisitor::visit_eigen_newton_solver_block(const ast::EigenNewtonSolv
     printer->add_line("int id, pnodecount;");
     printer->add_line("double v;");
     printer->add_line("Datum* indexes;");
+    printer->add_line("double* data;");
+    printer->add_line("ThreadDatum* thread;");
+
     if (ion_variable_struct_required()) {
         print_ion_variable();
     }
@@ -1842,8 +1845,8 @@ void CodegenCVisitor::visit_eigen_newton_solver_block(const ast::EigenNewtonSolv
     printer->end_block(2);
 
     printer->fmt_line(
-        "functor(NrnThread* nt, {}* inst, int id, int pnodecount, double v, Datum* indexes) : "
-        "nt{{nt}}, inst{{inst}}, id{{id}}, pnodecount{{pnodecount}}, v{{v}}, indexes{{indexes}} "
+        "functor(NrnThread* nt, {}* inst, int id, int pnodecount, double v, Datum* indexes, double* data, ThreadDatum* thread) : "
+        "nt{{nt}}, inst{{inst}}, id{{id}}, pnodecount{{pnodecount}}, v{{v}}, indexes{{indexes}}, data{{data}}, thread{{thread}} "
         "{{}}",
         instance_struct());
 
@@ -1875,7 +1878,7 @@ void CodegenCVisitor::visit_eigen_newton_solver_block(const ast::EigenNewtonSolv
 
     // call newton solver with functor and X matrix that contains state vars
     printer->add_line("// call newton solver");
-    printer->add_line("functor newton_functor(nt, inst, id, pnodecount, v, indexes);");
+    printer->add_line("functor newton_functor(nt, inst, id, pnodecount, v, indexes, data, thread);");
     printer->add_line("newton_functor.initialize();");
     printer->add_line(
         "int newton_iterations = nmodl::newton::newton_solver(nmodl_eigen_xm, newton_functor);");

--- a/src/codegen/codegen_c_visitor.hpp
+++ b/src/codegen/codegen_c_visitor.hpp
@@ -1025,6 +1025,12 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      */
     virtual bool is_constant_variable(const std::string& name) const;
 
+    /**
+     * Check if the given name exist in the symbol
+     * \return \c return a tuple <true, array_length> if variable
+     *            is an array otherwise <false, 0>
+     */
+    std::tuple<bool, int> check_if_var_is_array(const std::string& name);
 
     /**
      * Print declaration of macro NRN_PRCELLSTATE for debugging


### PR DESCRIPTION
* When we have TABLE statement used in a PROCEDURE and if such procedure
  is called from DERIVATIVE block then we end-up calling table statement
  related function from initialize() function:

  ```c++

        struct functor {
            NrnThread* nt;
            glia__dbbs_mod_collection__Ca__granule_cell_Instance* inst;
            int id, pnodecount;
            double v;
            Datum* indexes;
            double old_s, old_u;

            void initialize() {
                rate_glia__dbbs_mod_collection__Ca__granule_cell(id, pnodecount, inst, data, indexes, thread, nt, v, v);
                ...
  ```

  Here we are lacking `data` and `thread` variable as members in `struct functor`.

* This happens with the `glia__dbbs_mod_collection__Ca__granule_cell.mod` in #888