### PR TITLE
Improve / fix codegen support for PROTECT and MUTEX constructs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,9 +86,9 @@ stages:
         sudo apt-add-repository -y ppa:deadsnakes/ppa
         sudo apt-get update
         sudo apt-get install -y g++-8 flex bison libfl-dev cython libx11-dev libxcomposite-dev libncurses-dev mpich
-        sudo apt-get install -y python3.7 python3.7-dev python3.7-venv ninja-build
-        python3.7 -m pip install --upgrade pip setuptools
-        python3.7 -m pip install --user 'Jinja2>=2.9.3' 'PyYAML>=3.13' pytest pytest-cov 'sympy>=1.3' numpy
+        sudo apt-get install -y python3.8 python3.8-dev python3.8-venv ninja-build
+        python3.8 -m pip install --upgrade pip setuptools
+        python3.8 -m pip install --user 'Jinja2>=2.9.3' 'PyYAML>=3.13' pytest pytest-cov 'sympy>=1.3' numpy
         # we manually get version 3.15.0 to make sure that changes in the cmake
         # files do not require unsupported versions of cmake in our package.
         wget --quiet --output-document=- "https://github.com/Kitware/CMake/releases/download/$CMAKE_VER/$CMAKE_PKG.tar.gz" | tar xzpf -
@@ -102,7 +102,7 @@ stages:
         mkdir -p $(Build.Repository.LocalPath)/build
         cd $(Build.Repository.LocalPath)/build
         cmake --version
-        cmake .. -DPYTHON_EXECUTABLE=$(which python3.7) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=Release
+        cmake .. -DPYTHON_EXECUTABLE=$(which python3.8) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=Release
         make -j 2
         if [ $? -ne 0 ]
         then
@@ -129,7 +129,7 @@ stages:
         mkdir nrn/build
         cd nrn/build
         cmake --version
-        cmake .. -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_INTERVIEWS=OFF -DNRN_ENABLE_RX3D=OFF -DNRN_ENABLE_MPI=ON -DNRN_ENABLE_TESTS=ON -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_DIR=$HOME/nmodl -Dnmodl_PYTHONPATH=$HOME/nmodl/lib -DPYTHON_EXECUTABLE=$(which python3.7) -DCORENRN_NMODL_FLAGS="sympy --analytic"
+        cmake .. -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_INTERVIEWS=OFF -DNRN_ENABLE_RX3D=OFF -DNRN_ENABLE_MPI=ON -DNRN_ENABLE_TESTS=ON -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_DIR=$HOME/nmodl -Dnmodl_PYTHONPATH=$HOME/nmodl/lib -DPYTHON_EXECUTABLE=$(which python3.8) -DCORENRN_NMODL_FLAGS="sympy --analytic"
         make -j 2
         if [ $? -ne 0 ]
         then

--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,7 @@ setup(
         "nbsphinx>=0.3.2",
         "pytest>=3.7.2",
         "sphinxcontrib-applehelp<1.0.3",
+        "sphinxcontrib-htmlhelp<=2.0.0",
         "sphinx<6",
         "sphinx-rtd-theme",
     ]

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -9,6 +9,7 @@
 
 #include "ast/eigen_linear_solver_block.hpp"
 #include "ast/integer.hpp"
