### PR TITLE
Fix code generation for OpenMP GPU backend with NVHPC

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,14 +39,14 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2    
       - name: Install Python3 dependencies
         working-directory: ${{runner.workspace}}/nmodl
         run: |
           pip3 install -U pip setuptools scikit-build
           pip3 install --user -r requirements.txt
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
       - name: Restore compiler cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,8 +40,10 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Install Python3 dependencies
+        working-directory: ${{runner.workspace}}/nmodl
         run: |
-          pip3 install -U pip setuptools scikit-build Jinja2 PyYAML pytest sympy
+          pip3 install -U pip setuptools scikit-build
+          pip3 install --user -r requirements.txt
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2

--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -72,12 +72,13 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install Python3 dependencies
-        run: |
-          python3 -m pip install -U pip setuptools scikit-build Jinja2 PyYAML \
-            pytest sympy
-
       - uses: actions/checkout@v3
+
+      - name: Install Python3 dependencies
+        working-directory: ${{runner.workspace}}/nmodl
+        run: |
+          python3 -m pip install -U pip setuptools
+          python3 -m pip install --user -r requirements.txt
 
       - name: Register compiler warning problem matcher
         if: ${{matrix.config.flag_warnings == 'ON'}}

--- a/.github/workflows/nmodl-doc.yml
+++ b/.github/workflows/nmodl-doc.yml
@@ -50,15 +50,15 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-       
+
+      - uses: actions/checkout@v3
+
       - name: Install Python3 dependencies
         working-directory: ${{runner.workspace}}/nmodl
         run: |
           pip3 install -U pip setuptools scikit-build
           pip3 install --user -r requirements.txt
-          
-      - uses: actions/checkout@v3
-        
+
       # This step will set up an SSH connection on tmate.io for live debugging.
       # To trigger it, simply add 'live-debug-docs' to your last pushed commit message.
       - name: live debug session on failure

--- a/.github/workflows/nmodl-doc.yml
+++ b/.github/workflows/nmodl-doc.yml
@@ -52,9 +52,10 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
        
       - name: Install Python3 dependencies
+        working-directory: ${{runner.workspace}}/nmodl
         run: |
-          pip3 install -U pip setuptools scikit-build Jinja2 PyYAML pytest \
-            sympy
+          pip3 install -U pip setuptools scikit-build
+          pip3 install --user -r requirements.txt
           
       - uses: actions/checkout@v3
         

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,7 +37,7 @@ brew install flex bison cmake python3
 The necessary Python packages can then easily be added using the pip3 command.
 
 ```sh
-pip3 install Jinja2 PyYAML pytest sympy
+pip3 install --user -r requirements.txt
 ```
 
 Make sure to have latest flex/bison in $PATH :
@@ -63,7 +63,7 @@ apt-get install flex bison gcc python3 python3-pip
 The Python dependencies are installed using:
 
 ```sh
-pip3 install Jinja2 PyYAML pytest sympy
+pip3 install --user -r requirements.txt
 ```
 
 ## Build Project

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ stages:
         sudo apt-get install -y g++-8 flex bison libfl-dev cython libx11-dev libxcomposite-dev libncurses-dev mpich
         sudo apt-get install -y python3.8 python3.8-dev python3.8-venv ninja-build
         python3.8 -m pip install --upgrade pip setuptools
-        python3.8 -m pip install --user 'Jinja2>=2.9.3' 'PyYAML>=3.13' pytest pytest-cov 'sympy>=1.3' numpy
+        python3.8 -m pip install --user $(Build.Repository.LocalPath)/requirements.txt
         # we manually get version 3.15.0 to make sure that changes in the cmake
         # files do not require unsupported versions of cmake in our package.
         wget --quiet --output-document=- "https://github.com/Kitware/CMake/releases/download/$CMAKE_VER/$CMAKE_PKG.tar.gz" | tar xzpf -
@@ -156,7 +156,7 @@ stages:
     - script: |
         brew install flex bison cmake python@3
         python3 -m pip install --upgrade pip setuptools
-        python3 -m pip install --user 'Jinja2>=2.9.3' 'PyYAML>=3.13' pytest pytest-cov numpy 'sympy>=1.3'
+        python3 -m pip install --user $(Build.Repository.LocalPath)/requirements.txt
       displayName: 'Install Dependencies'
     - script: |
         export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ stages:
         sudo apt-get install -y g++-8 flex bison libfl-dev cython libx11-dev libxcomposite-dev libncurses-dev mpich
         sudo apt-get install -y python3.8 python3.8-dev python3.8-venv ninja-build
         python3.8 -m pip install --upgrade pip setuptools
-        python3.8 -m pip install --user $(Build.Repository.LocalPath)/requirements.txt
+        python3.8 -m pip install --user -r $(Build.Repository.LocalPath)/requirements.txt
         # we manually get version 3.15.0 to make sure that changes in the cmake
         # files do not require unsupported versions of cmake in our package.
         wget --quiet --output-document=- "https://github.com/Kitware/CMake/releases/download/$CMAKE_VER/$CMAKE_PKG.tar.gz" | tar xzpf -
