### PR TITLE
Fix reference to local variable.

### DIFF
--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -4060,7 +4060,7 @@ void CodegenCppVisitor::visit_for_netcon(const ast::ForNetcon& node) {
     // to the next netcon.
     const auto& args = node.get_parameters();
     RenameVisitor v;
-    auto& statement_block = node.get_statement_block();
+    const auto& statement_block = node.get_statement_block();
     for (size_t i_arg = 0; i_arg < args.size(); ++i_arg) {
         // sanitize node_name since we want to substitute names like (*w) as they are
         auto old_name =

--- a/src/language/nodes.py
+++ b/src/language/nodes.py
@@ -235,10 +235,14 @@ class ChildNode(BaseNode):
         return type_name
 
     @property
+    def _is_member_type_wrapped_as_shared_pointer(self):
+        return not (self.is_vector or self.is_base_type_node or self.is_ptr_excluded_node)
+
+    @property
     def member_rvalue_typename(self):
         """returns rvalue reference type when used as returned or parameter type"""
         typename = self.member_typename
-        if not self.is_integral_type_node:
+        if not self.is_integral_type_node and not self._is_member_type_wrapped_as_shared_pointer:
             return "const " + typename + "&"
         return typename
 

--- a/src/language/templates/ast/ast.cpp
+++ b/src/language/templates/ast/ast.cpp
@@ -30,7 +30,7 @@ std::string Ast::get_node_name() const {
   throw std::logic_error("get_node_name() not implemented");
 }
 
-const std::shared_ptr<StatementBlock>& Ast::get_statement_block() const {
+std::shared_ptr<StatementBlock> Ast::get_statement_block() const {
   throw std::runtime_error("get_statement_block not implemented");
 }
 

--- a/src/language/templates/ast/ast.hpp
+++ b/src/language/templates/ast/ast.hpp
@@ -273,7 +273,7 @@ struct Ast: public std::enable_shared_from_this<Ast> {
    *
    * \sa ast::StatementBlock
    */
-  virtual const std::shared_ptr<StatementBlock>& get_statement_block() const;
+  virtual std::shared_ptr<StatementBlock> get_statement_block() const;
 
   /**
    * \brief Set symbol table for the AST node

--- a/src/language/templates/pybind/pyast.hpp
+++ b/src/language/templates/pybind/pyast.hpp
@@ -114,8 +114,8 @@ struct PyAst: public Ast {
         PYBIND11_OVERRIDE(symtab::SymbolTable*, Ast, get_symbol_table, );
     }
 
-    const std::shared_ptr<StatementBlock>& get_statement_block() const override {
-        PYBIND11_OVERRIDE(const std::shared_ptr<StatementBlock>&, Ast, get_statement_block, );
+    std::shared_ptr<StatementBlock> get_statement_block() const override {
+        PYBIND11_OVERRIDE(std::shared_ptr<StatementBlock>, Ast, get_statement_block, );
     }
 
     void set_symbol_table(symtab::SymbolTable* newsymtab) override {

--- a/src/visitors/global_var_visitor.cpp
+++ b/src/visitors/global_var_visitor.cpp
@@ -25,7 +25,7 @@ void GlobalToRangeVisitor::visit_neuron_block(ast::NeuronBlock& node) {
     std::unordered_set<ast::GlobalVar*> global_variables_to_remove;
     std::unordered_set<ast::Statement*> global_statements_to_remove;
 
-    auto& statement_block = node.get_statement_block();
+    auto const& statement_block = node.get_statement_block();
     auto& statements = (*statement_block).get_statements();
     const auto& symbol_table = ast.get_symbol_table();
 

--- a/src/visitors/neuron_solve_visitor.cpp
+++ b/src/visitors/neuron_solve_visitor.cpp
@@ -32,7 +32,7 @@ void NeuronSolveVisitor::visit_derivative_block(ast::DerivativeBlock& node) {
     node.visit_children(*this);
     derivative_block = false;
     if (solve_blocks[derivative_block_name] == codegen::naming::EULER_METHOD) {
-        auto& statement_block = node.get_statement_block();
+        const auto& statement_block = node.get_statement_block();
         for (auto& e: euler_solution_expressions) {
             statement_block->emplace_back_statement(e);
         }

--- a/src/visitors/sympy_replace_solutions_visitor.cpp
+++ b/src/visitors/sympy_replace_solutions_visitor.cpp
@@ -161,8 +161,8 @@ void SympyReplaceSolutionsVisitor::visit_statement_block(ast::StatementBlock& no
 
 void SympyReplaceSolutionsVisitor::try_replace_tagged_statement(
     const ast::Node& node,
-    const std::shared_ptr<ast::Expression>& get_lhs(const ast::Node& node),
-    const std::shared_ptr<ast::Expression>& get_rhs(const ast::Node& node)) {
+    std::shared_ptr<ast::Expression> get_lhs(const ast::Node& node),
+    std::shared_ptr<ast::Expression> get_rhs(const ast::Node& node)) {
     interleaves_counter.new_equation(true);
 
     const auto& statement = std::static_pointer_cast<ast::Statement>(
@@ -212,11 +212,11 @@ void SympyReplaceSolutionsVisitor::try_replace_tagged_statement(
 
 void SympyReplaceSolutionsVisitor::visit_diff_eq_expression(ast::DiffEqExpression& node) {
     logger->debug("SympyReplaceSolutionsVisitor :: visit {}", to_nmodl(node));
-    auto get_lhs = [](const ast::Node& node) -> const std::shared_ptr<ast::Expression>& {
+    auto get_lhs = [](const ast::Node& node) -> std::shared_ptr<ast::Expression> {
         return dynamic_cast<const ast::DiffEqExpression&>(node).get_expression()->get_lhs();
     };
 
-    auto get_rhs = [](const ast::Node& node) -> const std::shared_ptr<ast::Expression>& {
+    auto get_rhs = [](const ast::Node& node) -> std::shared_ptr<ast::Expression> {
         return dynamic_cast<const ast::DiffEqExpression&>(node).get_expression()->get_rhs();
     };
 
@@ -225,11 +225,11 @@ void SympyReplaceSolutionsVisitor::visit_diff_eq_expression(ast::DiffEqExpressio
 
 void SympyReplaceSolutionsVisitor::visit_lin_equation(ast::LinEquation& node) {
     logger->debug("SympyReplaceSolutionsVisitor :: visit {}", to_nmodl(node));
-    auto get_lhs = [](const ast::Node& node) -> const std::shared_ptr<ast::Expression>& {
+    auto get_lhs = [](const ast::Node& node) -> std::shared_ptr<ast::Expression> {
         return dynamic_cast<const ast::LinEquation&>(node).get_left_linxpression();
     };
 
-    auto get_rhs = [](const ast::Node& node) -> const std::shared_ptr<ast::Expression>& {
+    auto get_rhs = [](const ast::Node& node) -> std::shared_ptr<ast::Expression> {
         return dynamic_cast<const ast::LinEquation&>(node).get_left_linxpression();
     };
 
@@ -239,11 +239,11 @@ void SympyReplaceSolutionsVisitor::visit_lin_equation(ast::LinEquation& node) {
 
 void SympyReplaceSolutionsVisitor::visit_non_lin_equation(ast::NonLinEquation& node) {
     logger->debug("SympyReplaceSolutionsVisitor :: visit {}", to_nmodl(node));
-    auto get_lhs = [](const ast::Node& node) -> const std::shared_ptr<ast::Expression>& {
+    auto get_lhs = [](const ast::Node& node) -> std::shared_ptr<ast::Expression> {
         return dynamic_cast<const ast::NonLinEquation&>(node).get_lhs();
     };
 
-    auto get_rhs = [](const ast::Node& node) -> const std::shared_ptr<ast::Expression>& {
+    auto get_rhs = [](const ast::Node& node) -> std::shared_ptr<ast::Expression> {
         return dynamic_cast<const ast::NonLinEquation&>(node).get_rhs();
     };
 

--- a/src/visitors/sympy_replace_solutions_visitor.hpp
+++ b/src/visitors/sympy_replace_solutions_visitor.hpp
@@ -253,8 +253,8 @@ class SympyReplaceSolutionsVisitor: public AstVisitor {
      */
     void try_replace_tagged_statement(
         const ast::Node& node,
-        const std::shared_ptr<ast::Expression>& get_lhs(const ast::Node& node),
-        const std::shared_ptr<ast::Expression>& get_rhs(const ast::Node& node));
+        std::shared_ptr<ast::Expression> get_lhs(const ast::Node& node),
+        std::shared_ptr<ast::Expression> get_rhs(const ast::Node& node));
 
     /**
      * \struct InterleavesCounter


### PR DESCRIPTION
During CI we see the following compiler warning:
```
/root/nrn/external/nmodl/ext/pybind11/include/pybind11/cast.h:1054:35: note: declared here
 1054 |     return cast_op<T>(load_type<T>(handle));
      |                       ~~~~~~~~~~~~^~~~~~~~
```
e.g. https://app.circleci.com/pipelines/github/neuronsimulator/nrn/5301/workflows/c43f0a31-36ec-4e95-93df-7df650db01d4/jobs/2887?invite=true#step-102-127220_85

If we track the definition of `cast_op` and `load_type` we find:
```
template <typename T>
typename make_caster<T>::template cast_op_type<T> cast_op(make_caster<T> &caster) {
    return caster.operator typename make_caster<T>::template cast_op_type<T>();
}
```
and
```
template <typename T>
make_caster<T> load_type(const handle &handle) {
    make_caster<T> conv;
    load_type(conv, handle);
    return conv;
}
```
The suspicion is that `make_caster<T>` will strip the `&` and store a copy
```
template <typename type>
using make_caster = type_caster<intrinsic_t<type>>;
```
However, then the returned reference does point to a local variable.

We fix this by returning `std::shared_ptr` by value.