### PR TITLE
First proposal of improvements on C++ generator

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,6 +86,7 @@ stages:
         sudo apt-get update
         sudo apt-get install -y g++-9 flex bison libfl-dev cython libx11-dev libxcomposite-dev libncurses-dev mpich
         sudo apt-get install -y python3.8 python3.8-dev python3.8-venv ninja-build
+        sudo apt-get remove -y python3-importlib-metadata
         python3.8 -m pip install --upgrade pip setuptools
         python3.8 -m pip install --user -r $(Build.Repository.LocalPath)/requirements.txt
         # we manually get version 3.15.0 to make sure that changes in the cmake

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -89,17 +89,19 @@ void CodegenAccVisitor::print_memory_allocation_routine() const {
     }
     printer->add_newline(2);
     auto args = "size_t num, size_t size, size_t alignment = 16";
-    printer->fmt_start_block("static inline void* mem_alloc({})", args);
-    printer->add_line("void* ptr;");
-    printer->add_line("cudaMallocManaged(&ptr, num*size);");
-    printer->add_line("cudaMemset(ptr, 0, num*size);");
-    printer->add_line("return ptr;");
-    printer->end_block(1);
+    printer->fmt_push_block("static inline void* mem_alloc({})", args);
+    printer->add_multi_line(R"CODE(
+        void* ptr;
+        cudaMallocManaged(&ptr, num*size);
+        cudaMemset(ptr, 0, num*size);
+        return ptr;
+    )CODE");
+    printer->pop_block(1);
 
     printer->add_newline(2);