@@ -156,7 +156,7 @@ stages:
     - script: |
         brew install flex bison cmake python@3
         python3 -m pip install --upgrade pip setuptools
-        python3 -m pip install --user $(Build.Repository.LocalPath)/requirements.txt
+        python3 -m pip install --user -r $(Build.Repository.LocalPath)/requirements.txt
       displayName: 'Install Dependencies'
     - script: |
         export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Jinja2>=2.9.3
 PyYAML>=3.13
 pytest
 pytest-cov
-sympy=1.9
+sympy==1.9
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Jinja2>=2.9.3
+PyYAML>=3.13
+pytest
+pytest-cov
+sympy=1.9
+numpy

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -1847,7 +1847,7 @@ void CodegenCVisitor::print_functor_definition(const ast::EigenNewtonSolverBlock
     printer->fmt_line("{0}* inst;", instance_struct());
     printer->add_line("int id, pnodecount;");
     printer->add_line("double v;");
-    printer->add_line("Datum* indexes;");
+    printer->add_line("const Datum* indexes;");
     printer->add_line("double* data;");
     printer->add_line("ThreadDatum* thread;");
 
@@ -1863,7 +1863,7 @@ void CodegenCVisitor::print_functor_definition(const ast::EigenNewtonSolverBlock
     printer->end_block(2);
 
     printer->fmt_line(
-        "{0}(NrnThread* nt, {1}* inst, int id, int pnodecount, double v, Datum* indexes, "
+        "{0}(NrnThread* nt, {1}* inst, int id, int pnodecount, double v, const Datum* indexes, "
         "double* data, ThreadDatum* thread) : "
         "nt{{nt}}, inst{{inst}}, id{{id}}, pnodecount{{pnodecount}}, v{{v}}, indexes{{indexes}}, "
         "data{{data}}, thread{{thread}} "

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -1868,7 +1868,8 @@ void CodegenCVisitor::print_functor_definition(const ast::EigenNewtonSolverBlock
         "nt{{nt}}, inst{{inst}}, id{{id}}, pnodecount{{pnodecount}}, v{{v}}, indexes{{indexes}}, "
         "data{{data}}, thread{{thread}} "
         "{{}}",
-        functor_name, instance_struct());
+        functor_name,
+        instance_struct());
 
     printer->add_indent();
 
@@ -1910,8 +1911,8 @@ void CodegenCVisitor::visit_eigen_newton_solver_block(const ast::EigenNewtonSolv
 
     // call newton solver with functor and X matrix that contains state vars
     printer->add_line("// call newton solver");
-    printer->fmt_line(
-        "{} newton_functor(nt, inst, id, pnodecount, v, indexes, data, thread);", info.functor_names[&node]);
+    printer->fmt_line("{} newton_functor(nt, inst, id, pnodecount, v, indexes, data, thread);",
+                      info.functor_names[&node]);
     printer->add_line("newton_functor.initialize();");
     printer->add_line(
         "int newton_iterations = nmodl::newton::newton_solver(nmodl_eigen_xm, newton_functor);");
@@ -3630,7 +3631,7 @@ void CodegenCVisitor::print_nrn_destructor() {
 
 
 void CodegenCVisitor::print_functors_definitions() {
-    for (const auto& functor_name : info.functor_names) {
+    for (const auto& functor_name: info.functor_names) {
         printer->add_newline(2);
         print_functor_definition(*functor_name.first);
     }

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -3467,7 +3467,7 @@ void CodegenCVisitor::print_global_function_common_code(BlockType type,
         printer->add_line("setup_instance(nt, ml);");
     }
     printer->fmt_line("auto* const inst = static_cast<{}*>(ml->instance);", instance_struct());
-    if (info.eigen_newton_solver_exist) {
+    if (info.eigen_newton_solver_exist && type == BlockType::State) {
         const auto eigen_newton_solver_blocks = collect_nodes(*info.nrn_state_block, {ast::AstNodeType::EIGEN_NEWTON_SOLVER_BLOCK});
         auto first_eigen_newton_solver_block = std::static_pointer_cast<const ast::EigenNewtonSolverBlock>(eigen_newton_solver_blocks[0]);
         print_functor_declaration(*first_eigen_newton_solver_block);

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -1838,6 +1838,8 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      */
     void print_instance_variable_setup();
 
+    void print_functor_declaration(const ast::EigenNewtonSolverBlock& node);
+
     void visit_binary_expression(const ast::BinaryExpression& node) override;
     void visit_binary_operator(const ast::BinaryOperator& node) override;
     void visit_boolean(const ast::Boolean& node) override;

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -1838,7 +1838,21 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
      */
     void print_instance_variable_setup();
 
-    void print_functor_declaration(const ast::EigenNewtonSolverBlock& node);
+    /**
+     * Go through the map of \c EigenNewtonSolverBlock s and their corresponding functor names
+     * and print the functor definitions before the definitions of the functions of the generated
+     * file
+     *
+     */
+    void print_functors_definitions();
+
+    /**
+     * @brief Based on the \c EigenNewtonSolverBlock passed print the definition needed for its
+     * functor
+     *
+     * @param node \c EigenNewtonSolverBlock for which to print the functor
+     */
+    void print_functor_definition(const ast::EigenNewtonSolverBlock& node);
 
     void visit_binary_expression(const ast::BinaryExpression& node) override;
     void visit_binary_operator(const ast::BinaryOperator& node) override;

--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -577,10 +577,11 @@ void CodegenHelperVisitor::visit_function_table_block(const ast::FunctionTableBl
 void CodegenHelperVisitor::visit_eigen_newton_solver_block(
     const ast::EigenNewtonSolverBlock& node) {
     info.eigen_newton_solver_exist = true;
-    // Avoid extra declaration for `functor` corresponding to the DERIVATIVE block which is not printed
-    // to the generated CPP file
+    // Avoid extra declaration for `functor` corresponding to the DERIVATIVE block which is not
+    // printed to the generated CPP file
     if (!under_derivative_block) {
-        const auto new_unique_functor_name = "functor_" + info.mod_suffix + "_" + std::to_string(info.functor_names.size());
+        const auto new_unique_functor_name = "functor_" + info.mod_suffix + "_" +
+                                             std::to_string(info.functor_names.size());
         info.functor_names[&node] = new_unique_functor_name;
     }
     node.visit_children(*this);

--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -577,6 +577,12 @@ void CodegenHelperVisitor::visit_function_table_block(const ast::FunctionTableBl
 void CodegenHelperVisitor::visit_eigen_newton_solver_block(
     const ast::EigenNewtonSolverBlock& node) {
     info.eigen_newton_solver_exist = true;
+    // Avoid extra declaration for `functor` corresponding to the DERIVATIVE block which is not printed
+    // to the generated CPP file
+    if (!under_derivative_block) {
+        const auto new_unique_functor_name = "functor_" + info.mod_suffix + "_" + std::to_string(info.functor_names.size());
+        info.functor_names[&node] = new_unique_functor_name;
+    }
     node.visit_children(*this);
 }
 

--- a/src/codegen/codegen_info.hpp
+++ b/src/codegen/codegen_info.hpp
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <unordered_set>
+#include <unordered_map>
 
 #include "ast/ast.hpp"
 #include "symtab/symbol_table.hpp"

--- a/src/codegen/codegen_info.hpp
+++ b/src/codegen/codegen_info.hpp
@@ -376,6 +376,9 @@ struct CodegenInfo {
     /// all variables/symbols used in the verbatim block
     std::unordered_set<std::string> variables_in_verbatim;
 
+    /// unique functor names for all the \c EigenNewtonSolverBlock s
+    std::unordered_map<const ast::EigenNewtonSolverBlock*, std::string> functor_names;
+
     /// true if eigen newton solver is used
     bool eigen_newton_solver_exist = false;
 

--- a/src/codegen/codegen_info.hpp
+++ b/src/codegen/codegen_info.hpp
@@ -13,8 +13,8 @@
  */
 
 #include <string>
-#include <unordered_set>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "ast/ast.hpp"
 #include "symtab/symbol_table.hpp"

--- a/test/integration/mod/test_functor.mod
+++ b/test/integration/mod/test_functor.mod
@@ -40,10 +40,10 @@ BREAKPOINT {
 	SOLVE integrate METHOD derivimplicit
 }
 
-DERIVATIVE integrate {
-	cai' = -ica/depth/F/2 * (1e7) + (cai0 - cai)/tau
-}
-
 PROCEDURE extra_solve() {
     SOLVE integrate
+}
+
+DERIVATIVE integrate {
+	cai' = -ica/depth/F/2 * (1e7) + (cai0 - cai)/tau
 }

--- a/test/integration/mod/test_functor.mod
+++ b/test/integration/mod/test_functor.mod
@@ -41,7 +41,7 @@ BREAKPOINT {
 }
 
 PROCEDURE extra_solve() {
-    SOLVE integrate
+    SOLVE integrate METHOD derivimplicit
 }
 
 DERIVATIVE integrate {

--- a/test/integration/mod/test_functor.mod
+++ b/test/integration/mod/test_functor.mod
@@ -1,0 +1,49 @@
+COMMENT
+Test for derivimplicit solver with sympy and Eigen. Based on cacum.mod
+ENDCOMMENT
+
+NEURON {
+	SUFFIX cacum
+	USEION ca READ ica WRITE cai
+	RANGE depth, tau, cai0
+}
+
+UNITS {
+	(mM) = (milli/liter)
+	(mA) = (milliamp)
+	F = (faraday) (coulombs)
+}
+
+PARAMETER {
+	depth = 1 (nm)	: assume volume = area*depth
+	tau = 10 (ms)
+	cai0 = 50e-6 (mM)	: Requires explicit use in INITIAL
+			: block for it to take precedence over cai0_ca_ion
+			: Do not forget to initialize in hoc if different
+			: from this default.
+}
+
+ASSIGNED {
+	ica (mA/cm2)
+}
+
+STATE {
+	cai (mM)
+}
+
+INITIAL {
+	cai = cai0
+	extra_solve()
+}
+
+BREAKPOINT {
+	SOLVE integrate METHOD derivimplicit
+}
+
+DERIVATIVE integrate {
+	cai' = -ica/depth/F/2 * (1e7) + (cai0 - cai)/tau
+}
+
+PROCEDURE extra_solve() {
+    SOLVE integrate
+}

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -87,6 +87,7 @@ target_link_libraries(
   util
   test_util
   printer
+  codegen
   ${NMODL_WRAPPER_LIBS})
 target_link_libraries(
   testcodegen

--- a/test/unit/visitor/sympy_solver.cpp
+++ b/test/unit/visitor/sympy_solver.cpp
@@ -11,18 +11,27 @@
 #include "parser/nmodl_driver.hpp"
 #include "test/unit/utils/test_utils.hpp"
 #include "visitors/checkparent_visitor.hpp"
+#include "codegen/codegen_cpp_visitor.hpp"
 #include "visitors/constant_folder_visitor.hpp"
+#include "visitors/inline_visitor.hpp"
+#include "visitors/neuron_solve_visitor.hpp"
 #include "visitors/kinetic_block_visitor.hpp"
 #include "visitors/loop_unroll_visitor.hpp"
 #include "visitors/nmodl_visitor.hpp"
+#include "visitors/solve_block_visitor.hpp"
 #include "visitors/sympy_solver_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"
 
 
 using namespace nmodl;
+using namespace codegen;
 using namespace visitor;
 using namespace test;
 using namespace test_utils;
+
+using Catch::Matchers::Contains;  // ContainsSubstring in newer Catch2
+
+using nmodl::test_utils::reindent_text;
 
 using ast::AstNodeType;
 using nmodl::parser::NmodlDriver;
@@ -2221,6 +2230,202 @@ SCENARIO("Solve KINETIC block using SympySolver Visitor", "[visitor][solver][sym
             REQUIRE_NOTHROW(result = run_sympy_solver_visitor(
                                 nmodl_text, false, false, AstNodeType::DERIVATIVE_BLOCK, true));
             compare_blocks(reindent_text(result[0]), reindent_text(expected_text));
+        }
+    }
+}
+
+/// Helper for creating C codegen visitor
+std::shared_ptr<CodegenCVisitor> create_c_visitor(const std::shared_ptr<ast::Program>& ast,
+                                                  const std::string& /* text */,
+                                                  std::stringstream& ss,
+                                                  bool inline_visitor = true,
+                                                  bool pade = false,
+                                                  bool cse = false) {
+    /// construct symbol table
+    SymtabVisitor().visit_program(*ast);
+
+    /// run all necessary pass
+    if (inline_visitor) {
+        InlineVisitor().visit_program(*ast);
+    }
+    // unroll loops and fold constants
+    ConstantFolderVisitor().visit_program(*ast);
+    LoopUnrollVisitor().visit_program(*ast);
+    ConstantFolderVisitor().visit_program(*ast);
+    SymtabVisitor().visit_program(*ast);
+
+    // run SympySolver on AST
+    SympySolverVisitor(pade, cse).visit_program(*ast);
+    SymtabVisitor(true).visit_program(*ast);
+
+    // Solve states
+    NeuronSolveVisitor().visit_program(*ast);
+    SolveBlockVisitor().visit_program(*ast);
+
+    // Update symtab before CodegenCVisitor
+    SymtabVisitor(true).visit_program(*ast);
+
+    // check that, after visitor rearrangement, parents are still up-to-date
+    CheckParentVisitor().check_ast(*ast);
+
+    /// create C code generation visitor
+    auto cv = std::make_shared<CodegenCVisitor>("temp.mod", ss, "double", false);
+    cv->setup(*ast);
+    return cv;
+}
+
+/// print entire code
+std::string get_cpp_code(const std::string& nmodl_text) {
+    const auto& ast = NmodlDriver().parse_string(nmodl_text);
+    std::stringstream ss;
+    auto cvisitor = create_c_visitor(ast, nmodl_text, ss);
+    cvisitor->visit_program(*ast);
+    return reindent_text(ss.str());
+}
+
+SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][derivimplicit]") {
+    GIVEN("A mod file containing two SOLVE statements") {
+        std::string const nmodl_text = R"(
+            NEURON {
+                SUFFIX cacum
+                USEION ca READ ica WRITE cai
+                RANGE depth, tau, cai0
+            }
+
+            UNITS {
+                (mM) = (milli/liter)
+                (mA) = (milliamp)
+                F = 96485.3 (coulombs)
+            }
+
+            PARAMETER {
+                depth = 1 (nm)	: assume volume = area*depth
+                tau = 10 (ms)
+                cai0 = 50e-6 (mM)	: Requires explicit use in INITIAL
+                        : block for it to take precedence over cai0_ca_ion
+                        : Do not forget to initialize in hoc if different
+                        : from this default.
+            }
+
+            ASSIGNED {
+                ica (mA/cm2)
+            }
+
+            STATE {
+                cai (mM)
+            }
+
+            INITIAL {
+                cai = cai0
+                extra_solve()
+            }
+
+            BREAKPOINT {
+                SOLVE integrate METHOD derivimplicit
+            }
+
+            DERIVATIVE integrate {
+                cai' = -ica/depth/F/2 * (1e7) + (cai0 - cai)/tau
+            }
+
+            PROCEDURE extra_solve() {
+                SOLVE integrate
+            }
+        )";
+
+        THEN("Three different functor structs defined and used") {
+            auto const generated = get_cpp_code(nmodl_text);
+
+            // Expected functor definitions
+            std::string expected_functor_cacum_0_definition = R"(struct functor_cacum_0 {
+        NrnThread* nt;
+        cacum_Instance* inst;
+        int id, pnodecount;
+        double v;
+        Datum* indexes;
+        double* data;
+        ThreadDatum* thread;
+        double old_cai;
+
+        void initialize() {
+            old_cai = inst->cai[id];
+        }
+
+        functor_cacum_0(NrnThread* nt, cacum_Instance* inst, int id, int pnodecount, double v, Datum* indexes, double* data, ThreadDatum* thread) : nt{nt}, inst{inst}, id{id}, pnodecount{pnodecount}, v{v}, indexes{indexes}, data{data}, thread{thread} {}
+        void operator()(const Eigen::Matrix<double, 1, 1>& nmodl_eigen_xm, Eigen::Matrix<double, 1, 1>& nmodl_eigen_fm, Eigen::Matrix<double, 1, 1>& nmodl_eigen_jm) const {
+            const double* nmodl_eigen_x = nmodl_eigen_xm.data();
+            double* nmodl_eigen_j = nmodl_eigen_jm.data();
+            double* nmodl_eigen_f = nmodl_eigen_fm.data();
+            nmodl_eigen_f[static_cast<int>(0)] =  -nmodl_eigen_x[static_cast<int>(0)] * nt->_dt / inst->tau[id] - nmodl_eigen_x[static_cast<int>(0)] + inst->cai0[id] * nt->_dt / inst->tau[id] + old_cai - 5000000.0 * nt->_dt * inst->ica[id] / (F * inst->depth[id]);
+            nmodl_eigen_j[static_cast<int>(0)] = ( -nt->_dt - inst->tau[id]) / inst->tau[id];
+        }
+
+        void finalize() {
+        }
+    };)";
+            std::string expected_functor_cacum_1_definition = R"(struct functor_cacum_1 {
+        NrnThread* nt;
+        cacum_Instance* inst;
+        int id, pnodecount;
+        double v;
+        Datum* indexes;
+        double* data;
+        ThreadDatum* thread;
+        double old_cai;
+
+        void initialize() {
+            old_cai = inst->cai[id];
+        }
+
+        functor_cacum_1(NrnThread* nt, cacum_Instance* inst, int id, int pnodecount, double v, Datum* indexes, double* data, ThreadDatum* thread) : nt{nt}, inst{inst}, id{id}, pnodecount{pnodecount}, v{v}, indexes{indexes}, data{data}, thread{thread} {}
+        void operator()(const Eigen::Matrix<double, 1, 1>& nmodl_eigen_xm, Eigen::Matrix<double, 1, 1>& nmodl_eigen_fm, Eigen::Matrix<double, 1, 1>& nmodl_eigen_jm) const {
+            const double* nmodl_eigen_x = nmodl_eigen_xm.data();
+            double* nmodl_eigen_j = nmodl_eigen_jm.data();
+            double* nmodl_eigen_f = nmodl_eigen_fm.data();
+            nmodl_eigen_f[static_cast<int>(0)] =  -nmodl_eigen_x[static_cast<int>(0)] * nt->_dt / inst->tau[id] - nmodl_eigen_x[static_cast<int>(0)] + inst->cai0[id] * nt->_dt / inst->tau[id] + old_cai - 5000000.0 * nt->_dt * inst->ica[id] / (F * inst->depth[id]);
+            nmodl_eigen_j[static_cast<int>(0)] = ( -nt->_dt - inst->tau[id]) / inst->tau[id];
+        }
+
+        void finalize() {
+        }
+    };)";
+            std::string expected_functor_cacum_2_definition = R"(struct functor_cacum_2 {
+        NrnThread* nt;
+        cacum_Instance* inst;
+        int id, pnodecount;
+        double v;
+        Datum* indexes;
+        double* data;
+        ThreadDatum* thread;
+        double old_cai;
+
+        void initialize() {
+            old_cai = inst->cai[id];
+        }
+
+        functor_cacum_2(NrnThread* nt, cacum_Instance* inst, int id, int pnodecount, double v, Datum* indexes, double* data, ThreadDatum* thread) : nt{nt}, inst{inst}, id{id}, pnodecount{pnodecount}, v{v}, indexes{indexes}, data{data}, thread{thread} {}
+        void operator()(const Eigen::Matrix<double, 1, 1>& nmodl_eigen_xm, Eigen::Matrix<double, 1, 1>& nmodl_eigen_fm, Eigen::Matrix<double, 1, 1>& nmodl_eigen_jm) const {
+            const double* nmodl_eigen_x = nmodl_eigen_xm.data();
+            double* nmodl_eigen_j = nmodl_eigen_jm.data();
+            double* nmodl_eigen_f = nmodl_eigen_fm.data();
+            nmodl_eigen_f[static_cast<int>(0)] =  -nmodl_eigen_x[static_cast<int>(0)] * nt->_dt / inst->tau[id] - nmodl_eigen_x[static_cast<int>(0)] + inst->cai0[id] * nt->_dt / inst->tau[id] + old_cai - 5000000.0 * nt->_dt * inst->ica[id] / (F * inst->depth[id]);
+            nmodl_eigen_j[static_cast<int>(0)] = ( -nt->_dt - inst->tau[id]) / inst->tau[id];
+        }
+
+        void finalize() {
+        }
+    };)";
+            // Expected functor usages
+            std::string expected_functor_cacum_0_usage = R"(functor_cacum_0 newton_functor(nt, inst, id, pnodecount, v, indexes, data, thread);)";
+            std::string expected_functor_cacum_1_usage = R"(functor_cacum_1 newton_functor(nt, inst, id, pnodecount, v, indexes, data, thread);)";
+            std::string expected_functor_cacum_2_usage = R"(functor_cacum_2 newton_functor(nt, inst, id, pnodecount, v, indexes, data, thread);)";
+
+            REQUIRE_THAT(generated, Contains(expected_functor_cacum_0_definition));
+            REQUIRE_THAT(generated, Contains(expected_functor_cacum_1_definition));
+            REQUIRE_THAT(generated, Contains(expected_functor_cacum_2_definition));
+            REQUIRE_THAT(generated, Contains(expected_functor_cacum_0_usage));
+            REQUIRE_THAT(generated, Contains(expected_functor_cacum_1_usage));
+            REQUIRE_THAT(generated, Contains(expected_functor_cacum_2_usage));
         }
     }
 }

--- a/test/unit/visitor/sympy_solver.cpp
+++ b/test/unit/visitor/sympy_solver.cpp
@@ -8,15 +8,15 @@
 #include <catch2/catch.hpp>
 
 #include "ast/program.hpp"
+#include "codegen/codegen_cpp_visitor.hpp"
 #include "parser/nmodl_driver.hpp"
 #include "test/unit/utils/test_utils.hpp"
 #include "visitors/checkparent_visitor.hpp"
-#include "codegen/codegen_cpp_visitor.hpp"
 #include "visitors/constant_folder_visitor.hpp"
 #include "visitors/inline_visitor.hpp"
-#include "visitors/neuron_solve_visitor.hpp"
 #include "visitors/kinetic_block_visitor.hpp"
 #include "visitors/loop_unroll_visitor.hpp"
+#include "visitors/neuron_solve_visitor.hpp"
 #include "visitors/nmodl_visitor.hpp"
 #include "visitors/solve_block_visitor.hpp"
 #include "visitors/sympy_solver_visitor.hpp"
@@ -2416,9 +2416,12 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
         }
     };)";
             // Expected functor usages
