### PR TITLE
Fix random bux in the inlining pass

### DIFF
--- a/src/visitors/inline_visitor.cpp
+++ b/src/visitors/inline_visitor.cpp
@@ -308,9 +308,12 @@ void InlineVisitor::visit_wrapped_expression(WrappedExpression& node) {
     const auto& e = node.get_expression();
     if (e->is_function_call()) {
         auto expression = dynamic_cast<FunctionCall*>(e.get());
+        // if node is inlined, replace it with corresponding variable name
+        // and remove entry from the bookkeeping map
         if (replaced_fun_calls.find(expression) != replaced_fun_calls.end()) {
             auto var = replaced_fun_calls[expression];
             node.set_expression(std::make_shared<Name>(new String(var)));
+            replaced_fun_calls.erase(expression);
         }
     }
 }


### PR DESCRIPTION
* when we inline AST nodes, we keep the track of which nodes being replaced by using a map containing address of those nodes.
* when inlining of a particular node is finished, we were not removing that node address from the map.
* if we get a situation where AST node with same address is created (dynamic allocation) during inlining pass, it might end-up replacing wrong node just because it has the same address as previously inlined node.
* to avoid this, make sure to clear map entry when inlining is done!

Fixes #809