### PR TITLE
Use NMODLHOME for NMODL_WRAPLIB

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -124,10 +124,6 @@ for example:
 ````sh
 export NMODL_PYLIB=/usr/local/Cellar/python/3.7.7/Frameworks/Python.framework/Versions/3.7/Python
 ````
-* 'NMODL_WRAPLIB': This variable should point to the `libpywrapper.so` built as part of NMODL, for example:
-```sh
-export NMODL_WRAPLIB=/opt/nmodl/lib/libpywrapper.so
-```
 
 **Note**: In order for all unit tests to function correctly when building without linking against libpython we must
 set `NMODL_PYLIB` before running cmake!

--- a/pywheel/shim/_binwrapper.py
+++ b/pywheel/shim/_binwrapper.py
@@ -27,13 +27,6 @@ def _config_exe(exe_name):
     NMODL_PREFIX = os.path.join(working_set.by_key[package_name].location, "nmodl")
     NMODL_HOME = os.path.join(NMODL_PREFIX, ".data")
     NMODL_BIN = os.path.join(NMODL_HOME, "bin")
-    NMODL_LIB = os.path.join(NMODL_HOME, "lib")
-
-    # add pywrapper path to environment
-    if sys.platform == "darwin":
-        os.environ["NMODL_WRAPLIB"] = os.path.join(NMODL_LIB, "libpywrapper.dylib")
-    else:
-        os.environ["NMODL_WRAPLIB"] = os.path.join(NMODL_LIB, "libpywrapper.so")
 
     # add libpython*.so path to environment
     os.environ["NMODL_PYLIB"] = find_libpython()

--- a/src/config/config.cpp.in
+++ b/src/config/config.cpp.in
@@ -13,6 +13,8 @@ const std::string nmodl::Version::GIT_REVISION = "@NMODL_GIT_REVISION@";
 /// NMODL version
 const std::string nmodl::Version::NMODL_VERSION = "@PROJECT_VERSION@";
 