-            std::string expected_functor_cacum_0_usage = R"(functor_cacum_0 newton_functor(nt, inst, id, pnodecount, v, indexes, data, thread);)";
-            std::string expected_functor_cacum_1_usage = R"(functor_cacum_1 newton_functor(nt, inst, id, pnodecount, v, indexes, data, thread);)";
-            std::string expected_functor_cacum_2_usage = R"(functor_cacum_2 newton_functor(nt, inst, id, pnodecount, v, indexes, data, thread);)";
+            std::string expected_functor_cacum_0_usage =
+                R"(functor_cacum_0 newton_functor(nt, inst, id, pnodecount, v, indexes, data, thread);)";
+            std::string expected_functor_cacum_1_usage =
+                R"(functor_cacum_1 newton_functor(nt, inst, id, pnodecount, v, indexes, data, thread);)";
+            std::string expected_functor_cacum_2_usage =
+                R"(functor_cacum_2 newton_functor(nt, inst, id, pnodecount, v, indexes, data, thread);)";
 
             REQUIRE_THAT(generated, Contains(expected_functor_cacum_0_definition));
             REQUIRE_THAT(generated, Contains(expected_functor_cacum_1_definition));

--- a/test/unit/visitor/sympy_solver.cpp
+++ b/test/unit/visitor/sympy_solver.cpp
@@ -2344,7 +2344,7 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
         cacum_Instance* inst;
         int id, pnodecount;
         double v;
