### PR TITLE
Informational codecov.

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,2 +1,11 @@
 ignore:
 - src/language/templates/
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Codecove should not determine whether CI is red or green. The I've tried heuristics always fail eventually. Hence, I'd prefer if it were informational only.