### PR TITLE
Keep myst-parser at 1.0.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ subprocess.call('doxygen Doxyfile', shell=True)
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "myst_parser==1.0.0",
+    "myst_parser",
     "nbsphinx",
     "sphinx.ext.autodoc",
     "sphinx.ext.coverage",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ subprocess.call('doxygen Doxyfile', shell=True)
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "myst_parser",
+    "myst_parser==1.0.0",
     "nbsphinx",
     "sphinx.ext.autodoc",
     "sphinx.ext.coverage",

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(
         "pytest>=3.7.2",
         "sphinxcontrib-applehelp",
         "sphinxcontrib-htmlhelp",
-        "sphinx<=7",  # myst_parser 2.0.0 only support sphinx >=6 <=7
+        "sphinx<7",  # myst_parser 2.0.0 only support sphinx >=6 <=7, sphinx_rtd_theme 1.2.2 is still on sphinx < 7
         "sphinx-rtd-theme",
     ]
     + install_requirements,

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ setup(
         "nbsphinx>=0.3.2",
         "pytest>=3.7.2",
         "sphinxcontrib-applehelp<1.0.3", # After this version it needs a toml file to work, no more setup.py
-        "sphinxcontrib-htmlhelp",
+        "sphinxcontrib-htmlhelp<=2.0.0", # After this version it needs a toml file to work, no more setup.py
         "sphinx<7",  # myst_parser 2.0.0 only support sphinx >=6 <=7, sphinx_rtd_theme 1.2.2 is still on sphinx < 7
         "sphinx-rtd-theme",
     ]

--- a/setup.py
+++ b/setup.py
@@ -117,14 +117,14 @@ setup(
         "jinja2>=2.9.3",
         "jupyter-client",
         "jupyter",
-        "myst_parser==1.0.0",
+        "myst_parser",
         "mistune<3",  # prevents a version conflict with nbconvert
         "nbconvert",
         "nbsphinx>=0.3.2",
         "pytest>=3.7.2",
-        "sphinxcontrib-applehelp<1.0.3",
-        "sphinxcontrib-htmlhelp<=2.0.0",
-        "sphinx<6",
+        "sphinxcontrib-applehelp",
+        "sphinxcontrib-htmlhelp",
+        "sphinx<=7",  # myst_parser 2.0.0 only support sphinx >=6 <=7
         "sphinx-rtd-theme",
     ]
     + install_requirements,

--- a/setup.py
+++ b/setup.py
@@ -118,11 +118,11 @@ setup(
         "jupyter-client",
         "jupyter",
         "myst_parser",
-        "mistune<3",  # prevents a version conflict with nbconvert
+        "mistune",
         "nbconvert",
         "nbsphinx>=0.3.2",
         "pytest>=3.7.2",
-        "sphinxcontrib-applehelp",
+        "sphinxcontrib-applehelp<1.0.3", # After this version it needs a toml file to work, no more setup.py
         "sphinxcontrib-htmlhelp",
         "sphinx<7",  # myst_parser 2.0.0 only support sphinx >=6 <=7, sphinx_rtd_theme 1.2.2 is still on sphinx < 7
         "sphinx-rtd-theme",

--- a/setup.py
+++ b/setup.py
@@ -124,6 +124,7 @@ setup(
         "pytest>=3.7.2",
         "sphinxcontrib-applehelp<1.0.3", # After this version it needs a toml file to work, no more setup.py
         "sphinxcontrib-htmlhelp<=2.0.0", # After this version it needs a toml file to work, no more setup.py
+        "sphinxcontrib-jquery", # sphinx-rtd-theme forgot to include it
         "sphinx<7",  # myst_parser 2.0.0 only support sphinx >=6 <=7, sphinx_rtd_theme 1.2.2 is still on sphinx < 7
         "sphinx-rtd-theme",
     ]

--- a/setup.py
+++ b/setup.py
@@ -113,20 +113,22 @@ setup(
         docs=Docs, doctest=get_sphinx_command, buildhtml=get_sphinx_command,
     ),
     zip_safe=False,
+    # myst_parser 2.0.0 want sphinx >= 6 but it leads to incompatibily with sphinxcontrib-applehelp and 
+    # sphinxcontrib-htmlhelp that want PEP-517 support instead of setup.py (name clash with '-' and '.')
+    # So we pin low versions of packages
     setup_requires=[
         "jinja2>=2.9.3",
         "jupyter-client",
         "jupyter",
-        "myst_parser",
-        "mistune",
+        "myst_parser<2.0.0",
+        "mistune<3",
         "nbconvert",
         "nbsphinx>=0.3.2",
         "pytest>=3.7.2",
         "sphinxcontrib-applehelp<1.0.3", # After this version it needs a toml file to work, no more setup.py
         "sphinxcontrib-htmlhelp<=2.0.0", # After this version it needs a toml file to work, no more setup.py
-        "sphinxcontrib-jquery", # sphinx-rtd-theme forgot to include it
-        "sphinx<7",  # myst_parser 2.0.0 only support sphinx >=6 <=7, sphinx_rtd_theme 1.2.2 is still on sphinx < 7
-        "sphinx-rtd-theme",
+        "sphinx<6",
+        "sphinx-rtd-theme", # needs sphinx < 7
     ]
     + install_requirements,
     install_requires=install_requirements,

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
         "jinja2>=2.9.3",
         "jupyter-client",
         "jupyter",
-        "myst_parser",
+        "myst_parser==1.0.0",
         "mistune<3",  # prevents a version conflict with nbconvert
         "nbconvert",
         "nbsphinx>=0.3.2",


### PR DESCRIPTION
The 2.0.0 has been release but need a sphinx >= 6, we still stick on sphinx 5.