-        Datum* indexes;
+        const Datum* indexes;
         double* data;
         ThreadDatum* thread;
         double old_cai;
@@ -2353,7 +2353,7 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
             old_cai = inst->cai[id];
         }
 
-        functor_cacum_0(NrnThread* nt, cacum_Instance* inst, int id, int pnodecount, double v, Datum* indexes, double* data, ThreadDatum* thread) : nt{nt}, inst{inst}, id{id}, pnodecount{pnodecount}, v{v}, indexes{indexes}, data{data}, thread{thread} {}
+        functor_cacum_0(NrnThread* nt, cacum_Instance* inst, int id, int pnodecount, double v, const Datum* indexes, double* data, ThreadDatum* thread) : nt{nt}, inst{inst}, id{id}, pnodecount{pnodecount}, v{v}, indexes{indexes}, data{data}, thread{thread} {}
         void operator()(const Eigen::Matrix<double, 1, 1>& nmodl_eigen_xm, Eigen::Matrix<double, 1, 1>& nmodl_eigen_fm, Eigen::Matrix<double, 1, 1>& nmodl_eigen_jm) const {
             const double* nmodl_eigen_x = nmodl_eigen_xm.data();
             double* nmodl_eigen_j = nmodl_eigen_jm.data();
@@ -2371,7 +2371,7 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
         cacum_Instance* inst;
         int id, pnodecount;
         double v;
-        Datum* indexes;
+        const Datum* indexes;
         double* data;
         ThreadDatum* thread;
         double old_cai;
@@ -2380,7 +2380,7 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
             old_cai = inst->cai[id];
         }
 