+#include "ast/protect_statement.hpp"
 
 
 namespace nmodl {
@@ -353,6 +354,13 @@ void CodegenAccVisitor::print_net_send_buf_count_update_to_device() const {
 void CodegenAccVisitor::print_dt_update_to_device() const {
     printer->fmt_line("#pragma acc update device({}) if (nt->compute_gpu)",
                       get_variable_name(naming::NTHREAD_DT_VARIABLE));
+}
+
+void CodegenAccVisitor::visit_protect_statement(const ast::ProtectStatement& node) {
+    print_atomic_reduction_pragma();
+    printer->add_indent();
+    node.get_expression()->accept(*this);
+    printer->add_text(";");
 }
 
 }  // namespace codegen

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -55,11 +55,9 @@ void CodegenAccVisitor::print_channel_iteration_block_parallel_hint(BlockType ty
 }
 
 
-void CodegenAccVisitor::print_atomic_reduction_pragma(bool skip) {
-    if (!skip) {
-        printer->add_line("nrn_pragma_acc(atomic update)");
-        printer->add_line("nrn_pragma_omp(atomic update)");
-    }
+void CodegenAccVisitor::print_atomic_reduction_pragma() {
+    printer->add_line("nrn_pragma_acc(atomic update)");
+    printer->add_line("nrn_pragma_omp(atomic update)");
 }
 
 
@@ -357,13 +355,6 @@ void CodegenAccVisitor::print_net_send_buf_count_update_to_device() const {
 void CodegenAccVisitor::print_dt_update_to_device() const {
     printer->fmt_line("#pragma acc update device({}) if (nt->compute_gpu)",
                       get_variable_name(naming::NTHREAD_DT_VARIABLE));
-}
-
-void CodegenAccVisitor::visit_protect_statement(const ast::ProtectStatement& node) {
-    print_atomic_reduction_pragma();
-    printer->add_indent();
-    node.get_expression()->accept(*this);
-    printer->add_text(";");
 }
 
 }  // namespace codegen

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -31,7 +31,8 @@ namespace codegen {
  *      for(int id=0; id<nodecount; id++) {
  *
  */
-void CodegenAccVisitor::print_channel_iteration_block_parallel_hint(BlockType type) {
+void CodegenAccVisitor::print_channel_iteration_block_parallel_hint(BlockType type,
+                                                                    const ast::Block* block) {
     if (info.artificial_cell) {
         return;
     }
@@ -54,9 +55,11 @@ void CodegenAccVisitor::print_channel_iteration_block_parallel_hint(BlockType ty
 }
 
 
-void CodegenAccVisitor::print_atomic_reduction_pragma() {
-    printer->add_line("nrn_pragma_acc(atomic update)");
-    printer->add_line("nrn_pragma_omp(atomic update)");
+void CodegenAccVisitor::print_atomic_reduction_pragma(bool skip) {
+    if (!skip) {
+        printer->add_line("nrn_pragma_acc(atomic update)");
+        printer->add_line("nrn_pragma_omp(atomic update)");
+    }
 }
 
 

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -38,11 +38,12 @@ class CodegenAccVisitor: public CodegenCVisitor {
 
 
     /// ivdep like annotation for channel iterations
-    void print_channel_iteration_block_parallel_hint(BlockType type) override;
+    void print_channel_iteration_block_parallel_hint(BlockType type,
+                                                     const ast::Block* block) override;
 
 
     /// atomic update pragma for reduction statements
-    void print_atomic_reduction_pragma() override;
+    void print_atomic_reduction_pragma(bool skip = false) override;
 
 
     /// memory allocation routine

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -127,6 +127,9 @@ class CodegenAccVisitor: public CodegenCVisitor {
 
     void print_net_send_buffering_grow() override;
 
+    // protect statement as atomic update on device
+    void visit_protect_statement(const ast::ProtectStatement& node) override;
+
 
   public:
     CodegenAccVisitor(const std::string& mod_file,

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -43,7 +43,7 @@ class CodegenAccVisitor: public CodegenCVisitor {
 
 
     /// atomic update pragma for reduction statements
-    void print_atomic_reduction_pragma(bool skip = false) override;
+    void print_atomic_reduction_pragma() override;
 
 
     /// memory allocation routine
@@ -127,9 +127,6 @@ class CodegenAccVisitor: public CodegenCVisitor {
     void print_device_atomic_capture_annotation() const override;
 
     void print_net_send_buffering_grow() override;
-
-    // protect statement as atomic update on device
-    void visit_protect_statement(const ast::ProtectStatement& node) override;
 
 
   public:

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -319,16 +319,16 @@ void CodegenCVisitor::visit_update_dt(const ast::UpdateDt& node) {
 }
 
 void CodegenCVisitor::visit_protect_statement(const ast::ProtectStatement& node) {
-    printer->fmt_start_block("#pragma omp critical {}", info.mod_suffix);
+    printer->add_line("#pragma omp atomic update");
     printer->add_indent();
     node.get_expression()->accept(*this);
     printer->add_text(";");
-    printer->add_newline();
-    printer->end_block(1);
 }
 
 void CodegenCVisitor::visit_mutex_lock(const ast::MutexLock& node) {
-    printer->fmt_start_block("#pragma omp critical {}", info.mod_suffix);
+    printer->fmt_line("#pragma omp critical ({})", info.mod_suffix);
+    printer->add_indent();
+    printer->start_block();
 }
 
 void CodegenCVisitor::visit_mutex_unlock(const ast::MutexUnlock& node) {
@@ -1121,7 +1121,7 @@ void CodegenCVisitor::print_net_init_acc_serial_annotation_block_end() {
  * for parallelization. For example:
  *
  * \code
- *      #pragma ivdep
+ *      #pragma omp simd
  *      for(int id = 0; id < nodecount; id++) {
  *
  *      #pragma acc parallel loop
@@ -1129,7 +1129,6 @@ void CodegenCVisitor::print_net_init_acc_serial_annotation_block_end() {
  * \endcode
  */
 void CodegenCVisitor::print_channel_iteration_block_parallel_hint(BlockType /* type */) {
-    printer->add_line("#pragma ivdep");
     printer->add_line("#pragma omp simd");
 }
 

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -1180,17 +1180,6 @@ void CodegenCVisitor::print_atomic_reduction_pragma() {
 }
 
 
-void CodegenCVisitor::print_shadow_reduction_statements() {
-    for (const auto& statement: shadow_statements) {
-        print_atomic_reduction_pragma();
-        auto lhs = get_variable_name(statement.lhs);
-        auto rhs = get_variable_name(shadow_varname(statement.lhs));
-        printer->fmt_line("{} {} {};", lhs, statement.op, rhs);
-    }
-    shadow_statements.clear();
-}
-
-
 void CodegenCVisitor::print_device_method_annotation() {
     // backend specific, nothing for cpu
 }
@@ -3512,7 +3501,6 @@ void CodegenCVisitor::print_nrn_init(bool skip_init_check) {
 
     print_initial_block(info.initial_node);
     printer->end_block(1);
-    print_shadow_reduction_statements();
 
     if (!info.changed_dt.empty()) {
         printer->fmt_line("{} = _save_prev_dt;", get_variable_name(naming::NTHREAD_DT_VARIABLE));
@@ -4365,11 +4353,6 @@ void CodegenCVisitor::print_nrn_state() {
         printer->add_line(text);
     }
     printer->end_block(1);
-    if (!shadow_statements.empty()) {
-        printer->start_block("for (int id = 0; id < nodecount; id++)");
-        print_shadow_reduction_statements();
-        printer->end_block(1);
-    }
 
     print_kernel_data_present_annotation_block_end();
 
@@ -4563,7 +4546,6 @@ void CodegenCVisitor::print_nrn_cur() {
     if (nrn_cur_reduction_loop_required()) {
         printer->start_block("for (int id = 0; id < nodecount; id++)");
         print_nrn_cur_matrix_shadow_reduction();
-        print_shadow_reduction_statements();
         printer->end_block(1);
         print_fast_imem_calculation();
     }

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -1147,9 +1147,17 @@ void CodegenCVisitor::print_channel_iteration_block_parallel_hint(BlockType /* t
     }
     // for openmp simd, we assume OpenMP is enabled and hence
     // openmp atomic reductions will handle PROTECT statements.
+    // note that nesting other openmp pragmas like "omp critical" is
+    // an error (e.g. with gcc) and hence check that as well.
     // TODO: Note that if user is explicitly providing flags to disable
     // OpenMP but enable OpenMP SIMD (only) then we can't do much in this case.
-    printer->add_line("#pragma omp simd");
+    auto has_mutex_node = std::find_if(nodes.cbegin(), nodes.cend(), [&](const auto& n) {
+        return n->get_node_type() == ast::AstNodeType::MUTEX_LOCK ||
+               n->get_node_type() == ast::AstNodeType::MUTEX_UNLOCK;
+    });
+    if (has_mutex_node == nodes.cend()) {
+        printer->add_line("#pragma omp simd");
+    }
 }
 
 

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -1419,10 +1419,8 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
 
     /**
      * Print atomic update pragma for reduction statements
-     *
-     * \param skip If true, skip printing Atomic reduction related pragma
      */
-    virtual void print_atomic_reduction_pragma(bool skip = false);
+    virtual void print_atomic_reduction_pragma();
 
 
     /**

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -1243,7 +1243,8 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      *
      * \param type The block type
      */
-    virtual void print_channel_iteration_block_parallel_hint(BlockType type);
+    virtual void print_channel_iteration_block_parallel_hint(BlockType type,
+                                                             const ast::Block* block);
 
 
     /**
@@ -1419,8 +1420,9 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
     /**
      * Print atomic update pragma for reduction statements
      *
+     * \param skip If true, skip printing Atomic reduction related pragma
      */
-    virtual void print_atomic_reduction_pragma();
+    virtual void print_atomic_reduction_pragma(bool skip = false);
 
 
     /**

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -286,12 +286,6 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
     std::shared_ptr<CodePrinter> printer;
 
     /**
-     * List of shadow statements in the current block
-     */
-    std::vector<ShadowUseStatement> shadow_statements;
-
-
-    /**
      * Return Nmodl language version
      * \return A version
      */

--- a/test/integration/mod/cabpump.mod
+++ b/test/integration/mod/cabpump.mod
@@ -78,5 +78,5 @@ PROCEDURE test_table_p(br) {
 
 INITIAL {
     var_init(var)
-    PROTECT ca = cainf + 1
+    PROTECT ca = ca + 1
 }

--- a/test/integration/mod/cabpump.mod
+++ b/test/integration/mod/cabpump.mod
@@ -9,6 +9,7 @@ NEURON {
         GLOBAL depth,cainf,taur
         RANGE var
         RANGE ainf
+        RANGE alpha
 }
 
 UNITS {
@@ -25,6 +26,7 @@ PARAMETER {
         taur =  200 (ms)	: rate of calcium removal for stress conditions
 	cainf	= 50e-6(mM)	:changed oct2
 	cai		(mM)
+	alpha = 1
 }
 
 ASSIGNED {
@@ -53,7 +55,11 @@ DERIVATIVE state {
         ca' = drive_channel/18 + (cainf -ca)/taur*11
 	cai = ca
 
-    if (FOO == 0) { }
+    if (FOO == 1) {
+        MUTEXLOCK
+        alpha = alpha + 1
+        MUTEXUNLOCK
+    }
 }
 
 : to test code generation for TABLE statement
@@ -72,5 +78,5 @@ PROCEDURE test_table_p(br) {
 
 INITIAL {
     var_init(var)
-    ca = cainf
+    PROTECT ca = cainf + 1
 }

--- a/test/unit/codegen/codegen_cpp_visitor.cpp
+++ b/test/unit/codegen/codegen_cpp_visitor.cpp
@@ -457,7 +457,6 @@ SCENARIO("Check that BEFORE/AFTER block are well generated", "[codegen][before/a
                 REQUIRE_THAT(generated,
                              Contains("hoc_reg_ba(mech_type, nrn_before_after_0_ba1, 11);"));
                 std::string generated_code = R"(
-        #pragma ivdep
         #pragma omp simd
         for (int id = 0; id < nodecount; id++) {
             int node_id = node_index[id];
@@ -478,7 +477,6 @@ SCENARIO("Check that BEFORE/AFTER block are well generated", "[codegen][before/a
                 REQUIRE_THAT(generated,
                              Contains("hoc_reg_ba(mech_type, nrn_before_after_1_ba1, 22);"));
                 std::string generated_code = R"(
-        #pragma ivdep
         #pragma omp simd
         for (int id = 0; id < nodecount; id++) {
             int node_id = node_index[id];
@@ -499,7 +497,6 @@ SCENARIO("Check that BEFORE/AFTER block are well generated", "[codegen][before/a
                 REQUIRE_THAT(generated,
                              Contains("hoc_reg_ba(mech_type, nrn_before_after_2_ba1, 13);"));
                 std::string generated_code = R"(
-        #pragma ivdep
         #pragma omp simd
         for (int id = 0; id < nodecount; id++) {
             int node_id = node_index[id];
@@ -520,7 +517,6 @@ SCENARIO("Check that BEFORE/AFTER block are well generated", "[codegen][before/a
                 REQUIRE_THAT(generated,
                              Contains("hoc_reg_ba(mech_type, nrn_before_after_3_ba1, 23);"));
                 std::string generated_code = R"(
-        #pragma ivdep
         #pragma omp simd
         for (int id = 0; id < nodecount; id++) {
             int node_id = node_index[id];
@@ -541,7 +537,6 @@ SCENARIO("Check that BEFORE/AFTER block are well generated", "[codegen][before/a
                 REQUIRE_THAT(generated,
                              Contains("hoc_reg_ba(mech_type, nrn_before_after_4_ba1, 14);"));
                 std::string generated_code = R"(
-        #pragma ivdep
         #pragma omp simd
         for (int id = 0; id < nodecount; id++) {
             int node_id = node_index[id];
@@ -652,12 +647,12 @@ SCENARIO("Check codegen for MUTEX and PROTECT", "[codegen][mutex_protect]") {
 
         THEN("Code with OpenMP critical sections is generated") {
             auto const generated = get_cpp_code(nmodl_text);
-            std::string expected_code = R"(#pragma omp critical TEST {
+            std::string expected_code = R"(#pragma omp critical (TEST)
+                {
                     inst->tmp[id] = 11.0;
                 }
-                #pragma omp critical TEST {
-                    inst->tmp[id] = 12.0;
-                })";
+                #pragma omp atomic update
+                inst->tmp[id] = 12.0;)";
             REQUIRE_THAT(generated, Contains(expected_code));
         }
     }

--- a/test/unit/codegen/codegen_cpp_visitor.cpp
+++ b/test/unit/codegen/codegen_cpp_visitor.cpp
@@ -649,10 +649,10 @@ SCENARIO("Check codegen for MUTEX and PROTECT", "[codegen][mutex_protect]") {
                 MUTEXLOCK
                 tmp = 11
                 MUTEXUNLOCK
-                PROTECT tmp = 12
+                PROTECT tmp = tmp / 2.5
             }
             PROCEDURE bar() {
-                PROTECT foo = 21
+                PROTECT foo = foo - 21
             }
         )";
 
@@ -664,11 +664,11 @@ SCENARIO("Check codegen for MUTEX and PROTECT", "[codegen][mutex_protect]") {
                     inst->tmp[id] = 11.0;
                 }
                 #pragma omp atomic update
-                inst->tmp[id] = 12.0;)";
+                inst->tmp[id] = inst->tmp[id] / 2.5;)";
 
             // atomic update for the PROTECT construct
             std::string expected_code_proc = R"(#pragma omp atomic update
-        inst->foo[id] = 21.0;)";
+        inst->foo[id] = inst->foo[id] - 21.0;)";
 
             REQUIRE_THAT(generated, Contains(expected_code_initial));
             REQUIRE_THAT(generated, Contains(expected_code_proc));


### PR DESCRIPTION
* typo/invalid syntax for mutex block from #961 : name for critical section should be in ( )
* ~avoid printing `ivdep` as on CPU also we have to respect PROTECT and MUTEX statements. So now onwards, just use OpenMP semantics rather than non-standard pragma like ivdep.~
* Print `ivdep` only if MUTEX or PROTECT constructs doesn't appear in that specific block.  
* protect statement now becomes semantically same as atomic statements. This adds some limitations but that's what allows us to rely on OpenMP / OpenACC for atomic udpates.
* PROTECT can be now used on GPU as well
* Update test

Related to https://github.com/neuronsimulator/nrn/issues/2191