### PR TITLE
Fix codegen_cpp_visitor.*pp based on cppcheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.vscode
 
 # HPC coding conventions
 .clang-format

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -1433,9 +1433,9 @@ void CodegenCppVisitor::print_table_check_function(const Block& node) {
         }
 
         for (const auto& variable: depend_variables) {
-            auto name = variable->get_node_name();
-            auto instance_name = get_variable_name(name);
-            printer->fmt_start_block("if (save_{} != {})", name, instance_name);
+            auto var_name = variable->get_node_name();
+            auto instance_name = get_variable_name(var_name);
+            printer->fmt_start_block("if (save_{} != {})", var_name, instance_name);
             printer->add_line("make_table = true;");
             printer->end_block(1);
         }
@@ -1466,10 +1466,10 @@ void CodegenCppVisitor::print_table_check_function(const Block& node) {
             if (node.is_procedure_block()) {
                 printer->fmt_line("{}({}, x);", function, internal_method_arguments());
                 for (const auto& variable: table_variables) {
-                    auto name = variable->get_node_name();
-                    auto instance_name = get_variable_name(name);
-                    auto table_name = get_variable_name("t_" + name);
-                    auto [is_array, array_length] = check_if_var_is_array(name);
+                    auto var_name = variable->get_node_name();
+                    auto instance_name = get_variable_name(var_name);
+                    auto table_name = get_variable_name("t_" + var_name);
+                    auto [is_array, array_length] = check_if_var_is_array(var_name);
                     if (is_array) {
                         for (int j = 0; j < array_length; j++) {
                             printer->fmt_line(
@@ -1489,9 +1489,9 @@ void CodegenCppVisitor::print_table_check_function(const Block& node) {
             printer->end_block(1);
 
             for (const auto& variable: depend_variables) {
-                auto name = variable->get_node_name();
-                auto instance_name = get_variable_name(name);
-                printer->fmt_line("save_{} = {};", name, instance_name);
+                auto var_name = variable->get_node_name();
+                auto instance_name = get_variable_name(var_name);
+                printer->fmt_line("save_{} = {};", var_name, instance_name);
             }
         }
         printer->end_block(1);
@@ -1506,7 +1506,6 @@ void CodegenCppVisitor::print_table_replacement_function(const ast::Block& node)
     auto table_variables = statement->get_table_vars();
     auto with = statement->get_with()->eval();
     auto use_table_var = get_variable_name(naming::USE_TABLE_VARIABLE);
-    auto float_type = default_float_data_type();
     auto tmin_name = get_variable_name("tmin_" + name);
     auto mfac_name = get_variable_name("mfac_" + name);
     auto function_name = method_name("f_" + name);
@@ -1538,14 +1537,14 @@ void CodegenCppVisitor::print_table_replacement_function(const ast::Block& node)
         printer->start_block("if (isnan(xi))");
         if (node.is_procedure_block()) {
             for (const auto& var: table_variables) {
-                auto name = get_variable_name(var->get_node_name());
+                auto var_name = get_variable_name(var->get_node_name());
                 auto [is_array, array_length] = check_if_var_is_array(var->get_node_name());
                 if (is_array) {
                     for (int j = 0; j < array_length; j++) {
-                        printer->fmt_line("{}[{}] = xi;", name, j);
+                        printer->fmt_line("{}[{}] = xi;", var_name, j);
                     }
                 } else {
-                    printer->fmt_line("{} = xi;", name);
+                    printer->fmt_line("{} = xi;", var_name);
                 }
             }
             printer->add_line("return 0;");
@@ -1558,10 +1557,10 @@ void CodegenCppVisitor::print_table_replacement_function(const ast::Block& node)
         printer->fmt_line("int index = (xi <= 0.) ? 0 : {};", with);
         if (node.is_procedure_block()) {
             for (const auto& variable: table_variables) {
-                auto name = variable->get_node_name();
-                auto instance_name = get_variable_name(name);
-                auto table_name = get_variable_name("t_" + name);
-                auto [is_array, array_length] = check_if_var_is_array(name);
+                auto var_name = variable->get_node_name();
+                auto instance_name = get_variable_name(var_name);
+                auto table_name = get_variable_name("t_" + var_name);
+                auto [is_array, array_length] = check_if_var_is_array(var_name);
                 if (is_array) {
                     for (int j = 0; j < array_length; j++) {
                         printer->fmt_line(
@@ -1582,9 +1581,9 @@ void CodegenCppVisitor::print_table_replacement_function(const ast::Block& node)
         printer->add_line("double theta = xi - double(i);");
         if (node.is_procedure_block()) {
             for (const auto& var: table_variables) {
-                auto name = var->get_node_name();
-                auto instance_name = get_variable_name(name);
-                auto table_name = get_variable_name("t_" + name);
+                auto var_name = var->get_node_name();
+                auto instance_name = get_variable_name(var_name);
+                auto table_name = get_variable_name("t_" + var_name);
                 auto [is_array, array_length] = check_if_var_is_array(var->get_node_name());
                 if (is_array) {
                     for (size_t j = 0; j < array_length; j++) {
@@ -1625,9 +1624,9 @@ void CodegenCppVisitor::print_check_table_thread_function() {
     printer->add_line("double v = 0;");
 
     for (const auto& function: info.functions_with_table) {
-        auto name = method_name("check_" + function->get_node_name());
+        auto method_name_str = method_name("check_" + function->get_node_name());
         auto arguments = internal_method_arguments();
-        printer->fmt_line("{}({});", name, arguments);
+        printer->fmt_line("{}({});", method_name_str, arguments);
     }
 
     printer->end_block(1);
@@ -1736,9 +1735,6 @@ void CodegenCppVisitor::print_function_tables(const ast::FunctionTableBlock& nod
  */
 bool is_functor_const(const ast::StatementBlock& variable_block,
                       const ast::StatementBlock& functor_block) {
-    // Save DUChain for every variable in variable_block
-    std::unordered_map<std::string, DUChain> chains;
-
     // Create complete_block with both variable declarations (done in variable_block) and solver
     // part (done in functor_block) to be able to run the SymtabVisitor and DefUseAnalyzeVisitor
     // then and get the proper DUChains for the variables defined in the variable_block
@@ -2418,7 +2414,8 @@ std::string CodegenCppVisitor::get_variable_name(const std::string& name, bool u
 void CodegenCppVisitor::print_backend_info() {
     time_t tr{};
     time(&tr);
-    auto date = std::string(asctime(localtime(&tr)));
+    char timeString[100];
+    std::strftime(timeString, std::size(timeString), "%A %c", std::localtime(&tr));
     auto version = nmodl::Version::NMODL_VERSION + " [" + nmodl::Version::GIT_REVISION + "]";
 
     printer->add_line("/*********************************************************");
@@ -2427,7 +2424,7 @@ void CodegenCppVisitor::print_backend_info() {
     printer->fmt_line("NMODL Version   : {}", nmodl_version());
     printer->fmt_line("Vectorized      : {}", info.vectorize);
     printer->fmt_line("Threadsafe      : {}", info.thread_safe);
-    printer->fmt_line("Created         : {}", stringutils::trim(date));
+    printer->fmt_line("Created         : {}", timeString);
     printer->fmt_line("Backend         : {}", backend_name());
     printer->fmt_line("NMODL Compiler  : {}", version);
     printer->add_line("*********************************************************/");
@@ -2711,7 +2708,7 @@ void CodegenCppVisitor::print_prcellstate_macros() const {
 
 
 void CodegenCppVisitor::print_mechanism_info() {
-    auto variable_printer = [&](std::vector<SymbolType>& variables) {
+    auto variable_printer = [&](const std::vector<SymbolType>& variables) {
         for (const auto& v: variables) {
             auto name = v->get_name();
             if (!info.point_process) {
@@ -2933,9 +2930,9 @@ void CodegenCppVisitor::print_mechanism_register() {
 
     // register semantics for index variables
     for (auto& semantic: info.semantics) {
-        auto args =
+        auto hoc_register_dparam_semantics_args =
             fmt::format("mech_type, {}, {}", semantic.index, add_escape_quote(semantic.name));
-        printer->fmt_line("hoc_register_dparam_semantics({});", args);
+        printer->fmt_line("hoc_register_dparam_semantics({});", hoc_register_dparam_semantics_args);
     }
 
     if (info.is_watch_used()) {
@@ -3059,7 +3056,6 @@ void CodegenCppVisitor::print_thread_memory_callbacks() {
 
 void CodegenCppVisitor::print_mechanism_range_var_structure(bool print_initialisers) {
     auto const value_initialise = print_initialisers ? "{}" : "";
-    auto float_type = default_float_data_type();
     auto int_type = default_int_data_type();
     printer->add_newline(2);
     printer->add_line("/** all mechanism instance variables and global variables */");
@@ -3797,7 +3793,6 @@ void CodegenCppVisitor::print_net_move_call(const FunctionCall& node) {
         printer->add_text(")");
     } else {
         auto point_process = get_variable_name("point_process");
-        std::string t = get_variable_name("t");
         printer->add_text("net_send_buffering(");
         printer->fmt_text("nt, ml->_net_send_buffer, 2, {}, {}, {}, ", tqitem, weight_index, point_process);
         print_vector_elements(arguments, ", ");

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -2868,18 +2868,18 @@ void CodegenCppVisitor::print_mechanism_register() {
     printer->add_line("_nrn_layout_reg(mech_type, 0);");  // 0 for SoA
 
     // register mechanism
-    auto args = register_mechanism_arguments();
-    auto nobjects = num_thread_objects();
+    const auto mech_arguments = register_mechanism_arguments();
+    const auto number_of_thread_objects = num_thread_objects();
     if (info.point_process) {
         printer->fmt_line("point_register_mech({}, {}, {}, {});",
-                          args,
+                          mech_arguments,
                           info.constructor_node ? method_name(naming::NRN_CONSTRUCTOR_METHOD)
                                                 : "nullptr",
                           info.destructor_node ? method_name(naming::NRN_DESTRUCTOR_METHOD)
                                                : "nullptr",
-                          nobjects);
+                          number_of_thread_objects);
     } else {
-        printer->fmt_line("register_mech({}, {});", args, nobjects);
+        printer->fmt_line("register_mech({}, {});", mech_arguments, number_of_thread_objects);
         if (info.constructor_node) {
             printer->fmt_line("register_constructor({});",
                               method_name(naming::NRN_CONSTRUCTOR_METHOD));
@@ -2930,9 +2930,9 @@ void CodegenCppVisitor::print_mechanism_register() {
 
     // register semantics for index variables
     for (auto& semantic: info.semantics) {
-        auto hoc_register_dparam_semantics_args =
+        auto args =
             fmt::format("mech_type, {}, {}", semantic.index, add_escape_quote(semantic.name));
-        printer->fmt_line("hoc_register_dparam_semantics({});", hoc_register_dparam_semantics_args);
+        printer->fmt_line("hoc_register_dparam_semantics({});", args);
     }
 
     if (info.is_watch_used()) {

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -8,6 +8,7 @@
 #include "codegen/codegen_cpp_visitor.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <ctime>
 #include <regex>
@@ -2412,10 +2413,9 @@ std::string CodegenCppVisitor::get_variable_name(const std::string& name, bool u
 
 
 void CodegenCppVisitor::print_backend_info() {
-    time_t tr{};
-    time(&tr);
-    char timeString[100];
-    std::strftime(timeString, std::size(timeString), "%A %c", std::localtime(&tr));
+    time_t current_time{};
+    time(&current_time);
+    std::string data_time_str{std::ctime(&current_time)};
     auto version = nmodl::Version::NMODL_VERSION + " [" + nmodl::Version::GIT_REVISION + "]";
 
     printer->add_line("/*********************************************************");
@@ -2424,7 +2424,7 @@ void CodegenCppVisitor::print_backend_info() {
     printer->fmt_line("NMODL Version   : {}", nmodl_version());
     printer->fmt_line("Vectorized      : {}", info.vectorize);
     printer->fmt_line("Threadsafe      : {}", info.thread_safe);
-    printer->fmt_line("Created         : {}", timeString);
+    printer->fmt_line("Created         : {}", stringutils::trim(data_time_str));
     printer->fmt_line("Backend         : {}", backend_name());
     printer->fmt_line("NMODL Compiler  : {}", version);
     printer->add_line("*********************************************************/");

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -192,19 +192,39 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     using ParamVector = std::vector<std::tuple<std::string, std::string, std::string, std::string>>;
 
     /**
+     * Code printer object for target (C++)
+     */
+    std::shared_ptr<CodePrinter> target_printer;
+
+    /**
+     * Code printer object for wrappers
+     */
+    std::shared_ptr<CodePrinter> wrapper_printer;
+
+    /**
+     * Pointer to active code printer
+     */
+    std::shared_ptr<CodePrinter> printer;
+
+    /**
      * Name of mod file (without .mod suffix)
      */
     std::string mod_filename;
 
     /**
-     * Flag to indicate if visitor should print the visited nodes
+     * Data type of floating point variables
      */
-    bool codegen = false;
+    std::string float_type = codegen::naming::DEFAULT_FLOAT_TYPE;
 
     /**
      * Flag to indicate if visitor should avoid ion variable copies
      */
     bool optimize_ionvar_copies = true;
+
+    /**
+     * Flag to indicate if visitor should print the visited nodes
+     */
+    bool codegen = false;
 
     /**
      * Variable name should be converted to instance name (but not for function arguments)
@@ -259,29 +279,9 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     int current_watch_statement = 0;
 
     /**
-     * Data type of floating point variables
-     */
-    std::string float_type = codegen::naming::DEFAULT_FLOAT_TYPE;
-
-    /**
      * All ast information for code generation
      */
     codegen::CodegenInfo info;
-
-    /**
-     * Code printer object for target (C++)
-     */
-    std::shared_ptr<CodePrinter> target_printer;
-
-    /**
-     * Code printer object for wrappers
-     */
-    std::shared_ptr<CodePrinter> wrapper_printer;
-
-    /**
-     * Pointer to active code printer
-     */
-    std::shared_ptr<CodePrinter> printer;
 
     /**
      * Return Nmodl language version

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -1662,34 +1662,6 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
 
 
     /**
-     * \copybrief nmodl::codegen::CodegenCppVisitor
-     *
-     * This constructor instantiates an NMODL C code generator and allows writing generated code
-     * using an nmodl::printer::CodePrinter defined elsewhere.
-     *
-     * \note No code generation is performed at this stage. Since the code
-     * generator classes are all based on \c AstVisitor the AST must be visited using e.g. \c
-     * visit_program in order to generate the C code corresponding to the AST.
-     *
-     * \param mod_filename   The name of the model for which code should be generated.
-     *                       It is used for constructing an output filename.
-     * \param float_type     The float type to use in the generated code. The string will be used
-     *                       as-is in the target code. This defaults to \c double.
-     * \param target_printer A printer defined outside this visitor to be used for the code
-     *                       generation
-     */
-    CodegenCppVisitor(std::string mod_filename,
-                      std::string float_type,
-                      const bool optimize_ionvar_copies,
-                      std::shared_ptr<CodePrinter>& target_printer)
-        : target_printer(target_printer)
-        , printer(target_printer)
-        , mod_filename(std::move(mod_filename))
-        , float_type(std::move(float_type))
-        , optimize_ionvar_copies(optimize_ionvar_copies) {}
-
-
-    /**
      * Print the \c nrn\_init function definition
      * \param skip_init_check \c true if we want the generated code to execute the initialization
      *                        conditionally

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -1583,8 +1583,9 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
                       const bool optimize_ionvar_copies,
                       const std::string& extension,
                       const std::string& wrapper_ext)
-        : target_printer(new CodePrinter(output_dir + "/" + mod_filename + extension))
-        , wrapper_printer(new CodePrinter(output_dir + "/" + mod_filename + wrapper_ext))
+        : target_printer(std::make_shared<CodePrinter>(output_dir + "/" + mod_filename + extension))
+        , wrapper_printer(
+              std::make_shared<CodePrinter>(output_dir + "/" + mod_filename + wrapper_ext))
         , printer(target_printer)
         , mod_filename(std::move(mod_filename))
         , float_type(std::move(float_type))
@@ -1596,8 +1597,8 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
                       const bool optimize_ionvar_copies,
                       const std::string& extension,
                       const std::string& wrapper_ext)
-        : target_printer(new CodePrinter(stream))
-        , wrapper_printer(new CodePrinter(stream))
+        : target_printer(std::make_shared<CodePrinter>(stream))
+        , wrapper_printer(std::make_shared<CodePrinter>(stream))
         , printer(target_printer)
         , mod_filename(std::move(mod_filename))
         , float_type(std::move(float_type))
@@ -1627,7 +1628,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
                       std::string float_type,
                       const bool optimize_ionvar_copies,
                       const std::string& extension = ".cpp")
-        : target_printer(new CodePrinter(output_dir + "/" + mod_filename + extension))
+        : target_printer(std::make_shared<CodePrinter>(output_dir + "/" + mod_filename + extension))
         , printer(target_printer)
         , mod_filename(std::move(mod_filename))
         , float_type(std::move(float_type))
@@ -1653,7 +1654,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
                       std::ostream& stream,
                       std::string float_type,
                       const bool optimize_ionvar_copies)
-        : target_printer(new CodePrinter(stream))
+        : target_printer(std::make_shared<CodePrinter>(stream))
         , printer(target_printer)
         , mod_filename(std::move(mod_filename))
         , float_type(std::move(float_type))

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -269,7 +269,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     codegen::CodegenInfo info;
 
     /**
-     * Code printer object for target (C)
+     * Code printer object for target (C++)
      */
     std::shared_ptr<CodePrinter> target_printer;
 
@@ -1577,30 +1577,30 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     virtual void print_wrapper_routines();
 
 
-    CodegenCppVisitor(const std::string& mod_filename,
+    CodegenCppVisitor(std::string mod_filename,
                       const std::string& output_dir,
-                      const std::string& float_type,
+                      std::string float_type,
                       const bool optimize_ionvar_copies,
                       const std::string& extension,
                       const std::string& wrapper_ext)
         : target_printer(new CodePrinter(output_dir + "/" + mod_filename + extension))
         , wrapper_printer(new CodePrinter(output_dir + "/" + mod_filename + wrapper_ext))
         , printer(target_printer)
-        , mod_filename(mod_filename)
-        , float_type(float_type)
+        , mod_filename(std::move(mod_filename))
+        , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
 
-    CodegenCppVisitor(const std::string& mod_filename,
+    CodegenCppVisitor(std::string mod_filename,
                       std::ostream& stream,
-                      const std::string& float_type,
+                      std::string float_type,
                       const bool optimize_ionvar_copies,
                       const std::string& extension,
                       const std::string& wrapper_ext)
         : target_printer(new CodePrinter(stream))
         , wrapper_printer(new CodePrinter(stream))
         , printer(target_printer)
-        , mod_filename(mod_filename)
-        , float_type(float_type)
+        , mod_filename(std::move(mod_filename))
+        , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
 
 
@@ -1622,14 +1622,14 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      *                     as-is in the target code. This defaults to \c double.
      * \param extension    The file extension to use. This defaults to \c .cpp .
      */
-    CodegenCppVisitor(const std::string& mod_filename,
+    CodegenCppVisitor(std::string mod_filename,
                       const std::string& output_dir,
                       std::string float_type,
                       const bool optimize_ionvar_copies,
                       const std::string& extension = ".cpp")
         : target_printer(new CodePrinter(output_dir + "/" + mod_filename + extension))
         , printer(target_printer)
-        , mod_filename(mod_filename)
+        , mod_filename(std::move(mod_filename))
         , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
 
@@ -1649,14 +1649,14 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * \param float_type   The float type to use in the generated code. The string will be used
      *                     as-is in the target code. This defaults to \c double.
      */
-    CodegenCppVisitor(const std::string& mod_filename,
+    CodegenCppVisitor(std::string mod_filename,
                       std::ostream& stream,
-                      const std::string& float_type,
+                      std::string float_type,
                       const bool optimize_ionvar_copies)
         : target_printer(new CodePrinter(stream))
         , printer(target_printer)
-        , mod_filename(mod_filename)
-        , float_type(float_type)
+        , mod_filename(std::move(mod_filename))
+        , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
 
 
@@ -1677,14 +1677,14 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * \param target_printer A printer defined outside this visitor to be used for the code
      *                       generation
      */
-    CodegenCppVisitor(const std::string& mod_filename,
-                      const std::string& float_type,
+    CodegenCppVisitor(std::string mod_filename,
+                      std::string float_type,
                       const bool optimize_ionvar_copies,
                       std::shared_ptr<CodePrinter>& target_printer)
         : target_printer(target_printer)
         , printer(target_printer)
-        , mod_filename(mod_filename)
-        , float_type(float_type)
+        , mod_filename(std::move(mod_filename))
+        , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
 
 

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -127,10 +127,10 @@ struct IndexVariableInfo {
     /// if the variable is qualified as constant (this is property of IndexVariable)
     bool is_constant = false;
 
-    IndexVariableInfo(std::shared_ptr<symtab::Symbol> symbol,
-                      bool is_vdata = false,
-                      bool is_index = false,
-                      bool is_integer = false)
+    explicit IndexVariableInfo(std::shared_ptr<symtab::Symbol> symbol,
+                               bool is_vdata = false,
+                               bool is_index = false,
+                               bool is_integer = false)
         : symbol(std::move(symbol))
         , is_vdata(is_vdata)
         , is_index(is_index)
@@ -1677,8 +1677,8 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * \param target_printer A printer defined outside this visitor to be used for the code
      *                       generation
      */
-    CodegenCppVisitor(std::string mod_filename,
-                      std::string float_type,
+    CodegenCppVisitor(const std::string& mod_filename,
+                      const std::string& float_type,
                       const bool optimize_ionvar_copies,
                       std::shared_ptr<CodePrinter>& target_printer)
         : target_printer(target_printer)
@@ -1890,12 +1890,15 @@ void CodegenCppVisitor::print_vector_elements(const std::vector<T>& elements,
 template <typename T>
 bool has_parameter_of_name(const T& node, const std::string& name) {
     auto parameters = node->get_parameters();
-    for (const auto& parameter: parameters) {
-        if (parameter->get_node_name() == name) {
-            return true;
+    struct ParameterHasName {
+        const std::string paramater_name;
+        explicit ParameterHasName(const std::string& name)
+            : paramater_name(name) {}
+        bool operator()(const decltype(*parameters.begin()) arg) const {
+            return arg->get_node_name() == paramater_name;
         }
-    }
-    return false;
+    };
+    return std::any_of(parameters.begin(), parameters.end(), ParameterHasName(name));
 }
 
 

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -1890,15 +1890,11 @@ void CodegenCppVisitor::print_vector_elements(const std::vector<T>& elements,
 template <typename T>
 bool has_parameter_of_name(const T& node, const std::string& name) {
     auto parameters = node->get_parameters();
-    struct ParameterHasName {
-        const std::string paramater_name;
-        explicit ParameterHasName(const std::string& name)
-            : paramater_name(name) {}
-        bool operator()(const decltype(*parameters.begin()) arg) const {
-            return arg->get_node_name() == paramater_name;
-        }
-    };
-    return std::any_of(parameters.begin(), parameters.end(), ParameterHasName(name));
+    return std::any_of(parameters.begin(),
+                       parameters.end(),
+                       [&name](const decltype(*parameters.begin()) arg) {
+                           return arg->get_node_name() == name;
+                       });
 }
 
 


### PR DESCRIPTION
On this free Friday I came across a static analysis tool called [cppchecker](https://cppcheck.sourceforge.io/).
I decided to try it out with NMODL and fix some issues.
Using and install it is pretty easy.
To install:
```
sudo apt-get install cppcheck
```
The output of its execution (filtered only for codegen_cpp_visitor) is the following
```
➜  nmodl git:(master) ✗ cppcheck . --enable=all -iext -ibuild -ibuild_master -ivenv_nmodl -icmake/hpc-coding-conventions 2>&1 | grep codegen_cpp_visitor -A 2
Checking src/codegen/codegen_cpp_visitor.cpp ...
src/codegen/codegen_cpp_visitor.cpp:2458:29: style: Obsolete function 'asctime' called. It is recommended to use 'strftime' instead. [asctimeCalled]
    auto date = std::string(asctime(localtime(&tr)));
                            ^
src/codegen/codegen_cpp_visitor.cpp:1473:18: style: Local variable 'name' shadows outer variable [shadowVariable]
            auto name = variable->get_node_name();
                 ^
src/codegen/codegen_cpp_visitor.cpp:1449:10: note: Shadowed declaration
    auto name = node.get_node_name();
         ^
src/codegen/codegen_cpp_visitor.cpp:1473:18: note: Shadow variable
            auto name = variable->get_node_name();
                 ^
src/codegen/codegen_cpp_visitor.cpp:1506:26: style: Local variable 'name' shadows outer variable [shadowVariable]
                    auto name = variable->get_node_name();
                         ^
src/codegen/codegen_cpp_visitor.cpp:1449:10: note: Shadowed declaration
    auto name = node.get_node_name();
         ^
src/codegen/codegen_cpp_visitor.cpp:1506:26: note: Shadow variable
                    auto name = variable->get_node_name();
                         ^
src/codegen/codegen_cpp_visitor.cpp:1529:22: style: Local variable 'name' shadows outer variable [shadowVariable]
                auto name = variable->get_node_name();
                     ^
src/codegen/codegen_cpp_visitor.cpp:1449:10: note: Shadowed declaration
    auto name = node.get_node_name();
         ^
src/codegen/codegen_cpp_visitor.cpp:1529:22: note: Shadow variable
                auto name = variable->get_node_name();
                     ^
src/codegen/codegen_cpp_visitor.cpp:1578:22: style: Local variable 'name' shadows outer variable [shadowVariable]
                auto name = get_variable_name(var->get_node_name());
                     ^
src/codegen/codegen_cpp_visitor.cpp:1541:10: note: Shadowed declaration
    auto name = node.get_node_name();
         ^
src/codegen/codegen_cpp_visitor.cpp:1578:22: note: Shadow variable
                auto name = get_variable_name(var->get_node_name());
                     ^
src/codegen/codegen_cpp_visitor.cpp:1598:22: style: Local variable 'name' shadows outer variable [shadowVariable]
                auto name = variable->get_node_name();
                     ^
src/codegen/codegen_cpp_visitor.cpp:1541:10: note: Shadowed declaration
    auto name = node.get_node_name();
         ^
src/codegen/codegen_cpp_visitor.cpp:1598:22: note: Shadow variable
                auto name = variable->get_node_name();
                     ^
src/codegen/codegen_cpp_visitor.cpp:1622:22: style: Local variable 'name' shadows outer variable [shadowVariable]
                auto name = var->get_node_name();
                     ^
src/codegen/codegen_cpp_visitor.cpp:1541:10: note: Shadowed declaration
    auto name = node.get_node_name();
         ^
src/codegen/codegen_cpp_visitor.cpp:1622:22: note: Shadow variable
                auto name = var->get_node_name();
                     ^
src/codegen/codegen_cpp_visitor.cpp:1665:14: style: Local variable 'name' shadows outer variable [shadowVariable]
        auto name = method_name("check_" + function->get_node_name());
             ^
src/codegen/codegen_cpp_visitor.cpp:1656:10: note: Shadowed declaration
    auto name = method_name("check_table_thread");
         ^
src/codegen/codegen_cpp_visitor.cpp:1665:14: note: Shadow variable
        auto name = method_name("check_" + function->get_node_name());
             ^
src/codegen/codegen_cpp_visitor.cpp:2973:14: style: Local variable 'args' shadows outer variable [shadowVariable]
        auto args =
             ^
src/codegen/codegen_cpp_visitor.cpp:2911:10: note: Shadowed declaration
    auto args = register_mechanism_arguments();
         ^
src/codegen/codegen_cpp_visitor.cpp:2973:14: note: Shadow variable
        auto args =
             ^
src/codegen/codegen_cpp_visitor.cpp:2751:58: style: Parameter 'variables' can be declared with const [constParameter]
    auto variable_printer = [&](std::vector<SymbolType>& variables) {
                                                         ^
src/codegen/codegen_cpp_visitor.cpp:580:23: style: Consider using std::accumulate algorithm instead of a raw loop. [useStlAlgorithm]
        num_variables += semantic.size;
                      ^
src/codegen/codegen_cpp_visitor.cpp:1546:21: style: Variable 'float_type' is assigned a value that is never used. [unreadVariable]
    auto float_type = default_float_data_type();
                    ^
src/codegen/codegen_cpp_visitor.cpp:1777:46: style: Unused variable: chains [unusedVariable]
    std::unordered_map<std::string, DUChain> chains;
                                             ^
src/codegen/codegen_cpp_visitor.cpp:3099:21: style: Variable 'float_type' is assigned a value that is never used. [unreadVariable]
    auto float_type = default_float_data_type();
                    ^
src/codegen/codegen_cpp_visitor.cpp:3837:23: style: Variable 't' is assigned a value that is never used. [unreadVariable]
        std::string t = get_variable_name("t");
                      ^
--
src/codegen/codegen_cpp_visitor.hpp:130:5: style: Struct 'IndexVariableInfo' has a constructor with 1 argument that is not explicit. [noExplicitConstructor]
    IndexVariableInfo(std::shared_ptr<symtab::Symbol> symbol,
    ^
--
src/codegen/codegen_cpp_visitor.hpp:1680:35: performance: Function parameter 'mod_filename' should be passed by const reference. [passedByValue]
    CodegenCppVisitor(std::string mod_filename,
                                  ^
src/codegen/codegen_cpp_visitor.hpp:1681:35: performance: Function parameter 'float_type' should be passed by const reference. [passedByValue]
                      std::string float_type,
                                  ^
src/codegen/codegen_cpp_visitor.hpp:1894:49: style: Consider using std::any_of algorithm instead of a raw loop. [useStlAlgorithm]
        if (parameter->get_node_name() == name) {
                                                ^
src/codegen/codegen_cpp_visitor.hpp:1917:25: style: Consider using std::transform algorithm instead of a raw loop. [useStlAlgorithm]
        internal_params.emplace_back("", type, "", param.get()->get_node_name());
                     
```
After the changes in this PR:
```
➜  nmodl git:(magkanar/cpp_checker) ✗ cppcheck . --enable=all -iext -ibuild -ibuild_master -ivenv_nmodl -icmake/hpc-coding-conventions 2>&1 | grep codegen_cpp_visitor -A 2
Checking src/codegen/codegen_cpp_visitor.cpp ...
6/128 files checked 17% done
Checking src/codegen/codegen_helper_visitor.cpp ...
--
src/codegen/codegen_cpp_visitor.hpp:1897:41: error: Syntax Error: AST broken, 'parameters' doesn't have a parent. [internalAstError]
        bool operator()(const decltype(*parameters.begin()) arg) const {
                                        ^
--
```
The only error still there seems to be something internal of the tool and is already reported [here](https://trac.cppcheck.net/ticket/10839)