-        functor_cacum_1(NrnThread* nt, cacum_Instance* inst, int id, int pnodecount, double v, Datum* indexes, double* data, ThreadDatum* thread) : nt{nt}, inst{inst}, id{id}, pnodecount{pnodecount}, v{v}, indexes{indexes}, data{data}, thread{thread} {}
+        functor_cacum_1(NrnThread* nt, cacum_Instance* inst, int id, int pnodecount, double v, const Datum* indexes, double* data, ThreadDatum* thread) : nt{nt}, inst{inst}, id{id}, pnodecount{pnodecount}, v{v}, indexes{indexes}, data{data}, thread{thread} {}
         void operator()(const Eigen::Matrix<double, 1, 1>& nmodl_eigen_xm, Eigen::Matrix<double, 1, 1>& nmodl_eigen_fm, Eigen::Matrix<double, 1, 1>& nmodl_eigen_jm) const {
             const double* nmodl_eigen_x = nmodl_eigen_xm.data();
             double* nmodl_eigen_j = nmodl_eigen_jm.data();
@@ -2398,7 +2398,7 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
         cacum_Instance* inst;
         int id, pnodecount;
         double v;
-        Datum* indexes;
+        const Datum* indexes;
         double* data;
         ThreadDatum* thread;
         double old_cai;
@@ -2407,7 +2407,7 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
             old_cai = inst->cai[id];
         }
 
