### PR TITLE
Avoid duplicate calculation of number of float variables

### DIFF
--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -535,54 +535,6 @@ std::string CodegenCppVisitor::breakpoint_current(std::string current) const {
 }
 
 
-int CodegenCppVisitor::float_variables_size() const {
-    auto count_length = [](int l, const SymbolType& variable) {
-        return l += variable->get_length();
-    };
-
-    int float_size = std::accumulate(info.range_parameter_vars.begin(),
-                                     info.range_parameter_vars.end(),
-                                     0,
-                                     count_length);
-    float_size += std::accumulate(info.range_assigned_vars.begin(),
-                                  info.range_assigned_vars.end(),
-                                  0,
-                                  count_length);
-    float_size += std::accumulate(info.range_state_vars.begin(),
-                                  info.range_state_vars.end(),
-                                  0,
-                                  count_length);
-    float_size +=
-        std::accumulate(info.assigned_vars.begin(), info.assigned_vars.end(), 0, count_length);
-
-    /// all state variables for which we add Dstate variables
-    float_size += std::accumulate(info.state_vars.begin(), info.state_vars.end(), 0, count_length);
-
-    /// for v_unused variable
-    if (info.vectorize) {
-        float_size++;
-    }
-    /// for g_unused variable
-    if (breakpoint_exist()) {
-        float_size++;
-    }
-    /// for tsave variable
-    if (net_receive_exist()) {
-        float_size++;
-    }
-    return float_size;
-}
-
-
-int CodegenCppVisitor::int_variables_size() const {
-    int num_variables = 0;
-    for (const auto& semantic: info.semantics) {
-        num_variables += semantic.size;
-    }
-    return num_variables;
-}
-
-
 /**
  * \details Depending upon the block type, we have to print read/write ion variables
  * during code generation. Depending on block/procedure being printed, this
@@ -2192,13 +2144,13 @@ void CodegenCppVisitor::print_num_variable_getter() {
     printer->add_newline(2);
     print_device_method_annotation();
     printer->start_block("static inline int float_variables_size()");
-    printer->fmt_line("return {};", float_variables_size());
+    printer->fmt_line("return {};", codegen_float_variables.size());
     printer->end_block(1);
 
     printer->add_newline(2);
     print_device_method_annotation();
     printer->start_block("static inline int int_variables_size()");
-    printer->fmt_line("return {};", int_variables_size());
+    printer->fmt_line("return {};", codegen_int_variables.size());
     printer->end_block(1);
 }
 

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -535,6 +535,12 @@ std::string CodegenCppVisitor::breakpoint_current(std::string current) const {
 }
 
 
+int CodegenCppVisitor::int_variables_size() const {
+    const auto count_semantics = [](int sum, const IndexSemantics& sem) { return sum += sem.size; };
+    return std::accumulate(info.semantics.begin(), info.semantics.end(), 0, count_semantics);
+}
+
+
 /**
  * \details Depending upon the block type, we have to print read/write ion variables
  * during code generation. Depending on block/procedure being printed, this
@@ -2150,7 +2156,7 @@ void CodegenCppVisitor::print_num_variable_getter() {
     printer->add_newline(2);
     print_device_method_annotation();
     printer->start_block("static inline int int_variables_size()");
-    printer->fmt_line("return {};", info.semantics.size());
+    printer->fmt_line("return {};", int_variables_size());
     printer->end_block(1);
 }
 

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -535,6 +535,11 @@ std::string CodegenCppVisitor::breakpoint_current(std::string current) const {
 }
 
 
+int CodegenCppVisitor::float_variables_size() const {
+    return codegen_float_variables.size();
+}
+
+
 int CodegenCppVisitor::int_variables_size() const {
     const auto count_semantics = [](int sum, const IndexSemantics& sem) { return sum += sem.size; };
     return std::accumulate(info.semantics.begin(), info.semantics.end(), 0, count_semantics);
@@ -2150,7 +2155,7 @@ void CodegenCppVisitor::print_num_variable_getter() {
     printer->add_newline(2);
     print_device_method_annotation();
     printer->start_block("static inline int float_variables_size()");
-    printer->fmt_line("return {};", codegen_float_variables.size());
+    printer->fmt_line("return {};", float_variables_size());
     printer->end_block(1);
 
     printer->add_newline(2);

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -2150,7 +2150,7 @@ void CodegenCppVisitor::print_num_variable_getter() {
     printer->add_newline(2);
     print_device_method_annotation();
     printer->start_block("static inline int int_variables_size()");
-    printer->fmt_line("return {};", codegen_int_variables.size());
+    printer->fmt_line("return {};", info.semantics.size());
     printer->end_block(1);
 }
 

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -504,6 +504,12 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
 
 
     /**
+     * Number of float variables in the model
+     */
+    int float_variables_size() const;
+
+
+    /**
      * Number of integer variables in the model
      */
     int int_variables_size() const;

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -504,18 +504,6 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
 
 
     /**
-     * Number of float variables in the model
-     */
-    int float_variables_size() const;
-
-
-    /**
-     * Number of integer variables in the model
-     */
-    int int_variables_size() const;
-
-
-    /**
      * Determine the position in the data array for a given float variable
      * \param name The name of a float variable
      * \return     The position index in the data array

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -504,6 +504,12 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
 
 
     /**
+     * Number of integer variables in the model
+     */
+    int int_variables_size() const;
+
+
+    /**
      * Determine the position in the data array for a given float variable
      * \param name The name of a float variable
      * \return     The position index in the data array


### PR DESCRIPTION
This PR addresses 2 things:
- Count properly the number of float variables based on `codegen_float_variables` vector size
- Refactor the counting of the `int` variables using `STL`