-    printer->start_block("static inline void mem_free(void* ptr)");
+    printer->push_block("static inline void mem_free(void* ptr)");
     printer->add_line("cudaFree(ptr);");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 /**
@@ -114,23 +116,23 @@ void CodegenAccVisitor::print_memory_allocation_routine() const {
  */
 void CodegenAccVisitor::print_abort_routine() const {
     printer->add_newline(2);
-    printer->start_block("static inline void coreneuron_abort()");
-    printer->add_line("printf(\"Error : Issue while running OpenACC kernel \\n\");");
+    printer->push_block("static inline void coreneuron_abort()");
+    printer->add_line(R"(printf("Error : Issue while running OpenACC kernel \n");)");
     printer->add_line("assert(0==1);");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 void CodegenAccVisitor::print_net_send_buffering_cnt_update() const {
-    printer->fmt_start_block("if (nt->compute_gpu)");
+    printer->fmt_push_block("if (nt->compute_gpu)");
     print_device_atomic_capture_annotation();
     printer->add_line("i = nsb->_cnt++;");
-    printer->restart_block("else");
+    printer->chain_block("else");
     printer->add_line("i = nsb->_cnt++;");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 void CodegenAccVisitor::print_net_send_buffering_grow() {
-    // can not grow buffer during gpu execution
+    // no-op since can not grow buffer during gpu execution
 }
 
 /**
@@ -174,7 +176,7 @@ void CodegenAccVisitor::print_net_init_acc_serial_annotation_block_begin() {
 
 void CodegenAccVisitor::print_net_init_acc_serial_annotation_block_end() {
     if (!info.artificial_cell) {
-        printer->end_block(1);
+        printer->pop_block(1);
     }
 }
 
@@ -198,7 +200,7 @@ void CodegenAccVisitor::print_fast_imem_calculation() {
 
     auto rhs_op = operator_for_rhs();
     auto d_op = operator_for_d();
-    printer->start_block("if (nt->nrn_fast_imem)");
+    printer->push_block("if (nt->nrn_fast_imem)");
     if (info.point_process) {
         print_atomic_reduction_pragma();
     }
@@ -207,7 +209,7 @@ void CodegenAccVisitor::print_fast_imem_calculation() {
         print_atomic_reduction_pragma();
     }
     printer->fmt_line("nt->nrn_fast_imem->nrn_sav_d[node_id] {} g;", d_op);
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 void CodegenAccVisitor::print_nrn_cur_matrix_shadow_reduction() {
@@ -220,7 +222,7 @@ void CodegenAccVisitor::print_nrn_cur_matrix_shadow_reduction() {
  */
 void CodegenAccVisitor::print_kernel_data_present_annotation_block_end() {
     if (!info.artificial_cell) {
-        printer->end_block(1);
+        printer->pop_block(1);
     }
 }
 
@@ -237,25 +239,27 @@ bool CodegenAccVisitor::nrn_cur_reduction_loop_required() {
 
 void CodegenAccVisitor::print_global_variable_device_update_annotation() {
     if (!info.artificial_cell) {
-        printer->start_block("if (nt->compute_gpu)");
+        printer->push_block("if (nt->compute_gpu)");
         printer->fmt_line("nrn_pragma_acc(update device ({}))", global_struct_instance());
         printer->fmt_line("nrn_pragma_omp(target update to({}))", global_struct_instance());
-        printer->end_block(1);
+        printer->pop_block(1);
     }
 }
 
 
 void CodegenAccVisitor::print_newtonspace_transfer_to_device() const {
     int list_num = info.derivimplicit_list_num;
-    printer->start_block("if(nt->compute_gpu)");
-    printer->add_line("double* device_vec = cnrn_target_copyin(vec, vec_size / sizeof(double));");
-    printer->add_line("void* device_ns = cnrn_target_deviceptr(*ns);");
-    printer->add_line("ThreadDatum* device_thread = cnrn_target_deviceptr(thread);");
+    printer->push_block("if(nt->compute_gpu)");
+    printer->add_multi_line(R"CODE(
+        double* device_vec = cnrn_target_copyin(vec, vec_size / sizeof(double));
+        void* device_ns = cnrn_target_deviceptr(*ns);
+        ThreadDatum* device_thread = cnrn_target_deviceptr(thread);
+    )CODE");
     printer->fmt_line("cnrn_target_memcpy_to_device(&(device_thread[{}]._pvoid), &device_ns);",
                       info.thread_data_index - 1);
     printer->fmt_line("cnrn_target_memcpy_to_device(&(device_thread[dith{}()].pval), &device_vec);",
                       list_num);
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
@@ -276,32 +280,34 @@ void CodegenAccVisitor::print_instance_struct_transfer_routines(
     if (info.artificial_cell) {
         return;
     }
-    printer->fmt_start_block(
+    printer->fmt_push_block(
         "static inline void copy_instance_to_device(NrnThread* nt, Memb_list* ml, {} const* inst)",
         instance_struct());
-    printer->start_block("if (!nt->compute_gpu)");
+    printer->push_block("if (!nt->compute_gpu)");
     printer->add_line("return;");
-    printer->end_block(1);
+    printer->pop_block(1);
     printer->fmt_line("auto tmp = *inst;");
     printer->add_line("auto* d_inst = cnrn_target_is_present(inst);");
-    printer->start_block("if (!d_inst)");
+    printer->push_block("if (!d_inst)");
     printer->add_line("d_inst = cnrn_target_copyin(inst);");
-    printer->end_block(1);
+    printer->pop_block(1);
     for (auto const& ptr_mem: ptr_members) {
         printer->fmt_line("tmp.{0} = cnrn_target_deviceptr(tmp.{0});", ptr_mem);
     }
-    printer->add_line("cnrn_target_memcpy_to_device(d_inst, &tmp);");
-    printer->add_line("auto* d_ml = cnrn_target_deviceptr(ml);");
-    printer->add_line("void* d_inst_void = d_inst;");
-    printer->add_line("cnrn_target_memcpy_to_device(&(d_ml->instance), &d_inst_void);");
-    printer->end_block(2);  // copy_instance_to_device
+    printer->add_multi_line(R"CODE(
+        cnrn_target_memcpy_to_device(d_inst, &tmp);
+        auto* d_ml = cnrn_target_deviceptr(ml);
+        void* d_inst_void = d_inst;
+        cnrn_target_memcpy_to_device(&(d_ml->instance), &d_inst_void);
+    )CODE");
+    printer->pop_block(2);  // copy_instance_to_device
 
-    printer->fmt_start_block("static inline void delete_instance_from_device({}* inst)",
-                             instance_struct());
-    printer->start_block("if (cnrn_target_is_present(inst))");
+    printer->fmt_push_block("static inline void delete_instance_from_device({}* inst)",
+                            instance_struct());
+    printer->push_block("if (cnrn_target_is_present(inst))");
     printer->add_line("cnrn_target_delete(inst);");
-    printer->end_block(1);
-    printer->end_block(2);  // delete_instance_from_device
+    printer->pop_block(1);
+    printer->pop_block(2);  // delete_instance_from_device
 }
 
 
@@ -334,9 +340,9 @@ void CodegenAccVisitor::print_device_atomic_capture_annotation() const {
 
 
 void CodegenAccVisitor::print_device_stream_wait() const {
-    printer->start_block("if(nt->compute_gpu)");
+    printer->push_block("if(nt->compute_gpu)");
     printer->add_line("nrn_pragma_acc(wait(nt->stream_id))");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
@@ -348,18 +354,18 @@ void CodegenAccVisitor::print_net_send_buf_count_update_to_host() const {
 
 void CodegenAccVisitor::print_net_send_buf_update_to_host() const {
     print_device_stream_wait();
-    printer->start_block("if (nsb && nt->compute_gpu)");
+    printer->push_block("if (nsb && nt->compute_gpu)");
     print_net_send_buf_count_update_to_host();
     printer->add_line("update_net_send_buffer_on_host(nt, nsb);");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
 void CodegenAccVisitor::print_net_send_buf_count_update_to_device() const {
-    printer->start_block("if (nt->compute_gpu)");
+    printer->push_block("if (nt->compute_gpu)");
     printer->add_line("nrn_pragma_acc(update device(nsb->_cnt))");
     printer->add_line("nrn_pragma_omp(target update to(nsb->_cnt))");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -88,8 +88,7 @@ void CodegenAccVisitor::print_memory_allocation_routine() const {
         return;
     }
     printer->add_newline(2);
-    auto args = "size_t num, size_t size, size_t alignment = 16";
-    printer->fmt_push_block("static inline void* mem_alloc({})", args);
+    printer->push_block("static inline void* mem_alloc(size_t num, size_t size, size_t alignment = 16)");
     printer->add_multi_line(R"CODE(
         void* ptr;
         cudaMallocManaged(&ptr, num*size);

--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -123,7 +123,7 @@ void CodegenAccVisitor::print_abort_routine() const {
 }
 
 void CodegenAccVisitor::print_net_send_buffering_cnt_update() const {
-    printer->fmt_push_block("if (nt->compute_gpu)");
+    printer->push_block("if (nt->compute_gpu)");
     print_device_atomic_capture_annotation();
     printer->add_line("i = nsb->_cnt++;");
     printer->chain_block("else");

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -19,8 +19,8 @@ namespace nmodl {
 namespace codegen {
 
 /**
- * @addtogroup codegen_backends
- * @{
+ * \addtogroup codegen_backends
+ * \{
  */
 
 /**
@@ -97,7 +97,8 @@ class CodegenAccVisitor: public CodegenCppVisitor {
     void print_instance_struct_transfer_routine_declarations() override;
 
     /// define helper functions for copying the instance struct to the device
-    void print_instance_struct_transfer_routines(std::vector<std::string> const&) override;
+    void print_instance_struct_transfer_routines(
+        const std::vector<std::string>& ptr_members) override;
 
     /// call helper function for copying the instance struct to the device
     void print_instance_struct_copy_to_device() override;
@@ -105,30 +106,32 @@ class CodegenAccVisitor: public CodegenCppVisitor {
     /// call helper function that deletes the instance struct from the device
     void print_instance_struct_delete_from_device() override;
 
-    // update derivimplicit advance flag on the gpu device
+    /// update derivimplicit advance flag on the gpu device
     void print_deriv_advance_flag_transfer_to_device() const override;
 
-    // update NetSendBuffer_t count from device to host
+    /// update NetSendBuffer_t count from device to host
     void print_net_send_buf_count_update_to_host() const override;
 
-    // update NetSendBuffer_t from device to host
+    /// update NetSendBuffer_t from device to host
     void print_net_send_buf_update_to_host() const override;
 
-    // update NetSendBuffer_t count from host to device
+    /// update NetSendBuffer_t count from host to device
     virtual void print_net_send_buf_count_update_to_device() const override;
 
-    // update dt from host to device
+    /// update dt from host to device
     virtual void print_dt_update_to_device() const override;
 
     // synchronise/wait on stream specific to NrnThread
     virtual void print_device_stream_wait() const override;
 
-    // print atomic capture pragma
+    /// print atomic capture pragma
     void print_device_atomic_capture_annotation() const override;
 
-    // print atomic update of NetSendBuffer_t cnt
+    /// print atomic update of NetSendBuffer_t cnt
     void print_net_send_buffering_cnt_update() const override;
 
+    /// Replace default implementation by a no-op
+    /// since the buffer cannot be grown up during gpu execution
     void print_net_send_buffering_grow() override;
 
 
@@ -146,7 +149,7 @@ class CodegenAccVisitor: public CodegenCppVisitor {
         : CodegenCppVisitor(mod_file, stream, float_type, optimize_ionvar_copies) {}
 };
 
-/** @} */  // end of codegen_backends
+/** \} */  // end of codegen_backends
 
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/codegen_compatibility_visitor.cpp
+++ b/src/codegen/codegen_compatibility_visitor.cpp
@@ -31,7 +31,7 @@ const std::map<ast::AstNodeType, CodegenCompatibilityVisitor::FunctionPointer>
 
 std::string CodegenCompatibilityVisitor::return_error_if_solve_method_is_unhandled(
     ast::Ast& /* node */,
-    const std::shared_ptr<ast::Ast>& ast_node) {
+    const std::shared_ptr<ast::Ast>& ast_node) const {
     auto solve_block_ast_node = std::dynamic_pointer_cast<ast::SolveBlock>(ast_node);
     std::stringstream unhandled_method_error_message;
     auto method = solve_block_ast_node->get_method();
@@ -53,7 +53,7 @@ std::string CodegenCompatibilityVisitor::return_error_if_solve_method_is_unhandl
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::string CodegenCompatibilityVisitor::return_error_global_var(
     ast::Ast& node,
-    const std::shared_ptr<ast::Ast>& ast_node) {
+    const std::shared_ptr<ast::Ast>& ast_node) const {
     auto global_var = std::dynamic_pointer_cast<ast::GlobalVar>(ast_node);
     std::stringstream error_message_global_var;
     if (node.get_symbol_table()->lookup(global_var->get_node_name())->get_write_count() > 0) {
@@ -69,7 +69,7 @@ std::string CodegenCompatibilityVisitor::return_error_global_var(
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::string CodegenCompatibilityVisitor::return_error_param_var(
     ast::Ast& node,
-    const std::shared_ptr<ast::Ast>& ast_node) {
+    const std::shared_ptr<ast::Ast>& ast_node) const {
     auto param_assign = std::dynamic_pointer_cast<ast::ParamAssign>(ast_node);
     std::stringstream error_message_global_var;
     auto symbol = node.get_symbol_table()->lookup(param_assign->get_node_name());
@@ -85,7 +85,7 @@ std::string CodegenCompatibilityVisitor::return_error_param_var(
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 std::string CodegenCompatibilityVisitor::return_error_if_no_bbcore_read_write(
     ast::Ast& node,
-    const std::shared_ptr<ast::Ast>& /* ast_node */) {
+    const std::shared_ptr<ast::Ast>& /* ast_node */) const {
     std::stringstream error_message_no_bbcore_read_write;
     const auto& verbatim_nodes = collect_nodes(node, {AstNodeType::VERBATIM});
     auto found_bbcore_read = false;
@@ -129,15 +129,15 @@ std::string CodegenCompatibilityVisitor::return_error_if_no_bbcore_read_write(
  * some kind of incompatibility return false.
  */
 
-bool CodegenCompatibilityVisitor::find_unhandled_ast_nodes(Ast& node) {
+bool CodegenCompatibilityVisitor::find_unhandled_ast_nodes(Ast& node) const {
     std::vector<ast::AstNodeType> unhandled_ast_types;
     unhandled_ast_types.reserve(unhandled_ast_types_func.size());
-    for (auto kv: unhandled_ast_types_func) {
-        unhandled_ast_types.push_back(kv.first);
+    for (auto [node_type, _]: unhandled_ast_types_func) {
+        unhandled_ast_types.push_back(node_type);
     }
-    unhandled_ast_nodes = collect_nodes(node, unhandled_ast_types);
+    const auto& unhandled_ast_nodes = collect_nodes(node, unhandled_ast_types);
 
-    std::stringstream ss;
+    std::ostringstream ss;
     for (const auto& it: unhandled_ast_nodes) {
         auto node_type = it->get_node_type();
         ss << (this->*unhandled_ast_types_func.find(node_type)->second)(node, it);

--- a/src/codegen/codegen_compatibility_visitor.hpp
+++ b/src/codegen/codegen_compatibility_visitor.hpp
@@ -28,8 +28,8 @@ namespace codegen {
 using namespace ast;
 
 /**
- * @addtogroup codegen_backends
- * @{
+ * \addtogroup codegen_backends
+ * \{
  */
 
 /**
@@ -44,22 +44,18 @@ class CodegenCompatibilityVisitor: public visitor::AstVisitor {
     /// function needed to be called for every kind of error
     typedef std::string (CodegenCompatibilityVisitor::*FunctionPointer)(
         ast::Ast& node,
-        const std::shared_ptr<ast::Ast>&);
+        const std::shared_ptr<ast::Ast>&) const;
 
     /// associated container to find the function needed to be called in
     /// for every ast::AstNodeType that is unsupported
     static const std::map<ast::AstNodeType, FunctionPointer> unhandled_ast_types_func;
 
     /// Set of handled solvers by the NMODL \c C++ code generator
-    const std::set<std::string> handled_solvers{codegen::naming::CNEXP_METHOD,
-                                                codegen::naming::EULER_METHOD,
-                                                codegen::naming::DERIVIMPLICIT_METHOD,
-                                                codegen::naming::SPARSE_METHOD,
-                                                codegen::naming::AFTER_CVODE_METHOD};
-
-    /// Vector that stores all the ast::Node that are unhandled
-    /// by the NMODL \c C++ code generator
-    std::vector<std::shared_ptr<ast::Ast>> unhandled_ast_nodes;
+    static const inline std::set<std::string> handled_solvers{codegen::naming::CNEXP_METHOD,
+                                                              codegen::naming::EULER_METHOD,
+                                                              codegen::naming::DERIVIMPLICIT_METHOD,
+                                                              codegen::naming::SPARSE_METHOD,
+                                                              codegen::naming::AFTER_CVODE_METHOD};
 
   public:
     /// \name Ctor & dtor
@@ -70,12 +66,12 @@ class CodegenCompatibilityVisitor: public visitor::AstVisitor {
 
     /// \}
 
-    /// Function that searches the ast::Ast for nodes that
+    /// Search the ast::Ast for nodes that
     /// are incompatible with NMODL \c C++ code generator
     ///
     /// \param node Ast
     /// \return bool if there are unhandled nodes or not
-    bool find_unhandled_ast_nodes(Ast& node);
+    bool find_unhandled_ast_nodes(Ast& node) const;
 
   private:
     /// Takes as parameter an std::shared_ptr<ast::Ast>,
@@ -87,7 +83,7 @@ class CodegenCompatibilityVisitor: public visitor::AstVisitor {
     /// \return std::string error
     std::string return_error_if_solve_method_is_unhandled(
         ast::Ast& node,
-        const std::shared_ptr<ast::Ast>& ast_node);
+        const std::shared_ptr<ast::Ast>& ast_node) const;
 
     /// Takes as parameter an std::shared_ptr<ast::Ast> node
     /// and returns a relative error with the name, the type
@@ -98,7 +94,8 @@ class CodegenCompatibilityVisitor: public visitor::AstVisitor {
     /// \param ast_node Ast node which is checked
     /// \return std::string error
     template <typename T>
-    std::string return_error_with_name(ast::Ast& node, const std::shared_ptr<ast::Ast>& ast_node) {
+    std::string return_error_with_name(ast::Ast& /* node */,
+                                       const std::shared_ptr<ast::Ast>& ast_node) const {
         auto real_type_block = std::dynamic_pointer_cast<T>(ast_node);
         auto token = real_type_block->get_token();
         try {
@@ -122,8 +119,8 @@ class CodegenCompatibilityVisitor: public visitor::AstVisitor {
     /// \param ast_node Ast node which is checked
     /// \return std::string error
     template <typename T>
-    std::string return_error_without_name(ast::Ast& node,
-                                          const std::shared_ptr<ast::Ast>& ast_node) {
+    std::string return_error_without_name(ast::Ast& /* node */,
+                                          const std::shared_ptr<ast::Ast>& ast_node) const {
         auto real_type_block = std::dynamic_pointer_cast<T>(ast_node);
         return fmt::format("{}construct found at [{}] is not handled\n",
                            real_type_block->get_nmodl_name(),
@@ -138,9 +135,11 @@ class CodegenCompatibilityVisitor: public visitor::AstVisitor {
     /// \param node Ast
     /// \param ast_node Ast node which is checked
     /// \return std::string error
-    std::string return_error_global_var(ast::Ast& node, const std::shared_ptr<ast::Ast>& ast_node);
+    std::string return_error_global_var(ast::Ast& node,
+                                        const std::shared_ptr<ast::Ast>& ast_node) const;
 
-    std::string return_error_param_var(ast::Ast& node, const std::shared_ptr<ast::Ast>& ast_node);
+    std::string return_error_param_var(ast::Ast& node,
+                                       const std::shared_ptr<ast::Ast>& ast_node) const;
 
     /// Takes as parameter the ast::Ast and checks if the
     /// functions "bbcore_read" and "bbcore_write" are defined
@@ -151,11 +150,12 @@ class CodegenCompatibilityVisitor: public visitor::AstVisitor {
     /// \param node Ast
     /// \param ast_node Not used by the function
     /// \return std::string error
-    std::string return_error_if_no_bbcore_read_write(ast::Ast& node,
-                                                     const std::shared_ptr<ast::Ast>& ast_node);
+    std::string return_error_if_no_bbcore_read_write(
+        ast::Ast& node,
+        const std::shared_ptr<ast::Ast>& ast_node) const;
 };
 
-/** @} */  // end of codegen_backends
+/** \} */  // end of codegen_backends
 
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -34,16 +34,13 @@ namespace codegen {
 using namespace ast;
 
 using visitor::DefUseAnalyzeVisitor;
-using visitor::DUChain;
 using visitor::DUState;
 using visitor::RenameVisitor;
 using visitor::SymtabVisitor;
 using visitor::VarUsageVisitor;
 
 using symtab::syminfo::NmodlType;
-using SymbolType = std::shared_ptr<symtab::Symbol>;
-
-namespace codegen_utils = nmodl::codegen::utils;
+// using SymbolType = std::shared_ptr<symtab::Symbol>;
 
 /****************************************************************************************/
 /*                            Overloaded visitor routines                               */
@@ -156,8 +153,7 @@ void CodegenCppVisitor::visit_local_list_statement(const LocalListStatement& nod
     if (!codegen) {
         return;
     }
-    auto type = local_var_type() + " ";
-    printer->add_text(type);
+    printer->add_text(local_var_type(), ' ');
     print_vector_elements(node.get_variables(), ", ");
 }
 
@@ -329,11 +325,11 @@ void CodegenCppVisitor::visit_protect_statement(const ast::ProtectStatement& nod
 void CodegenCppVisitor::visit_mutex_lock(const ast::MutexLock& node) {
     printer->fmt_line("#pragma omp critical ({})", info.mod_suffix);
     printer->add_indent();
-    printer->start_block();
+    printer->push_block();
 }
 
 void CodegenCppVisitor::visit_mutex_unlock(const ast::MutexUnlock& node) {
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 /****************************************************************************************/
@@ -456,12 +452,12 @@ int CodegenCppVisitor::position_of_int_var(const std::string& name) const {
  * representation (1e+20, 1E-15) then keep it as it is.
  */
 std::string CodegenCppVisitor::format_double_string(const std::string& s_value) {
-    return codegen_utils::format_double_string<CodegenCppVisitor>(s_value);
+    return utils::format_double_string<CodegenCppVisitor>(s_value);
 }
 
 
 std::string CodegenCppVisitor::format_float_string(const std::string& s_value) {
-    return codegen_utils::format_float_string<CodegenCppVisitor>(s_value);
+    return utils::format_float_string<CodegenCppVisitor>(s_value);
 }
 
 
@@ -471,23 +467,23 @@ std::string CodegenCppVisitor::format_float_string(const std::string& s_value) {
  * block can appear as statement using expression statement which need to
  * be inspected.
  */
-bool CodegenCppVisitor::need_semicolon(Statement* node) {
+bool CodegenCppVisitor::need_semicolon(const Statement& node) {
     // clang-format off
-    if (node->is_if_statement()
-        || node->is_else_if_statement()
-        || node->is_else_statement()
-        || node->is_from_statement()
-        || node->is_verbatim()
-        || node->is_from_statement()
-        || node->is_conductance_hint()
-        || node->is_while_statement()
-        || node->is_protect_statement()
-        || node->is_mutex_lock()
-        || node->is_mutex_unlock()) {
+    if (node.is_if_statement()
+        || node.is_else_if_statement()
+        || node.is_else_statement()
+        || node.is_from_statement()
+        || node.is_verbatim()
+        || node.is_from_statement()
+        || node.is_conductance_hint()
+        || node.is_while_statement()
+        || node.is_protect_statement()
+        || node.is_mutex_lock()
+        || node.is_mutex_unlock()) {
         return false;
     }
-    if (node->is_expression_statement()) {
-        auto expression = dynamic_cast<ExpressionStatement*>(node)->get_expression();
+    if (node.is_expression_statement()) {
+        auto expression = dynamic_cast<const ExpressionStatement&>(node).get_expression();
         if (expression->is_statement_block()
             || expression->is_eigen_newton_solver_block()
             || expression->is_eigen_linear_solver_block()
@@ -554,7 +550,7 @@ int CodegenCppVisitor::int_variables_size() const {
  * different variable names, we rely on backend-specific read_ion_variable_name
  * and write_ion_variable_name method which will be overloaded.
  */
-std::vector<std::string> CodegenCppVisitor::ion_read_statements(BlockType type) {
+std::vector<std::string> CodegenCppVisitor::ion_read_statements(BlockType type) const {
     if (optimize_ion_variable_copies()) {
         return ion_read_statements_optimized(type);
     }
@@ -584,14 +580,14 @@ std::vector<std::string> CodegenCppVisitor::ion_read_statements(BlockType type) 
 }
 
 
-std::vector<std::string> CodegenCppVisitor::ion_read_statements_optimized(BlockType type) {
+std::vector<std::string> CodegenCppVisitor::ion_read_statements_optimized(BlockType type) const {
     std::vector<std::string> statements;
     for (const auto& ion: info.ions) {
         for (const auto& var: ion.writes) {
             if (ion.is_ionic_conc(var)) {
                 auto variables = read_ion_variable_name(var);
                 auto first = "ionvar." + variables.first;
-                auto second = get_variable_name(variables.second);
+                const auto& second = get_variable_name(variables.second);
                 statements.push_back(fmt::format("{} = {};", first, second));
             }
         }
@@ -789,7 +785,7 @@ void CodegenCppVisitor::update_index_semantics() {
 }
 
 
-std::vector<SymbolType> CodegenCppVisitor::get_float_variables() {
+std::vector<CodegenCppVisitor::SymbolType> CodegenCppVisitor::get_float_variables() const {
     // sort with definition order
     auto comparator = [](const SymbolType& first, const SymbolType& second) -> bool {
         return first->get_definition_order() < second->get_definition_order();
@@ -799,7 +795,7 @@ std::vector<SymbolType> CodegenCppVisitor::get_float_variables() {
     auto states = info.state_vars;
 
     // each state variable has corresponding Dstate variable
-    for (auto& state: states) {
+    for (const auto& state: states) {
         auto name = "D" + state->get_name();
         auto symbol = make_symbol(name);
         if (state->is_array()) {
@@ -979,18 +975,21 @@ std::vector<IndexVariableInfo> CodegenCppVisitor::get_int_variables() {
 /****************************************************************************************/
 
 std::string CodegenCppVisitor::get_parameter_str(const ParamVector& params) {
-    std::string param{};
-    for (auto iter = params.begin(); iter != params.end(); iter++) {
-        param += fmt::format("{}{} {}{}",
-                             std::get<0>(*iter),
-                             std::get<1>(*iter),
-                             std::get<2>(*iter),
-                             std::get<3>(*iter));
-        if (!nmodl::utils::is_last(iter, params)) {
-            param += ", ";
+    std::string str;
+    bool is_first = true;
+    for (const auto& param: params) {
+        if (is_first) {
+            is_first = false;
+        } else {
+            str += ", ";
         }
+        str += fmt::format("{}{} {}{}",
+                           std::get<0>(param),
+                           std::get<1>(param),
+                           std::get<2>(param),
+                           std::get<3>(param));
     }
-    return param;
+    return str;
 }
 
 
@@ -1172,25 +1171,25 @@ bool CodegenCppVisitor::optimize_ion_variable_copies() const {
 void CodegenCppVisitor::print_memory_allocation_routine() const {
     printer->add_newline(2);
     auto args = "size_t num, size_t size, size_t alignment = 16";
-    printer->fmt_start_block("static inline void* mem_alloc({})", args);
+    printer->fmt_push_block("static inline void* mem_alloc({})", args);
     printer->add_line("void* ptr;");
     printer->add_line("posix_memalign(&ptr, alignment, num*size);");
     printer->add_line("memset(ptr, 0, size);");
     printer->add_line("return ptr;");
-    printer->end_block(1);
+    printer->pop_block(1);
 
     printer->add_newline(2);
-    printer->start_block("static inline void mem_free(void* ptr)");
+    printer->push_block("static inline void mem_free(void* ptr)");
     printer->add_line("free(ptr);");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
 void CodegenCppVisitor::print_abort_routine() const {
     printer->add_newline(2);
-    printer->start_block("static inline void coreneuron_abort()");
+    printer->push_block("static inline void coreneuron_abort()");
     printer->add_line("abort();");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
@@ -1222,7 +1221,7 @@ std::string CodegenCppVisitor::global_var_struct_type_qualifier() {
 }
 
 void CodegenCppVisitor::print_global_var_struct_decl() {
-    printer->fmt_line("{} {};", global_struct(), global_struct_instance());
+    printer->add_line(global_struct(), ' ', global_struct_instance(), ';');
 }
 
 /****************************************************************************************/
@@ -1240,10 +1239,10 @@ void CodegenCppVisitor::print_statement_block(const ast::StatementBlock& node,
                                               bool open_brace,
                                               bool close_brace) {
     if (open_brace) {
-        printer->start_block();
+        printer->push_block();
     }
 
-    auto statements = node.get_statements();
+    const auto& statements = node.get_statements();
     for (const auto& statement: statements) {
         if (statement_to_skip(*statement)) {
             continue;
@@ -1254,8 +1253,8 @@ void CodegenCppVisitor::print_statement_block(const ast::StatementBlock& node,
             printer->add_indent();
         }
         statement->accept(*this);
-        if (need_semicolon(statement.get())) {
-            printer->add_text(";");
+        if (need_semicolon(*statement)) {
+            printer->add_text(';');
         }
         if (!statement->is_mutex_lock() && !statement->is_mutex_unlock()) {
             printer->add_newline();
@@ -1263,13 +1262,13 @@ void CodegenCppVisitor::print_statement_block(const ast::StatementBlock& node,
     }
 
     if (close_brace) {
-        printer->end_block();
+        printer->pop_block();
     }
 }
 
 
 void CodegenCppVisitor::print_function_call(const FunctionCall& node) {
-    auto name = node.get_node_name();
+    const auto& name = node.get_node_name();
     auto function_name = name;
     if (defined_method(name)) {
         function_name = method_name(name);
@@ -1290,8 +1289,8 @@ void CodegenCppVisitor::print_function_call(const FunctionCall& node) {
         return;
     }
 
-    auto arguments = node.get_arguments();
-    printer->fmt_text("{}(", function_name);
+    const auto& arguments = node.get_arguments();
+    printer->add_text(function_name, '(');
 
     if (defined_method(name)) {
         printer->add_text(internal_method_arguments());
@@ -1301,7 +1300,7 @@ void CodegenCppVisitor::print_function_call(const FunctionCall& node) {
     }
 
     print_vector_elements(arguments, ", ");
-    printer->add_text(")");
+    printer->add_text(')');
 }
 
 
@@ -1363,12 +1362,12 @@ void CodegenCppVisitor::print_function_prototypes() {
     printer->add_newline(2);
     for (const auto& node: info.functions) {
         print_function_declaration(*node, node->get_node_name());
-        printer->add_text(";");
+        printer->add_text(';');
         printer->add_newline();
     }
     for (const auto& node: info.procedures) {
         print_function_declaration(*node, node->get_node_name());
-        printer->add_text(";");
+        printer->add_text(';');
         printer->add_newline();
     }
     codegen = false;
@@ -1420,13 +1419,13 @@ void CodegenCppVisitor::print_table_check_function(const Block& node) {
 
     printer->add_newline(2);
     print_device_method_annotation();
-    printer->fmt_start_block("void check_{}({})",
-                             method_name(name),
-                             get_parameter_str(internal_params));
+    printer->fmt_push_block("void check_{}({})",
+                            method_name(name),
+                            get_parameter_str(internal_params));
     {
-        printer->fmt_start_block("if ({} == 0)", use_table_var);
+        printer->fmt_push_block("if ({} == 0)", use_table_var);
         printer->add_line("return;");
-        printer->end_block(1);
+        printer->pop_block(1);
 
         printer->add_line("static bool make_table = true;");
         for (const auto& variable: depend_variables) {
@@ -1434,27 +1433,27 @@ void CodegenCppVisitor::print_table_check_function(const Block& node) {
         }
 
         for (const auto& variable: depend_variables) {
-            auto var_name = variable->get_node_name();
-            auto instance_name = get_variable_name(var_name);
-            printer->fmt_start_block("if (save_{} != {})", var_name, instance_name);
+            const auto& var_name = variable->get_node_name();
+            const auto& instance_name = get_variable_name(var_name);
+            printer->fmt_push_block("if (save_{} != {})", var_name, instance_name);
             printer->add_line("make_table = true;");
-            printer->end_block(1);
+            printer->pop_block(1);
         }
 
-        printer->start_block("if (make_table)");
+        printer->push_block("if (make_table)");
         {
             printer->add_line("make_table = false;");
 
             printer->add_indent();
-            printer->fmt_text("{} = ", tmin_name);
+            printer->add_text(tmin_name, " = ");
             from->accept(*this);
-            printer->add_text(";");
+            printer->add_text(';');
             printer->add_newline();
 
             printer->add_indent();
             printer->add_text("double tmax = ");
             to->accept(*this);
-            printer->add_text(";");
+            printer->add_text(';');
             printer->add_newline();
 
 
@@ -1462,7 +1461,7 @@ void CodegenCppVisitor::print_table_check_function(const Block& node) {
             printer->fmt_line("{} = 1./dx;", mfac_name);
 
             printer->fmt_line("double x = {};", tmin_name);
-            printer->fmt_start_block("for (std::size_t i = 0; i < {}; x += dx, i++)", with + 1);
+            printer->fmt_push_block("for (std::size_t i = 0; i < {}; x += dx, i++)", with + 1);
             auto function = method_name("f_" + name);
             if (node.is_procedure_block()) {
                 printer->fmt_line("{}({}, x);", function, internal_method_arguments());
@@ -1487,7 +1486,7 @@ void CodegenCppVisitor::print_table_check_function(const Block& node) {
                                   function,
                                   internal_method_arguments());
             }
-            printer->end_block(1);
+            printer->pop_block(1);
 
             for (const auto& variable: depend_variables) {
                 auto var_name = variable->get_node_name();
@@ -1495,9 +1494,9 @@ void CodegenCppVisitor::print_table_check_function(const Block& node) {
                 printer->fmt_line("save_{} = {};", var_name, instance_name);
             }
         }
-        printer->end_block(1);
+        printer->pop_block(1);
     }
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
@@ -1513,10 +1512,10 @@ void CodegenCppVisitor::print_table_replacement_function(const ast::Block& node)
 
     printer->add_newline(2);
     print_function_declaration(node, name);
-    printer->start_block();
+    printer->push_block();
     {
         const auto& params = node.get_parameters();
-        printer->fmt_start_block("if ({} == 0)", use_table_var);
+        printer->fmt_push_block("if ({} == 0)", use_table_var);
         if (node.is_procedure_block()) {
             printer->fmt_line("{}({}, {});",
                               function_name,
@@ -1529,13 +1528,13 @@ void CodegenCppVisitor::print_table_replacement_function(const ast::Block& node)
                               internal_method_arguments(),
                               params[0].get()->get_node_name());
         }
-        printer->end_block(1);
+        printer->pop_block(1);
 
         printer->fmt_line("double xi = {} * ({} - {});",
                           mfac_name,
                           params[0].get()->get_node_name(),
                           tmin_name);
-        printer->start_block("if (isnan(xi))");
+        printer->push_block("if (isnan(xi))");
         if (node.is_procedure_block()) {
             for (const auto& var: table_variables) {
                 auto var_name = get_variable_name(var->get_node_name());
@@ -1552,9 +1551,9 @@ void CodegenCppVisitor::print_table_replacement_function(const ast::Block& node)
         } else {
             printer->add_line("return xi;");
         }
-        printer->end_block(1);
+        printer->pop_block(1);
 
-        printer->fmt_start_block("if (xi <= 0. || xi >= {}.)", with);
+        printer->fmt_push_block("if (xi <= 0. || xi >= {}.)", with);
         printer->fmt_line("int index = (xi <= 0.) ? 0 : {};", with);
         if (node.is_procedure_block()) {
             for (const auto& variable: table_variables) {
@@ -1576,7 +1575,7 @@ void CodegenCppVisitor::print_table_replacement_function(const ast::Block& node)
             auto table_name = get_variable_name("t_" + name);
             printer->fmt_line("return {}[index];", table_name);
         }
-        printer->end_block(1);
+        printer->pop_block(1);
 
         printer->add_line("int i = int(xi);");
         printer->add_line("double theta = xi - double(i);");
@@ -1606,7 +1605,7 @@ void CodegenCppVisitor::print_table_replacement_function(const ast::Block& node)
             printer->fmt_line("return {0}[i] + theta * ({0}[i+1] - {0}[i]);", table_name);
         }
     }
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
@@ -1619,7 +1618,7 @@ void CodegenCppVisitor::print_check_table_thread_function() {
     auto name = method_name("check_table_thread");
     auto parameters = external_method_parameters(true);
 
-    printer->fmt_start_block("static void {} ({})", name, parameters);
+    printer->fmt_push_block("static void {} ({})", name, parameters);
     printer->add_line("setup_instance(nt, ml);");
     printer->fmt_line("auto* const inst = static_cast<{0}*>(ml->instance);", instance_struct());
     printer->add_line("double v = 0;");
@@ -1630,7 +1629,7 @@ void CodegenCppVisitor::print_check_table_thread_function() {
         printer->fmt_line("{}({});", method_name_str, arguments);
     }
 
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
@@ -1639,7 +1638,7 @@ void CodegenCppVisitor::print_function_or_procedure(const ast::Block& node,
     printer->add_newline(2);
     print_function_declaration(node, name);
     printer->add_text(" ");
-    printer->start_block();
+    printer->push_block();
 
     // function requires return variable declaration
     if (node.is_function_block()) {
@@ -1651,7 +1650,7 @@ void CodegenCppVisitor::print_function_or_procedure(const ast::Block& node,
 
     print_statement_block(*node.get_statement_block(), false, false);
     printer->fmt_line("return ret_{};", name);
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
@@ -1705,7 +1704,7 @@ void CodegenCppVisitor::print_function_tables(const ast::FunctionTableBlock& nod
         params.emplace_back("", "double", "", i->get_node_name());
     }
     printer->fmt_line("double {}({})", method_name(name), get_parameter_str(params));
-    printer->start_block();
+    printer->push_block();
     printer->fmt_line("double _arg[{}];", p.size());
     for (size_t i = 0; i < p.size(); ++i) {
         printer->fmt_line("_arg[{}] = {};", i, p[i]->get_node_name());
@@ -1713,14 +1712,14 @@ void CodegenCppVisitor::print_function_tables(const ast::FunctionTableBlock& nod
     printer->fmt_line("return hoc_func_table({}, {}, _arg);",
                       get_variable_name(std::string("_ptable_" + name), true),
                       p.size());
-    printer->end_block(1);
+    printer->pop_block(1);
 
-    printer->fmt_start_block("double table_{}()", method_name(name));
+    printer->fmt_push_block("double table_{}()", method_name(name));
     printer->fmt_line("hoc_spec_table(&{}, {});",
                       get_variable_name(std::string("_ptable_" + name)),
                       p.size());
     printer->add_line("return 0.;");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 /**
@@ -1776,9 +1775,9 @@ void CodegenCppVisitor::print_functor_definition(const ast::EigenNewtonSolverBlo
     int N = node.get_n_state_vars()->get_value();
 
     const auto functor_name = info.functor_names[&node];
-    printer->fmt_start_block("struct {0}", functor_name);
+    printer->fmt_push_block("struct {0}", functor_name);
     printer->add_line("NrnThread* nt;");
-    printer->fmt_line("{0}* inst;", instance_struct());
+    printer->add_line(instance_struct(), "* inst;");
     printer->add_line("int id, pnodecount;");
     printer->add_line("double v;");
     printer->add_line("const Datum* indexes;");
@@ -1792,9 +1791,9 @@ void CodegenCppVisitor::print_functor_definition(const ast::EigenNewtonSolverBlo
     print_statement_block(*node.get_variable_block(), false, false);
     printer->add_newline();
 
-    printer->start_block("void initialize()");
+    printer->push_block("void initialize()");
     print_statement_block(*node.get_initialize_block(), false, false);
-    printer->end_block(2);
+    printer->pop_block(2);
 
     printer->fmt_line(
         "{0}(NrnThread* nt, {1}* inst, int id, int pnodecount, double v, const Datum* indexes, "
@@ -1817,19 +1816,19 @@ void CodegenCppVisitor::print_functor_definition(const ast::EigenNewtonSolverBlo
         float_type,
         N,
         is_functor_const(variable_block, functor_block) ? "const " : "");
-    printer->start_block();
+    printer->push_block();
     printer->fmt_line("const {}* nmodl_eigen_x = nmodl_eigen_xm.data();", float_type);
     printer->fmt_line("{}* nmodl_eigen_j = nmodl_eigen_jm.data();", float_type);
     printer->fmt_line("{}* nmodl_eigen_f = nmodl_eigen_fm.data();", float_type);
     print_statement_block(functor_block, false, false);
-    printer->end_block(2);
+    printer->pop_block(2);
 
     // assign newton solver results in matrix X to state vars
-    printer->start_block("void finalize()");
+    printer->push_block("void finalize()");
     print_statement_block(*node.get_finalize_block(), false, false);
-    printer->end_block(1);
+    printer->pop_block(1);
 
-    printer->end_block(";");
+    printer->pop_block(";");
 }
 
 void CodegenCppVisitor::visit_eigen_newton_solver_block(const ast::EigenNewtonSolverBlock& node) {
@@ -1885,12 +1884,12 @@ void CodegenCppVisitor::visit_eigen_linear_solver_block(const ast::EigenLinearSo
 void CodegenCppVisitor::print_eigen_linear_solver(const std::string& float_type, int N) {
     if (N <= 4) {
         // Faster compared to LU, given the template specialization in Eigen.
-        printer->add_line("bool invertible;");
-        printer->add_line("nmodl_eigen_jm.computeInverseWithCheck(nmodl_eigen_jm_inv,invertible);");
-        printer->add_line("nmodl_eigen_xm = nmodl_eigen_jm_inv*nmodl_eigen_fm;");
-        printer->add_line(
-            "if (!invertible) assert(false && \"Singular or ill-conditioned matrix "
-            "(Eigen::inverse)!\");");
+        printer->add_multi_line(R"CODE(
+            bool invertible;
+            nmodl_eigen_jm.computeInverseWithCheck(nmodl_eigen_jm_inv,invertible);
+            nmodl_eigen_xm = nmodl_eigen_jm_inv*nmodl_eigen_fm;
+            if (!invertible) assert(false && "Singular or ill-conditioned matrix (Eigen::inverse)!");
+        )CODE");
     } else {
         // In Eigen the default storage order is ColMajor.
         // Crout's implementation requires matrices stored in RowMajor order (C-style arrays).
@@ -1935,7 +1934,7 @@ std::string CodegenCppVisitor::internal_method_arguments() {
  * @todo: figure out how to correctly handle qualifiers
  */
 CodegenCppVisitor::ParamVector CodegenCppVisitor::internal_method_parameters() {
-    auto params = ParamVector();
+    ParamVector params;
     params.emplace_back("", "int", "", "id");
     params.emplace_back("", "int", "", "pnodecount");
     params.emplace_back("", fmt::format("{}*", instance_struct()), "", "inst");
@@ -1951,12 +1950,12 @@ CodegenCppVisitor::ParamVector CodegenCppVisitor::internal_method_parameters() {
 }
 
 
-std::string CodegenCppVisitor::external_method_arguments() {
+const char* CodegenCppVisitor::external_method_arguments() noexcept {
     return "id, pnodecount, data, indexes, thread, nt, ml, v";
 }
 
 
-std::string CodegenCppVisitor::external_method_parameters(bool table) {
+const char* CodegenCppVisitor::external_method_parameters(bool table) noexcept {
     if (table) {
         return "int id, int pnodecount, double* data, Datum* indexes, "
                "ThreadDatum* thread, NrnThread* nt, Memb_list* ml, int tml_id";
@@ -1966,7 +1965,7 @@ std::string CodegenCppVisitor::external_method_parameters(bool table) {
 }
 
 
-std::string CodegenCppVisitor::nrn_thread_arguments() {
+std::string CodegenCppVisitor::nrn_thread_arguments() const {
     if (ion_variable_struct_required()) {
         return "id, pnodecount, ionvar, data, indexes, thread, nt, ml, v";
     }
@@ -2142,24 +2141,24 @@ void CodegenCppVisitor::print_nmodl_constants() {
 void CodegenCppVisitor::print_first_pointer_var_index_getter() {
     printer->add_newline(2);
     print_device_method_annotation();
-    printer->start_block("static inline int first_pointer_var_index()");
+    printer->push_block("static inline int first_pointer_var_index()");
     printer->fmt_line("return {};", info.first_pointer_var_index);
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
 void CodegenCppVisitor::print_num_variable_getter() {
     printer->add_newline(2);
     print_device_method_annotation();
-    printer->start_block("static inline int float_variables_size()");
+    printer->push_block("static inline int float_variables_size()");
     printer->fmt_line("return {};", float_variables_size());
-    printer->end_block(1);
+    printer->pop_block(1);
 
     printer->add_newline(2);
     print_device_method_annotation();
-    printer->start_block("static inline int int_variables_size()");
+    printer->push_block("static inline int int_variables_size()");
     printer->fmt_line("return {};", int_variables_size());
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
@@ -2169,42 +2168,42 @@ void CodegenCppVisitor::print_net_receive_arg_size_getter() {
     }
     printer->add_newline(2);
     print_device_method_annotation();
-    printer->start_block("static inline int num_net_receive_args()");
+    printer->push_block("static inline int num_net_receive_args()");
     printer->fmt_line("return {};", info.num_net_receive_parameters);
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
 void CodegenCppVisitor::print_mech_type_getter() {
     printer->add_newline(2);
     print_device_method_annotation();
-    printer->start_block("static inline int get_mech_type()");
+    printer->push_block("static inline int get_mech_type()");
     // false => get it from the host-only global struct, not the instance structure
     printer->fmt_line("return {};", get_variable_name("mech_type", false));
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
 void CodegenCppVisitor::print_memb_list_getter() {
     printer->add_newline(2);
     print_device_method_annotation();
-    printer->start_block("static inline Memb_list* get_memb_list(NrnThread* nt)");
-    printer->start_block("if (!nt->_ml_list)");
+    printer->push_block("static inline Memb_list* get_memb_list(NrnThread* nt)");
+    printer->push_block("if (!nt->_ml_list)");
     printer->add_line("return nullptr;");
-    printer->end_block(1);
+    printer->pop_block(1);
     printer->add_line("return nt->_ml_list[get_mech_type()];");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
 void CodegenCppVisitor::print_namespace_start() {
     printer->add_newline(2);
-    printer->start_block("namespace coreneuron");
+    printer->push_block("namespace coreneuron");
 }
 
 
 void CodegenCppVisitor::print_namespace_stop() {
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
@@ -2230,33 +2229,33 @@ void CodegenCppVisitor::print_thread_getters() {
         printer->add_line("/** thread specific helper routines for derivimplicit */");
 
         printer->add_newline(1);
-        printer->fmt_start_block("static inline int* deriv{}_advance(ThreadDatum* thread)", list);
+        printer->fmt_push_block("static inline int* deriv{}_advance(ThreadDatum* thread)", list);
         printer->fmt_line("return &(thread[{}].i);", tid);
-        printer->end_block(2);
+        printer->pop_block(2);
 
-        printer->fmt_start_block("static inline int dith{}()", list);
+        printer->fmt_push_block("static inline int dith{}()", list);
         printer->fmt_line("return {};", tid+1);
-        printer->end_block(2);
+        printer->pop_block(2);
 
-        printer->fmt_start_block("static inline void** newtonspace{}(ThreadDatum* thread)", list);
+        printer->fmt_push_block("static inline void** newtonspace{}(ThreadDatum* thread)", list);
         printer->fmt_line("return &(thread[{}]._pvoid);", tid+2);
-        printer->end_block(1);
+        printer->pop_block(1);
     }
 
     if (info.vectorize && !info.thread_variables.empty()) {
         printer->add_newline(2);
         printer->add_line("/** tid for thread variables */");
-        printer->start_block("static inline int thread_var_tid()");
+        printer->push_block("static inline int thread_var_tid()");
         printer->fmt_line("return {};", info.thread_var_thread_id);
-        printer->end_block(1);
+        printer->pop_block(1);
     }
 
     if (info.vectorize && !info.top_local_variables.empty()) {
         printer->add_newline(2);
         printer->add_line("/** tid for top local tread variables */");
-        printer->start_block("static inline int top_local_var_tid()");
+        printer->push_block("static inline int top_local_var_tid()");
         printer->fmt_line("return {};", info.top_local_thread_id);
-        printer->end_block(1);
+        printer->pop_block(1);
     }
     // clang-format on
 }
@@ -2341,7 +2340,7 @@ std::string CodegenCppVisitor::update_if_ion_variable_name(const std::string& na
 
 
 std::string CodegenCppVisitor::get_variable_name(const std::string& name, bool use_instance) const {
-    std::string varname = update_if_ion_variable_name(name);
+    const std::string& varname = update_if_ion_variable_name(name);
 
     // clang-format off
     auto symbol_comparator = [&varname](const SymbolType& sym) {
@@ -2419,39 +2418,43 @@ void CodegenCppVisitor::print_backend_info() {
     auto version = nmodl::Version::NMODL_VERSION + " [" + nmodl::Version::GIT_REVISION + "]";
 
     printer->add_line("/*********************************************************");
-    printer->fmt_line("Model Name      : {}", info.mod_suffix);
-    printer->fmt_line("Filename        : {}", info.mod_file + ".mod");
-    printer->fmt_line("NMODL Version   : {}", nmodl_version());
+    printer->add_line("Model Name      : ", info.mod_suffix);
+    printer->add_line("Filename        : ", info.mod_file, ".mod");
+    printer->add_line("NMODL Version   : ", nmodl_version());
     printer->fmt_line("Vectorized      : {}", info.vectorize);
     printer->fmt_line("Threadsafe      : {}", info.thread_safe);
-    printer->fmt_line("Created         : {}", stringutils::trim(data_time_str));
-    printer->fmt_line("Backend         : {}", backend_name());
-    printer->fmt_line("NMODL Compiler  : {}", version);
+    printer->add_line("Created         : ", stringutils::trim(data_time_str));
+    printer->add_line("Backend         : ", backend_name());
+    printer->add_line("NMODL Compiler  : ", version);
     printer->add_line("*********************************************************/");
 }
 
 
 void CodegenCppVisitor::print_standard_includes() {
     printer->add_newline();
-    printer->add_line("#include <math.h>");
-    printer->add_line("#include <stdio.h>");
-    printer->add_line("#include <stdlib.h>");
-    printer->add_line("#include <string.h>");
+    printer->add_multi_line(R"CODE(
+        #include <math.h>
+        #include <stdio.h>
+        #include <stdlib.h>
+        #include <string.h>
+    )CODE");
 }
 
 
 void CodegenCppVisitor::print_coreneuron_includes() {
     printer->add_newline();
-    printer->add_line("#include <coreneuron/nrnconf.h>");
-    printer->add_line("#include <coreneuron/sim/multicore.hpp>");
-    printer->add_line("#include <coreneuron/mechanism/register_mech.hpp>");
-    printer->add_line("#include <coreneuron/gpu/nrn_acc_manager.hpp>");
-    printer->add_line("#include <coreneuron/utils/randoms/nrnran123.h>");
-    printer->add_line("#include <coreneuron/nrniv/nrniv_decl.h>");
-    printer->add_line("#include <coreneuron/utils/ivocvect.hpp>");
-    printer->add_line("#include <coreneuron/utils/nrnoc_aux.hpp>");
-    printer->add_line("#include <coreneuron/mechanism/mech/mod2c_core_thread.hpp>");
-    printer->add_line("#include <coreneuron/sim/scopmath/newton_thread.hpp>");
+    printer->add_multi_line(R"CODE(
+        #include <coreneuron/gpu/nrn_acc_manager.hpp>
+        #include <coreneuron/mechanism/mech/mod2c_core_thread.hpp>
+        #include <coreneuron/mechanism/register_mech.hpp>
+        #include <coreneuron/nrnconf.h>
+        #include <coreneuron/nrniv/nrniv_decl.h>
+        #include <coreneuron/sim/multicore.hpp>
+        #include <coreneuron/sim/scopmath/newton_thread.hpp>
+        #include <coreneuron/utils/ivocvect.hpp>
+        #include <coreneuron/utils/nrnoc_aux.hpp>
+        #include <coreneuron/utils/randoms/nrnran123.h>
+    )CODE");
     if (info.eigen_newton_solver_exist) {
         printer->add_line("#include <newton/newton.hpp>");
     }
@@ -2487,14 +2490,14 @@ void CodegenCppVisitor::print_coreneuron_includes() {
  * same for some variables to keep same code as neuron.
  */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-void CodegenCppVisitor::print_mechanism_global_var_structure(bool print_initialisers) {
-    const auto value_initialise = print_initialisers ? "{}" : "";
+void CodegenCppVisitor::print_mechanism_global_var_structure(bool print_initializers) {
+    const auto value_initialise = print_initializers ? "{}" : "";
     const auto qualifier = global_var_struct_type_qualifier();
 
     auto float_type = default_float_data_type();
     printer->add_newline(2);
     printer->add_line("/** all global variables */");
-    printer->fmt_start_block("struct {}", global_struct());
+    printer->fmt_push_block("struct {}", global_struct());
 
     for (const auto& ion: info.ions) {
         auto name = fmt::format("{}_type", ion.name);
@@ -2575,7 +2578,7 @@ void CodegenCppVisitor::print_mechanism_global_var_structure(bool print_initiali
                               qualifier,
                               float_type,
                               name,
-                              print_initialisers ? fmt::format("{{{:g}}}", value) : std::string{});
+                              print_initializers ? fmt::format("{{{:g}}}", value) : std::string{});
         }
         codegen_global_variables.push_back(var);
     }
@@ -2588,7 +2591,7 @@ void CodegenCppVisitor::print_mechanism_global_var_structure(bool print_initiali
                           qualifier,
                           float_type,
                           name,
-                          print_initialisers ? fmt::format("{{{:g}}}", value) : std::string{});
+                          print_initializers ? fmt::format("{{{:g}}}", value) : std::string{});
         codegen_global_variables.push_back(var);
     }
 
@@ -2601,7 +2604,7 @@ void CodegenCppVisitor::print_mechanism_global_var_structure(bool print_initiali
                             info.prime_variables_by_order.size())};
         }
         auto const initializer_list = [&](auto const& primes, const char* prefix) -> std::string {
-            if (!print_initialisers) {
+            if (!print_initializers) {
                 return {};
             }
             std::string list{"{"};
@@ -2637,7 +2640,7 @@ void CodegenCppVisitor::print_mechanism_global_var_structure(bool print_initiali
     }
 
     if (info.table_count > 0) {
-        printer->fmt_line("{}double usetable{};", qualifier, print_initialisers ? "{1}" : "");
+        printer->fmt_line("{}double usetable{};", qualifier, print_initializers ? "{1}" : "");
         codegen_global_variables.push_back(make_symbol(naming::USE_TABLE_VARIABLE));
 
         for (const auto& block: info.functions_with_table) {
@@ -2681,7 +2684,7 @@ void CodegenCppVisitor::print_mechanism_global_var_structure(bool print_initiali
         codegen_global_variables.push_back(make_symbol("ext_call_thread"));
     }
 
-    printer->end_block(";");
+    printer->pop_block(";");
 
     print_global_var_struct_assertions();
     print_global_var_struct_decl();
@@ -2717,7 +2720,7 @@ void CodegenCppVisitor::print_mechanism_info() {
             if (v->is_array()) {
                 name += fmt::format("[{}]", v->get_length());
             }
-            printer->add_line(add_escape_quote(name) + ",");
+            printer->add_line(add_escape_quote(name), ",");
         }
     };
 
@@ -2725,8 +2728,8 @@ void CodegenCppVisitor::print_mechanism_info() {
     printer->add_line("/** channel information */");
     printer->add_line("static const char *mechanism[] = {");
     printer->increase_indent();
-    printer->add_line(add_escape_quote(nmodl_version()) + ",");
-    printer->add_line(add_escape_quote(info.mod_suffix) + ",");
+    printer->add_line(add_escape_quote(nmodl_version()), ",");
+    printer->add_line(add_escape_quote(info.mod_suffix), ",");
     variable_printer(info.range_parameter_vars);
     printer->add_line("0,");
     variable_printer(info.range_assigned_vars);
@@ -2853,16 +2856,16 @@ static std::string get_register_type_for_ba_block(const ast::Block* block) {
 void CodegenCppVisitor::print_mechanism_register() {
     printer->add_newline(2);
     printer->add_line("/** register channel with the simulator */");
-    printer->fmt_start_block("void _{}_reg()", info.mod_file);
+    printer->fmt_push_block("void _{}_reg()", info.mod_file);
 
     // type related information
     auto suffix = add_escape_quote(info.mod_suffix);
     printer->add_newline();
     printer->fmt_line("int mech_type = nrn_get_mechtype({});", suffix);
     printer->fmt_line("{} = mech_type;", get_variable_name("mech_type", false));
-    printer->start_block("if (mech_type == -1)");
+    printer->push_block("if (mech_type == -1)");
     printer->add_line("return;");
-    printer->end_block(1);
+    printer->pop_block(1);
 
     printer->add_newline();
     printer->add_line("_nrn_layout_reg(mech_type, 0);");  // 0 for SoA
@@ -2988,7 +2991,7 @@ void CodegenCppVisitor::print_mechanism_register() {
 
     // register variables for hoc
     printer->add_line("hoc_register_var(hoc_scalar_double, hoc_vector_double, NULL);");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
@@ -3000,7 +3003,7 @@ void CodegenCppVisitor::print_thread_memory_callbacks() {
     // thread_mem_init callback
     printer->add_newline(2);
     printer->add_line("/** thread memory allocation callback */");
-    printer->start_block("static void thread_mem_init(ThreadDatum* thread) ");
+    printer->push_block("static void thread_mem_init(ThreadDatum* thread) ");
 
     if (info.vectorize && info.derivimplicit_used()) {
         printer->fmt_line("thread[dith{}()].pval = nullptr;", info.derivimplicit_list_num);
@@ -3015,19 +3018,19 @@ void CodegenCppVisitor::print_thread_memory_callbacks() {
         auto thread_data = get_variable_name("thread_data");
         auto thread_data_in_use = get_variable_name("thread_data_in_use");
         auto allocation = fmt::format("(double*)mem_alloc({}, sizeof(double))", length);
-        printer->fmt_start_block("if ({})", thread_data_in_use);
+        printer->fmt_push_block("if ({})", thread_data_in_use);
         printer->fmt_line("thread[thread_var_tid()].pval = {};", allocation);
-        printer->restart_block("else");
+        printer->chain_block("else");
         printer->fmt_line("thread[thread_var_tid()].pval = {};", thread_data);
         printer->fmt_line("{} = 1;", thread_data_in_use);
-        printer->end_block(1);
+        printer->pop_block(1);
     }
-    printer->end_block(3);
+    printer->pop_block(3);
 
 
     // thread_mem_cleanup callback
     printer->add_line("/** thread memory cleanup callback */");
-    printer->start_block("static void thread_mem_cleanup(ThreadDatum* thread) ");
+    printer->push_block("static void thread_mem_cleanup(ThreadDatum* thread) ");
 
     // clang-format off
     if (info.vectorize && info.derivimplicit_used()) {
@@ -3044,29 +3047,29 @@ void CodegenCppVisitor::print_thread_memory_callbacks() {
     if (info.thread_var_data_size != 0) {
         auto thread_data = get_variable_name("thread_data");
         auto thread_data_in_use = get_variable_name("thread_data_in_use");
-        printer->fmt_start_block("if (thread[thread_var_tid()].pval == {})", thread_data);
+        printer->fmt_push_block("if (thread[thread_var_tid()].pval == {})", thread_data);
         printer->fmt_line("{} = 0;", thread_data_in_use);
-        printer->restart_block("else");
+        printer->chain_block("else");
         printer->add_line("free(thread[thread_var_tid()].pval);");
-        printer->end_block(1);
+        printer->pop_block(1);
     }
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
-void CodegenCppVisitor::print_mechanism_range_var_structure(bool print_initialisers) {
-    auto const value_initialise = print_initialisers ? "{}" : "";
+void CodegenCppVisitor::print_mechanism_range_var_structure(bool print_initializers) {
+    auto const value_initialise = print_initializers ? "{}" : "";
     auto int_type = default_int_data_type();
     printer->add_newline(2);
     printer->add_line("/** all mechanism instance variables and global variables */");
-    printer->fmt_start_block("struct {} ", instance_struct());
+    printer->fmt_push_block("struct {} ", instance_struct());
 
     for (auto const& [var, type]: info.neuron_global_variables) {
         auto const name = var->get_name();
         printer->fmt_line("{}* {}{};",
                           type,
                           name,
-                          print_initialisers ? fmt::format("{{&coreneuron::{}}}", name)
+                          print_initializers ? fmt::format("{{&coreneuron::{}}}", name)
                                              : std::string{});
     }
     for (auto& var: codegen_float_variables) {
@@ -3090,9 +3093,9 @@ void CodegenCppVisitor::print_mechanism_range_var_structure(bool print_initialis
     printer->fmt_line("{}* {}{};",
                       global_struct(),
                       naming::INST_GLOBAL_MEMBER,
-                      print_initialisers ? fmt::format("{{&{}}}", global_struct_instance())
+                      print_initializers ? fmt::format("{{&{}}}", global_struct_instance())
                                          : std::string{});
-    printer->end_block(";");
+    printer->pop_block(";");
 }
 
 
@@ -3102,7 +3105,7 @@ void CodegenCppVisitor::print_ion_var_structure() {
     }
     printer->add_newline(2);
     printer->add_line("/** ion write variables */");
-    printer->start_block("struct IonCurVar");
+    printer->push_block("struct IonCurVar");
 
     std::string float_type = default_float_data_type();
     std::vector<std::string> members;
@@ -3122,14 +3125,15 @@ void CodegenCppVisitor::print_ion_var_structure() {
 
     print_ion_var_constructor(members);
 
-    printer->end_block(";");
+    printer->pop_block(";");
 }
 
 
 void CodegenCppVisitor::print_ion_var_constructor(const std::vector<std::string>& members) {
     // constructor
     printer->add_newline();
-    printer->add_line("IonCurVar() : ", 0);
+    printer->add_indent();
+    printer->add_text("IonCurVar() : ");
     for (int i = 0; i < members.size(); i++) {
         printer->fmt_text("{}(0)", members[i]);
         if (i + 1 < members.size()) {
@@ -3155,14 +3159,14 @@ void CodegenCppVisitor::print_setup_range_variable() {
     auto type = float_data_type();
     printer->add_newline(2);
     printer->add_line("/** allocate and setup array for range variable */");
-    printer->fmt_start_block("static inline {}* setup_range_variable(double* variable, int n)",
-                             type);
+    printer->fmt_push_block("static inline {}* setup_range_variable(double* variable, int n)",
+                            type);
     printer->fmt_line("{0}* data = ({0}*) mem_alloc(n, sizeof({0}));", type);
-    printer->start_block("for(size_t i = 0; i < n; i++)");
+    printer->push_block("for(size_t i = 0; i < n; i++)");
     printer->add_line("data[i] = variable[i];");
-    printer->end_block(1);
+    printer->pop_block(1);
     printer->add_line("return data;");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
@@ -3195,8 +3199,8 @@ void CodegenCppVisitor::print_instance_variable_setup() {
 
     printer->add_newline();
     printer->add_line("// Allocate instance structure");
-    printer->fmt_start_block("static void {}(NrnThread* nt, Memb_list* ml, int type)",
-                             method_name(naming::NRN_PRIVATE_CONSTRUCTOR_METHOD));
+    printer->fmt_push_block("static void {}(NrnThread* nt, Memb_list* ml, int type)",
+                            method_name(naming::NRN_PRIVATE_CONSTRUCTOR_METHOD));
     printer->add_line("assert(!ml->instance);");
     printer->add_line("assert(!ml->global_variables);");
     printer->add_line("assert(ml->global_variables_size == 0);");
@@ -3207,7 +3211,7 @@ void CodegenCppVisitor::print_instance_variable_setup() {
     printer->add_line("ml->instance = inst;");
     printer->fmt_line("ml->global_variables = inst->{};", naming::INST_GLOBAL_MEMBER);
     printer->fmt_line("ml->global_variables_size = sizeof({});", global_struct());
-    printer->end_block(2);
+    printer->pop_block(2);
 
     auto const cast_inst_and_assert_validity = [&]() {
         printer->fmt_line("auto* const inst = static_cast<{}*>(ml->instance);", instance_struct());
@@ -3225,19 +3229,21 @@ void CodegenCppVisitor::print_instance_variable_setup() {
     print_instance_struct_transfer_routine_declarations();
 
     printer->add_line("// Deallocate the instance structure");
-    printer->fmt_start_block("static void {}(NrnThread* nt, Memb_list* ml, int type)",
-                             method_name(naming::NRN_PRIVATE_DESTRUCTOR_METHOD));
+    printer->fmt_push_block("static void {}(NrnThread* nt, Memb_list* ml, int type)",
+                            method_name(naming::NRN_PRIVATE_DESTRUCTOR_METHOD));
     cast_inst_and_assert_validity();
     print_instance_struct_delete_from_device();
-    printer->add_line("delete inst;");
-    printer->add_line("ml->instance = nullptr;");
-    printer->add_line("ml->global_variables = nullptr;");
-    printer->add_line("ml->global_variables_size = 0;");
-    printer->end_block(2);
+    printer->add_multi_line(R"CODE(
+        delete inst;
+        ml->instance = nullptr;
+        ml->global_variables = nullptr;
+        ml->global_variables_size = 0;
+    )CODE");
+    printer->pop_block(2);
 
 
     printer->add_line("/** initialize mechanism instance variables */");
-    printer->start_block("static inline void setup_instance(NrnThread* nt, Memb_list* ml)");
+    printer->push_block("static inline void setup_instance(NrnThread* nt, Memb_list* ml)");
     cast_inst_and_assert_validity();
 
     std::string stride;
@@ -3287,7 +3293,7 @@ void CodegenCppVisitor::print_instance_variable_setup() {
         ptr_members.push_back(std::move(name));
     }
     print_instance_struct_copy_to_device();
-    printer->end_block(2);  // setup_instance
+    printer->pop_block(2);  // setup_instance
 
     print_instance_struct_transfer_routines(ptr_members);
 }
@@ -3353,7 +3359,7 @@ void CodegenCppVisitor::print_global_function_common_code(BlockType type,
     }
 
     print_global_method_annotation();
-    printer->fmt_start_block("void {}({})", method, args);
+    printer->fmt_push_block("void {}({})", method, args);
     if (type != BlockType::Destructor && type != BlockType::Constructor) {
         // We do not (currently) support DESTRUCTOR and CONSTRUCTOR blocks
         // running anything on the GPU.
@@ -3363,11 +3369,13 @@ void CodegenCppVisitor::print_global_function_common_code(BlockType type,
         /// Related to https://github.com/BlueBrain/nmodl/issues/692
         printer->add_line("#ifndef CORENEURON_BUILD");
     }
-    printer->add_line("int nodecount = ml->nodecount;");
-    printer->add_line("int pnodecount = ml->_nodecount_padded;");
-    printer->add_line("const int* node_index = ml->nodeindices;");
-    printer->add_line("double* data = ml->data;");
-    printer->add_line("const double* voltage = nt->_actual_v;");
+    printer->add_multi_line(R"CODE(
+        int nodecount = ml->nodecount;
+        int pnodecount = ml->_nodecount_padded;
+        const int* node_index = ml->nodeindices;
+        double* data = ml->data;
+        const double* voltage = nt->_actual_v;
+    )CODE");
 
     if (type == BlockType::Equation) {
         printer->add_line("double* vec_rhs = nt->_actual_rhs;");
@@ -3401,13 +3409,13 @@ void CodegenCppVisitor::print_nrn_init(bool skip_init_check) {
         print_deriv_advance_flag_transfer_to_device();
         printer->fmt_line("auto ns = newtonspace{}(thread);", list_num);
         printer->fmt_line("auto& th = thread[dith{}()];", list_num);
-        printer->start_block("if (*ns == nullptr)");
+        printer->push_block("if (*ns == nullptr)");
         printer->fmt_line("int vec_size = 2*{}*pnodecount*sizeof(double);", nequation);
         printer->fmt_line("double* vec = makevector(vec_size);", nequation);
         printer->fmt_line("th.pval = vec;", list_num);
         printer->fmt_line("*ns = nrn_cons_newtonspace({}, pnodecount);", nequation);
         print_newtonspace_transfer_to_device();
-        printer->end_block(1);
+        printer->pop_block(1);
         // clang-format on
     }
 
@@ -3417,7 +3425,7 @@ void CodegenCppVisitor::print_nrn_init(bool skip_init_check) {
     print_global_variable_device_update_annotation();
 
     if (skip_init_check) {
-        printer->start_block("if (_nrn_skip_initmodel == 0)");
+        printer->push_block("if (_nrn_skip_initmodel == 0)");
     }
 
     if (!info.changed_dt.empty()) {
@@ -3430,21 +3438,21 @@ void CodegenCppVisitor::print_nrn_init(bool skip_init_check) {
     }
 
     print_channel_iteration_block_parallel_hint(BlockType::Initial, info.initial_node);
-    printer->start_block("for (int id = 0; id < nodecount; id++)");
+    printer->push_block("for (int id = 0; id < nodecount; id++)");
 
     if (info.net_receive_node != nullptr) {
         printer->fmt_line("{} = -1e20;", get_variable_name("tsave"));
     }
 
     print_initial_block(info.initial_node);
-    printer->end_block(1);
+    printer->pop_block(1);
 
     if (!info.changed_dt.empty()) {
         printer->fmt_line("{} = _save_prev_dt;", get_variable_name(naming::NTHREAD_DT_VARIABLE));
         print_dt_update_to_device();
     }
 
-    printer->end_block(1);
+    printer->pop_block(1);
 
     if (info.derivimplicit_used()) {
         printer->add_line("deriv_advance_flag = 1;");
@@ -3457,7 +3465,7 @@ void CodegenCppVisitor::print_nrn_init(bool skip_init_check) {
 
     print_kernel_data_present_annotation_block_end();
     if (skip_init_check) {
-        printer->end_block(1);
+        printer->pop_block(1);
     }
     codegen = false;
 }
@@ -3487,7 +3495,7 @@ void CodegenCppVisitor::print_before_after_block(const ast::Block* node, size_t 
     print_global_function_common_code(BlockType::BeforeAfter, function_name);
 
     print_channel_iteration_block_parallel_hint(BlockType::BeforeAfter, node);
-    printer->start_block("for (int id = 0; id < nodecount; id++)");
+    printer->push_block("for (int id = 0; id < nodecount; id++)");
 
     printer->add_line("int node_id = node_index[id];");
     printer->add_line("double v = voltage[node_id];");
@@ -3512,8 +3520,8 @@ void CodegenCppVisitor::print_before_after_block(const ast::Block* node, size_t 
     }
 
     /// loop end including data annotation block
-    printer->end_block(1);
-    printer->end_block(1);
+    printer->pop_block(1);
+    printer->pop_block(1);
     print_kernel_data_present_annotation_block_end();
 
     codegen = false;
@@ -3527,7 +3535,7 @@ void CodegenCppVisitor::print_nrn_constructor() {
         print_statement_block(*block, false, false);
     }
     printer->add_line("#endif");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
@@ -3539,7 +3547,7 @@ void CodegenCppVisitor::print_nrn_destructor() {
         print_statement_block(*block, false, false);
     }
     printer->add_line("#endif");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
@@ -3556,9 +3564,9 @@ void CodegenCppVisitor::print_functors_definitions() {
 void CodegenCppVisitor::print_nrn_alloc() {
     printer->add_newline(2);
     auto method = method_name(naming::NRN_ALLOC_METHOD);
-    printer->fmt_start_block("static void {}(double* data, Datum* indexes, int type)", method);
+    printer->fmt_push_block("static void {}(double* data, Datum* indexes, int type)", method);
     printer->add_line("// do nothing");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 /**
@@ -3574,19 +3582,19 @@ void CodegenCppVisitor::print_watch_activate() {
     printer->add_newline(2);
     auto inst = fmt::format("{}* inst", instance_struct());
 
-    printer->fmt_start_block(
+    printer->fmt_push_block(
         "static void nrn_watch_activate({}, int id, int pnodecount, int watch_id, "
         "double v, bool &watch_remove)",
         inst);
 
     // initialize all variables only during first watch statement
-    printer->start_block("if (watch_remove == false)");
+    printer->push_block("if (watch_remove == false)");
     for (int i = 0; i < info.watch_count; i++) {
         auto name = get_variable_name(fmt::format("watch{}", i + 1));
         printer->fmt_line("{} = 0;", name);
     }
     printer->add_line("watch_remove = true;");
-    printer->end_block(1);
+    printer->pop_block(1);
 
     /**
      * \todo Similar to neuron/coreneuron we are using
@@ -3594,7 +3602,7 @@ void CodegenCppVisitor::print_watch_activate() {
      */
     for (int i = 0; i < info.watch_statements.size(); i++) {
         auto statement = info.watch_statements[i];
-        printer->fmt_start_block("if (watch_id == {})", i);
+        printer->fmt_push_block("if (watch_id == {})", i);
 
         auto varname = get_variable_name(fmt::format("watch{}", i + 1));
         printer->add_indent();
@@ -3604,9 +3612,9 @@ void CodegenCppVisitor::print_watch_activate() {
         printer->add_text(");");
         printer->add_newline();
 
-        printer->end_block(1);
+        printer->pop_block(1);
     }
-    printer->end_block(1);
+    printer->pop_block(1);
     codegen = false;
 }
 
@@ -3630,7 +3638,7 @@ void CodegenCppVisitor::print_watch_check() {
     // we don't need to have ivdep pragma related check
     print_channel_iteration_block_parallel_hint(BlockType::Watch, nullptr);
 
-    printer->start_block("for (int id = 0; id < nodecount; id++)");
+    printer->push_block("for (int id = 0; id < nodecount; id++)");
 
     if (info.is_voltage_used_by_watch_statements()) {
         printer->add_line("int node_id = node_index[id];");
@@ -3643,11 +3651,11 @@ void CodegenCppVisitor::print_watch_check() {
 
     for (int i = 0; i < info.watch_statements.size(); i++) {
         auto statement = info.watch_statements[i];
-        auto watch = statement->get_statements().front();
-        auto varname = get_variable_name(fmt::format("watch{}", i + 1));
+        const auto& watch = statement->get_statements().front();
+        const auto& varname = get_variable_name(fmt::format("watch{}", i + 1));
 
         // start block 1
-        printer->fmt_start_block("if ({}&2 && watch_untriggered)", varname);
+        printer->fmt_push_block("if ({}&2 && watch_untriggered)", varname);
 
         // start block 2
         printer->add_indent();
@@ -3658,15 +3666,15 @@ void CodegenCppVisitor::print_watch_check() {
         printer->increase_indent();
 
         // start block 3
-        printer->fmt_start_block("if (({}&1) == 0)", varname);
+        printer->fmt_push_block("if (({}&1) == 0)", varname);
 
         printer->add_line("watch_untriggered = false;");
 
-        auto tqitem = get_variable_name("tqitem");
-        auto point_process = get_variable_name("point_process");
+        const auto& tqitem = get_variable_name("tqitem");
+        const auto& point_process = get_variable_name("point_process");
         printer->add_indent();
         printer->add_text("net_send_buffering(");
-        auto t = get_variable_name("t");
+        const auto& t = get_variable_name("t");
         printer->fmt_text("nt, ml->_net_send_buffer, 0, {}, -1, {}, {}+0.0, ",
                           tqitem,
                           point_process,
@@ -3674,34 +3682,37 @@ void CodegenCppVisitor::print_watch_check() {
         watch->get_value()->accept(*this);
         printer->add_text(");");
         printer->add_newline();
-        printer->end_block(1);
+        printer->pop_block(1);
 
-        printer->fmt_line("{} = 3;", varname);
+        printer->add_line(varname, " = 3;");
         // end block 3
 
         // start block 3
         printer->decrease_indent();
-        printer->start_block("} else");
-        printer->fmt_line("{} = 2;", varname);
-        printer->end_block(1);
+        printer->push_block("} else");
+        printer->add_line(varname, " = 2;");
+        printer->pop_block(1);
         // end block 3
 
-        printer->end_block(1);
+        printer->pop_block(1);
         // end block 1
     }
 
-    printer->end_block(1);
+    printer->pop_block(1);
     print_send_event_move();
     print_kernel_data_present_annotation_block_end();
-    printer->end_block(1);
+    printer->pop_block(1);
     codegen = false;
 }
 
 
 void CodegenCppVisitor::print_net_receive_common_code(const Block& node, bool need_mech_inst) {
-    printer->add_line("int tid = pnt->_tid;");
-    printer->add_line("int id = pnt->_i_instance;");
-    printer->add_line("double v = 0;");
+    printer->add_multi_line(R"CODE(
+        int tid = pnt->_tid;
+        int id = pnt->_i_instance;
+        double v = 0;
+    )CODE");
+
     if (info.artificial_cell || node.is_initial_block()) {
         printer->add_line("NrnThread* nt = nrn_threads + tid;");
         printer->add_line("Memb_list* ml = nt->_ml_list[pnt->_type];");
@@ -3710,12 +3721,14 @@ void CodegenCppVisitor::print_net_receive_common_code(const Block& node, bool ne
         print_kernel_data_present_annotation_block_begin();
     }
 
-    printer->add_line("int nodecount = ml->nodecount;");
-    printer->add_line("int pnodecount = ml->_nodecount_padded;");
-    printer->add_line("double* data = ml->data;");
-    printer->add_line("double* weights = nt->weights;");
-    printer->add_line("Datum* indexes = ml->pdata;");
-    printer->add_line("ThreadDatum* thread = ml->_thread;");
+    printer->add_multi_line(R"CODE(
+        int nodecount = ml->nodecount;
+        int pnodecount = ml->_nodecount_padded;
+        double* data = ml->data;
+        double* weights = nt->weights;
+        Datum* indexes = ml->pdata;
+        ThreadDatum* thread = ml->_thread;
+    )CODE");
     if (need_mech_inst) {
         printer->fmt_line("auto* const inst = static_cast<{0}*>(ml->instance);", instance_struct());
     }
@@ -3745,7 +3758,7 @@ void CodegenCppVisitor::print_net_receive_common_code(const Block& node, bool ne
 
 void CodegenCppVisitor::print_net_send_call(const FunctionCall& node) {
     auto const& arguments = node.get_arguments();
-    auto tqitem = get_variable_name("tqitem");
+    const auto& tqitem = get_variable_name("tqitem");
     std::string weight_index = "weight_index";
     std::string pnt = "pnt";
 
@@ -3764,14 +3777,14 @@ void CodegenCppVisitor::print_net_send_call(const FunctionCall& node) {
     if (info.artificial_cell) {
         printer->fmt_text("artcell_net_send(&{}, {}, {}, nt->_t+", tqitem, weight_index, pnt);
     } else {
-        auto point_process = get_variable_name("point_process");
-        std::string t = get_variable_name("t");
+        const auto& point_process = get_variable_name("point_process");
+        const auto& t = get_variable_name("t");
         printer->add_text("net_send_buffering(");
         printer->fmt_text("nt, ml->_net_send_buffer, 0, {}, {}, {}, {}+", tqitem, weight_index, point_process, t);
     }
     // clang-format off
     print_vector_elements(arguments, ", ");
-    printer->add_text(")");
+    printer->add_text(')');
 }
 
 
@@ -3781,7 +3794,7 @@ void CodegenCppVisitor::print_net_move_call(const FunctionCall& node) {
     }
 
     auto const& arguments = node.get_arguments();
-    auto tqitem = get_variable_name("tqitem");
+    const auto& tqitem = get_variable_name("tqitem");
     std::string weight_index = "-1";
     std::string pnt = "pnt";
 
@@ -3792,7 +3805,7 @@ void CodegenCppVisitor::print_net_move_call(const FunctionCall& node) {
         print_vector_elements(arguments, ", ");
         printer->add_text(")");
     } else {
-        auto point_process = get_variable_name("point_process");
+        const auto& point_process = get_variable_name("point_process");
         printer->add_text("net_send_buffering(");
         printer->fmt_text("nt, ml->_net_send_buffer, 2, {}, {}, {}, ", tqitem, weight_index, point_process);
         print_vector_elements(arguments, ", ");
@@ -3808,7 +3821,7 @@ void CodegenCppVisitor::print_net_event_call(const FunctionCall& node) {
         printer->add_text("net_event(pnt, ");
         print_vector_elements(arguments, ", ");
     } else {
-        auto point_process = get_variable_name("point_process");
+        const auto& point_process = get_variable_name("point_process");
         printer->add_text("net_send_buffering(");
         printer->fmt_text("nt, ml->_net_send_buffer, 1, -1, -1, {}, ", point_process);
         print_vector_elements(arguments, ", ");
@@ -3842,9 +3855,9 @@ void CodegenCppVisitor::print_net_event_call(const FunctionCall& node) {
  * So, the `R` in AST needs to be renamed with `(*R)`.
  */
 static void rename_net_receive_arguments(const ast::NetReceiveBlock& net_receive_node, const ast::Node& node) {
-    auto parameters = net_receive_node.get_parameters();
+    const auto& parameters = net_receive_node.get_parameters();
     for (auto& parameter: parameters) {
-        auto name = parameter->get_node_name();
+        const auto& name = parameter->get_node_name();
         auto var_used = VarUsageVisitor().variable_used(node, name);
         if (var_used) {
             RenameVisitor vr(name, "(*" + name + ")");
@@ -3868,7 +3881,7 @@ void CodegenCppVisitor::print_net_init() {
     auto args = "Point_process* pnt, int weight_index, double flag";
     printer->add_newline(2);
     printer->add_line("/** initialize block for net receive */");
-    printer->fmt_start_block("static void net_init({})", args);
+    printer->fmt_push_block("static void net_init({})", args);
     auto block = node->get_statement_block().get();
     if (block->get_statements().empty()) {
         printer->add_line("// do nothing");
@@ -3882,7 +3895,7 @@ void CodegenCppVisitor::print_net_init() {
             print_net_send_buf_update_to_host();
         }
     }
-    printer->end_block(1);
+    printer->pop_block(1);
     codegen = false;
     printing_net_init = false;
 }
@@ -3892,16 +3905,18 @@ void CodegenCppVisitor::print_send_event_move() {
     printer->add_newline();
     printer->add_line("NetSendBuffer_t* nsb = ml->_net_send_buffer;");
     print_net_send_buf_update_to_host();
-    printer->start_block("for (int i=0; i < nsb->_cnt; i++)");
-    printer->add_line("int type = nsb->_sendtype[i];");
-    printer->add_line("int tid = nt->id;");
-    printer->add_line("double t = nsb->_nsb_t[i];");
-    printer->add_line("double flag = nsb->_nsb_flag[i];");
-    printer->add_line("int vdata_index = nsb->_vdata_index[i];");
-    printer->add_line("int weight_index = nsb->_weight_index[i];");
-    printer->add_line("int point_index = nsb->_pnt_index[i];");
-    printer->add_line("net_sem_from_gpu(type, vdata_index, weight_index, tid, point_index, t, flag);");
-    printer->end_block(1);
+    printer->push_block("for (int i=0; i < nsb->_cnt; i++)");
+    printer->add_multi_line(R"CODE(
+        int type = nsb->_sendtype[i];
+        int tid = nt->id;
+        double t = nsb->_nsb_t[i];
+        double flag = nsb->_nsb_flag[i];
+        int vdata_index = nsb->_vdata_index[i];
+        int weight_index = nsb->_weight_index[i];
+        int point_index = nsb->_pnt_index[i];
+        net_sem_from_gpu(type, vdata_index, weight_index, tid, point_index, t, flag);
+    )CODE");
+    printer->pop_block(1);
     printer->add_line("nsb->_cnt = 0;");
     print_net_send_buf_count_update_to_device();
 }
@@ -3914,21 +3929,21 @@ std::string CodegenCppVisitor::net_receive_buffering_declaration() {
 
 void CodegenCppVisitor::print_get_memb_list() {
     printer->add_line("Memb_list* ml = get_memb_list(nt);");
-    printer->start_block("if (!ml)");
+    printer->push_block("if (!ml)");
     printer->add_line("return;");
-    printer->end_block(2);
+    printer->pop_block(2);
 }
 
 
 void CodegenCppVisitor::print_net_receive_loop_begin() {
     printer->add_line("int count = nrb->_displ_cnt;");
     print_channel_iteration_block_parallel_hint(BlockType::NetReceive, info.net_receive_node);
-    printer->start_block("for (int i = 0; i < count; i++)");
+    printer->push_block("for (int i = 0; i < count; i++)");
 }
 
 
 void CodegenCppVisitor::print_net_receive_loop_end() {
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
@@ -3937,11 +3952,11 @@ void CodegenCppVisitor::print_net_receive_buffering(bool need_mech_inst) {
         return;
     }
     printer->add_newline(2);
-    printer->start_block(net_receive_buffering_declaration());
+    printer->push_block(net_receive_buffering_declaration());
 
     print_get_memb_list();
 
-    auto net_receive = method_name("net_receive_kernel");
+    const auto& net_receive = method_name("net_receive_kernel");
 
     print_kernel_data_present_annotation_block_begin();
 
@@ -3952,15 +3967,17 @@ void CodegenCppVisitor::print_net_receive_buffering(bool need_mech_inst) {
     print_net_receive_loop_begin();
     printer->add_line("int start = nrb->_displ[i];");
     printer->add_line("int end = nrb->_displ[i+1];");
-    printer->start_block("for (int j = start; j < end; j++)");
-    printer->add_line("int index = nrb->_nrb_index[j];");
-    printer->add_line("int offset = nrb->_pnt_index[index];");
-    printer->add_line("double t = nrb->_nrb_t[index];");
-    printer->add_line("int weight_index = nrb->_weight_index[index];");
-    printer->add_line("double flag = nrb->_nrb_flag[index];");
-    printer->add_line("Point_process* point_process = nt->pntprocs + offset;");
-    printer->fmt_line("{}(t, point_process, inst, nt, ml, weight_index, flag);", net_receive);
-    printer->end_block(1);
+    printer->push_block("for (int j = start; j < end; j++)");
+    printer->add_multi_line(R"CODE(
+        int index = nrb->_nrb_index[j];
+        int offset = nrb->_pnt_index[index];
+        double t = nrb->_nrb_t[index];
+        int weight_index = nrb->_weight_index[index];
+        double flag = nrb->_nrb_flag[index];
+        Point_process* point_process = nt->pntprocs + offset;
+    )CODE");
+    printer->add_line(net_receive, "(t, point_process, inst, nt, ml, weight_index, flag);");
+    printer->pop_block(1);
     print_net_receive_loop_end();
 
     print_device_stream_wait();
@@ -3972,7 +3989,7 @@ void CodegenCppVisitor::print_net_receive_buffering(bool need_mech_inst) {
     }
 
     print_kernel_data_present_annotation_block_end();
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 void CodegenCppVisitor::print_net_send_buffering_cnt_update() const {
@@ -3980,9 +3997,9 @@ void CodegenCppVisitor::print_net_send_buffering_cnt_update() const {
 }
 
 void CodegenCppVisitor::print_net_send_buffering_grow() {
-    printer->start_block("if (i >= nsb->_size)");
+    printer->push_block("if (i >= nsb->_size)");
     printer->add_line("nsb->grow();");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 void CodegenCppVisitor::print_net_send_buffering() {
@@ -3995,19 +4012,21 @@ void CodegenCppVisitor::print_net_send_buffering() {
     auto args =
         "const NrnThread* nt, NetSendBuffer_t* nsb, int type, int vdata_index, "
         "int weight_index, int point_index, double t, double flag";
-    printer->fmt_start_block("static inline void net_send_buffering({})", args);
+    printer->fmt_push_block("static inline void net_send_buffering({})", args);
     printer->add_line("int i = 0;");
     print_net_send_buffering_cnt_update();
     print_net_send_buffering_grow();
-    printer->start_block("if (i < nsb->_size)");
-    printer->add_line("nsb->_sendtype[i] = type;");
-    printer->add_line("nsb->_vdata_index[i] = vdata_index;");
-    printer->add_line("nsb->_weight_index[i] = weight_index;");
-    printer->add_line("nsb->_pnt_index[i] = point_index;");
-    printer->add_line("nsb->_nsb_t[i] = t;");
-    printer->add_line("nsb->_nsb_flag[i] = flag;");
-    printer->end_block(1);
-    printer->end_block(1);
+    printer->push_block("if (i < nsb->_size)");
+    printer->add_multi_line(R"CODE(
+         nsb->_sendtype[i] = type;
+         nsb->_vdata_index[i] = vdata_index;
+         nsb->_weight_index[i] = weight_index;
+         nsb->_pnt_index[i] = point_index;
+         nsb->_nsb_t[i] = t;
+         nsb->_nsb_flag[i] = flag;
+    )CODE");
+    printer->pop_block(1);
+    printer->pop_block(1);
 }
 
 
@@ -4023,7 +4042,7 @@ void CodegenCppVisitor::visit_for_netcon(const ast::ForNetcon& node) {
         // sanitize node_name since we want to substitute names like (*w) as they are
         auto old_name =
             std::regex_replace(args[i_arg]->get_node_name(), regex_special_chars, R"(\$&)");
-        auto new_name = fmt::format("weights[{} + nt->_fornetcon_weight_perm[i]]", i_arg);
+        const auto& new_name = fmt::format("weights[{} + nt->_fornetcon_weight_perm[i]]", i_arg);
         v.set(old_name, new_name);
         statement_block->accept(v);
     }
@@ -4060,7 +4079,7 @@ void CodegenCppVisitor::print_net_receive_kernel() {
     rename_net_receive_arguments(*info.net_receive_node, *node);
 
     std::string name;
-    auto params = ParamVector();
+    ParamVector params;
     if (!info.artificial_cell) {
         name = method_name("net_receive_kernel");
         params.emplace_back("", "double", "", "t");
@@ -4079,7 +4098,7 @@ void CodegenCppVisitor::print_net_receive_kernel() {
     }
 
     printer->add_newline(2);
-    printer->fmt_start_block("static inline void {}({})", name, get_parameter_str(params));
+    printer->fmt_push_block("static inline void {}({})", name, get_parameter_str(params));
     print_net_receive_common_code(*node, info.artificial_cell);
     if (info.artificial_cell) {
         printer->add_line("double t = nt->_t;");
@@ -4101,7 +4120,7 @@ void CodegenCppVisitor::print_net_receive_kernel() {
     printer->add_indent();
     node->get_statement_block()->accept(*this);
     printer->add_newline();
-    printer->end_block();
+    printer->pop_block();
     printer->add_newline();
 
     printing_net_receive = false;
@@ -4116,26 +4135,28 @@ void CodegenCppVisitor::print_net_receive() {
     codegen = true;
     printing_net_receive = true;
     if (!info.artificial_cell) {
-        std::string name = method_name("net_receive");
-        auto params = ParamVector();
+        const auto& name = method_name("net_receive");
+        ParamVector params;
         params.emplace_back("", "Point_process*", "", "pnt");
         params.emplace_back("", "int", "", "weight_index");
         params.emplace_back("", "double", "", "flag");
         printer->add_newline(2);
-        printer->fmt_start_block("static void {}({})", name, get_parameter_str(params));
+        printer->fmt_push_block("static void {}({})", name, get_parameter_str(params));
         printer->add_line("NrnThread* nt = nrn_threads + pnt->_tid;");
         printer->add_line("Memb_list* ml = get_memb_list(nt);");
         printer->add_line("NetReceiveBuffer_t* nrb = ml->_net_receive_buffer;");
-        printer->start_block("if (nrb->_cnt >= nrb->_size)");
+        printer->push_block("if (nrb->_cnt >= nrb->_size)");
         printer->add_line("realloc_net_receive_buffer(nt, ml);");
-        printer->end_block(1);
-        printer->add_line("int id = nrb->_cnt;");
-        printer->add_line("nrb->_pnt_index[id] = pnt-nt->pntprocs;");
-        printer->add_line("nrb->_weight_index[id] = weight_index;");
-        printer->add_line("nrb->_nrb_t[id] = nt->_t;");
-        printer->add_line("nrb->_nrb_flag[id] = flag;");
-        printer->add_line("nrb->_cnt++;");
-        printer->end_block(1);
+        printer->pop_block(1);
+        printer->add_multi_line(R"CODE(
+            int id = nrb->_cnt;
+            nrb->_pnt_index[id] = pnt-nt->pntprocs;
+            nrb->_weight_index[id] = weight_index;
+            nrb->_nrb_t[id] = nt->_t;
+            nrb->_nrb_flag[id] = flag;
+            nrb->_cnt++;
+        )CODE");
+        printer->pop_block(1);
     }
     printing_net_receive = false;
     codegen = false;
@@ -4149,20 +4170,20 @@ void CodegenCppVisitor::print_net_receive() {
  * actual variable names? [resolved now?]
  * slist needs to added as local variable
  */
-void CodegenCppVisitor::print_derivimplicit_kernel(Block* block) {
+void CodegenCppVisitor::print_derivimplicit_kernel(const Block& block) {
     auto ext_args = external_method_arguments();
     auto ext_params = external_method_parameters();
     auto suffix = info.mod_suffix;
     auto list_num = info.derivimplicit_list_num;
-    auto block_name = block->get_node_name();
+    auto block_name = block.get_node_name();
     auto primes_size = info.primes_size;
     auto stride = "*pnodecount+id";
 
     printer->add_newline(2);
 
-    printer->start_block("namespace");
-    printer->fmt_start_block("struct _newton_{}_{}", block_name, info.mod_suffix);
-    printer->fmt_start_block("int operator()({}) const", external_method_parameters());
+    printer->push_block("namespace");
+            printer->fmt_push_block("struct _newton_{}_{}", block_name, info.mod_suffix);
+            printer->fmt_push_block("int operator()({}) const", external_method_parameters());
     auto const instance = fmt::format("auto* const inst = static_cast<{0}*>(ml->instance);",
                                       instance_struct());
     auto const slist1 = fmt::format("auto const& slist{} = {};",
@@ -4190,37 +4211,37 @@ void CodegenCppVisitor::print_derivimplicit_kernel(Block* block) {
     printer->add_line(dlist1);
     printer->add_line(dlist2);
     codegen = true;
-    print_statement_block(*block->get_statement_block(), false, false);
+    print_statement_block(*block.get_statement_block(), false, false);
     codegen = false;
     printer->add_line("int counter = -1;");
-    printer->fmt_start_block("for (int i=0; i<{}; i++)", info.num_primes);
-    printer->fmt_start_block("if (*deriv{}_advance(thread))", list_num);
+            printer->fmt_push_block("for (int i=0; i<{}; i++)", info.num_primes);
+            printer->fmt_push_block("if (*deriv{}_advance(thread))", list_num);
     printer->fmt_line(
         "dlist{0}[(++counter){1}] = "
         "data[dlist{2}[i]{1}]-(data[slist{2}[i]{1}]-savstate{2}[i{1}])/nt->_dt;",
         list_num + 1,
         stride,
         list_num);
-    printer->restart_block("else");
+            printer->chain_block("else");
     printer->fmt_line("dlist{0}[(++counter){1}] = data[slist{2}[i]{1}]-savstate{2}[i{1}];",
                       list_num + 1,
                       stride,
                       list_num);
-    printer->end_block(1);
-    printer->end_block(1);
+    printer->pop_block(1);
+    printer->pop_block(1);
     printer->add_line("return 0;");
-    printer->end_block(1);  // operator()
-    printer->end_block(";");   // struct
-    printer->end_block(2);  // namespace
-    printer->fmt_start_block("int {}_{}({})", block_name, suffix, ext_params);
+    printer->pop_block(1);  // operator()
+    printer->pop_block(";");   // struct
+    printer->pop_block(2);  // namespace
+    printer->fmt_push_block("int {}_{}({})", block_name, suffix, ext_params);
     printer->add_line(instance);
     printer->fmt_line("double* savstate{} = (double*) thread[dith{}()].pval;", list_num, list_num);
     printer->add_line(slist1);
     printer->add_line(slist2);
     printer->add_line(dlist2);
-    printer->fmt_start_block("for (int i=0; i<{}; i++)", info.num_primes);
+    printer->fmt_push_block("for (int i=0; i<{}; i++)", info.num_primes);
     printer->fmt_line("savstate{}[i{}] = data[slist{}[i]{}];", list_num, stride, list_num, stride);
-    printer->end_block(1);
+    printer->pop_block(1);
     printer->fmt_line(
         "int reset = nrn_newton_thread(static_cast<NewtonSpace*>(*newtonspace{}(thread)), {}, "
         "slist{}, _newton_{}_{}{{}}, dlist{}, {});",
@@ -4232,7 +4253,7 @@ void CodegenCppVisitor::print_derivimplicit_kernel(Block* block) {
         list_num + 1,
         ext_args);
     printer->add_line("return reset;");
-    printer->end_block(3);
+    printer->pop_block(3);
 }
 
 
@@ -4277,7 +4298,7 @@ void CodegenCppVisitor::print_nrn_state() {
     printer->add_line("/** update state */");
     print_global_function_common_code(BlockType::State);
     print_channel_iteration_block_parallel_hint(BlockType::State, info.nrn_state_block);
-    printer->start_block("for (int id = 0; id < nodecount; id++)");
+    printer->push_block("for (int id = 0; id < nodecount; id++)");
 
     printer->add_line("int node_id = node_index[id];");
     printer->add_line("double v = voltage[node_id];");
@@ -4305,16 +4326,16 @@ void CodegenCppVisitor::print_nrn_state() {
         print_statement_block(*block, false, false);
     }
 
-    auto write_statements = ion_write_statements(BlockType::State);
+    const auto& write_statements = ion_write_statements(BlockType::State);
     for (auto& statement: write_statements) {
-        auto text = process_shadow_update_statement(statement, BlockType::State);
+        const auto& text = process_shadow_update_statement(statement, BlockType::State);
         printer->add_line(text);
     }
-    printer->end_block(1);
+    printer->pop_block(1);
 
     print_kernel_data_present_annotation_block_end();
 
-    printer->end_block(1);
+    printer->pop_block(1);
     codegen = false;
 }
 
@@ -4325,21 +4346,21 @@ void CodegenCppVisitor::print_nrn_state() {
 
 
 void CodegenCppVisitor::print_nrn_current(const BreakpointBlock& node) {
-    auto args = internal_method_parameters();
+    const auto& args = internal_method_parameters();
     const auto& block = node.get_statement_block();
     printer->add_newline(2);
     print_device_method_annotation();
-    printer->fmt_start_block("inline double nrn_current_{}({})",
-                             info.mod_suffix,
-                             get_parameter_str(args));
+            printer->fmt_push_block("inline double nrn_current_{}({})",
+                                    info.mod_suffix,
+                                    get_parameter_str(args));
     printer->add_line("double current = 0.0;");
     print_statement_block(*block, false, false);
     for (auto& current: info.currents) {
-        auto name = get_variable_name(current);
+        const auto& name = get_variable_name(current);
         printer->fmt_line("current += {};", name);
     }
     printer->add_line("return current;");
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 
@@ -4370,10 +4391,10 @@ void CodegenCppVisitor::print_nrn_cur_conductance_kernel(const BreakpointBlock& 
 
     for (const auto& conductance: info.conductances) {
         if (!conductance.ion.empty()) {
-            auto lhs = std::string(naming::ION_VARNAME_PREFIX) + "di" + conductance.ion + "dv";
-            auto rhs = get_variable_name(conductance.variable);
-            ShadowUseStatement statement{lhs, "+=", rhs};
-            auto text = process_shadow_update_statement(statement, BlockType::Equation);
+            const auto& lhs = std::string(naming::ION_VARNAME_PREFIX) + "di" + conductance.ion + "dv";
+            const auto& rhs = get_variable_name(conductance.variable);
+            const ShadowUseStatement statement{lhs, "+=", rhs};
+            const auto& text = process_shadow_update_statement(statement, BlockType::Equation);
             printer->add_line(text);
         }
     }
@@ -4387,7 +4408,7 @@ void CodegenCppVisitor::print_nrn_cur_non_conductance_kernel() {
     for (auto& ion: info.ions) {
         for (auto& var: ion.writes) {
             if (ion.is_ionic_current(var)) {
-                auto name = get_variable_name(var);
+                const auto& name = get_variable_name(var);
                 printer->fmt_line("double di{} = {};", ion.name, name);
             }
         }
@@ -4399,14 +4420,14 @@ void CodegenCppVisitor::print_nrn_cur_non_conductance_kernel() {
     for (auto& ion: info.ions) {
         for (auto& var: ion.writes) {
             if (ion.is_ionic_current(var)) {
-                auto lhs = std::string(naming::ION_VARNAME_PREFIX) + "di" + ion.name + "dv";
+                const auto& lhs = std::string(naming::ION_VARNAME_PREFIX) + "di" + ion.name + "dv";
                 auto rhs = fmt::format("(di{}-{})/0.001", ion.name, get_variable_name(var));
                 if (info.point_process) {
                     auto area = get_variable_name(naming::NODE_AREA_VARIABLE);
                     rhs += fmt::format("*1.e2/{}", area);
                 }
-                ShadowUseStatement statement{lhs, "+=", rhs};
-                auto text = process_shadow_update_statement(statement, BlockType::Equation);
+                const ShadowUseStatement statement{lhs, "+=", rhs};
+                const auto& text = process_shadow_update_statement(statement, BlockType::Equation);
                 printer->add_line(text);
             }
         }
@@ -4422,7 +4443,7 @@ void CodegenCppVisitor::print_nrn_cur_kernel(const BreakpointBlock& node) {
         print_ion_variable();
     }
 
-    auto read_statements = ion_read_statements(BlockType::Equation);
+    const auto& read_statements = ion_read_statements(BlockType::Equation);
     for (auto& statement: read_statements) {
         printer->add_line(statement);
     }
@@ -4433,14 +4454,14 @@ void CodegenCppVisitor::print_nrn_cur_kernel(const BreakpointBlock& node) {
         print_nrn_cur_conductance_kernel(node);
     }
 
-    auto write_statements = ion_write_statements(BlockType::Equation);
+    const auto& write_statements = ion_write_statements(BlockType::Equation);
     for (auto& statement: write_statements) {
         auto text = process_shadow_update_statement(statement, BlockType::Equation);
         printer->add_line(text);
     }
 
     if (info.point_process) {
-        auto area = get_variable_name(naming::NODE_AREA_VARIABLE);
+        const auto& area = get_variable_name(naming::NODE_AREA_VARIABLE);
         printer->fmt_line("double mfactor = 1.e2/{};", area);
         printer->add_line("g = g*mfactor;");
         printer->add_line("rhs = rhs*mfactor;");
@@ -4464,17 +4485,17 @@ void CodegenCppVisitor::print_fast_imem_calculation() {
         d = "g";
     }
 
-    printer->start_block("if (nt->nrn_fast_imem)");
+    printer->push_block("if (nt->nrn_fast_imem)");
     if (nrn_cur_reduction_loop_required()) {
-        printer->start_block("for (int id = 0; id < nodecount; id++)");
+        printer->push_block("for (int id = 0; id < nodecount; id++)");
         printer->add_line("int node_id = node_index[id];");
     }
     printer->fmt_line("nt->nrn_fast_imem->nrn_sav_rhs[node_id] {} {};", rhs_op, rhs);
     printer->fmt_line("nt->nrn_fast_imem->nrn_sav_d[node_id] {} {};", d_op, d);
     if (nrn_cur_reduction_loop_required()) {
-        printer->end_block(1);
+        printer->pop_block(1);
     }
-    printer->end_block(1);
+    printer->pop_block(1);
 }
 
 void CodegenCppVisitor::print_nrn_cur() {
@@ -4491,23 +4512,23 @@ void CodegenCppVisitor::print_nrn_cur() {
     printer->add_line("/** update current */");
     print_global_function_common_code(BlockType::Equation);
     print_channel_iteration_block_parallel_hint(BlockType::Equation, info.breakpoint_node);
-    printer->start_block("for (int id = 0; id < nodecount; id++)");
+    printer->push_block("for (int id = 0; id < nodecount; id++)");
     print_nrn_cur_kernel(*info.breakpoint_node);
     print_nrn_cur_matrix_shadow_update();
     if (!nrn_cur_reduction_loop_required()) {
         print_fast_imem_calculation();
     }
-    printer->end_block(1);
+    printer->pop_block(1);
 
     if (nrn_cur_reduction_loop_required()) {
-        printer->start_block("for (int id = 0; id < nodecount; id++)");
+        printer->push_block("for (int id = 0; id < nodecount; id++)");
         print_nrn_cur_matrix_shadow_reduction();
-        printer->end_block(1);
+        printer->pop_block(1);
         print_fast_imem_calculation();
     }
 
     print_kernel_data_present_annotation_block_end();
-    printer->end_block(1);
+    printer->pop_block(1);
     codegen = false;
 }
 
@@ -4545,9 +4566,9 @@ void CodegenCppVisitor::print_common_getters() {
 }
 
 
-void CodegenCppVisitor::print_data_structures(bool print_initialisers) {
-    print_mechanism_global_var_structure(print_initialisers);
-    print_mechanism_range_var_structure(print_initialisers);
+void CodegenCppVisitor::print_data_structures(bool print_initializers) {
+    print_mechanism_global_var_structure(print_initializers);
+    print_mechanism_range_var_structure(print_initializers);
     print_ion_var_structure();
 }
 
@@ -4555,15 +4576,19 @@ void CodegenCppVisitor::print_v_unused() const {
     if (!info.vectorize) {
         return;
     }
-    printer->add_line("#if NRN_PRCELLSTATE");
-    printer->add_line("inst->v_unused[id] = v;");
-    printer->add_line("#endif");
+    printer->add_multi_line(R"CODE(
+        #if NRN_PRCELLSTATE
+        inst->v_unused[id] = v;
+        #endif
+    )CODE");
 }
 
 void CodegenCppVisitor::print_g_unused() const {
-    printer->add_line("#if NRN_PRCELLSTATE");
-    printer->add_line("inst->g_unused[id] = g;");
-    printer->add_line("#endif");
+    printer->add_multi_line(R"CODE(
+        #if NRN_PRCELLSTATE
+        inst->g_unused[id] = g;
+        #endif
+    )CODE");
 }
 
 void CodegenCppVisitor::print_compute_functions() {
@@ -4581,7 +4606,7 @@ void CodegenCppVisitor::print_compute_functions() {
         print_before_after_block(info.before_after_blocks[i], i);
     }
     for (const auto& callback: info.derivimplicit_callbacks) {
-        auto block = callback->get_node_to_solve().get();
+        const auto& block = *callback->get_node_to_solve();
         print_derivimplicit_kernel(block);
     }
     print_net_send_buffering();
@@ -4630,7 +4655,7 @@ void CodegenCppVisitor::print_wrapper_routines() {
 }
 
 
-void CodegenCppVisitor::set_codegen_global_variables(std::vector<SymbolType>& global_vars) {
+void CodegenCppVisitor::set_codegen_global_variables(const std::vector<SymbolType>& global_vars) {
     codegen_global_variables = global_vars;
 }
 

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -40,7 +40,6 @@ using visitor::SymtabVisitor;
 using visitor::VarUsageVisitor;
 
 using symtab::syminfo::NmodlType;
-// using SymbolType = std::shared_ptr<symtab::Symbol>;
 
 /****************************************************************************************/
 /*                            Overloaded visitor routines                               */

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -2491,7 +2491,7 @@ void CodegenCppVisitor::print_coreneuron_includes() {
  */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void CodegenCppVisitor::print_mechanism_global_var_structure(bool print_initializers) {
-    const auto value_initialise = print_initializers ? "{}" : "";
+    const auto value_initialize = print_initializers ? "{}" : "";
     const auto qualifier = global_var_struct_type_qualifier();
 
     auto float_type = default_float_data_type();
@@ -2501,12 +2501,12 @@ void CodegenCppVisitor::print_mechanism_global_var_structure(bool print_initiali
 
     for (const auto& ion: info.ions) {
         auto name = fmt::format("{}_type", ion.name);
-        printer->fmt_line("{}int {}{};", qualifier, name, value_initialise);
+        printer->fmt_line("{}int {}{};", qualifier, name, value_initialize);
         codegen_global_variables.push_back(make_symbol(name));
     }
 
     if (info.point_process) {
-        printer->fmt_line("{}int point_type{};", qualifier, value_initialise);
+        printer->fmt_line("{}int point_type{};", qualifier, value_initialize);
         codegen_global_variables.push_back(make_symbol("point_type"));
     }
 
@@ -2514,7 +2514,7 @@ void CodegenCppVisitor::print_mechanism_global_var_structure(bool print_initiali
         auto name = var->get_name() + "0";
         auto symbol = program_symtab->lookup(name);
         if (symbol == nullptr) {
-            printer->fmt_line("{}{} {}{};", qualifier, float_type, name, value_initialise);
+            printer->fmt_line("{}{} {}{};", qualifier, float_type, name, value_initialize);
             codegen_global_variables.push_back(make_symbol(name));
         }
     }
@@ -2545,7 +2545,7 @@ void CodegenCppVisitor::print_mechanism_global_var_structure(bool print_initiali
     }
 
     if (!info.thread_variables.empty()) {
-        printer->fmt_line("{}int thread_data_in_use{};", qualifier, value_initialise);
+        printer->fmt_line("{}int thread_data_in_use{};", qualifier, value_initialize);
         printer->fmt_line("{}{} thread_data[{}] /* TODO init thread_data */;",
                           qualifier,
                           float_type,
@@ -2557,10 +2557,10 @@ void CodegenCppVisitor::print_mechanism_global_var_structure(bool print_initiali
     }
 
     // TODO: remove this entirely?
-    printer->fmt_line("{}int reset{};", qualifier, value_initialise);
+    printer->fmt_line("{}int reset{};", qualifier, value_initialize);
     codegen_global_variables.push_back(make_symbol("reset"));
 
-    printer->fmt_line("{}int mech_type{};", qualifier, value_initialise);
+    printer->fmt_line("{}int mech_type{};", qualifier, value_initialize);
     codegen_global_variables.push_back(make_symbol("mech_type"));
 
     for (const auto& var: info.global_variables) {
@@ -2644,9 +2644,9 @@ void CodegenCppVisitor::print_mechanism_global_var_structure(bool print_initiali
         codegen_global_variables.push_back(make_symbol(naming::USE_TABLE_VARIABLE));
 
         for (const auto& block: info.functions_with_table) {
-            auto name = block->get_node_name();
-            printer->fmt_line("{}{} tmin_{}{};", qualifier, float_type, name, value_initialise);
-            printer->fmt_line("{}{} mfac_{}{};", qualifier, float_type, name, value_initialise);
+            const auto& name = block->get_node_name();
+            printer->fmt_line("{}{} tmin_{}{};", qualifier, float_type, name, value_initialize);
+            printer->fmt_line("{}{} mfac_{}{};", qualifier, float_type, name, value_initialize);
             codegen_global_variables.push_back(make_symbol("tmin_" + name));
             codegen_global_variables.push_back(make_symbol("mfac_" + name));
         }
@@ -2662,10 +2662,10 @@ void CodegenCppVisitor::print_mechanism_global_var_structure(bool print_initiali
                                   name,
                                   array_len,
                                   num_values,
-                                  value_initialise);
+                                  value_initialize);
             } else {
                 printer->fmt_line(
-                    "{}{} {}[{}]{};", qualifier, float_type, name, num_values, value_initialise);
+                        "{}{} {}[{}]{};", qualifier, float_type, name, num_values, value_initialize);
             }
             codegen_global_variables.push_back(make_symbol(name));
         }
@@ -2680,7 +2680,7 @@ void CodegenCppVisitor::print_mechanism_global_var_structure(bool print_initiali
         printer->fmt_line("{}ThreadDatum ext_call_thread[{}]{};",
                           qualifier,
                           info.thread_data_index,
-                          value_initialise);
+                          value_initialize);
         codegen_global_variables.push_back(make_symbol("ext_call_thread"));
     }
 
@@ -3058,7 +3058,7 @@ void CodegenCppVisitor::print_thread_memory_callbacks() {
 
 
 void CodegenCppVisitor::print_mechanism_range_var_structure(bool print_initializers) {
-    auto const value_initialise = print_initializers ? "{}" : "";
+    auto const value_initialize = print_initializers ? "{}" : "";
     auto int_type = default_int_data_type();
     printer->add_newline(2);
     printer->add_line("/** all mechanism instance variables and global variables */");
@@ -3073,20 +3073,20 @@ void CodegenCppVisitor::print_mechanism_range_var_structure(bool print_initializ
                                              : std::string{});
     }
     for (auto& var: codegen_float_variables) {
-        auto name = var->get_name();
+        const auto& name = var->get_name();
         auto type = get_range_var_float_type(var);
         auto qualifier = is_constant_variable(name) ? "const " : "";
-        printer->fmt_line("{}{}* {}{};", qualifier, type, name, value_initialise);
+        printer->fmt_line("{}{}* {}{};", qualifier, type, name, value_initialize);
     }
     for (auto& var: codegen_int_variables) {
-        auto name = var.symbol->get_name();
+        const auto& name = var.symbol->get_name();
         if (var.is_index || var.is_integer) {
             auto qualifier = var.is_constant ? "const " : "";
-            printer->fmt_line("{}{}* {}{};", qualifier, int_type, name, value_initialise);
+            printer->fmt_line("{}{}* {}{};", qualifier, int_type, name, value_initialize);
         } else {
             auto qualifier = var.is_constant ? "const " : "";
             auto type = var.is_vdata ? "void*" : default_float_data_type();
-            printer->fmt_line("{}{}* {}{};", qualifier, type, name, value_initialise);
+            printer->fmt_line("{}{}* {}{};", qualifier, type, name, value_initialize);
         }
     }
 

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -329,7 +329,7 @@ void CodegenCppVisitor::visit_mutex_lock(const ast::MutexLock& node) {
 }
 
 void CodegenCppVisitor::visit_mutex_unlock(const ast::MutexUnlock& node) {
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 /****************************************************************************************/
@@ -1176,12 +1176,12 @@ void CodegenCppVisitor::print_memory_allocation_routine() const {
     printer->add_line("posix_memalign(&ptr, alignment, num*size);");
     printer->add_line("memset(ptr, 0, size);");
     printer->add_line("return ptr;");
-    printer->pop_block(1);
+    printer->pop_block();
 
     printer->add_newline(2);
     printer->push_block("static inline void mem_free(void* ptr)");
     printer->add_line("free(ptr);");
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -1189,7 +1189,7 @@ void CodegenCppVisitor::print_abort_routine() const {
     printer->add_newline(2);
     printer->push_block("static inline void coreneuron_abort()");
     printer->add_line("abort();");
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -1262,7 +1262,7 @@ void CodegenCppVisitor::print_statement_block(const ast::StatementBlock& node,
     }
 
     if (close_brace) {
-        printer->pop_block();
+        printer->pop_block_nl(0);
     }
 }
 
@@ -1425,7 +1425,7 @@ void CodegenCppVisitor::print_table_check_function(const Block& node) {
     {
         printer->fmt_push_block("if ({} == 0)", use_table_var);
         printer->add_line("return;");
-        printer->pop_block(1);
+        printer->pop_block();
 
         printer->add_line("static bool make_table = true;");
         for (const auto& variable: depend_variables) {
@@ -1437,7 +1437,7 @@ void CodegenCppVisitor::print_table_check_function(const Block& node) {
             const auto& instance_name = get_variable_name(var_name);
             printer->fmt_push_block("if (save_{} != {})", var_name, instance_name);
             printer->add_line("make_table = true;");
-            printer->pop_block(1);
+            printer->pop_block();
         }
 
         printer->push_block("if (make_table)");
@@ -1486,7 +1486,7 @@ void CodegenCppVisitor::print_table_check_function(const Block& node) {
                                   function,
                                   internal_method_arguments());
             }
-            printer->pop_block(1);
+            printer->pop_block();
 
             for (const auto& variable: depend_variables) {
                 auto var_name = variable->get_node_name();
@@ -1494,9 +1494,9 @@ void CodegenCppVisitor::print_table_check_function(const Block& node) {
                 printer->fmt_line("save_{} = {};", var_name, instance_name);
             }
         }
-        printer->pop_block(1);
+        printer->pop_block();
     }
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -1528,7 +1528,7 @@ void CodegenCppVisitor::print_table_replacement_function(const ast::Block& node)
                               internal_method_arguments(),
                               params[0].get()->get_node_name());
         }
-        printer->pop_block(1);
+        printer->pop_block();
 
         printer->fmt_line("double xi = {} * ({} - {});",
                           mfac_name,
@@ -1551,7 +1551,7 @@ void CodegenCppVisitor::print_table_replacement_function(const ast::Block& node)
         } else {
             printer->add_line("return xi;");
         }
-        printer->pop_block(1);
+        printer->pop_block();
 
         printer->fmt_push_block("if (xi <= 0. || xi >= {}.)", with);
         printer->fmt_line("int index = (xi <= 0.) ? 0 : {};", with);
@@ -1575,7 +1575,7 @@ void CodegenCppVisitor::print_table_replacement_function(const ast::Block& node)
             auto table_name = get_variable_name("t_" + name);
             printer->fmt_line("return {}[index];", table_name);
         }
-        printer->pop_block(1);
+        printer->pop_block();
 
         printer->add_line("int i = int(xi);");
         printer->add_line("double theta = xi - double(i);");
@@ -1605,7 +1605,7 @@ void CodegenCppVisitor::print_table_replacement_function(const ast::Block& node)
             printer->fmt_line("return {0}[i] + theta * ({0}[i+1] - {0}[i]);", table_name);
         }
     }
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -1629,7 +1629,7 @@ void CodegenCppVisitor::print_check_table_thread_function() {
         printer->fmt_line("{}({});", method_name_str, arguments);
     }
 
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -1650,7 +1650,7 @@ void CodegenCppVisitor::print_function_or_procedure(const ast::Block& node,
 
     print_statement_block(*node.get_statement_block(), false, false);
     printer->fmt_line("return ret_{};", name);
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -1712,14 +1712,14 @@ void CodegenCppVisitor::print_function_tables(const ast::FunctionTableBlock& nod
     printer->fmt_line("return hoc_func_table({}, {}, _arg);",
                       get_variable_name(std::string("_ptable_" + name), true),
                       p.size());
-    printer->pop_block(1);
+    printer->pop_block();
 
     printer->fmt_push_block("double table_{}()", method_name(name));
     printer->fmt_line("hoc_spec_table(&{}, {});",
                       get_variable_name(std::string("_ptable_" + name)),
                       p.size());
     printer->add_line("return 0.;");
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 /**
@@ -1793,7 +1793,8 @@ void CodegenCppVisitor::print_functor_definition(const ast::EigenNewtonSolverBlo
 
     printer->push_block("void initialize()");
     print_statement_block(*node.get_initialize_block(), false, false);
-    printer->pop_block(2);
+    printer->pop_block();
+    printer->add_newline();
 
     printer->fmt_line(
         "{0}(NrnThread* nt, {1}* inst, int id, int pnodecount, double v, const Datum* indexes, "
@@ -1821,12 +1822,13 @@ void CodegenCppVisitor::print_functor_definition(const ast::EigenNewtonSolverBlo
     printer->fmt_line("{}* nmodl_eigen_j = nmodl_eigen_jm.data();", float_type);
     printer->fmt_line("{}* nmodl_eigen_f = nmodl_eigen_fm.data();", float_type);
     print_statement_block(functor_block, false, false);
-    printer->pop_block(2);
+    printer->pop_block();
+    printer->add_newline();
 
     // assign newton solver results in matrix X to state vars
     printer->push_block("void finalize()");
     print_statement_block(*node.get_finalize_block(), false, false);
-    printer->pop_block(1);
+    printer->pop_block();
 
     printer->pop_block(";");
 }
@@ -2143,7 +2145,7 @@ void CodegenCppVisitor::print_first_pointer_var_index_getter() {
     print_device_method_annotation();
     printer->push_block("static inline int first_pointer_var_index()");
     printer->fmt_line("return {};", info.first_pointer_var_index);
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -2152,13 +2154,13 @@ void CodegenCppVisitor::print_num_variable_getter() {
     print_device_method_annotation();
     printer->push_block("static inline int float_variables_size()");
     printer->fmt_line("return {};", float_variables_size());
-    printer->pop_block(1);
+    printer->pop_block();
 
     printer->add_newline(2);
     print_device_method_annotation();
     printer->push_block("static inline int int_variables_size()");
     printer->fmt_line("return {};", int_variables_size());
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -2170,7 +2172,7 @@ void CodegenCppVisitor::print_net_receive_arg_size_getter() {
     print_device_method_annotation();
     printer->push_block("static inline int num_net_receive_args()");
     printer->fmt_line("return {};", info.num_net_receive_parameters);
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -2180,7 +2182,7 @@ void CodegenCppVisitor::print_mech_type_getter() {
     printer->push_block("static inline int get_mech_type()");
     // false => get it from the host-only global struct, not the instance structure
     printer->fmt_line("return {};", get_variable_name("mech_type", false));
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -2190,9 +2192,9 @@ void CodegenCppVisitor::print_memb_list_getter() {
     printer->push_block("static inline Memb_list* get_memb_list(NrnThread* nt)");
     printer->push_block("if (!nt->_ml_list)");
     printer->add_line("return nullptr;");
-    printer->pop_block(1);
+    printer->pop_block();
     printer->add_line("return nt->_ml_list[get_mech_type()];");
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -2203,7 +2205,7 @@ void CodegenCppVisitor::print_namespace_start() {
 
 
 void CodegenCppVisitor::print_namespace_stop() {
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -2231,15 +2233,17 @@ void CodegenCppVisitor::print_thread_getters() {
         printer->add_newline(1);
         printer->fmt_push_block("static inline int* deriv{}_advance(ThreadDatum* thread)", list);
         printer->fmt_line("return &(thread[{}].i);", tid);
-        printer->pop_block(2);
+        printer->pop_block();
+        printer->add_newline();
 
         printer->fmt_push_block("static inline int dith{}()", list);
         printer->fmt_line("return {};", tid+1);
-        printer->pop_block(2);
+        printer->pop_block();
+        printer->add_newline();
 
         printer->fmt_push_block("static inline void** newtonspace{}(ThreadDatum* thread)", list);
         printer->fmt_line("return &(thread[{}]._pvoid);", tid+2);
-        printer->pop_block(1);
+        printer->pop_block();
     }
 
     if (info.vectorize && !info.thread_variables.empty()) {
@@ -2247,7 +2251,7 @@ void CodegenCppVisitor::print_thread_getters() {
         printer->add_line("/** tid for thread variables */");
         printer->push_block("static inline int thread_var_tid()");
         printer->fmt_line("return {};", info.thread_var_thread_id);
-        printer->pop_block(1);
+        printer->pop_block();
     }
 
     if (info.vectorize && !info.top_local_variables.empty()) {
@@ -2255,7 +2259,7 @@ void CodegenCppVisitor::print_thread_getters() {
         printer->add_line("/** tid for top local tread variables */");
         printer->push_block("static inline int top_local_var_tid()");
         printer->fmt_line("return {};", info.top_local_thread_id);
-        printer->pop_block(1);
+        printer->pop_block();
     }
     // clang-format on
 }
@@ -2665,7 +2669,7 @@ void CodegenCppVisitor::print_mechanism_global_var_structure(bool print_initiali
                                   value_initialize);
             } else {
                 printer->fmt_line(
-                        "{}{} {}[{}]{};", qualifier, float_type, name, num_values, value_initialize);
+                    "{}{} {}[{}]{};", qualifier, float_type, name, num_values, value_initialize);
             }
             codegen_global_variables.push_back(make_symbol(name));
         }
@@ -2865,7 +2869,7 @@ void CodegenCppVisitor::print_mechanism_register() {
     printer->fmt_line("{} = mech_type;", get_variable_name("mech_type", false));
     printer->push_block("if (mech_type == -1)");
     printer->add_line("return;");
-    printer->pop_block(1);
+    printer->pop_block();
 
     printer->add_newline();
     printer->add_line("_nrn_layout_reg(mech_type, 0);");  // 0 for SoA
@@ -2991,7 +2995,7 @@ void CodegenCppVisitor::print_mechanism_register() {
 
     // register variables for hoc
     printer->add_line("hoc_register_var(hoc_scalar_double, hoc_vector_double, NULL);");
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -3023,9 +3027,10 @@ void CodegenCppVisitor::print_thread_memory_callbacks() {
         printer->chain_block("else");
         printer->fmt_line("thread[thread_var_tid()].pval = {};", thread_data);
         printer->fmt_line("{} = 1;", thread_data_in_use);
-        printer->pop_block(1);
+        printer->pop_block();
     }
-    printer->pop_block(3);
+    printer->pop_block();
+    printer->add_newline(2);
 
 
     // thread_mem_cleanup callback
@@ -3051,9 +3056,9 @@ void CodegenCppVisitor::print_thread_memory_callbacks() {
         printer->fmt_line("{} = 0;", thread_data_in_use);
         printer->chain_block("else");
         printer->add_line("free(thread[thread_var_tid()].pval);");
-        printer->pop_block(1);
+        printer->pop_block();
     }
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -3164,9 +3169,9 @@ void CodegenCppVisitor::print_setup_range_variable() {
     printer->fmt_line("{0}* data = ({0}*) mem_alloc(n, sizeof({0}));", type);
     printer->push_block("for(size_t i = 0; i < n; i++)");
     printer->add_line("data[i] = variable[i];");
-    printer->pop_block(1);
+    printer->pop_block();
     printer->add_line("return data;");
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -3211,7 +3216,8 @@ void CodegenCppVisitor::print_instance_variable_setup() {
     printer->add_line("ml->instance = inst;");
     printer->fmt_line("ml->global_variables = inst->{};", naming::INST_GLOBAL_MEMBER);
     printer->fmt_line("ml->global_variables_size = sizeof({});", global_struct());
-    printer->pop_block(2);
+    printer->pop_block();
+    printer->add_newline();
 
     auto const cast_inst_and_assert_validity = [&]() {
         printer->fmt_line("auto* const inst = static_cast<{}*>(ml->instance);", instance_struct());
@@ -3239,7 +3245,8 @@ void CodegenCppVisitor::print_instance_variable_setup() {
         ml->global_variables = nullptr;
         ml->global_variables_size = 0;
     )CODE");
-    printer->pop_block(2);
+    printer->pop_block();
+    printer->add_newline();
 
 
     printer->add_line("/** initialize mechanism instance variables */");
@@ -3293,7 +3300,8 @@ void CodegenCppVisitor::print_instance_variable_setup() {
         ptr_members.push_back(std::move(name));
     }
     print_instance_struct_copy_to_device();
-    printer->pop_block(2);  // setup_instance
+    printer->pop_block();  // setup_instance
+    printer->add_newline();
 
     print_instance_struct_transfer_routines(ptr_members);
 }
@@ -3415,7 +3423,7 @@ void CodegenCppVisitor::print_nrn_init(bool skip_init_check) {
         printer->fmt_line("th.pval = vec;", list_num);
         printer->fmt_line("*ns = nrn_cons_newtonspace({}, pnodecount);", nequation);
         print_newtonspace_transfer_to_device();
-        printer->pop_block(1);
+        printer->pop_block();
         // clang-format on
     }
 
@@ -3445,14 +3453,14 @@ void CodegenCppVisitor::print_nrn_init(bool skip_init_check) {
     }
 
     print_initial_block(info.initial_node);
-    printer->pop_block(1);
+    printer->pop_block();
 
     if (!info.changed_dt.empty()) {
         printer->fmt_line("{} = _save_prev_dt;", get_variable_name(naming::NTHREAD_DT_VARIABLE));
         print_dt_update_to_device();
     }
 
-    printer->pop_block(1);
+    printer->pop_block();
 
     if (info.derivimplicit_used()) {
         printer->add_line("deriv_advance_flag = 1;");
@@ -3465,7 +3473,7 @@ void CodegenCppVisitor::print_nrn_init(bool skip_init_check) {
 
     print_kernel_data_present_annotation_block_end();
     if (skip_init_check) {
-        printer->pop_block(1);
+        printer->pop_block();
     }
     codegen = false;
 }
@@ -3520,8 +3528,8 @@ void CodegenCppVisitor::print_before_after_block(const ast::Block* node, size_t 
     }
 
     /// loop end including data annotation block
-    printer->pop_block(1);
-    printer->pop_block(1);
+    printer->pop_block();
+    printer->pop_block();
     print_kernel_data_present_annotation_block_end();
 
     codegen = false;
@@ -3535,7 +3543,7 @@ void CodegenCppVisitor::print_nrn_constructor() {
         print_statement_block(*block, false, false);
     }
     printer->add_line("#endif");
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -3547,7 +3555,7 @@ void CodegenCppVisitor::print_nrn_destructor() {
         print_statement_block(*block, false, false);
     }
     printer->add_line("#endif");
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -3566,7 +3574,7 @@ void CodegenCppVisitor::print_nrn_alloc() {
     auto method = method_name(naming::NRN_ALLOC_METHOD);
     printer->fmt_push_block("static void {}(double* data, Datum* indexes, int type)", method);
     printer->add_line("// do nothing");
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 /**
@@ -3594,7 +3602,7 @@ void CodegenCppVisitor::print_watch_activate() {
         printer->fmt_line("{} = 0;", name);
     }
     printer->add_line("watch_remove = true;");
-    printer->pop_block(1);
+    printer->pop_block();
 
     /**
      * \todo Similar to neuron/coreneuron we are using
@@ -3612,9 +3620,9 @@ void CodegenCppVisitor::print_watch_activate() {
         printer->add_text(");");
         printer->add_newline();
 
-        printer->pop_block(1);
+        printer->pop_block();
     }
-    printer->pop_block(1);
+    printer->pop_block();
     codegen = false;
 }
 
@@ -3682,7 +3690,7 @@ void CodegenCppVisitor::print_watch_check() {
         watch->get_value()->accept(*this);
         printer->add_text(");");
         printer->add_newline();
-        printer->pop_block(1);
+        printer->pop_block();
 
         printer->add_line(varname, " = 3;");
         // end block 3
@@ -3691,17 +3699,17 @@ void CodegenCppVisitor::print_watch_check() {
         printer->decrease_indent();
         printer->push_block("} else");
         printer->add_line(varname, " = 2;");
-        printer->pop_block(1);
+        printer->pop_block();
         // end block 3
 
-        printer->pop_block(1);
+        printer->pop_block();
         // end block 1
     }
 
-    printer->pop_block(1);
+    printer->pop_block();
     print_send_event_move();
     print_kernel_data_present_annotation_block_end();
-    printer->pop_block(1);
+    printer->pop_block();
     codegen = false;
 }
 
@@ -3895,7 +3903,7 @@ void CodegenCppVisitor::print_net_init() {
             print_net_send_buf_update_to_host();
         }
     }
-    printer->pop_block(1);
+    printer->pop_block();
     codegen = false;
     printing_net_init = false;
 }
@@ -3916,7 +3924,7 @@ void CodegenCppVisitor::print_send_event_move() {
         int point_index = nsb->_pnt_index[i];
         net_sem_from_gpu(type, vdata_index, weight_index, tid, point_index, t, flag);
     )CODE");
-    printer->pop_block(1);
+    printer->pop_block();
     printer->add_line("nsb->_cnt = 0;");
     print_net_send_buf_count_update_to_device();
 }
@@ -3931,7 +3939,8 @@ void CodegenCppVisitor::print_get_memb_list() {
     printer->add_line("Memb_list* ml = get_memb_list(nt);");
     printer->push_block("if (!ml)");
     printer->add_line("return;");
-    printer->pop_block(2);
+    printer->pop_block();
+    printer->add_newline();
 }
 
 
@@ -3943,7 +3952,7 @@ void CodegenCppVisitor::print_net_receive_loop_begin() {
 
 
 void CodegenCppVisitor::print_net_receive_loop_end() {
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -3977,7 +3986,7 @@ void CodegenCppVisitor::print_net_receive_buffering(bool need_mech_inst) {
         Point_process* point_process = nt->pntprocs + offset;
     )CODE");
     printer->add_line(net_receive, "(t, point_process, inst, nt, ml, weight_index, flag);");
-    printer->pop_block(1);
+    printer->pop_block();
     print_net_receive_loop_end();
 
     print_device_stream_wait();
@@ -3989,7 +3998,7 @@ void CodegenCppVisitor::print_net_receive_buffering(bool need_mech_inst) {
     }
 
     print_kernel_data_present_annotation_block_end();
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 void CodegenCppVisitor::print_net_send_buffering_cnt_update() const {
@@ -3999,7 +4008,7 @@ void CodegenCppVisitor::print_net_send_buffering_cnt_update() const {
 void CodegenCppVisitor::print_net_send_buffering_grow() {
     printer->push_block("if (i >= nsb->_size)");
     printer->add_line("nsb->grow();");
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 void CodegenCppVisitor::print_net_send_buffering() {
@@ -4025,8 +4034,8 @@ void CodegenCppVisitor::print_net_send_buffering() {
          nsb->_nsb_t[i] = t;
          nsb->_nsb_flag[i] = flag;
     )CODE");
-    printer->pop_block(1);
-    printer->pop_block(1);
+    printer->pop_block();
+    printer->pop_block();
 }
 
 
@@ -4121,7 +4130,6 @@ void CodegenCppVisitor::print_net_receive_kernel() {
     node->get_statement_block()->accept(*this);
     printer->add_newline();
     printer->pop_block();
-    printer->add_newline();
 
     printing_net_receive = false;
     codegen = false;
@@ -4147,7 +4155,7 @@ void CodegenCppVisitor::print_net_receive() {
         printer->add_line("NetReceiveBuffer_t* nrb = ml->_net_receive_buffer;");
         printer->push_block("if (nrb->_cnt >= nrb->_size)");
         printer->add_line("realloc_net_receive_buffer(nt, ml);");
-        printer->pop_block(1);
+        printer->pop_block();
         printer->add_multi_line(R"CODE(
             int id = nrb->_cnt;
             nrb->_pnt_index[id] = pnt-nt->pntprocs;
@@ -4156,7 +4164,7 @@ void CodegenCppVisitor::print_net_receive() {
             nrb->_nrb_flag[id] = flag;
             nrb->_cnt++;
         )CODE");
-        printer->pop_block(1);
+        printer->pop_block();
     }
     printing_net_receive = false;
     codegen = false;
@@ -4227,12 +4235,13 @@ void CodegenCppVisitor::print_derivimplicit_kernel(const Block& block) {
                       list_num + 1,
                       stride,
                       list_num);
-    printer->pop_block(1);
-    printer->pop_block(1);
+    printer->pop_block();
+    printer->pop_block();
     printer->add_line("return 0;");
-    printer->pop_block(1);  // operator()
+    printer->pop_block();  // operator()
     printer->pop_block(";");   // struct
-    printer->pop_block(2);  // namespace
+    printer->pop_block();  // namespace
+    printer->add_newline();
     printer->fmt_push_block("int {}_{}({})", block_name, suffix, ext_params);
     printer->add_line(instance);
     printer->fmt_line("double* savstate{} = (double*) thread[dith{}()].pval;", list_num, list_num);
@@ -4241,7 +4250,7 @@ void CodegenCppVisitor::print_derivimplicit_kernel(const Block& block) {
     printer->add_line(dlist2);
     printer->fmt_push_block("for (int i=0; i<{}; i++)", info.num_primes);
     printer->fmt_line("savstate{}[i{}] = data[slist{}[i]{}];", list_num, stride, list_num, stride);
-    printer->pop_block(1);
+    printer->pop_block();
     printer->fmt_line(
         "int reset = nrn_newton_thread(static_cast<NewtonSpace*>(*newtonspace{}(thread)), {}, "
         "slist{}, _newton_{}_{}{{}}, dlist{}, {});",
@@ -4253,7 +4262,8 @@ void CodegenCppVisitor::print_derivimplicit_kernel(const Block& block) {
         list_num + 1,
         ext_args);
     printer->add_line("return reset;");
-    printer->pop_block(3);
+    printer->pop_block();
+    printer->add_newline(2);
 }
 
 
@@ -4331,11 +4341,11 @@ void CodegenCppVisitor::print_nrn_state() {
         const auto& text = process_shadow_update_statement(statement, BlockType::State);
         printer->add_line(text);
     }
-    printer->pop_block(1);
+    printer->pop_block();
 
     print_kernel_data_present_annotation_block_end();
 
-    printer->pop_block(1);
+    printer->pop_block();
     codegen = false;
 }
 
@@ -4360,7 +4370,7 @@ void CodegenCppVisitor::print_nrn_current(const BreakpointBlock& node) {
         printer->fmt_line("current += {};", name);
     }
     printer->add_line("return current;");
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 
@@ -4493,9 +4503,9 @@ void CodegenCppVisitor::print_fast_imem_calculation() {
     printer->fmt_line("nt->nrn_fast_imem->nrn_sav_rhs[node_id] {} {};", rhs_op, rhs);
     printer->fmt_line("nt->nrn_fast_imem->nrn_sav_d[node_id] {} {};", d_op, d);
     if (nrn_cur_reduction_loop_required()) {
-        printer->pop_block(1);
+        printer->pop_block();
     }
-    printer->pop_block(1);
+    printer->pop_block();
 }
 
 void CodegenCppVisitor::print_nrn_cur() {
@@ -4518,17 +4528,17 @@ void CodegenCppVisitor::print_nrn_cur() {
     if (!nrn_cur_reduction_loop_required()) {
         print_fast_imem_calculation();
     }
-    printer->pop_block(1);
+    printer->pop_block();
 
     if (nrn_cur_reduction_loop_required()) {
         printer->push_block("for (int id = 0; id < nodecount; id++)");
         print_nrn_cur_matrix_shadow_reduction();
-        printer->pop_block(1);
+        printer->pop_block();
         print_fast_imem_calculation();
     }
 
     print_kernel_data_present_annotation_block_end();
-    printer->pop_block(1);
+    printer->pop_block();
     codegen = false;
 }
 

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -32,18 +32,19 @@
 #include "visitors/ast_visitor.hpp"
 
 
-namespace nmodl {
 /// encapsulates code generation backend implementations
+namespace nmodl {
+
 namespace codegen {
 
 /**
- * @defgroup codegen Code Generation Implementation
- * @brief Implementations of code generation backends
+ * \defgroup codegen Code Generation Implementation
+ * \brief Implementations of code generation backends
  *
- * @defgroup codegen_details Codegen Helpers
- * @ingroup codegen
- * @brief Helper routines/types for code generation
- * @{
+ * \defgroup codegen_details Codegen Helpers
+ * \ingroup codegen
+ * \brief Helper routines/types for code generation
+ * \{
  */
 
 /**
@@ -53,7 +54,7 @@ namespace codegen {
  * Note: do not assign integers to these enums
  *
  */
-enum BlockType {
+enum class BlockType {
     /// initial block
     Initial,
 
@@ -112,7 +113,7 @@ struct IndexVariableInfo {
     /// symbol for the variable
     const std::shared_ptr<symtab::Symbol> symbol;
 
-    /// if variable reside in vdata field of NrnThread
+    /// if variable resides in vdata field of NrnThread
     /// typically true for bbcore pointer
     bool is_vdata = false;
 
@@ -153,7 +154,7 @@ struct ShadowUseStatement {
     std::string rhs;
 };
 
-/** @} */  // end of codegen_details
+/** \} */  // end of codegen_details
 
 
 using printer::CodePrinter;
@@ -188,6 +189,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * - type (e.g. \c double)
      * - pointer qualifier (e.g. \c \_\_restrict\_\_)
      * - parameter name (e.g. \c data)
+     *
      */
     using ParamVector = std::vector<std::tuple<std::string, std::string, std::string, std::string>>;
 
@@ -305,7 +307,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * Operator for rhs vector update (matrix update)
      */
-    std::string operator_for_rhs() const noexcept {
+    const char* operator_for_rhs() const noexcept {
         return info.electrode_current ? "+=" : "-=";
     }
 
@@ -313,7 +315,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * Operator for diagonal vector update (matrix update)
      */
-    std::string operator_for_d() const noexcept {
+    const char* operator_for_d() const noexcept {
         return info.electrode_current ? "-=" : "+=";
     }
 
@@ -321,7 +323,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * Data type for the local variables
      */
-    std::string local_var_type() const noexcept {
+    const char* local_var_type() const noexcept {
         return codegen::naming::DEFAULT_LOCAL_VAR_TYPE;
     }
 
@@ -329,7 +331,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * Default data type for floating point elements
      */
-    std::string default_float_data_type() const noexcept {
+    const char* default_float_data_type() const noexcept {
         return codegen::naming::DEFAULT_FLOAT_TYPE;
     }
 
@@ -345,7 +347,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * Default data type for integer (offset) elements
      */
-    std::string default_int_data_type() const noexcept {
+    const char* default_int_data_type() const noexcept {
         return codegen::naming::DEFAULT_INTEGER_TYPE;
     }
 
@@ -492,7 +494,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * \param node The AST Statement node to check
      * \return     \c true if this Statement requires a semicolon
      */
-    static bool need_semicolon(ast::Statement* node);
+    static bool need_semicolon(const ast::Statement& node);
 
 
     /**
@@ -634,7 +636,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * Determine all \c float variables required during code generation
      * \return A \c vector of \c float variables
      */
-    std::vector<SymbolType> get_float_variables();
+    std::vector<SymbolType> get_float_variables() const;
 
 
     /**
@@ -651,10 +653,10 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * current printer. Elements are expected to be of type nmodl::ast::Ast and are printed by being
      * visited. Care is taken to omit the separator after the the last element.
      *
-     * \tparam The element type in the vector, which must be of type nmodl::ast::Ast
+     * \tparam T The element type in the vector, which must be of type nmodl::ast::Ast
      * \param  elements The vector of elements to be printed
-     * \param  prefix A prefix string to printed before each element
-     * \param  separator The seperator string to be printed between all elements
+     * \param  separator The separator string to print between all elements
+     * \param  prefix A prefix string to print before each element
      */
     template <typename T>
     void print_vector_elements(const std::vector<T>& elements,
@@ -667,7 +669,8 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * The procedure parameters are stored in a vector of 4-tuples each representing a parameter.
      *
      * \param params The parameters that should be concatenated into the function parameter
-     * declaration \return The string representing the declaration of function parameters
+     * declaration
+     * \return The string representing the declaration of function parameters
      */
     static std::string get_parameter_str(const ParamVector& params);
 
@@ -722,7 +725,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * \param type The type of code block being generated
      * \return     A \c vector of strings representing the reading of ion variables
      */
-    std::vector<std::string> ion_read_statements(BlockType type);
+    std::vector<std::string> ion_read_statements(BlockType type) const;
 
 
     /**
@@ -731,7 +734,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * \param type The type of code block being generated
      * \return     A \c vector of strings representing the reading of ion variables
      */
-    std::vector<std::string> ion_read_statements_optimized(BlockType type);
+    std::vector<std::string> ion_read_statements_optimized(BlockType type) const;
 
 
     /**
@@ -789,7 +792,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * Arguments for external functions called from generated code
      * \return A string representing the arguments passed to an external function
      */
-    static std::string external_method_arguments();
+    static const char* external_method_arguments() noexcept;
 
 
     /**
@@ -801,7 +804,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * \param table
      * \return      A string representing the parameters of the function
      */
-    static std::string external_method_parameters(bool table = false);
+    static const char* external_method_parameters(bool table = false) noexcept;
 
 
     /**
@@ -813,7 +816,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * Arguments for "_threadargs_" macro in neuron implementation
      */
-    std::string nrn_thread_arguments();
+    std::string nrn_thread_arguments() const;
 
 
     /**
@@ -980,10 +983,10 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * Print the structure that wraps all global variables used in the NMODL
      *
-     * @param print_initialisers Whether to include default values in the struct
+     * \param print_initializers Whether to include default values in the struct
      *                           definition (true: int foo{42}; false: int foo;)
      */
-    void print_mechanism_global_var_structure(bool print_initialisers);
+    void print_mechanism_global_var_structure(bool print_initializers);
 
 
     /**
@@ -1374,9 +1377,9 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * Print derivative kernel when \c derivimplicit method is used
      *
-     * \param block The corresponding AST node represening an NMODL \c derivimplicit block
+     * \param block The corresponding AST node representing an NMODL \c derivimplicit block
      */
-    void print_derivimplicit_kernel(ast::Block* block);
+    void print_derivimplicit_kernel(const ast::Block& block);
 
 
     /**
@@ -1540,9 +1543,9 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
 
     /**
      * Print all classes
-     * @param print_initialisers Whether to include default values.
+     * \param print_initializers Whether to include default values.
      */
-    void print_data_structures(bool print_initialisers);
+    void print_data_structures(bool print_initializers);
 
 
     /**
@@ -1577,6 +1580,8 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     virtual void print_wrapper_routines();
 
 
+    /// This constructor is private, see the public section below to find how to create an instance
+    /// of this class.
     CodegenCppVisitor(std::string mod_filename,
                       const std::string& output_dir,
                       std::string float_type,
@@ -1591,12 +1596,14 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
         , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
 
+    /// This constructor is private, see the public section below to find how to create an instance
+    /// of this class.
     CodegenCppVisitor(std::string mod_filename,
                       std::ostream& stream,
                       std::string float_type,
                       const bool optimize_ionvar_copies,
-                      const std::string& extension,
-                      const std::string& wrapper_ext)
+                      const std::string& /* extension */,
+                      const std::string& /* wrapper_ext */)
         : target_printer(std::make_shared<CodePrinter>(stream))
         , wrapper_printer(std::make_shared<CodePrinter>(stream))
         , printer(target_printer)
@@ -1663,8 +1670,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
 
     /**
      * Print the \c nrn\_init function definition
-     * \param skip_init_check \c true if we want the generated code to execute the initialization
-     *                        conditionally
+     * \param skip_init_check \c true to generate code executing the initialization conditionally
      */
     void print_nrn_init(bool skip_init_check = true);
 
@@ -1744,8 +1750,8 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
 
     /**
      * Print NMODL before / after block in target backend code
-     * @param node AST node of type before/after type being printed
-     * @param block_id Index of the before/after block
+     * \param node AST node of type before/after type being printed
+     * \param block_id Index of the before/after block
      */
     virtual void print_before_after_block(const ast::Block* node, size_t block_id);
 
@@ -1761,23 +1767,23 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * Set the global variables to be generated in target backend code
      * \param global_vars
      */
-    void set_codegen_global_variables(std::vector<SymbolType>& global_vars);
+    void set_codegen_global_variables(const std::vector<SymbolType>& global_vars);
 
     /**
      * Find unique variable name defined in nmodl::utils::SingletonRandomString by the
      * nmodl::visitor::SympySolverVisitor
-     * @param original_name Original name of variable to change
-     * @return std::string Unique name produced as [original_name]_[random_string]
+     * \param original_name Original name of variable to change
+     * \return std::string Unique name produced as [original_name]_[random_string]
      */
     std::string find_var_unique_name(const std::string& original_name) const;
 
     /**
      * Print the structure that wraps all range and int variables required for the NMODL
      *
-     * @param print_initialisers Whether or not default values for variables
+     * \param print_initializers Whether or not default values for variables
      *                           be included in the struct declaration.
      */
-    void print_mechanism_range_var_structure(bool print_initialisers);
+    void print_mechanism_range_var_structure(bool print_initializers);
 
     /**
      * Print the function that initialize instance structure
@@ -1793,10 +1799,10 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     void print_functors_definitions();
 
     /**
-     * @brief Based on the \c EigenNewtonSolverBlock passed print the definition needed for its
+     * \brief Based on the \c EigenNewtonSolverBlock passed print the definition needed for its
      * functor
      *
-     * @param node \c EigenNewtonSolverBlock for which to print the functor
+     * \param node \c EigenNewtonSolverBlock for which to print the functor
      */
     void print_functor_definition(const ast::EigenNewtonSolverBlock& node);
 
@@ -1890,7 +1896,7 @@ void CodegenCppVisitor::print_function_declaration(const T& node, const std::str
     }
 
     // procedures have "int" return type by default
-    std::string return_type = "int";
+    const char* return_type = "int";
     if (node.is_function_block()) {
         return_type = default_float_data_type();
     }

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -1667,6 +1667,11 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
         , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
 
+    /**
+     * Main and only member function to call after creating an instance of this class.
+     * \param program the AST to translate to C++ code
+     */
+    void visit_program(const ast::Program& program) override;
 
     /**
      * Print the \c nrn\_init function definition
@@ -1825,7 +1830,6 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     void visit_name(const ast::Name& node) override;
     void visit_paren_expression(const ast::ParenExpression& node) override;
     void visit_prime_name(const ast::PrimeName& node) override;
-    void visit_program(const ast::Program& node) override;
     void visit_statement_block(const ast::StatementBlock& node) override;
     void visit_string(const ast::String& node) override;
     void visit_solution_expression(const ast::SolutionExpression& node) override;

--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -464,9 +464,9 @@ void CodegenHelperVisitor::find_table_variables() {
 void CodegenHelperVisitor::find_neuron_global_variables() {
     // TODO: it would be nicer not to have this hardcoded list
     using pair = std::pair<const char*, const char*>;
-    for (auto [var, type]: {pair{naming::CELSIUS_VARIABLE, "double"},
-                            pair{"secondorder", "int"},
-                            pair{"pi", "double"}}) {
+    for (const auto& [var, type]: {pair{naming::CELSIUS_VARIABLE, "double"},
+                                   pair{"secondorder", "int"},
+                                   pair{"pi", "double"}}) {
         auto sym = psymtab->lookup(var);
         if (sym && (sym->get_read_count() || sym->get_write_count())) {
             info.neuron_global_variables.emplace_back(std::move(sym), type);

--- a/src/codegen/codegen_info.cpp
+++ b/src/codegen/codegen_info.cpp
@@ -18,7 +18,7 @@ namespace codegen {
 using visitor::VarUsageVisitor;
 
 /// if any ion has write variable
-bool CodegenInfo::ion_has_write_variable() const {
+bool CodegenInfo::ion_has_write_variable() const noexcept {
     return std::any_of(ions.begin(), ions.end(), [](auto const& ion) {
         return !ion.writes.empty();
     });
@@ -26,7 +26,7 @@ bool CodegenInfo::ion_has_write_variable() const {
 
 
 /// if given variable is ion write variable
-bool CodegenInfo::is_ion_write_variable(const std::string& name) const {
+bool CodegenInfo::is_ion_write_variable(const std::string& name) const noexcept {
     return std::any_of(ions.begin(), ions.end(), [&name](auto const& ion) {
         return std::any_of(ion.writes.begin(), ion.writes.end(), [&name](auto const& var) {
             return var == name;
@@ -36,7 +36,7 @@ bool CodegenInfo::is_ion_write_variable(const std::string& name) const {
 
 
 /// if given variable is ion read variable
-bool CodegenInfo::is_ion_read_variable(const std::string& name) const {
+bool CodegenInfo::is_ion_read_variable(const std::string& name) const noexcept {
     return std::any_of(ions.begin(), ions.end(), [&name](auto const& ion) {
         return std::any_of(ion.reads.begin(), ion.reads.end(), [&name](auto const& var) {
             return var == name;
@@ -46,13 +46,13 @@ bool CodegenInfo::is_ion_read_variable(const std::string& name) const {
 
 
 /// if either read or write variable
-bool CodegenInfo::is_ion_variable(const std::string& name) const {
+bool CodegenInfo::is_ion_variable(const std::string& name) const noexcept {
     return is_ion_read_variable(name) || is_ion_write_variable(name);
 }
 
 
 /// if a current (ionic or non-specific)
-bool CodegenInfo::is_current(const std::string& name) const {
+bool CodegenInfo::is_current(const std::string& name) const noexcept {
     return std::any_of(currents.begin(), currents.end(), [&name](auto const& var) {
         return var == name;
     });
@@ -60,20 +60,20 @@ bool CodegenInfo::is_current(const std::string& name) const {
 
 /// true is a given variable name if a ionic current
 /// (i.e. currents excluding non-specific current)
-bool CodegenInfo::is_ionic_current(const std::string& name) const {
+bool CodegenInfo::is_ionic_current(const std::string& name) const noexcept {
     return std::any_of(ions.begin(), ions.end(), [&name](auto const& ion) {
         return ion.is_ionic_current(name);
     });
 }
 
 /// true if given variable name is a ionic concentration
-bool CodegenInfo::is_ionic_conc(const std::string& name) const {
+bool CodegenInfo::is_ionic_conc(const std::string& name) const noexcept {
     return std::any_of(ions.begin(), ions.end(), [&name](auto const& ion) {
         return ion.is_ionic_conc(name);
     });
 }
 
-bool CodegenInfo::function_uses_table(std::string& name) const {
+bool CodegenInfo::function_uses_table(const std::string& name) const noexcept {
     return std::any_of(functions_with_table.begin(),
                        functions_with_table.end(),
                        [&name](auto const& function) { return name == function->get_node_name(); });

--- a/src/codegen/codegen_info.hpp
+++ b/src/codegen/codegen_info.hpp
@@ -9,12 +9,13 @@
 
 /**
  * \file
- * \brief Variour types to store code generation specific information
+ * \brief Various types to store code generation specific information
  */
 
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 #include "ast/ast.hpp"
 #include "symtab/symbol_table.hpp"
@@ -23,8 +24,8 @@ namespace nmodl {
 namespace codegen {
 
 /**
- * @addtogroup codegen_details
- * @{
+ * \addtogroup codegen_details
+ * \{
  */
 
 /**
@@ -62,7 +63,7 @@ struct Ion {
 
     Ion() = delete;
 
-    Ion(std::string name)
+    explicit Ion(std::string name)
         : name(std::move(name)) {}
 
     /**
@@ -134,7 +135,7 @@ struct IndexSemantics {
     IndexSemantics() = delete;
     IndexSemantics(int index, std::string name, int size)
         : index(index)
-        , name(name)
+        , name(std::move(name))
         , size(size) {}
 };
 
@@ -201,7 +202,7 @@ struct CodegenInfo {
     /// number of watch expressions
     int watch_count = 0;
 
-    // number of table statements
+    /// number of table statements
     int table_count = 0;
 
     /**
@@ -302,7 +303,7 @@ struct CodegenInfo {
     /// range variables which are assigned variables as well
     std::vector<SymbolType> range_assigned_vars;
 
-    /// reamining assigned variables
+    /// remaining assigned variables
     std::vector<SymbolType> assigned_vars;
 
     /// all state variables
@@ -326,8 +327,8 @@ struct CodegenInfo {
     /// note that if tqitem doesn't exist then the default value should be 0
     int tqitem_index = 0;
 
-    // updated dt to use with steadystate solver (in initial block)
-    // empty string means no change in dt
+    /// updated dt to use with steadystate solver (in initial block)
+    /// empty string means no change in dt
     std::string changed_dt;
 
     /// global variables
@@ -390,25 +391,25 @@ struct CodegenInfo {
     bool eigen_linear_solver_exist = false;
 
     /// if any ion has write variable
-    bool ion_has_write_variable() const;
+    bool ion_has_write_variable() const noexcept;
 
     /// if given variable is ion write variable
-    bool is_ion_write_variable(const std::string& name) const;
+    bool is_ion_write_variable(const std::string& name) const noexcept;
 
     /// if given variable is ion read variable
-    bool is_ion_read_variable(const std::string& name) const;
+    bool is_ion_read_variable(const std::string& name) const noexcept;
 
     /// if either read or write variable
-    bool is_ion_variable(const std::string& name) const;
+    bool is_ion_variable(const std::string& name) const noexcept;
 
     /// if given variable is a current
-    bool is_current(const std::string& name) const;
+    bool is_current(const std::string& name) const noexcept;
 
     /// if given variable is a ionic current
-    bool is_ionic_current(const std::string& name) const;
+    bool is_ionic_current(const std::string& name) const noexcept;
 
     /// if given variable is a ionic concentration
-    bool is_ionic_conc(const std::string& name) const;
+    bool is_ionic_conc(const std::string& name) const noexcept;
 
     /// if watch statements are used
     bool is_watch_used() const noexcept {
@@ -424,7 +425,7 @@ struct CodegenInfo {
         return !derivimplicit_callbacks.empty();
     }
 
-    bool function_uses_table(std::string& name) const;
+    bool function_uses_table(const std::string& name) const noexcept;
 
     /// true if EigenNewtonSolver is used in nrn_state block
     bool nrn_state_has_eigen_solver_block() const;
@@ -436,7 +437,7 @@ struct CodegenInfo {
     bool require_wrote_conc = false;
 };
 
-/** @} */  // end of codegen_backends
+/** \} */  // end of codegen_backends
 
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/printer/code_printer.cpp
+++ b/src/printer/code_printer.cpp
@@ -24,23 +24,23 @@ CodePrinter::CodePrinter(const std::string& filename) {
     }
 
     sbuf = ofs.rdbuf();
-    result = std::make_shared<std::ostream>(sbuf);
+    result = std::make_unique<std::ostream>(sbuf);
 }
 
-void CodePrinter::start_block() {
-    *result << "{";
+void CodePrinter::push_block() {
+    *result << '{';
     add_newline();
     indent_level++;
 }
 
-void CodePrinter::start_block(std::string&& expression) {
+void CodePrinter::push_block(const std::string& expression) {
     add_indent();
     *result << expression << " {";
     add_newline();
     indent_level++;
 }
 
-void CodePrinter::restart_block(std::string const& expression) {
+void CodePrinter::chain_block(std::string const& expression) {
     --indent_level;
     add_indent();
     *result << "} " << expression << " {";
@@ -49,41 +49,59 @@ void CodePrinter::restart_block(std::string const& expression) {
 }
 
 void CodePrinter::add_indent() {
-    *result << std::string(indent_level * NUM_SPACES, ' ');
-}
-
-void CodePrinter::add_text(const std::string& text) {
-    *result << text;
-}
-
-void CodePrinter::add_line(const std::string& text, int num_new_lines) {
-    add_indent();
-    *result << text;
-    add_newline(num_new_lines);
+    for (std::size_t i = 0; i < indent_level * NUM_SPACES; ++i) {
+        *result << ' ';
+    }
 }
 
 void CodePrinter::add_multi_line(const std::string& text) {
-    auto lines = stringutils::split_string(text, '\n');
+    const auto& lines = stringutils::split_string(text, '\n');
+
+    int prefix_length{};
+    int start_line{};
+    while (start_line < lines.size()) {
+        const auto& line = lines[start_line];
+        // skip first empty line, if any
+        if (line.empty()) {
+            ++start_line;
+            continue;
+        }
+        // The common indentation of all blocks if the number of spaces
+        // at the beginning of the first non-empty line.
+        for (auto line_it = line.begin(); line_it != line.end() && *line_it == ' '; ++line_it) {
+            prefix_length += 1;
+        }
+        break;
+    }
+
     for (const auto& line: lines) {
-        add_line(line);
+        if (line.size() < prefix_length) {
+            // ignore lines made of ' ' characters
+            if (std::find_if_not(line.begin(), line.end(), [](char c) { return c == ' '; }) !=
+                line.end()) {
+                throw std::invalid_argument("Indentation mismatch");
+            }
+        } else {
+            add_line(line.substr(prefix_length));
+        }
     }
 }
 
-void CodePrinter::add_newline(int n) {
-    for (int i = 0; i < n; i++) {
-        *result << std::endl;
+void CodePrinter::add_newline(std::size_t n) {
+    for (std::size_t i{}; i < n; ++i) {
+        *result << '\n';
     }
 }
 
-void CodePrinter::end_block(int num_newlines) {
+void CodePrinter::pop_block(int num_newlines) {
     indent_level--;
     add_indent();
-    *result << "}";
+    *result << '}';
     add_newline(num_newlines);
 }
 
-void CodePrinter::end_block(std::string_view suffix, std::size_t num_newlines) {
-    end_block(0);
+void CodePrinter::pop_block(const std::string_view& suffix, std::size_t num_newlines) {
+    pop_block(0);
     *result << suffix;
     add_newline(num_newlines);
 }

--- a/src/printer/code_printer.cpp
+++ b/src/printer/code_printer.cpp
@@ -100,7 +100,7 @@ void CodePrinter::pop_block() {
     add_newline(1);
 }
 
-void CodePrinter::pop_block_nl(int num_newlines) {
+void CodePrinter::pop_block_nl(std::size_t num_newlines) {
     indent_level--;
     add_indent();
     *result << '}';

--- a/src/printer/code_printer.cpp
+++ b/src/printer/code_printer.cpp
@@ -108,7 +108,7 @@ void CodePrinter::pop_block_nl(std::size_t num_newlines) {
 }
 
 void CodePrinter::pop_block(const std::string_view& suffix, std::size_t num_newlines) {
-    pop_block(0);
+    pop_block_nl(0);
     *result << suffix;
     add_newline(num_newlines);
 }

--- a/src/printer/code_printer.cpp
+++ b/src/printer/code_printer.cpp
@@ -94,10 +94,7 @@ void CodePrinter::add_newline(std::size_t n) {
 }
 
 void CodePrinter::pop_block() {
-    indent_level--;
-    add_indent();
-    *result << '}';
-    add_newline(1);
+    pop_block_nl(1);
 }
 
 void CodePrinter::pop_block_nl(std::size_t num_newlines) {

--- a/src/printer/code_printer.cpp
+++ b/src/printer/code_printer.cpp
@@ -93,7 +93,14 @@ void CodePrinter::add_newline(std::size_t n) {
     }
 }
 
-void CodePrinter::pop_block(int num_newlines) {
+void CodePrinter::pop_block() {
+    indent_level--;
+    add_indent();
+    *result << '}';
+    add_newline(1);
+}
+
+void CodePrinter::pop_block_nl(int num_newlines) {
     indent_level--;
     add_indent();
     *result << '}';

--- a/src/printer/code_printer.hpp
+++ b/src/printer/code_printer.hpp
@@ -43,16 +43,16 @@ class CodePrinter {
   private:
     std::ofstream ofs;
     std::streambuf* sbuf = nullptr;
-    std::shared_ptr<std::ostream> result;
+    std::unique_ptr<std::ostream> result;
     size_t indent_level = 0;
-    const int NUM_SPACES = 4;
+    const size_t NUM_SPACES = 4;
 
   public:
     CodePrinter()
-        : result(std::make_shared<std::ostream>(std::cout.rdbuf())) {}
+        : result(std::make_unique<std::ostream>(std::cout.rdbuf())) {}
 
     CodePrinter(std::ostream& stream)
-        : result(std::make_shared<std::ostream>(stream.rdbuf())) {}
+        : result(std::make_unique<std::ostream>(stream.rdbuf())) {}
 
     CodePrinter(const std::string& filename);
 
@@ -64,17 +64,25 @@ class CodePrinter {
     void add_indent();
 
     /// start a block scope without indentation (i.e. "{\n")
-    void start_block();
+    void push_block();
 
     /// start a block scope with an expression (i.e. "[indent][expression] {\n")
-    void start_block(std::string&& expression);
+    void push_block(const std::string& expression);
 
     /// end a block and immediately start a new one (i.e. "[indent-1]} [expression] {\n")
-    void restart_block(std::string const& expression);
+    void chain_block(std::string const& expression);
 
-    void add_text(const std::string&);
+    template <typename... Args>
+    void add_text(Args&&... args) {
+        (operator<<(*result, args), ...);
+    }
 
-    void add_line(const std::string&, int num_new_lines = 1);
+    template <typename... Args>
+    void add_line(Args&&... args) {
+        add_indent();
+        add_text(std::forward<Args>(args)...);
+        add_newline(1);
+    }
 
     /// fmt_line(x, y, z) is just shorthand for add_line(fmt::format(x, y, z))
     template <typename... Args>
@@ -82,10 +90,10 @@ class CodePrinter {
         add_line(fmt::format(std::forward<Args>(args)...));
     }
 
-    /// fmt_start_block(args...) is just shorthand for start_block(fmt::format(args...))
+    /// fmt_push_block(args...) is just shorthand for push_block(fmt::format(args...))
     template <typename... Args>
-    void fmt_start_block(Args&&... args) {
-        start_block(fmt::format(std::forward<Args>(args)...));
+    void fmt_push_block(Args&&... args) {
+        push_block(fmt::format(std::forward<Args>(args)...));
     }
 
     /// fmt_text(args...) is just shorthand for add_text(fmt::format(args...))
@@ -96,7 +104,7 @@ class CodePrinter {
 
     void add_multi_line(const std::string&);
 
-    void add_newline(int n = 1);
+    void add_newline(std::size_t n = 1);
 
     void increase_indent() {
         indent_level++;
@@ -107,10 +115,10 @@ class CodePrinter {
     }
 
     /// end of current block scope (i.e. end with "}")
-    void end_block(int num_newlines = 0);
+    void pop_block(int num_newlines = 0);
 
     /// end a block with `suffix` before the newline(s) (i.e. [indent]}[suffix]\n*num_newlines)
-    void end_block(std::string_view suffix, std::size_t num_newlines = 1);
+    void pop_block(const std::string_view& suffix, std::size_t num_newlines = 1);
 
     int indent_spaces() {
         return NUM_SPACES * indent_level;

--- a/src/printer/code_printer.hpp
+++ b/src/printer/code_printer.hpp
@@ -114,8 +114,12 @@ class CodePrinter {
         indent_level--;
     }
 
-    /// end of current block scope (i.e. end with "}")
-    void pop_block(int num_newlines = 0);
+    /// end of current block scope (i.e. end with "}") and adds one NL character
+    void pop_block();
+
+    /// same as \a pop_block but control the number of NL characters (0 or more) with \a
+    /// num_newlines parameter
+    void pop_block_nl(int num_newlines = 0);
 
     /// end a block with `suffix` before the newline(s) (i.e. [indent]}[suffix]\n*num_newlines)
     void pop_block(const std::string_view& suffix, std::size_t num_newlines = 1);

--- a/src/printer/code_printer.hpp
+++ b/src/printer/code_printer.hpp
@@ -119,7 +119,7 @@ class CodePrinter {
 
     /// same as \a pop_block but control the number of NL characters (0 or more) with \a
     /// num_newlines parameter
-    void pop_block_nl(int num_newlines = 0);
+    void pop_block_nl(std::size_t num_newlines = 0);
 
     /// end a block with `suffix` before the newline(s) (i.e. [indent]}[suffix]\n*num_newlines)
     void pop_block(const std::string_view& suffix, std::size_t num_newlines = 1);

--- a/src/symtab/symbol.hpp
+++ b/src/symtab/symbol.hpp
@@ -111,7 +111,7 @@ class Symbol {
 
     Symbol() = delete;
 
-    Symbol(std::string name)
+    explicit Symbol(std::string name)
         : name(std::move(name)) {}
 
     Symbol(std::string name, ast::Ast* node)
@@ -244,14 +244,14 @@ class Symbol {
         nodes.push_back(node);
     }
 
-    std::vector<ast::Ast*> get_nodes() const noexcept {
+    const std::vector<ast::Ast*>& get_nodes() const noexcept {
         return nodes;
     }
 
     std::vector<ast::Ast*> get_nodes_by_type(
         std::initializer_list<ast::AstNodeType> l) const noexcept;
 
-    ModToken get_token() const noexcept {
+    const ModToken& get_token() const noexcept {
         return token;
     }
 

--- a/src/symtab/symbol_properties.cpp
+++ b/src/symtab/symbol_properties.cpp
@@ -199,13 +199,11 @@ std::vector<std::string> to_string_vector(const Status& obj) {
 }
 
 std::ostream& operator<<(std::ostream& os, const NmodlType& obj) {
-    os << to_string(obj);
-    return os;
+    return os << to_string(obj);
 }
 
 std::ostream& operator<<(std::ostream& os, const Status& obj) {
-    os << to_string(obj);
-    return os;
+    return os << to_string(obj);
 }
 
 }  // namespace syminfo

--- a/src/symtab/symbol_table.hpp
+++ b/src/symtab/symbol_table.hpp
@@ -84,13 +84,13 @@ class SymbolTable {
     };
 
     /// name of the block
-    std::string symtab_name;
+    const std::string symtab_name;
 
     /// table holding all symbols in the current block
     Table table;
 
     /// pointer to ast node for which current symbol table created
-    ast::Ast* node = nullptr;
+    const ast::Ast* node = nullptr;
 
     /// true if current symbol table is global. blocks like NEURON,
     /// PARAMETER defines global variables and hence they go into
@@ -110,8 +110,8 @@ class SymbolTable {
     /// \name Ctor & dtor
     /// \{
 
-    SymbolTable(std::string name, ast::Ast* node, bool global = false)
-        : symtab_name(name)
+    SymbolTable(std::string name, const ast::Ast* node, bool global = false)
+        : symtab_name(std::move(name))
         , node(node)
         , global(global) {}
 
@@ -123,7 +123,7 @@ class SymbolTable {
     /// \name Getter
     /// \{
 
-    SymbolTable* get_parent_table() const {
+    SymbolTable* get_parent_table() const noexcept {
         return parent;
     }
 
@@ -161,21 +161,21 @@ class SymbolTable {
     /// \}
 
     /// convert symbol table to string
-    std::string to_string() {
-        std::stringstream s;
+    std::string to_string() const {
+        std::ostringstream s;
         print(s, 0);
         return s.str();
     }
 
-    std::string name() const {
+    const std::string& name() const noexcept {
         return symtab_name;
     }
 
-    bool global_scope() const {
+    bool global_scope() const noexcept {
         return global;
     }
 
-    void insert(std::shared_ptr<Symbol> symbol) {
+    void insert(const std::shared_ptr<Symbol>& symbol) {
         table.insert(symbol);
     }
 
@@ -191,7 +191,7 @@ class SymbolTable {
      * Create a copy of symbol table
      * \todo Revisit the usage as tokens will be pointing to old nodes
      */
-    SymbolTable* clone() {
+    SymbolTable* clone() const {
         return new SymbolTable(*this);
     }
 
@@ -207,7 +207,7 @@ class SymbolTable {
     bool under_global_scope();
 
     /// insert new symbol table as one of the children block
-    void insert_table(const std::string& name, std::shared_ptr<SymbolTable> table);
+    void insert_table(const std::string& name, const std::shared_ptr<SymbolTable>& table);
 
     void print(std::ostream& ss, int level) const;
 

--- a/src/utils/string_utils.hpp
+++ b/src/utils/string_utils.hpp
@@ -90,7 +90,6 @@ enum class text_alignment { left, right, center };
  * \return a copy of the given string with every " and \ characters prefixed with an extra \
  */
 [[nodiscard]] static inline std::string escape_quotes(const std::string& text) {
-    std::ostringstream oss;
     std::string result;
 
     for (auto c: text) {

--- a/test/unit/symtab/symbol_table.cpp
+++ b/test/unit/symtab/symbol_table.cpp
@@ -183,7 +183,7 @@ SCENARIO("Symbol table allows operations like insert, lookup") {
             THEN("table size increases") {
                 REQUIRE(table->symbol_count() == 1);
             }
-            THEN("lookup returns a inserted symbol") {
+            THEN("lookup returns an inserted symbol") {
                 REQUIRE(table->lookup("alpha") != nullptr);
                 REQUIRE(table->lookup("beta") == nullptr);
             }
@@ -227,6 +227,29 @@ SCENARIO("Symbol table allows operations like insert, lookup") {
             THEN("children symbol table can lookup into parent table scope") {
                 REQUIRE(next_table->lookup("alpha") == nullptr);
                 REQUIRE(next_table->lookup_in_scope("alpha") != nullptr);
+            }
+            THEN("children can figure if it is in global scope or not") {
+                REQUIRE(next_table->global_scope() == table->global_scope());
+            }
+        }
+        WHEN("pretty-printing a symbol table to a stream") {
+            std::ostringstream oss;
+            table->print(oss, 0);
+            auto text = oss.str();
+            THEN("nothing is written when the table is empty") {
+                REQUIRE(text.empty());
+            }
+            table->insert(symbol);
+            table->print(oss, 0);
+            text = oss.str();
+            THEN("the symbol present in the table can be found in the written string") {
+                REQUIRE(text.find(symbol->get_name()) != std::string::npos);
+            }
+        }
+        WHEN("creating a clone of symbol table") {
+            const std::unique_ptr<SymbolTable> clone(table->clone());
+            THEN("clone has the same name") {
+                REQUIRE(clone->name() == table->name());
             }
         }
         WHEN("query for symbol with and without properties") {
@@ -313,7 +336,7 @@ SCENARIO("Global symbol table (ModelSymbol) allows scope based operations") {
                                     Catch::Matchers::ContainsSubstring("Can not insert"));
             }
         }
-        WHEN("enter scope multipel times") {
+        WHEN("enter scope multiple times") {
             auto program1 = std::make_shared<ast::Program>();
             auto program2 = std::make_shared<ast::Program>();
             mod_symtab.enter_scope("scope1", program1.get(), false, old_symtab);
@@ -333,7 +356,7 @@ SCENARIO("Global symbol table (ModelSymbol) allows scope based operations") {
                 REQUIRE(symbol->get_properties() == properties);
             }
         }
-        WHEN("added same symbol with exisiting property") {
+        WHEN("added same symbol with existing property") {
             mod_symtab.enter_scope("scope", program.get(), true, old_symtab);
             mod_symtab.insert(symbol1);
             mod_symtab.insert(symbol2);


### PR DESCRIPTION
* Reduce number of copies
* `CodePrinter::add_text`:
  * now supports multiple arguments
  * use it instead of trivial but expensive calls to `fmt::format`.
* `CodePrinter::add_multi_line`:
  * Rework the implementation to support C++ raw string literals
  * Use it instead of 3 or more consecutive calls to `add_line`
* `CodePrinter::start_block`: rename to `push_block`
* `CodePrinter::end_block`: rename to pop_block
* `CodePrinter::chain_block`: rename to chain_block