### PR TITLE
Simplify CodegenCppVisitor

### DIFF
--- a/src/codegen/codegen_acc_visitor.cpp
+++ b/src/codegen/codegen_acc_visitor.cpp
@@ -77,7 +77,7 @@ void CodegenAccVisitor::print_backend_includes() {
 
 
 std::string CodegenAccVisitor::backend_name() const {
-    return "C-OpenAcc (api-compatibility)";
+    return "C++-OpenAcc (api-compatibility)";
 }
 
 

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -25,7 +25,7 @@ namespace codegen {
 
 /**
  * \class CodegenAccVisitor
- * \brief %Visitor for printing C code with OpenACC backend
+ * \brief %Visitor for printing C++ code with OpenACC backend
  */
 class CodegenAccVisitor: public CodegenCppVisitor {
   protected:

--- a/src/codegen/codegen_acc_visitor.hpp
+++ b/src/codegen/codegen_acc_visitor.hpp
@@ -33,7 +33,7 @@ class CodegenAccVisitor: public CodegenCppVisitor {
     std::string backend_name() const override;
 
 
-    /// common includes : standard c/c++, coreneuron and backend specific
+    /// common includes : standard c++, coreneuron and backend specific
     void print_backend_includes() override;
 
 

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -1145,12 +1145,12 @@ void CodegenCppVisitor::print_global_method_annotation() {
 
 
 void CodegenCppVisitor::print_backend_namespace_start() {
-    // no separate namespace for C (cpu) backend
+    // no separate namespace for C++ (cpu) backend
 }
 
 
 void CodegenCppVisitor::print_backend_namespace_stop() {
-    // no separate namespace for C (cpu) backend
+    // no separate namespace for C++ (cpu) backend
 }
 
 
@@ -1160,7 +1160,7 @@ void CodegenCppVisitor::print_backend_includes() {
 
 
 std::string CodegenCppVisitor::backend_name() const {
-    return "C (api-compatibility)";
+    return "C++ (api-compatibility)";
 }
 
 
@@ -1893,7 +1893,7 @@ void CodegenCppVisitor::print_eigen_linear_solver(const std::string& float_type,
             "(Eigen::inverse)!\");");
     } else {
         // In Eigen the default storage order is ColMajor.
-        // Crout's implementation requires matrices stored in RowMajor order (C-style arrays).
+        // Crout's implementation requires matrices stored in RowMajor order (C++-style arrays).
         // Therefore, the transposeInPlace is critical such that the data() method to give the rows
         // instead of the columns.
         printer->add_line("if (!nmodl_eigen_jm.IsRowMajor) nmodl_eigen_jm.transposeInPlace();");
@@ -2473,7 +2473,7 @@ void CodegenCppVisitor::print_coreneuron_includes() {
 
 /**
  * \details Variables required for type of ion, type of point process etc. are
- * of static int type. For any backend type (C,C++), it's ok to have
+ * of static int type. For the C++ backend type, it's ok to have
  * these variables as file scoped static variables.
  *
  * Initial values of state variables (h0) are also defined as static

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -696,7 +696,7 @@ bool CodegenCppVisitor::ion_variable_struct_required() const {
 /**
  * \details This can be override in the backend. For example, parameters can be constant
  * except in INITIAL block where they are set to 0. As initial block is/can be
- * executed on c/cpu backend, gpu backend can mark the parameter as constant.
+ * executed on c++/cpu backend, gpu backend can mark the parameter as constant.
  */
 bool CodegenCppVisitor::is_constant_variable(const std::string& name) const {
     auto symbol = program_symtab->lookup_in_scope(name);

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -194,17 +194,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * Code printer object for target (C++)
      */
-    std::shared_ptr<CodePrinter> target_printer;
-
-    /**
-     * Code printer object for wrappers
-     */
-    std::shared_ptr<CodePrinter> wrapper_printer;
-
-    /**
-     * Pointer to active code printer
-     */
-    std::shared_ptr<CodePrinter> printer;
+    std::unique_ptr<CodePrinter> printer;
 
     /**
      * Name of mod file (without .mod suffix)
@@ -1583,10 +1573,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
                       const bool optimize_ionvar_copies,
                       const std::string& extension,
                       const std::string& wrapper_ext)
-        : target_printer(std::make_shared<CodePrinter>(output_dir + "/" + mod_filename + extension))
-        , wrapper_printer(
-              std::make_shared<CodePrinter>(output_dir + "/" + mod_filename + wrapper_ext))
-        , printer(target_printer)
+        : printer(std::make_unique<CodePrinter>(output_dir + "/" + mod_filename + extension))
         , mod_filename(std::move(mod_filename))
         , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
@@ -1597,9 +1584,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
                       const bool optimize_ionvar_copies,
                       const std::string& extension,
                       const std::string& wrapper_ext)
-        : target_printer(std::make_shared<CodePrinter>(stream))
-        , wrapper_printer(std::make_shared<CodePrinter>(stream))
-        , printer(target_printer)
+        : printer(std::make_unique<CodePrinter>(stream))
         , mod_filename(std::move(mod_filename))
         , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
@@ -1628,8 +1613,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
                       std::string float_type,
                       const bool optimize_ionvar_copies,
                       const std::string& extension = ".cpp")
-        : target_printer(std::make_shared<CodePrinter>(output_dir + "/" + mod_filename + extension))
-        , printer(target_printer)
+        : printer(std::make_unique<CodePrinter>(output_dir + "/" + mod_filename + extension))
         , mod_filename(std::move(mod_filename))
         , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
@@ -1654,8 +1638,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
                       std::ostream& stream,
                       std::string float_type,
                       const bool optimize_ionvar_copies)
-        : target_printer(std::make_shared<CodePrinter>(stream))
-        , printer(target_printer)
+        : printer(std::make_unique<CodePrinter>(stream))
         , mod_filename(std::move(mod_filename))
         , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -168,7 +168,7 @@ using printer::CodePrinter;
 
 /**
  * \class CodegenCppVisitor
- * \brief %Visitor for printing C code compatible with legacy api of CoreNEURON
+ * \brief %Visitor for printing C++ code compatible with legacy api of CoreNEURON
  *
  * \todo
  *  - Handle define statement (i.e. macros)
@@ -566,7 +566,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      *
      * This function typically returns the accessor expression in backend code for the given symbol.
      * Since the model variables are stored in data arrays and accessed by offset, this function
-     * will return the C string representing the array access at the correct offset
+     * will return the C++ string representing the array access at the correct offset
      *
      * \param symbol       The symbol of a variable for which we want to obtain its name
      * \param use_instance Should the variable be accessed via instance or data array
@@ -581,7 +581,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      *
      * This function typically returns the accessor expression in backend code for the given symbol.
      * Since the model variables are stored in data arrays and accessed by offset, this function
-     * will return the C string representing the array access at the correct offset
+     * will return the C++ string representing the array access at the correct offset
      *
      * \param symbol       The symbol of a variable for which we want to obtain its name
      * \param name         The name of the index variable
@@ -599,7 +599,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * \param symbol The symbol of a variable for which we want to obtain its name
      * \param use_instance Should the variable be accessed via the (host-only)
      * global variable or the instance-specific copy (also available on GPU).
-     * \return       The C string representing the access to the global variable
+     * \return       The C++ string representing the access to the global variable
      */
     std::string global_variable_name(const SymbolType& symbol, bool use_instance = true) const;
 
@@ -609,7 +609,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      *
      * \param name         Variable name that is being printed
      * \param use_instance Should the variable be accessed via instance or data array
-     * \return             The C string representing the access to the variable in the neuron thread
+     * \return             The C++ string representing the access to the variable in the neuron thread
      * structure
      */
     std::string get_variable_name(const std::string& name, bool use_instance = true) const;
@@ -619,7 +619,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * Determine the variable name for the "current" used in breakpoint block taking into account
      * intermediate code transformations.
      * \param current The variable name for the current used in the model
-     * \return        The name for the current to be printed in C
+     * \return        The name for the current to be printed in C++
      */
     std::string breakpoint_current(std::string current) const;
 
@@ -840,7 +840,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * The used global type qualifier
      *
-     * For C code generation this is empty
+     * For C++ code generation this is empty
      * \return ""
      *
      * \return "uniform "
@@ -850,7 +850,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * Instantiate global var instance
      *
-     * For C code generation this is empty
+     * For C++ code generation this is empty
      * \return ""
      */
     virtual void print_global_var_struct_decl();
@@ -875,7 +875,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * Prints the start of namespace for the backend-specific code
      *
-     * For the C backend no additional namespace is required
+     * For the C++ backend no additional namespace is required
      */
     virtual void print_backend_namespace_start();
 
@@ -883,7 +883,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * Prints the end of namespace for the backend-specific code
      *
-     * For the C backend no additional namespace is required
+     * For the C++ backend no additional namespace is required
      */
     virtual void print_backend_namespace_stop();
 
@@ -934,7 +934,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
 
 
     /**
-     * Print backend specific includes (none needed for C backend)
+     * Print backend specific includes (none needed for C++ backend)
      */
     virtual void print_backend_includes();
 
@@ -1139,7 +1139,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * Print the pragma annotation to update global variables from host to the device
      *
-     * \note This is not used for the C backend
+     * \note This is not used for the C++ backend
      */
     virtual void print_global_variable_device_update_annotation();
 
@@ -1154,7 +1154,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * Print the backend specific device method annotation
      *
-     * \note This is not used for the C backend
+     * \note This is not used for the C++ backend
      */
     virtual void print_device_method_annotation();
 
@@ -1162,7 +1162,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * Print backend specific global method annotation
      *
-     * \note This is not used for the C backend
+     * \note This is not used for the C++ backend
      */
     virtual void print_global_method_annotation();
 
@@ -1607,18 +1607,18 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
 
   public:
     /**
-     * \brief Constructs the C code generator visitor
+     * \brief Constructs the C++ code generator visitor
      *
-     * This constructor instantiates an NMODL C code generator and allows writing generated code
+     * This constructor instantiates an NMODL C++ code generator and allows writing generated code
      * directly to a file in \c [output_dir]/[mod_filename].[extension].
      *
      * \note No code generation is performed at this stage. Since the code
      * generator classes are all based on \c AstVisitor the AST must be visited using e.g. \c
-     * visit_program in order to generate the C code corresponding to the AST.
+     * visit_program in order to generate the C++ code corresponding to the AST.
      *
      * \param mod_filename The name of the model for which code should be generated.
      *                     It is used for constructing an output filename.
-     * \param output_dir   The directory where target C file should be generated.
+     * \param output_dir   The directory where target C++ file should be generated.
      * \param float_type   The float type to use in the generated code. The string will be used
      *                     as-is in the target code. This defaults to \c double.
      * \param extension    The file extension to use. This defaults to \c .cpp .
@@ -1637,12 +1637,12 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /**
      * \copybrief nmodl::codegen::CodegenCppVisitor
      *
-     * This constructor instantiates an NMODL C code generator and allows writing generated code
+     * This constructor instantiates an NMODL C++ code generator and allows writing generated code
      * into an output stream.
      *
      * \note No code generation is performed at this stage. Since the code
      * generator classes are all based on \c AstVisitor the AST must be visited using e.g. \c
-     * visit_program in order to generate the C code corresponding to the AST.
+     * visit_program in order to generate the C++ code corresponding to the AST.
      *
      * \param mod_filename The name of the model for which code should be generated.
      *                     It is used for constructing an output filename.

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -599,8 +599,8 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      *
      * \param name         Variable name that is being printed
      * \param use_instance Should the variable be accessed via instance or data array
-     * \return             The C++ string representing the access to the variable in the neuron thread
-     * structure
+     * \return             The C++ string representing the access to the variable in the neuron
+     * thread structure
      */
     std::string get_variable_name(const std::string& name, bool use_instance = true) const;
 

--- a/src/codegen/codegen_naming.hpp
+++ b/src/codegen/codegen_naming.hpp
@@ -152,7 +152,7 @@ static constexpr char NRN_STATE_METHOD[] = "nrn_state";
 /// nrn_cur method in generated code
 static constexpr char NRN_CUR_METHOD[] = "nrn_cur";
 
-/// nrn_watch_check method in generated c file
+/// nrn_watch_check method in generated c++ file
 static constexpr char NRN_WATCH_CHECK_METHOD[] = "nrn_watch_check";
 
 /// verbatim name of the variable for nrn thread arguments


### PR DESCRIPTION
- Rename C to C++ in multiple places
- Remove wrapper_printer and target_printer since we only print a single C++ file now for all the backends (C++, OpenACC/OpenMP). There is no more ISPC which needed the wrapper.