### PR TITLE
Fixes issue with code generation of net_send_buffering()

### DIFF
--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -120,6 +120,16 @@ void CodegenAccVisitor::print_abort_routine() const {
     printer->end_block(1);
 }
 
+void CodegenAccVisitor::print_net_send_buffering_cnt_update() const {
+    printer->fmt_start_block("if (nt->compute_gpu)");
+    print_device_atomic_capture_annotation();
+    printer->add_line("i = nsb->_cnt++;");
+    printer->decrease_indent();
+    printer->start_block("} else");
+    printer->add_line("i = nsb->_cnt++;");
+    printer->end_block(1);
+}
+
 void CodegenAccVisitor::print_net_send_buffering_grow() {
     // can not grow buffer during gpu execution
 }

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -347,8 +347,10 @@ void CodegenAccVisitor::print_net_send_buf_update_to_host() const {
 
 
 void CodegenAccVisitor::print_net_send_buf_count_update_to_device() const {
-    printer->add_line("nrn_pragma_acc(update device(nsb->_cnt) if(nt->compute_gpu))");
-    printer->add_line("nrn_pragma_omp(target update to(nsb->_cnt) if(nt->compute_gpu))");
+    printer->start_block("if (nt->compute_gpu)");
+    printer->add_line("nrn_pragma_acc(update device(nsb->_cnt))");
+    printer->add_line("nrn_pragma_omp(target update to(nsb->_cnt))");
+    printer->end_block(1);
 }
 
 

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -332,14 +332,14 @@ void CodegenAccVisitor::print_device_stream_wait() const {
 
 
 void CodegenAccVisitor::print_net_send_buf_count_update_to_host() const {
-    printer->add_line("nrn_pragma_acc(update self(nsb->_cnt) if(nt->compute_gpu))");
-    printer->add_line("nrn_pragma_omp(target update from(nsb->_cnt) if(nt->compute_gpu))");
+    printer->add_line("nrn_pragma_acc(update self(nsb->_cnt))");
+    printer->add_line("nrn_pragma_omp(target update from(nsb->_cnt))");
 }
 
 
 void CodegenAccVisitor::print_net_send_buf_update_to_host() const {
     print_device_stream_wait();
-    printer->start_block("if (nsb)");
+    printer->start_block("if (nsb && nt->compute_gpu)");
     print_net_send_buf_count_update_to_host();
     printer->add_line("update_net_send_buffer_on_host(nt, nsb);");
     printer->end_block(1);

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -124,8 +124,7 @@ void CodegenAccVisitor::print_net_send_buffering_cnt_update() const {
     printer->fmt_start_block("if (nt->compute_gpu)");
     print_device_atomic_capture_annotation();
     printer->add_line("i = nsb->_cnt++;");
-    printer->decrease_indent();
-    printer->start_block("} else");
+    printer->restart_block("else");
     printer->add_line("i = nsb->_cnt++;");
     printer->end_block(1);
 }

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -126,6 +126,9 @@ class CodegenAccVisitor: public CodegenCVisitor {
     // print atomic capture pragma
     void print_device_atomic_capture_annotation() const override;
 
+    // print atomic update of NetSendBuffer_t cnt
+    void print_net_send_buffering_cnt_update() const override;
+
     void print_net_send_buffering_grow() override;
 
 

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -3715,7 +3715,7 @@ void CodegenCVisitor::print_watch_check() {
         printer->add_text("net_send_buffering(");
         auto t = get_variable_name("t");
         printer->add_text(
-            fmt::format("ml->_net_send_buffer, 0, {}, -1, {}, {}+0.0, ", tqitem, point_process, t));
+            fmt::format("nt, ml->_net_send_buffer, 0, {}, -1, {}, {}+0.0, ", tqitem, point_process, t));
         watch->get_value()->accept(*this);
         printer->add_text(");");
         printer->add_newline();
@@ -3811,7 +3811,7 @@ void CodegenCVisitor::print_net_send_call(const FunctionCall& node) {
         auto point_process = get_variable_name("point_process");
         std::string t = get_variable_name("t");
         printer->add_text("net_send_buffering(");
-        printer->fmt_text("ml->_net_send_buffer, 0, {}, {}, {}, {}+", tqitem, weight_index, point_process, t);
+        printer->fmt_text("nt, ml->_net_send_buffer, 0, {}, {}, {}, {}+", tqitem, weight_index, point_process, t);
     }
     // clang-format off
     print_vector_elements(arguments, ", ");
@@ -3839,7 +3839,7 @@ void CodegenCVisitor::print_net_move_call(const FunctionCall& node) {
         auto point_process = get_variable_name("point_process");
         std::string t = get_variable_name("t");
         printer->add_text("net_send_buffering(");
-        printer->fmt_text("ml->_net_send_buffer, 2, {}, {}, {}, ", tqitem, weight_index, point_process);
+        printer->fmt_text("nt, ml->_net_send_buffer, 2, {}, {}, {}, ", tqitem, weight_index, point_process);
         print_vector_elements(arguments, ", ");
         printer->add_text(", 0.0");
         printer->add_text(")");
@@ -3855,7 +3855,7 @@ void CodegenCVisitor::print_net_event_call(const FunctionCall& node) {
     } else {
         auto point_process = get_variable_name("point_process");
         printer->add_text("net_send_buffering(");
-        printer->fmt_text("ml->_net_send_buffer, 1, -1, -1, {}, ", point_process);
+        printer->fmt_text("nt, ml->_net_send_buffer, 1, -1, -1, {}, ", point_process);
         print_vector_elements(arguments, ", ");
         printer->add_text(", 0.0");
     }
@@ -4032,12 +4032,17 @@ void CodegenCVisitor::print_net_send_buffering() {
     printer->add_newline(2);
     print_device_method_annotation();
     auto args =
-        "NetSendBuffer_t* nsb, int type, int vdata_index, "
+        "const NrnThread* nt, NetSendBuffer_t* nsb, int type, int vdata_index, "
         "int weight_index, int point_index, double t, double flag";
     printer->fmt_start_block("static inline void net_send_buffering({})", args);
     printer->add_line("int i = 0;");
+    printer->fmt_start_block("if (nt->compute_gpu)");
     print_device_atomic_capture_annotation();
     printer->add_line("i = nsb->_cnt++;");
+    printer->decrease_indent();
+    printer->start_block("} else");
+    printer->add_line("i = nsb->_cnt++;");
+    printer->end_block(1);
     print_net_send_buffering_grow();
     printer->start_block("if (i < nsb->_size)");
     printer->add_line("nsb->_sendtype[i] = type;");

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -3714,7 +3714,10 @@ void CodegenCVisitor::print_watch_check() {
         printer->add_indent();
         printer->add_text("net_send_buffering(");
         auto t = get_variable_name("t");
-        printer->fmt_text("nt, ml->_net_send_buffer, 0, {}, -1, {}, {}+0.0, ", tqitem, point_process, t);
+        printer->fmt_text("nt, ml->_net_send_buffer, 0, {}, -1, {}, {}+0.0, ",
+                          tqitem,
+                          point_process,
+                          t);
         watch->get_value()->accept(*this);
         printer->add_text(");");
         printer->add_newline();

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -3714,8 +3714,8 @@ void CodegenCVisitor::print_watch_check() {
         printer->add_indent();
         printer->add_text("net_send_buffering(");
         auto t = get_variable_name("t");
-        printer->add_text(
-            fmt::format("nt, ml->_net_send_buffer, 0, {}, -1, {}, {}+0.0, ", tqitem, point_process, t));
+        printer->add_text(fmt::format(
+            "nt, ml->_net_send_buffer, 0, {}, -1, {}, {}+0.0, ", tqitem, point_process, t));
         watch->get_value()->accept(*this);
         printer->add_text(");");
         printer->add_newline();

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -3714,8 +3714,7 @@ void CodegenCVisitor::print_watch_check() {
         printer->add_indent();
         printer->add_text("net_send_buffering(");
         auto t = get_variable_name("t");
-        printer->add_text(fmt::format(
-            "nt, ml->_net_send_buffer, 0, {}, -1, {}, {}+0.0, ", tqitem, point_process, t));
+        printer->fmt_text("nt, ml->_net_send_buffer, 0, {}, -1, {}, {}+0.0, ", tqitem, point_process, t);
         watch->get_value()->accept(*this);
         printer->add_text(");");
         printer->add_newline();

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -4018,6 +4018,10 @@ void CodegenCVisitor::print_net_receive_buffering(bool need_mech_inst) {
     printer->end_block(1);
 }
 
+void CodegenCVisitor::print_net_send_buffering_cnt_update() const {
+    printer->add_line("i = nsb->_cnt++;");
+}
+
 void CodegenCVisitor::print_net_send_buffering_grow() {
     printer->start_block("if (i >= nsb->_size)");
     printer->add_line("nsb->grow();");
@@ -4036,13 +4040,7 @@ void CodegenCVisitor::print_net_send_buffering() {
         "int weight_index, int point_index, double t, double flag";
     printer->fmt_start_block("static inline void net_send_buffering({})", args);
     printer->add_line("int i = 0;");
-    printer->fmt_start_block("if (nt->compute_gpu)");
-    print_device_atomic_capture_annotation();
-    printer->add_line("i = nsb->_cnt++;");
-    printer->decrease_indent();
-    printer->start_block("} else");
-    printer->add_line("i = nsb->_cnt++;");
-    printer->end_block(1);
+    print_net_send_buffering_cnt_update();
     print_net_send_buffering_grow();
     printer->start_block("if (i < nsb->_size)");
     printer->add_line("nsb->_sendtype[i] = type;");

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -1316,6 +1316,14 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
 
 
     /**
+     * Print the code related to the update of NetSendBuffer_t cnt. For GPU this needs to be done
+     * with atomic operation, on CPU it's not needed.
+     * 
+     */
+    virtual void print_net_send_buffering_cnt_update() const;
+
+
+    /**
      * Print statement that grows NetSendBuffering_t structure if needed.
      * This function should be overridden for backends that cannot dynamically reallocate the buffer
      */

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -1318,7 +1318,7 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
     /**
      * Print the code related to the update of NetSendBuffer_t cnt. For GPU this needs to be done
      * with atomic operation, on CPU it's not needed.
-     * 
+     *
      */
     virtual void print_net_send_buffering_cnt_update() const;
 

--- a/test/unit/codegen/codegen_cpp_visitor.cpp
+++ b/test/unit/codegen/codegen_cpp_visitor.cpp
@@ -8,6 +8,7 @@
 #include <catch2/catch.hpp>
 
 #include "ast/program.hpp"
+#include "codegen/codegen_acc_visitor.hpp"
 #include "codegen/codegen_cpp_visitor.hpp"
 #include "codegen/codegen_helper_visitor.hpp"
 #include "parser/nmodl_driver.hpp"
@@ -47,6 +48,24 @@ std::shared_ptr<CodegenCVisitor> create_c_visitor(const std::shared_ptr<ast::Pro
     return cv;
 }
 
+/// Helper for creating OpenACC codegen visitor
+std::shared_ptr<CodegenAccVisitor> create_acc_visitor(const std::shared_ptr<ast::Program>& ast,
+                                                      const std::string& /* text */,
+                                                      std::stringstream& ss) {
+    /// construct symbol table
+    SymtabVisitor().visit_program(*ast);
+
+    /// run all necessary pass
+    InlineVisitor().visit_program(*ast);
+    NeuronSolveVisitor().visit_program(*ast);
+    SolveBlockVisitor().visit_program(*ast);
+
+    /// create C code generation visitor
+    auto cv = std::make_shared<CodegenAccVisitor>("temp.mod", ss, "double", false);
+    cv->setup(*ast);
+    return cv;
+}
+
 /// print instance structure for testing purpose
 std::string get_instance_var_setup_function(std::string& nmodl_text) {
     const auto& ast = NmodlDriver().parse_string(nmodl_text);
@@ -57,11 +76,16 @@ std::string get_instance_var_setup_function(std::string& nmodl_text) {
 }
 
 /// print entire code
-std::string get_cpp_code(const std::string& nmodl_text) {
+std::string get_cpp_code(const std::string& nmodl_text, const bool generate_gpu_code = false) {
     const auto& ast = NmodlDriver().parse_string(nmodl_text);
     std::stringstream ss;
-    auto cvisitor = create_c_visitor(ast, nmodl_text, ss);
-    cvisitor->visit_program(*ast);
+    if (generate_gpu_code) {
+        auto accvisitor = create_acc_visitor(ast, nmodl_text, ss);
+        accvisitor->visit_program(*ast);
+    } else {
+        auto cvisitor = create_c_visitor(ast, nmodl_text, ss);
+        cvisitor->visit_program(*ast);
+    }
     return reindent_text(ss.str());
 }
 
@@ -745,7 +769,7 @@ SCENARIO("Check that codegen generate event functions well", "[codegen][net_even
 
         THEN("Correct code is generated") {
             auto const generated = get_cpp_code(nmodl_text);
-            std::string net_send_expected_code =
+            std::string cpu_net_send_expected_code =
                 R"(static inline void net_send_buffering(const NrnThread* nt, NetSendBuffer_t* nsb, int type, int vdata_index, int weight_index, int point_index, double t, double flag) {
         int i = 0;
         i = nsb->_cnt++;
@@ -761,7 +785,28 @@ SCENARIO("Check that codegen generate event functions well", "[codegen][net_even
             nsb->_nsb_flag[i] = flag;
         }
     })";
-            REQUIRE_THAT(generated, Contains(net_send_expected_code));
+            REQUIRE_THAT(generated, Contains(cpu_net_send_expected_code));
+            auto const gpu_generated = get_cpp_code(nmodl_text, true);
+            std::string gpu_net_send_expected_code =
+                R"(static inline void net_send_buffering(const NrnThread* nt, NetSendBuffer_t* nsb, int type, int vdata_index, int weight_index, int point_index, double t, double flag) {
+        int i = 0;
+        if (nt->compute_gpu) {
+            nrn_pragma_acc(atomic capture)
+            nrn_pragma_omp(atomic capture)
+            i = nsb->_cnt++;
+        } else {
+            i = nsb->_cnt++;
+        }
+        if (i < nsb->_size) {
+            nsb->_sendtype[i] = type;
+            nsb->_vdata_index[i] = vdata_index;
+            nsb->_weight_index[i] = weight_index;
+            nsb->_pnt_index[i] = point_index;
+            nsb->_nsb_t[i] = t;
+            nsb->_nsb_flag[i] = flag;
+        }
+    })";
+            REQUIRE_THAT(gpu_generated, Contains(gpu_net_send_expected_code));
             std::string net_receive_kernel_expected_code =
                 R"(static inline void net_receive_kernel_(double t, Point_process* pnt, _Instance* inst, NrnThread* nt, Memb_list* ml, int weight_index, double flag) {
         int tid = pnt->_tid;

--- a/test/unit/codegen/codegen_cpp_visitor.cpp
+++ b/test/unit/codegen/codegen_cpp_visitor.cpp
@@ -746,7 +746,7 @@ SCENARIO("Check that codegen generate event functions well", "[codegen][net_even
         THEN("Correct code is generated") {
             auto const generated = get_cpp_code(nmodl_text);
             std::string net_send_expected_code =
-                R"(static inline void net_send_buffering(NetSendBuffer_t* nsb, int type, int vdata_index, int weight_index, int point_index, double t, double flag) {
+                R"(static inline void net_send_buffering(const NrnThread* nt, NetSendBuffer_t* nsb, int type, int vdata_index, int weight_index, int point_index, double t, double flag) {
         int i = 0;
         i = nsb->_cnt++;
         if (i >= nsb->_size) {
@@ -777,10 +777,10 @@ SCENARIO("Check that codegen generate event functions well", "[codegen][net_even
         inst->tsave[id] = t;
         {
             if (flag == 0.0) {
-                net_send_buffering(ml->_net_send_buffer, 1, -1, -1, point_process, t, 0.0);
-                net_send_buffering(ml->_net_send_buffer, 2, inst->tqitem[0*pnodecount+id], -1, point_process, t + 1.0, 0.0);
+                net_send_buffering(nt, ml->_net_send_buffer, 1, -1, -1, point_process, t, 0.0);
+                net_send_buffering(nt, ml->_net_send_buffer, 2, inst->tqitem[0*pnodecount+id], -1, point_process, t + 1.0, 0.0);
             } else {
-                net_send_buffering(ml->_net_send_buffer, 0, inst->tqitem[0*pnodecount+id], weight_index, point_process, t+1.0, 1.0);
+                net_send_buffering(nt, ml->_net_send_buffer, 0, inst->tqitem[0*pnodecount+id], weight_index, point_process, t+1.0, 1.0);
             }
         }
     })";


### PR DESCRIPTION
- If `OpenMP` GPU backend is enabled then `#pragma omp atomic capture` is not executed properly on CPU with NVHPC 23.1 (more details and tests in https://github.com/neuronsimulator/nrn/pull/2239)
- Wrap the update of `nsb->_cnt` inside an `if-statement` based on `nt->compute_gpu`