### PR TITLE
Update plots for paper ready manuscript

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,9 +81,9 @@ stages:
         sudo apt-add-repository -y ppa:deadsnakes/ppa
         sudo apt-get update
         sudo apt-get install -y g++-8 flex bison libfl-dev cython libx11-dev libxcomposite-dev libncurses-dev mpich
-        sudo apt-get install -y python3.7 python3.7-dev python3.7-venv ninja-build
-        python3.7 -m pip install --upgrade pip setuptools
-        python3.7 -m pip install --user 'Jinja2>=2.9.3' 'PyYAML>=3.13' pytest pytest-cov 'sympy>=1.3,<1.6' numpy
+        sudo apt-get install -y python3.8 python3.8-dev python3.8-venv ninja-build
+        python3.8 -m pip install --upgrade pip setuptools
+        python3.8 -m pip install --user 'Jinja2>=2.9.3' 'PyYAML>=3.13' pytest pytest-cov 'sympy>=1.3,<1.6' numpy
         # we manually get version 3.15.0 to make sure that changes in the cmake
         # files do not require unsupported versions of cmake in our package.
         wget --quiet --output-document=- "https://github.com/Kitware/CMake/releases/download/$CMAKE_VER/$CMAKE_PKG.tar.gz" | tar xzpf -
@@ -108,7 +108,7 @@ stages:
         mkdir -p $(Build.Repository.LocalPath)/build
         cd $(Build.Repository.LocalPath)/build
         cmake --version
-        cmake .. -DPYTHON_EXECUTABLE=$(which python3.7) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=Release -DNMODL_ENABLE_LLVM=ON -DLLVM_DIR=/usr/lib/llvm-13/share/llvm/cmake/
+        cmake .. -DPYTHON_EXECUTABLE=$(which python3.8) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=Release -DNMODL_ENABLE_LLVM=ON -DLLVM_DIR=/usr/lib/llvm-13/share/llvm/cmake/
         make -j 2
         if [ $? -ne 0 ]
         then
@@ -135,7 +135,7 @@ stages:
         mkdir nrn/build
         cd nrn/build
         cmake --version
-        cmake .. -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_INTERVIEWS=OFF -DNRN_ENABLE_RX3D=OFF -DNRN_ENABLE_MPI=ON -DNRN_ENABLE_TESTS=ON -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_DIR=$HOME/nmodl -Dnmodl_PYTHONPATH=$HOME/nmodl/lib -DPYTHON_EXECUTABLE=$(which python3.7) -DCORENRN_NMODL_FLAGS="sympy --analytic"
+        cmake .. -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_INTERVIEWS=OFF -DNRN_ENABLE_RX3D=OFF -DNRN_ENABLE_MPI=ON -DNRN_ENABLE_TESTS=ON -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_DIR=$HOME/nmodl -Dnmodl_PYTHONPATH=$HOME/nmodl/lib -DPYTHON_EXECUTABLE=$(which python3.8) -DCORENRN_NMODL_FLAGS="sympy --analytic"
         make -j 2
         if [ $? -ne 0 ]
         then
@@ -159,7 +159,7 @@ stages:
         mkdir CoreNeuron/build_ispc
         cd CoreNeuron/build_ispc
         cmake --version
-        cmake .. -DCORENRN_ENABLE_MPI=OFF -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_DIR=$HOME/nmodl -DPYTHON_EXECUTABLE=$(which python3.7) -DCORENRN_NMODL_FLAGS="sympy --analytic" -DCORENRN_ENABLE_ISPC=ON -DCMAKE_ISPC_COMPILER=$(Build.Repository.LocalPath)/$CMAKE_PKG/ispc/bin/ispc
+        cmake .. -DCORENRN_ENABLE_MPI=OFF -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_DIR=$HOME/nmodl -DPYTHON_EXECUTABLE=$(which python3.8) -DCORENRN_NMODL_FLAGS="sympy --analytic" -DCORENRN_ENABLE_ISPC=ON -DCMAKE_ISPC_COMPILER=$(Build.Repository.LocalPath)/$CMAKE_PKG/ispc/bin/ispc
         make -j 2
         if [ $? -ne 0 ]
         then

