### PR TITLE
Fix mechanism registration function for non POINT_PROCESSes

### DIFF
--- a/src/codegen/codegen_naming.hpp
+++ b/src/codegen/codegen_naming.hpp
@@ -152,6 +152,9 @@ static constexpr char NRN_STATE_METHOD[] = "nrn_state";
 /// nrn_cur method in generated code
 static constexpr char NRN_CUR_METHOD[] = "nrn_cur";
 
+/// nrn_jacob method in generated code
+static constexpr char NRN_JACOB_METHOD[] = "nrn_jacob";
+
 /// nrn_watch_check method in generated c++ file
 static constexpr char NRN_WATCH_CHECK_METHOD[] = "nrn_watch_check";
 
@@ -163,6 +166,9 @@ static constexpr char THREAD_ARGS_PROTO[] = "_threadargsproto_";
 
 /// prefix for ion variable
 static constexpr char ION_VARNAME_PREFIX[] = "ion_";
+
+/// hoc_nrnpointerindex name
+static constexpr char NRN_POINTERINDEX[] = "hoc_nrnpointerindex";
 
 
 /// commonly used variables in verbatim block and how they

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -400,11 +400,12 @@ void CodegenNeuronCppVisitor::print_mechanism_register() {
     printer->add_newline();
 
     const auto compute_functions_parameters =
-        breakpoint_exist() ? fmt::format("{}, {}, {}",
-                                         nrn_cur_required() ? method_name(naming::NRN_CUR_METHOD) : "nullptr",
-                                         method_name(naming::NRN_JACOB_METHOD),
-                                         nrn_state_required() ? method_name(naming::NRN_STATE_METHOD) : "nullptr")
-                           : "nullptr, nullptr, nullptr";
+        breakpoint_exist()
+            ? fmt::format("{}, {}, {}",
+                          nrn_cur_required() ? method_name(naming::NRN_CUR_METHOD) : "nullptr",
+                          method_name(naming::NRN_JACOB_METHOD),
+                          nrn_state_required() ? method_name(naming::NRN_STATE_METHOD) : "nullptr")
+            : "nullptr, nullptr, nullptr";
     const auto register_mech_args = fmt::format("{}, {}, {}, {}, {}, {}",
                                                 get_channel_info_var_name(),
                                                 method_name(naming::NRN_ALLOC_METHOD),

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -324,12 +324,19 @@ void CodegenNeuronCppVisitor::print_sdlists_init(bool print_initializers) {
 
 void CodegenNeuronCppVisitor::print_mechanism_global_var_structure(bool print_initializers) {
     /// TODO: Print only global variables printed in NEURON
-    printer->add_line();
+    printer->add_newline(2);
     printer->add_line("/* NEURON global variables */");
     if (info.primes_size != 0) {
         printer->fmt_line("static neuron::container::field_index _slist1[{0}], _dlist1[{0}];",
                           info.primes_size);
     }
+    printer->add_line("static int mech_type;");
+
+    printer->fmt_line("static int {} = {};",
+                      naming::NRN_POINTERINDEX,
+                      info.pointer_variables.size() > 0
+                          ? static_cast<int>(info.pointer_variables.size())
+                          : -1);
 }
 
 
@@ -388,11 +395,28 @@ void CodegenNeuronCppVisitor::print_mechanism_register() {
     /// TODO: Write this according to NEURON
     printer->add_newline(2);
     printer->add_line("/** register channel with the simulator */");
-    printer->fmt_push_block("void _{}_reg()", info.mod_file);
+    printer->fmt_push_block("extern \"C\" void _{}_reg()", info.mod_file);
     print_sdlists_init(true);
+    printer->add_newline();
+
+    const auto compute_functions_parameters =
+        breakpoint_exist() ? fmt::format("{}, {}, {}",
+                                         method_name(naming::NRN_CUR_METHOD),
+                                         method_name(naming::NRN_JACOB_METHOD),
+                                         method_name(naming::NRN_STATE_METHOD))
+                           : "nullptr, nullptr, nullptr";
+    const auto register_mech_args = fmt::format("{}, {}, {}, {}, {}, {}",
+                                                get_channel_info_var_name(),
+                                                method_name(naming::NRN_ALLOC_METHOD),
+                                                compute_functions_parameters,
+                                                method_name(naming::NRN_INIT_METHOD),
+                                                naming::NRN_POINTERINDEX,
+                                                1 + info.thread_data_index);
+    printer->fmt_line("register_mech({});", register_mech_args);
+
     // type related information
     printer->add_newline();
-    printer->fmt_line("int mech_type = nrn_get_mechtype({}[1]);", get_channel_info_var_name());
+    printer->fmt_line("mech_type = nrn_get_mechtype({}[1]);", get_channel_info_var_name());
 
     // More things to add here
     printer->add_line("_nrn_mechanism_register_data_fields(mech_type,");
@@ -425,6 +449,7 @@ void CodegenNeuronCppVisitor::print_mechanism_register() {
 
 
 void CodegenNeuronCppVisitor::print_mechanism_range_var_structure(bool print_initializers) {
+    printer->add_newline(2);
     printer->add_line("/* NEURON RANGE variables macro definitions */");
     for (auto i = 0; i < codegen_float_variables.size(); ++i) {
         const auto float_var = codegen_float_variables[i];
@@ -454,6 +479,34 @@ void CodegenNeuronCppVisitor::print_global_function_common_code(BlockType type,
 }
 
 
+void CodegenNeuronCppVisitor::print_nrn_init(bool skip_init_check) {
+    codegen = true;
+    printer->add_newline(2);
+    printer->add_line("/** initialize channel */");
+
+    printer->fmt_line(
+        "static void {}(_nrn_model_sorted_token const& _sorted_token, NrnThread* _nt, Memb_list* "
+        "_ml_arg, int _type) {{}}",
+        method_name(naming::NRN_INIT_METHOD));
+
+    codegen = false;
+}
+
+
+void CodegenNeuronCppVisitor::print_nrn_jacob() {
+    codegen = true;
+    printer->add_newline(2);
+    printer->add_line("/** nrn_jacob function */");
+
+    printer->fmt_line(
+        "static void {}(_nrn_model_sorted_token const& _sorted_token, NrnThread* "
+        "_nt, Memb_list* _ml_arg, int _type) {{}}",
+        method_name(naming::NRN_JACOB_METHOD));
+
+    codegen = false;
+}
+
+
 /// TODO: Edit for NEURON
 void CodegenNeuronCppVisitor::print_nrn_constructor() {
     return;
@@ -468,7 +521,11 @@ void CodegenNeuronCppVisitor::print_nrn_destructor() {
 
 /// TODO: Print the equivalent of `nrn_alloc_<mech_name>`
 void CodegenNeuronCppVisitor::print_nrn_alloc() {
-    return;
+    printer->add_newline(2);
+    auto method = method_name(naming::NRN_ALLOC_METHOD);
+    printer->fmt_push_block("static void {}(Prop* _prop)", method);
+    printer->add_line("// do nothing");
+    printer->pop_block();
 }
 
 
@@ -483,6 +540,12 @@ void CodegenNeuronCppVisitor::print_nrn_state() {
         return;
     }
     codegen = true;
+    printer->add_newline(2);
+
+    printer->fmt_line(
+        "void {}(_nrn_model_sorted_token const& _sorted_token, NrnThread* _nt,  Memb_list* "
+        "_ml_arg, int _type) {{}}",
+        method_name(naming::NRN_STATE_METHOD));
 
     printer->add_line("void nrn_state() {}");
     /// TODO: Fill in
@@ -533,6 +596,12 @@ void CodegenNeuronCppVisitor::print_nrn_cur() {
     }
 
     codegen = true;
+    printer->add_newline(2);
+
+    printer->fmt_line(
+        "void {}(_nrn_model_sorted_token const& _sorted_token, NrnThread* _nt, Memb_list* _ml_arg, "
+        "int _type) {{}}",
+        method_name(naming::NRN_CUR_METHOD));
 
     printer->add_line("void nrn_cur() {}");
     /// TODO: Fill in
@@ -542,7 +611,7 @@ void CodegenNeuronCppVisitor::print_nrn_cur() {
 
 
 /****************************************************************************************/
-/*                            Main code printing entry points                            */
+/*                            Main code printing entry points                           */
 /****************************************************************************************/
 
 void CodegenNeuronCppVisitor::print_headers_include() {
@@ -590,6 +659,7 @@ void CodegenNeuronCppVisitor::print_mechanism_variables_macros() {
     using _nrn_model_sorted_token = neuron::model_sorted_token;
     using _nrn_mechanism_cache_range = neuron::cache::MechanismRange<number_of_floating_point_variables, number_of_datum_variables>;
     using _nrn_mechanism_cache_instance = neuron::cache::MechanismInstance<number_of_floating_point_variables, number_of_datum_variables>;
+    using _nrn_non_owning_id_without_container = neuron::container::non_owning_identifier_without_container;
     template <typename T>
     using _nrn_mechanism_field = neuron::mechanism::field<T>;
     template <typename... Args>
@@ -641,8 +711,10 @@ void CodegenNeuronCppVisitor::print_g_unused() const {
 
 /// TODO: Edit for NEURON
 void CodegenNeuronCppVisitor::print_compute_functions() {
+    print_nrn_init();
     print_nrn_cur();
     print_nrn_state();
+    print_nrn_jacob();
 }
 
 
@@ -657,6 +729,7 @@ void CodegenNeuronCppVisitor::print_codegen_routines() {
     print_prcellstate_macros();
     print_mechanism_info();
     print_data_structures(true);
+    print_nrn_alloc();
     print_global_variables_for_hoc();
     print_compute_functions();  // only nrn_cur and nrn_state
     print_mechanism_register();

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -603,7 +603,6 @@ void CodegenNeuronCppVisitor::print_nrn_cur() {
         "int _type) {{}}",
         method_name(naming::NRN_CUR_METHOD));
 
-    printer->add_line("void nrn_cur() {}");
     /// TODO: Fill in
 
     codegen = false;

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -547,7 +547,6 @@ void CodegenNeuronCppVisitor::print_nrn_state() {
         "_ml_arg, int _type) {{}}",
         method_name(naming::NRN_STATE_METHOD));
 
-    printer->add_line("void nrn_state() {}");
     /// TODO: Fill in
 
     codegen = false;

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -401,9 +401,9 @@ void CodegenNeuronCppVisitor::print_mechanism_register() {
 
     const auto compute_functions_parameters =
         breakpoint_exist() ? fmt::format("{}, {}, {}",
-                                         method_name(naming::NRN_CUR_METHOD),
+                                         nrn_cur_required() ? method_name(naming::NRN_CUR_METHOD) : "nullptr",
                                          method_name(naming::NRN_JACOB_METHOD),
-                                         method_name(naming::NRN_STATE_METHOD))
+                                         nrn_state_required() ? method_name(naming::NRN_STATE_METHOD) : "nullptr")
                            : "nullptr, nullptr, nullptr";
     const auto register_mech_args = fmt::format("{}, {}, {}, {}, {}, {}",
                                                 get_channel_info_var_name(),

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -362,6 +362,13 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
 
 
     /**
+     * Print the \c nrn\_init function definition
+     * \param skip_init_check \c true to generate code executing the initialization conditionally
+     */
+    void print_nrn_init(bool skip_init_check = true);
+
+
+    /**
      * Print nrn_constructor function definition
      *
      */
@@ -380,6 +387,13 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
      *
      */
     void print_nrn_alloc() override;
+
+
+    /**
+     * Print nrn_jacob function definition
+     *
+     */
+    void print_nrn_jacob();
 
 
     /****************************************************************************************/


### PR DESCRIPTION
- Make generated code compilable and loadable with `NEURON` by implementing the registration function
- Provided empty stubs for needed `nrn_*` functions
- Supersedes https://github.com/BlueBrain/nmodl/pull/1103