### PR TITLE
Unconditionally format generated code but in CI

### DIFF
--- a/src/language/CMakeLists.txt
+++ b/src/language/CMakeLists.txt
@@ -7,17 +7,11 @@ set_source_files_properties(${NMODL_GENERATED_SOURCES} PROPERTIES GENERATED TRUE
 # .clang-format configuration file. It's important that we only try to format code if formatting was
 # enabled and NMODL's .clang-format exists, otherwise clang-format will search too far up the
 # directory tree and find the wrong configuration file. This can break compilation.
-if(NMODL_CLANG_FORMAT OR NMODL_FORMATTING)
-  set(CODE_GENERATOR_OPTS -v --clang-format=${ClangFormat_EXECUTABLE})
-  foreach(clang_format_opt ${NMODL_ClangFormat_OPTIONS} --style=file)
-    list(APPEND CODE_GENERATOR_OPTS --clang-format-opts=${clang_format_opt})
-  endforeach()
-endif()
 
 add_custom_command(
   OUTPUT ${NMODL_GENERATED_SOURCES}
-  COMMAND ${PYTHON_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/code_generator.py
-          ${CODE_GENERATOR_OPTS} --base-dir ${PROJECT_BINARY_DIR}/src
+  COMMAND ${PYTHON_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/code_generator.py --base-dir
+          ${PROJECT_BINARY_DIR}/src
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   DEPENDS ${CODE_GENERATOR_PY_FILES}
   DEPENDS ${CODE_GENERATOR_YAML_FILES}


### PR DESCRIPTION
Rely on utility `cmake/hpc-coding-conventions/bin/format`