--- a/test/benchmark/NMODL_paper_graphs.ipynb
+++ b/test/benchmark/NMODL_paper_graphs.ipynb
@@ -24,7 +24,11 @@
    "outputs": [],
    "source": [
     "# from IPython.display import display, HTML\n",
-    "# display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
+    "# display(HTML(\"<style>.container { width:100% !important; }</style>\"))\n",
+    "# Avoid Type 3 fonts\n",
+    "import matplotlib\n",
+    "matplotlib.rcParams['pdf.fonttype'] = 42\n",
+    "matplotlib.rcParams['ps.fonttype'] = 42"
    ]
   },
   {
@@ -1661,7 +1665,9 @@
     "            sns.barplot(x='architecture', y='runtime', hue='compiler', data=df_state, ax=axes[0,ax_index])\n",
     "            axes[0,ax_index].set_yscale('symlog', base=2, linthresh=0.015)\n",
     "            axes[0,ax_index].set_ylim(0.125,2)\n",
-    "            axes[0,ax_index].set_yticks([0.125, 0.25, 0.5, 1, 2])\n",
+    "            axes[0, ax_index].set_yticks(\n",
+    "                [0.125, 0.25, 0.5, 1, 2], [0.125, 0.25, 0.5, 1, 2]\n",
+    "            )\n",
     "            axes[0,ax_index].axhline(1., ls='--', color =\"black\")\n",
     "            axes[0,ax_index].xaxis.label.set_visible(False)\n",
     "            axes[0,ax_index].yaxis.label.set_visible(False)\n",
@@ -1679,7 +1685,9 @@
     "        print(df_cur, type(df_cur))\n",
     "        axes[0,ax_index].set_yscale('symlog', base=2, linthresh=0.015)\n",
     "        axes[0,ax_index].set_ylim(0.125,2)\n",
-    "        axes[0,ax_index].set_yticks([0.125, 0.25, 0.5, 1, 2])\n",
+    "        axes[0, ax_index].set_yticks(\n",
+    "                [0.125, 0.25, 0.5, 1, 2], [0.125, 0.25, 0.5, 1, 2]\n",
+    "            )\n",
     "        # axes[0,ax_index].set_yticklabels([0.5, 1, 2, 4, 8])\n",
     "        #axes[0,ax_index].axhline(1., linewidth=2, color=(0, 0, 0, 0.9))\n",
     "        axes[0,ax_index].xaxis.label.set_visible(False)\n",
@@ -1699,7 +1707,7 @@
     "    #    fig.text(0.5, 0.04, 'Target Microarchitecture-Instruction Set', ha='center', va='center')\n",
     "    fig.text(0.06, 0.5, 'Speedup relative to {}'.format(baseline_name), ha='center', va='center', rotation='vertical')\n",
     "    plt.legend(bbox_to_anchor=(1.04,1), loc=\"upper left\")\n",
-    "    plt.savefig(\"{}/combined_benchmark_{}.pdf\".format(output_dir, graph_suffix), format=\"pdf\", bbox_inches=\"tight\")\n",
+    "    plt.savefig(\"{}/paper_{}.pdf\".format(output_dir, graph_suffix), format=\"pdf\", bbox_inches=\"tight\")\n",
     "    plt.show()\n",
     "    plt.close()"
    ]
@@ -1763,7 +1771,7 @@
     "hh_expsyn_cpu_results = {}\n",
     "hh_expsyn_cpu_results = load_pickle_result_file([\"./reference_data/hh_expsyn_mavx512f.pickle\", \"./reference_data/hh_expsyn_nvhpc_cpu.pickle\"], hh_expsyn_cpu_results)\n",
     "json_object = json.dumps(hh_expsyn_cpu_results, indent = 4) \n",