-        functor_cacum_2(NrnThread* nt, cacum_Instance* inst, int id, int pnodecount, double v, Datum* indexes, double* data, ThreadDatum* thread) : nt{nt}, inst{inst}, id{id}, pnodecount{pnodecount}, v{v}, indexes{indexes}, data{data}, thread{thread} {}
+        functor_cacum_2(NrnThread* nt, cacum_Instance* inst, int id, int pnodecount, double v, const Datum* indexes, double* data, ThreadDatum* thread) : nt{nt}, inst{inst}, id{id}, pnodecount{pnodecount}, v{v}, indexes{indexes}, data{data}, thread{thread} {}
         void operator()(const Eigen::Matrix<double, 1, 1>& nmodl_eigen_xm, Eigen::Matrix<double, 1, 1>& nmodl_eigen_fm, Eigen::Matrix<double, 1, 1>& nmodl_eigen_jm) const {
             const double* nmodl_eigen_x = nmodl_eigen_xm.data();
             double* nmodl_eigen_j = nmodl_eigen_jm.data();

--- a/test/unit/visitor/sympy_solver.cpp
+++ b/test/unit/visitor/sympy_solver.cpp
@@ -2338,8 +2338,8 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
             auto const generated = get_cpp_code(nmodl_text);
 
             // Expected functor definitions
-            std::string expected_functor_cacum_0_definition = 
-        R"(struct functor_cacum_0 {
+            std::string expected_functor_cacum_0_definition =
+                R"(struct functor_cacum_0 {
         NrnThread* nt;
         cacum_Instance* inst;
         int id, pnodecount;
@@ -2365,8 +2365,8 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
         void finalize() {
         }
     };)";
