### PR TITLE
Pin python executable to python3.11 in macos CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -148,14 +148,14 @@ stages:
       submodules: True
     - script: |
         brew install flex bison cmake python@3
-        python3 -m pip install --upgrade pip setuptools
-        python3 -m pip install --user -r $(Build.Repository.LocalPath)/requirements.txt
+        python3.11 -m pip install --upgrade pip setuptools
+        python3.11 -m pip install --user -r $(Build.Repository.LocalPath)/requirements.txt
       displayName: 'Install Dependencies'
     - script: |
         export PATH=/usr/local/opt/flex/bin:/usr/local/opt/bison/bin:$PATH;
         mkdir -p $(Build.Repository.LocalPath)/build
         cd $(Build.Repository.LocalPath)/build
-        cmake .. -DPYTHON_EXECUTABLE=$(which python3) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DNMODL_ENABLE_PYTHON_BINDINGS=OFF
+        cmake .. -DPYTHON_EXECUTABLE=$(which python3.11) -DCMAKE_INSTALL_PREFIX=$HOME/nmodl -DCMAKE_BUILD_TYPE=RelWithDebInfo -DNMODL_ENABLE_PYTHON_BINDINGS=OFF
         make -j 2
         if [ $? -ne 0 ]
         then
@@ -178,7 +178,7 @@ stages:
         mkdir nrn/build
         cd nrn/build
         cmake --version
-        cmake .. -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_INTERVIEWS=OFF -DNRN_ENABLE_RX3D=OFF -DNRN_ENABLE_MPI=OFF -DNRN_ENABLE_TESTS=ON -DCORENRN_ENABLE_MPI=OFF -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_DIR=$HOME/nmodl -Dnmodl_PYTHONPATH=$HOME/nmodl/lib -DPYTHON_EXECUTABLE=$(which python3) -DCORENRN_NMODL_FLAGS="sympy --analytic"
+        cmake .. -DNRN_ENABLE_CORENEURON=ON -DNRN_ENABLE_INTERVIEWS=OFF -DNRN_ENABLE_RX3D=OFF -DNRN_ENABLE_MPI=OFF -DNRN_ENABLE_TESTS=ON -DCORENRN_ENABLE_MPI=OFF -DCORENRN_ENABLE_NMODL=ON -DCORENRN_NMODL_DIR=$HOME/nmodl -Dnmodl_PYTHONPATH=$HOME/nmodl/lib -DPYTHON_EXECUTABLE=$(which python3.11) -DCORENRN_NMODL_FLAGS="sympy --analytic"
         make -j 2
         if [ $? -ne 0 ]
         then


### PR DESCRIPTION
- Avoid issues in the macos CI when running the NEURON tests
- With python 3.12 there are segfaults like: https://dev.azure.com/pramodskumbhar/nmodl/_build/results?buildId=5583&view=logs&j=5626a9d3-6922-580f-de1b-e2793843ae46&t=9d2c9d40-0b90-55cb-1eab-972ff27e1011