### PR TITLE
Various codegen fixes

### DIFF
--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -3568,10 +3568,12 @@ void CodegenCVisitor::print_nrn_destructor() {
 
 
 void CodegenCVisitor::print_functors_definitions() {
+    codegen = true;
     for (const auto& functor_name: info.functor_names) {
         printer->add_newline(2);
         print_functor_definition(*functor_name.first);
     }
+    codegen = false;
 }
 
 
@@ -4589,6 +4591,7 @@ void CodegenCVisitor::print_g_unused() const {
 void CodegenCVisitor::print_compute_functions() {
     print_top_verbatim_blocks();
     print_function_prototypes();
+    print_functors_definitions();
     for (const auto& procedure: info.procedures) {
         print_procedure(*procedure);
     }
@@ -4636,7 +4639,6 @@ void CodegenCVisitor::print_codegen_routines() {
     print_nrn_alloc();
     print_nrn_constructor();
     print_nrn_destructor();
-    print_functors_definitions();
     print_compute_functions();
     print_check_table_thread_function();
     print_mechanism_register();

--- a/src/visitors/kinetic_block_visitor.cpp
+++ b/src/visitors/kinetic_block_visitor.cpp
@@ -398,7 +398,7 @@ void KineticBlockVisitor::visit_kinetic_block(ast::KineticBlock& node) {
         }
         // divide by COMPARTMENT factor if present
         if (!compartment_factors[j].empty()) {
-            ode_rhs = fmt::format("({})/({})", ode_rhs, compartment_factors[j]);
+            ode_rhs = fmt::format("({})/({})", ode_rhs.empty() ? "1" : ode_rhs, compartment_factors[j]);
         }
         // if rhs of ODE is not empty, add to list of ODEs
         if (!ode_rhs.empty()) {


### PR DESCRIPTION
Fixes compilation of mod files of `dbbs-mod-collection` (after small changes in mod files in https://github.com/iomaganaris/dbbs-mod-collection/tree/magkanar/nmodl)

- Move definition of functors after declaration of functions
- Fix issue with parsing `()` from `sympy` if `ode_rhs` is empty (Fixes #1008)