-            std::string expected_functor_cacum_1_definition = 
-        R"(struct functor_cacum_1 {
+            std::string expected_functor_cacum_1_definition =
+                R"(struct functor_cacum_1 {
         NrnThread* nt;
         cacum_Instance* inst;
         int id, pnodecount;
@@ -2392,8 +2392,8 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
         void finalize() {
         }
     };)";
-            std::string expected_functor_cacum_2_definition = 
-        R"(struct functor_cacum_2 {
+            std::string expected_functor_cacum_2_definition =
+                R"(struct functor_cacum_2 {
         NrnThread* nt;
         cacum_Instance* inst;
         int id, pnodecount;

--- a/test/unit/visitor/sympy_solver.cpp
+++ b/test/unit/visitor/sympy_solver.cpp
@@ -2280,7 +2280,8 @@ std::string get_cpp_code(const std::string& nmodl_text) {
     std::stringstream ss;
     auto cvisitor = create_c_visitor(ast, nmodl_text, ss);
     cvisitor->visit_program(*ast);
-    return reindent_text(ss.str());
+    auto generated_string = ss.str();
+    return reindent_text(generated_string);
 }
 
 SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][derivimplicit]") {
@@ -2337,7 +2338,8 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
             auto const generated = get_cpp_code(nmodl_text);
 
             // Expected functor definitions