+const std::string nmodl::CMakeInfo::SHARED_LIBRARY_SUFFIX = "@CMAKE_SHARED_LIBRARY_SUFFIX@";
+
 /**
  * \brief Path of nrnutils.lib file
  *

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -74,4 +74,8 @@ struct NrnUnitsLib {
     }
 };
 
+struct CMakeInfo {
+    static const std::string SHARED_LIBRARY_SUFFIX;
+};
+
 }  // namespace nmodl

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(pyembed PRIVATE util)
 
 if(NOT LINK_AGAINST_PYTHON)
   add_library(pywrapper SHARED ${CMAKE_CURRENT_SOURCE_DIR}/wrapper.cpp)
-  set_target_properties(pywrapper PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+  set_target_properties(pywrapper PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${NMODL_PROJECT_BINARY_DIR}/lib)
 else()
   add_library(pywrapper ${CMAKE_CURRENT_SOURCE_DIR}/wrapper.cpp)
   set_property(TARGET pywrapper PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -30,7 +30,8 @@ target_link_libraries(pyembed PRIVATE util)
 
 if(NOT LINK_AGAINST_PYTHON)
   add_library(pywrapper SHARED ${CMAKE_CURRENT_SOURCE_DIR}/wrapper.cpp)
-  set_target_properties(pywrapper PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${NMODL_PROJECT_BINARY_DIR}/lib)
+  set_target_properties(pywrapper PROPERTIES LIBRARY_OUTPUT_DIRECTORY
+                                             ${NMODL_PROJECT_BINARY_DIR}/lib)
 else()
   add_library(pywrapper ${CMAKE_CURRENT_SOURCE_DIR}/wrapper.cpp)
   set_property(TARGET pywrapper PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/src/pybind/pyembed.cpp
+++ b/src/pybind/pyembed.cpp
@@ -47,16 +47,14 @@ void EmbeddedPythonLoader::load_libraries() {
     }
     auto pybind_wraplib_env = fs::path(std::getenv("NMODL_WRAPLIB"));
     if (!fs::exists(pybind_wraplib_env)) {
-        const auto nmodl_home = fs::path(std::getenv("NMODLHOME"));
-        auto path = nmodl_home / "lib" / "libpywrapper";
-        path.concat(CMakeInfo::SHARED_LIBRARY_SUFFIX);
-        if (!fs::exists(path)) {
+        pybind_wraplib_env = fs::path(std::getenv("NMODLHOME")) / "lib" / "libpywrapper";
+        pybind_wraplib_env.concat(CMakeInfo::SHARED_LIBRARY_SUFFIX);
+        if (!fs::exists(pybind_wraplib_env)) {
             logger->critical(
                 "NMODLHOME or NMODL_WRAPLIB environment variable must be set to load the pybind "
                 "wrapper library");
             throw std::runtime_error("NMODLHOME or NMODL_WRAPLIB not set");
         }
-        pybind_wraplib_env = path;
     }
     pybind_wrapper_handle = dlopen(pybind_wraplib_env.c_str(), dlopen_opts);
     if (!pybind_wrapper_handle) {

--- a/src/pybind/pyembed.cpp
+++ b/src/pybind/pyembed.cpp
@@ -9,9 +9,9 @@
 #include <dlfcn.h>
 #include <filesystem>
 
+#include "config/config.h"
 #include "pybind/pyembed.hpp"
 #include "utils/logger.hpp"
-#include "config/config.h"
 
 namespace fs = std::filesystem;
 
@@ -52,7 +52,8 @@ void EmbeddedPythonLoader::load_libraries() {
         path.concat(CMakeInfo::SHARED_LIBRARY_SUFFIX);
         if (!fs::exists(path)) {
             logger->critical(
-                "NMODLHOME or NMODL_WRAPLIB environment variable must be set to load the pybind wrapper library");
+                "NMODLHOME or NMODL_WRAPLIB environment variable must be set to load the pybind "
+                "wrapper library");
             throw std::runtime_error("NMODLHOME or NMODL_WRAPLIB not set");
         }
         pybind_wraplib_env = path;

--- a/src/pybind/pyembed.cpp
+++ b/src/pybind/pyembed.cpp
@@ -45,16 +45,13 @@ void EmbeddedPythonLoader::load_libraries() {
         logger->critical(errstr);
         throw std::runtime_error("Failed to dlopen");
     }
-    auto pybind_wraplib_env = fs::path(std::getenv("NMODL_WRAPLIB"));
+    auto pybind_wraplib_env = fs::path(std::getenv("NMODLHOME")) / "lib" / "libpywrapper";
+    pybind_wraplib_env.concat(CMakeInfo::SHARED_LIBRARY_SUFFIX);
     if (!fs::exists(pybind_wraplib_env)) {
-        pybind_wraplib_env = fs::path(std::getenv("NMODLHOME")) / "lib" / "libpywrapper";
-        pybind_wraplib_env.concat(CMakeInfo::SHARED_LIBRARY_SUFFIX);
-        if (!fs::exists(pybind_wraplib_env)) {
-            logger->critical(
-                "NMODLHOME or NMODL_WRAPLIB environment variable must be set to load the pybind "
-                "wrapper library");
-            throw std::runtime_error("NMODLHOME or NMODL_WRAPLIB not set");
-        }
+        logger->critical(
+            "NMODLHOME environment variable must be set to load the pybind "
+            "wrapper library");
+        throw std::runtime_error("NMODLHOME not set");
     }
     pybind_wrapper_handle = dlopen(pybind_wraplib_env.c_str(), dlopen_opts);
     if (!pybind_wrapper_handle) {

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -114,8 +114,6 @@ set(test_env ${NMODL_SANITIZER_ENABLE_ENVIRONMENT})
 set(testvisitor_env "PYTHONPATH=${PROJECT_BINARY_DIR}/lib:$ENV{PYTHONPATH}")
 if(NOT LINK_AGAINST_PYTHON)
   list(APPEND testvisitor_env "NMODL_PYLIB=$ENV{NMODL_PYLIB}")
-  list(APPEND testvisitor_env
-       "NMODL_WRAPLIB=${PROJECT_BINARY_DIR}/lib/nmodl/libpywrapper${CMAKE_SHARED_LIBRARY_SUFFIX}")
 endif()
 
 foreach(


### PR DESCRIPTION
Use NMODLHOME for wraplib and modlunit

Also fix that `libpywrapper` is written in `CMAKE_BINARY_PREFIX` but read by tests in `NMODL_PROJECT_BINARY_PREFIX`.

That is not the case for `nrnunits.lib` that is written in `NMODL_PROJECT_BINARY_PREFIX`.

The problem was that when installed through nrn cmake, both files appears in different path.