### PR TITLE
sympy@1.11.1 yields (-A-B) not -(A+B)

### DIFF
--- a/packaging/build_requirements.txt
+++ b/packaging/build_requirements.txt
@@ -1,4 +1,4 @@
 Jinja2>=2.9.3
 PyYAML>=3.13
 pytest
-sympy>=1.3,<1.6
+sympy>=1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Jinja2>=2.9.3
 PyYAML>=3.13
 pytest
 pytest-cov
-sympy==1.9
+sympy
 numpy

--- a/test/unit/visitor/sympy_solver.cpp
+++ b/test/unit/visitor/sympy_solver.cpp
@@ -2359,12 +2359,7 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
             double* nmodl_eigen_j = nmodl_eigen_jm.data();
             double* nmodl_eigen_f = nmodl_eigen_fm.data();
             nmodl_eigen_f[static_cast<int>(0)] =  -nmodl_eigen_x[static_cast<int>(0)] * nt->_dt / inst->tau[id] - nmodl_eigen_x[static_cast<int>(0)] + inst->cai0[id] * nt->_dt / inst->tau[id] + old_cai - 5000000.0 * nt->_dt * inst->ica[id] / (F * inst->depth[id]);
-            nmodl_eigen_j[static_cast<int>(0)] =  -(nt->_dt + inst->tau[id]) / inst->tau[id];
-        }
-
-        void finalize() {
-        }
-    };)";
+            nmodl_eigen_j[static_cast<int>(0)] =)";
             std::string expected_functor_cacum_1_definition =
                 R"(struct functor_cacum_1 {
         NrnThread* nt;
@@ -2386,12 +2381,7 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
             double* nmodl_eigen_j = nmodl_eigen_jm.data();
             double* nmodl_eigen_f = nmodl_eigen_fm.data();
             nmodl_eigen_f[static_cast<int>(0)] =  -nmodl_eigen_x[static_cast<int>(0)] * nt->_dt / inst->tau[id] - nmodl_eigen_x[static_cast<int>(0)] + inst->cai0[id] * nt->_dt / inst->tau[id] + old_cai - 5000000.0 * nt->_dt * inst->ica[id] / (F * inst->depth[id]);
-            nmodl_eigen_j[static_cast<int>(0)] =  -(nt->_dt + inst->tau[id]) / inst->tau[id];
-        }
-
-        void finalize() {
-        }
-    };)";
+            nmodl_eigen_j[static_cast<int>(0)] =)";
             std::string expected_functor_cacum_2_definition =
                 R"(struct functor_cacum_2 {
         NrnThread* nt;
@@ -2413,12 +2403,7 @@ SCENARIO("Code generation for EigenNewtonSolver", "[visitor][solver][sympy][deri
             double* nmodl_eigen_j = nmodl_eigen_jm.data();
             double* nmodl_eigen_f = nmodl_eigen_fm.data();
             nmodl_eigen_f[static_cast<int>(0)] =  -nmodl_eigen_x[static_cast<int>(0)] * nt->_dt / inst->tau[id] - nmodl_eigen_x[static_cast<int>(0)] + inst->cai0[id] * nt->_dt / inst->tau[id] + old_cai - 5000000.0 * nt->_dt * inst->ica[id] / (F * inst->depth[id]);
-            nmodl_eigen_j[static_cast<int>(0)] =  -(nt->_dt + inst->tau[id]) / inst->tau[id];
-        }
-
-        void finalize() {
-        }
-    };)";
+            nmodl_eigen_j[static_cast<int>(0)] =)";
             // Expected functor usages
             std::string expected_functor_cacum_0_usage =
                 R"(functor_cacum_0 newton_functor(nt, inst, id, pnodecount, v, indexes, data, thread);)";


### PR DESCRIPTION
This version is included in the 2023 redeployment on BB5, see: https://bbpgitlab.epfl.ch/hpc/nmodl/-/jobs/586400

https://github.com/BlueBrain/spack/pull/1866 was needed in order for the tests to execute.
https://github.com/BlueBrain/spack/pull/1867 was needed in order for nvhpc compilation to succeed.