-            std::string expected_functor_cacum_0_definition = R"(struct functor_cacum_0 {
+            std::string expected_functor_cacum_0_definition = 
+        R"(struct functor_cacum_0 {
         NrnThread* nt;
         cacum_Instance* inst;
         int id, pnodecount;
@@ -2357,13 +2359,14 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
             double* nmodl_eigen_j = nmodl_eigen_jm.data();
             double* nmodl_eigen_f = nmodl_eigen_fm.data();
             nmodl_eigen_f[static_cast<int>(0)] =  -nmodl_eigen_x[static_cast<int>(0)] * nt->_dt / inst->tau[id] - nmodl_eigen_x[static_cast<int>(0)] + inst->cai0[id] * nt->_dt / inst->tau[id] + old_cai - 5000000.0 * nt->_dt * inst->ica[id] / (F * inst->depth[id]);
-            nmodl_eigen_j[static_cast<int>(0)] = ( -nt->_dt - inst->tau[id]) / inst->tau[id];
+            nmodl_eigen_j[static_cast<int>(0)] =  -(nt->_dt + inst->tau[id]) / inst->tau[id];
         }
 
         void finalize() {
         }
     };)";
-            std::string expected_functor_cacum_1_definition = R"(struct functor_cacum_1 {
+            std::string expected_functor_cacum_1_definition = 
+        R"(struct functor_cacum_1 {
         NrnThread* nt;
         cacum_Instance* inst;
         int id, pnodecount;
@@ -2383,13 +2386,14 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
             double* nmodl_eigen_j = nmodl_eigen_jm.data();
             double* nmodl_eigen_f = nmodl_eigen_fm.data();
             nmodl_eigen_f[static_cast<int>(0)] =  -nmodl_eigen_x[static_cast<int>(0)] * nt->_dt / inst->tau[id] - nmodl_eigen_x[static_cast<int>(0)] + inst->cai0[id] * nt->_dt / inst->tau[id] + old_cai - 5000000.0 * nt->_dt * inst->ica[id] / (F * inst->depth[id]);
-            nmodl_eigen_j[static_cast<int>(0)] = ( -nt->_dt - inst->tau[id]) / inst->tau[id];
+            nmodl_eigen_j[static_cast<int>(0)] =  -(nt->_dt + inst->tau[id]) / inst->tau[id];
         }
 
         void finalize() {
         }
     };)";
-            std::string expected_functor_cacum_2_definition = R"(struct functor_cacum_2 {
+            std::string expected_functor_cacum_2_definition = 
+        R"(struct functor_cacum_2 {
         NrnThread* nt;
         cacum_Instance* inst;
         int id, pnodecount;
@@ -2409,7 +2413,7 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
             double* nmodl_eigen_j = nmodl_eigen_jm.data();
             double* nmodl_eigen_f = nmodl_eigen_fm.data();
             nmodl_eigen_f[static_cast<int>(0)] =  -nmodl_eigen_x[static_cast<int>(0)] * nt->_dt / inst->tau[id] - nmodl_eigen_x[static_cast<int>(0)] + inst->cai0[id] * nt->_dt / inst->tau[id] + old_cai - 5000000.0 * nt->_dt * inst->ica[id] / (F * inst->depth[id]);
-            nmodl_eigen_j[static_cast<int>(0)] = ( -nt->_dt - inst->tau[id]) / inst->tau[id];
+            nmodl_eigen_j[static_cast<int>(0)] =  -(nt->_dt + inst->tau[id]) / inst->tau[id];
         }
 
         void finalize() {


### PR DESCRIPTION
- Solves the issues described in https://forums.developer.nvidia.com/t/issue-with-locally-defined-classes-in-openmp-offload-region-since-nvhpc-22-5/228735/7 by defining the `functor` structs in the beginning of the file
- Each time there is an `EigenNewtonSolverBlock` there will be another `functor` struct defined. This is to make sure that the proper structs are always defined regardless of the order and where they are defined (`nrn_init` block, `nrn_state` or function)
- Added integration and unit tests
- In BB5 we have sympy 1.9 and in the other CIs there was 1.11. These two different versions generated different code and the new unit tests will fail in one or the other. To solve this issue I created a `requirements.txt` which is used to install all the python packages needed in all of the CIs. Currently I have pinned the sympy version the same as BB5. It can be updated once we update the version in BB5 as well