### PR TITLE
GHCI: do not use set-output again

### DIFF
--- a/.github/workflows/nmodl-doc.yml
+++ b/.github/workflows/nmodl-doc.yml
@@ -88,7 +88,7 @@ jobs:
           cd _skbuild/linux-x86_64-3.8/setuptools/sphinx;
           rm -rf doctest doctrees && touch .nojekyll;
           echo "<meta http-equiv=\"refresh\" content=\"0; url=./html/index.html\" />" > index.html;
-          echo ::set-output name=status::done
+          echo "status=done" >> $GITHUB_OUTPUT
         env:
           CCACHE_DIR: ${{runner.workspace}}/ccache
           


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon (31st may). Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/