### PR TITLE
Fix compilation of generated MOD file for NEURON

### DIFF
--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -1258,13 +1258,15 @@ std::string CodegenCoreneuronCppVisitor::process_verbatim_text(std::string const
 
 
 std::string CodegenCoreneuronCppVisitor::register_mechanism_arguments() const {
+    auto nrn_channel_info_var_name = get_channel_info_var_name();
     auto nrn_cur = nrn_cur_required() ? method_name(naming::NRN_CUR_METHOD) : "nullptr";
     auto nrn_state = nrn_state_required() ? method_name(naming::NRN_STATE_METHOD) : "nullptr";
     auto nrn_alloc = method_name(naming::NRN_ALLOC_METHOD);
     auto nrn_init = method_name(naming::NRN_INIT_METHOD);
     auto const nrn_private_constructor = method_name(naming::NRN_PRIVATE_CONSTRUCTOR_METHOD);
     auto const nrn_private_destructor = method_name(naming::NRN_PRIVATE_DESTRUCTOR_METHOD);
-    return fmt::format("mechanism, {}, {}, nullptr, {}, {}, {}, {}, first_pointer_var_index()",
+    return fmt::format("{}, {}, {}, nullptr, {}, {}, {}, {}, first_pointer_var_index()",
+                       nrn_channel_info_var_name,
                        nrn_alloc,
                        nrn_cur,
                        nrn_state,

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -219,7 +219,7 @@ void CodegenCppVisitor::print_mechanism_info() {
 
     printer->add_newline(2);
     printer->add_line("/** channel information */");
-    printer->add_line("static const char *mechanism[] = {");
+    printer->fmt_line("static const char *{}[] = {{", get_channel_info_var_name());
     printer->increase_indent();
     printer->add_line(add_escape_quote(nmodl_version()), ",");
     printer->add_line(add_escape_quote(info.mod_suffix), ",");

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -375,6 +375,14 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
         return info.electrode_current ? "-=" : "+=";
     }
 
+    /**
+     * Name of channel info variable
+     *
+     */
+    std::string get_channel_info_var_name() const noexcept {
+        return std::string("mechanism_info");
+    }
+
 
     /****************************************************************************************/
     /*                     Common helper routines accross codegen functions                 */

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -391,12 +391,11 @@ void CodegenNeuronCppVisitor::print_mechanism_register() {
     printer->fmt_push_block("void _{}_reg()", info.mod_file);
     print_sdlists_init(true);
     // type related information
-    auto suffix = add_escape_quote(info.mod_suffix);
     printer->add_newline();
-    printer->fmt_line("int mech_type = nrn_get_mechtype({});", suffix);
+    printer->fmt_line("int mech_type = nrn_get_mechtype({}[1]);", get_channel_info_var_name());
 
     // More things to add here
-    printer->add_line("_nrn_mechanism_register_data_fields(_mechtype,");
+    printer->add_line("_nrn_mechanism_register_data_fields(mech_type,");
     printer->increase_indent();
     const auto codegen_float_variables_size = codegen_float_variables.size();
     for (int i = 0; i < codegen_float_variables_size; ++i) {

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -298,23 +298,23 @@ void CodegenNeuronCppVisitor::print_sdlists_init(bool print_initializers) {
             /// TODO: Also needs a test
             printer->fmt_push_block("for (int _i = 0; _i < {}; ++_i)", prime_var->get_length());
             printer->fmt_line("/* {}[{}] */", prime_var->get_name(), prime_var->get_length());
-            printer->fmt_line("_slist1[{}+_i] = {{{}, _i}}",
+            printer->fmt_line("_slist1[{}+_i] = {{{}, _i}};",
                               i,
                               position_of_float_var(prime_var->get_name()));
             const auto prime_var_deriv_name = "D" + prime_var->get_name();
             printer->fmt_line("/* {}[{}] */", prime_var_deriv_name, prime_var->get_length());
-            printer->fmt_line("_dlist1[{}+_i] = {{{}, _i}}",
+            printer->fmt_line("_dlist1[{}+_i] = {{{}, _i}};",
                               i,
                               position_of_float_var(prime_var_deriv_name));
             printer->pop_block();
         } else {
             printer->fmt_line("/* {} */", prime_var->get_name());
-            printer->fmt_line("_slist1[{}] = {{{}, 0}}",
+            printer->fmt_line("_slist1[{}] = {{{}, 0}};",
                               i,
                               position_of_float_var(prime_var->get_name()));
             const auto prime_var_deriv_name = "D" + prime_var->get_name();
             printer->fmt_line("/* {} */", prime_var_deriv_name);
-            printer->fmt_line("_dlist1[{}] = {{{}, 0}}",
+            printer->fmt_line("_dlist1[{}] = {{{}, 0}};",
                               i,
                               position_of_float_var(prime_var_deriv_name));
         }

--- a/test/unit/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/test/unit/codegen/codegen_neuron_cpp_visitor.cpp
@@ -232,8 +232,8 @@ void _nrn_mechanism_register_data_fields(Args&&... args) {
         /* Ds */
         _dlist1[0] = {7, 0};
 
-        int mech_type = nrn_get_mechtype("pas_test");
-        _nrn_mechanism_register_data_fields(_mechtype,
+        int mech_type = nrn_get_mechtype(mechanism_info[1]);
+        _nrn_mechanism_register_data_fields(mech_type,
             _nrn_mechanism_field<double>{"g"} /* 0 */,
             _nrn_mechanism_field<double>{"e"} /* 1 */,
             _nrn_mechanism_field<double>{"i"} /* 2 */,

--- a/test/unit/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/test/unit/codegen/codegen_neuron_cpp_visitor.cpp
@@ -156,7 +156,7 @@ void _nrn_mechanism_register_data_fields(Args&&... args) {
         }
         THEN("Correct channel information are printed") {
             std::string expected_channel_info = R"(/** channel information */
-    static const char *mechanism[] = {
+    static const char *mechanism_info[] = {
         "6.2.0",
         "pas_test",
         "g_pas_test",

--- a/test/unit/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/test/unit/codegen/codegen_neuron_cpp_visitor.cpp
@@ -228,9 +228,9 @@ void _nrn_mechanism_register_data_fields(Args&&... args) {
             std::string expected_placeholder_reg = R"(/** register channel with the simulator */
     void __test_reg() {
         /* s */
-        _slist1[0] = {4, 0}
+        _slist1[0] = {4, 0};
         /* Ds */
-        _dlist1[0] = {7, 0}
+        _dlist1[0] = {7, 0};
 
         int mech_type = nrn_get_mechtype("pas_test");
         _nrn_mechanism_register_data_fields(_mechtype,


### PR DESCRIPTION
- Added missing `;` in instantiation of `slist/dlist`
- Use a variable name for the channel info array that doesn't clash with other NEURON declarations
- Fix use of `mech_type` variable in NEURON code