### PR TITLE
Bug fix in code generation in net_send() calll in INITIAL block under NET_RECEIVE

### DIFF
--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -3771,8 +3771,9 @@ void CodegenCVisitor::print_net_send_call(const FunctionCall& node) {
     std::string weight_index = "weight_index";
     std::string pnt = "pnt";
 
-    // for non-net_receieve functions i.e. initial block, the weight_index argument is 0.
-    if (!printing_net_receive) {
+    // for functions not generated from NET_RECEIVE blocks (i.e. top level INITIAL block)
+    // the weight_index argument is 0.
+    if (!printing_net_receive && !printing_net_init) {
         weight_index = "0";
         auto var = get_variable_name("point_process");
         if (info.artificial_cell) {
@@ -3797,7 +3798,7 @@ void CodegenCVisitor::print_net_send_call(const FunctionCall& node) {
 
 
 void CodegenCVisitor::print_net_move_call(const FunctionCall& node) {
-    if (!printing_net_receive) {
+    if (!printing_net_receive && !printing_net_init) {
         throw std::runtime_error("Error : net_move only allowed in NET_RECEIVE block");
     }
 
@@ -3886,6 +3887,7 @@ void CodegenCVisitor::print_net_init() {
     rename_net_receive_arguments(*info.net_receive_node, *node);
 
     codegen = true;
+    printing_net_init = true;
     auto args = "Point_process* pnt, int weight_index, double flag";
     printer->add_newline(2);
     printer->add_line("/** initialize block for net receive */");
@@ -3905,6 +3907,7 @@ void CodegenCVisitor::print_net_init() {
     }
     printer->end_block(1);
     codegen = false;
+    printing_net_init = false;
 }
 
 

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -238,6 +238,12 @@ class CodegenCVisitor: public visitor::ConstAstVisitor {
     bool printing_net_receive = false;
 
     /**
+     * \c true if currently initial block of net_receive being printed
+     */
+    bool printing_net_init = false;
+
+
+    /**
      * \c true if currently printing top level verbatim blocks
      */
     bool printing_top_verbatim_blocks = false;

--- a/test/unit/codegen/codegen_cpp_visitor.cpp
+++ b/test/unit/codegen/codegen_cpp_visitor.cpp
@@ -941,6 +941,39 @@ SCENARIO("Check that codegen generate event functions well", "[codegen][net_even
             REQUIRE_THAT(generated, Contains(expected_code));
         }
     }
+
+    GIVEN("A mod file with an INITIAL with net_send() inside NET_RECEIVE") {
+        std::string const nmodl_text = R"(
+            NET_RECEIVE(w) {
+                INITIAL {
+                    net_send(5, 1)
+                }
+            }
+        )";
+        THEN("It should generate a net_send_buffering with weight_index as parameter variable") {
+            auto const generated = get_cpp_code(nmodl_text);
+            std::string expected_code(
+                "net_send_buffering(nt, ml->_net_send_buffer, 0, inst->tqitem[0*pnodecount+id], "
+                "weight_index, point_process, nt->_t+5.0, 1.0);");
+            REQUIRE_THAT(generated, Contains(expected_code));
+        }
+    }
+
+    GIVEN("A mod file with a top level INITIAL block with net_send()") {
+        std::string const nmodl_text = R"(
+            INITIAL {
+                net_send(5, 1)
+            }
+        )";
+        THEN("It should generate a net_send_buffering with weight_index parameter as 0") {
+            auto const generated = get_cpp_code(nmodl_text);
+            std::string expected_code(
+                "net_send_buffering(nt, ml->_net_send_buffer, 0, inst->tqitem[0*pnodecount+id], 0, "
+                "point_process, nt->_t+5.0, 1.0);");
+            REQUIRE_THAT(generated, Contains(expected_code));
+        }
+    }
+
     GIVEN("A mod file with FOR_NETCONS") {
         std::string const nmodl_text = R"(
             NET_RECEIVE(w) {


### PR DESCRIPTION
- when we emit a call to `net_send_buffering()`, the `weight_index` is either `0` or an argument `weight_index` itself depending on whether the code printed is for `NET_RECEIVE` block or a top-level `INITIAL` block.

```python
INITIAL {
    net_send(x, y)
}
```

vs

```python
NET_RECEIVE {
      INITIAL {
          net_send(x, y)
      }
}
```

- BUT, `NET_RECEIVE` block can contain `INITIAL` block itself (where we emit `net_init()` function).
- So, before using `weight_index=0` in `net_send_buffering()`, check if we are printing `INITIAL` block of `NET_RECEIVE` or top level `INITIAL` block.

NOTES:

* This issue was revealed by a hippocampus test of BBP BlueConfig where the delayed connection feature in `ProbAMPANMDA_EMS.mod` rely on this pattern: https://bbpgitlab.epfl.ch/hpc/sim/blueconfigs/-/pipelines/111363.
* The hippocampus test now passes for spike-level comparison. But note that there is a separate issue with UNITS precision: #1016.
* **Fixing the above issue will generate the exact same results for the hippocampus model!**
* Create a separate issue in NEURON if a manful test could be added to cover the 