### PR TITLE
Small improvements in CodegenCppVisitor constructors

### DIFF
--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -4659,11 +4659,6 @@ void CodegenCppVisitor::print_codegen_routines() {
 }
 
 
-void CodegenCppVisitor::print_wrapper_routines() {
-    // nothing to do
-}
-
-
 void CodegenCppVisitor::set_codegen_global_variables(const std::vector<SymbolType>& global_vars) {
     codegen_global_variables = global_vars;
 }
@@ -4691,7 +4686,6 @@ void CodegenCppVisitor::setup(const Program& node) {
 void CodegenCppVisitor::visit_program(const Program& node) {
     setup(node);
     print_codegen_routines();
-    print_wrapper_routines();
 }
 
 }  // namespace codegen

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -1564,39 +1564,6 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     virtual void print_codegen_routines();
 
 
-    /**
-     * Print entry point to code generation for wrappers
-     */
-    virtual void print_wrapper_routines();
-
-
-    /// This constructor is private, see the public section below to find how to create an instance
-    /// of this class.
-    CodegenCppVisitor(std::string mod_filename,
-                      const std::string& output_dir,
-                      std::string float_type,
-                      const bool optimize_ionvar_copies,
-                      const std::string& extension,
-                      const std::string& wrapper_ext)
-        : printer(std::make_unique<CodePrinter>(output_dir + "/" + mod_filename + extension))
-        , mod_filename(std::move(mod_filename))
-        , float_type(std::move(float_type))
-        , optimize_ionvar_copies(optimize_ionvar_copies) {}
-
-    /// This constructor is private, see the public section below to find how to create an instance
-    /// of this class.
-    CodegenCppVisitor(std::string mod_filename,
-                      std::ostream& stream,
-                      std::string float_type,
-                      const bool optimize_ionvar_copies,
-                      const std::string& /* extension */,
-                      const std::string& /* wrapper_ext */)
-        : printer(std::make_unique<CodePrinter>(stream))
-        , mod_filename(std::move(mod_filename))
-        , float_type(std::move(float_type))
-        , optimize_ionvar_copies(optimize_ionvar_copies) {}
-
-
   public:
     /**
      * \brief Constructs the C++ code generator visitor
@@ -1613,14 +1580,12 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * \param output_dir   The directory where target C++ file should be generated.
      * \param float_type   The float type to use in the generated code. The string will be used
      *                     as-is in the target code. This defaults to \c double.
-     * \param extension    The file extension to use. This defaults to \c .cpp .
      */
     CodegenCppVisitor(std::string mod_filename,
                       const std::string& output_dir,
                       std::string float_type,
-                      const bool optimize_ionvar_copies,
-                      const std::string& extension = ".cpp")
-        : printer(std::make_unique<CodePrinter>(output_dir + "/" + mod_filename + extension))
+                      const bool optimize_ionvar_copies)
+        : printer(std::make_unique<CodePrinter>(output_dir + "/" + mod_filename + ".cpp"))
         , mod_filename(std::move(mod_filename))
         , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -529,7 +529,7 @@ int main(int argc, const char* argv[]) {
             }
 
             else if (c_backend) {
-                logger->info("Running C backend code generator");
+                logger->info("Running C++ backend code generator");
                 CodegenCppVisitor visitor(modfile,
                                           output_dir,
                                           data_type,


### PR DESCRIPTION
- There is no purpose of having private constructors any more
- No reason for anything related to `wrappers`
- Remove mention of `C` code in logs