-    "generate_graph_pandas_combined_relative_log(hh_expsyn_cpu_results, compilers_comparison_config, \"hh_expsyn_cpu_relative_log\", \"graphs_output_pandas\", False, xaxis_label=\"skylake-avx512 Target Microarchitecture\", plot_size=(10,3.5))"
+    "generate_graph_pandas_combined_relative_log(hh_expsyn_cpu_results, compilers_comparison_config, \"hh_expsyn_cpu_relative_log\", \"graphs_output_pandas\", False, xaxis_label=\"skylake-avx512 Target Microarchitecture\", plot_size=(13,3.5))"
    ]
   },
   {
@@ -1835,7 +1843,7 @@
     "    ax.xaxis.label.set_visible(False)\n",
     "    ax.set_yscale('symlog', base=2, linthresh=0.015)\n",
     "    ax.set_ylim(0.5, 2)\n",
-    "    ax.set_yticks([0.5, 1, 2])\n",
+    "    ax.set_yticks([0.5, 1, 2], [0.5, 1, 2])\n",
     "    # ax.yaxis.label.set_visible(False)\n",
     "    plt.ylabel('Speedup relative to {}'.format(baseline_name))\n",
     "    # ax.get_legend().remove()\n",
@@ -1852,7 +1860,7 @@
     "    # fig.text(0.06, 0.5, 'Relative Performance ({} = 1)'.format(baseline_name), ha='center', va='center', rotation='vertical')\n",
     "    # plt.xlabel(\"Kernel Name\")\n",
     "    # plt.legend(bbox_to_anchor=(1.04,1), loc=\"upper left\")\n",
-    "    plt.savefig(\"{}/combined_benchmark_{}.pdf\".format(output_dir, graph_suffix), format=\"pdf\", bbox_inches=\"tight\")\n",
+    "    plt.savefig(\"{}/paper_{}.pdf\".format(output_dir, graph_suffix), format=\"pdf\", bbox_inches=\"tight\")\n",
     "    plt.show()\n",
     "    plt.close()"
    ]
@@ -2505,7 +2513,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.6"
   },
   "vscode": {
    "interpreter": {

--- a/test/benchmark/plot_benchmarks_cpu_gpu.py
+++ b/test/benchmark/plot_benchmarks_cpu_gpu.py
@@ -7,6 +7,10 @@ import pandas as pd
 import pickle
 import seaborn as sns
 
+# Avoid Type 3 fonts
+import matplotlib
+matplotlib.rcParams['pdf.fonttype'] = 42
+matplotlib.rcParams['ps.fonttype'] = 42
 
 def _get_flags_string(flags):
     return flags.replace(" ", "_").replace('-','').replace('=','_')
@@ -334,7 +338,6 @@ def generate_graph_pandas_combined_relative_gpu_log(
     ax.set_yscale("symlog", base=2, linthresh=0.015)
     ax.set_ylim(0.5, 2)
     ax.set_yticks([0.5, 1, 2], [0.5, 1, 2])
-    ax.set_title(f"GPU benchmarks{ref_title_str}")
     plt.ylabel("Speedup relative to {}".format(baseline_name))
     plt.legend(loc="upper right")
     if print_values:
@@ -418,7 +421,7 @@ def plot_cpu_results():
         "graphs_output_pandas",
         False,
         xaxis_label="skylake-avx512 Target Microarchitecture",
-        plot_size=(10, 3.5),
+        plot_size=(13, 3.5),
     )
     # newly collected data
     hh_expsyn_cpu_results = load_pickle_result_file(
@@ -435,7 +438,7 @@ def plot_cpu_results():
         "graphs_output_pandas",
         False,
         xaxis_label="skylake-avx512 Target Microarchitecture",
-        plot_size=(10, 3.5),
+        plot_size=(13, 3.5),
     )
 
 


### PR DESCRIPTION
- Update plots with new (right?) sizes and without Type 3 fonts.
- The plots in the paper got generated by `plot_benchmarks_cpu_gpu.py` using only the reference results
- Changed name in the generated plots by jupyter notebook to distinguish them