### PR TITLE
Update symtab after inline visitor 

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -443,6 +443,7 @@ int main(int argc, const char* argv[]) {
         if (nmodl_inline) {
             logger->info("Running nmodl inline visitor");
             InlineVisitor().visit_program(*ast);
+            SymtabVisitor(update_symtab).visit_program(*ast);
             ast_to_nmodl(*ast, filepath("inline"));
         }
 

--- a/src/visitors/inline_visitor.cpp
+++ b/src/visitors/inline_visitor.cpp
@@ -173,7 +173,6 @@ bool InlineVisitor::inline_function_call(ast::Block& callee,
     RenameVisitor visitor(function_name, new_varname);
     inlined_block->visit_children(visitor);
 
-    /// \todo Have to re-run symtab visitor pass to update symbol table
     inlined_block->set_symbol_table(nullptr);
 
     /// each argument is added as new assignment statement


### PR DESCRIPTION
- Inline visitor invalidates symtab for the inlined blocks and symtab needs to be updated