### PR TITLE
Skip printing of INDEPENDENT block from AST to NMODL

### DIFF
--- a/src/language/node_info.py
+++ b/src/language/node_info.py
@@ -155,6 +155,7 @@ PROGRAM_BLOCK = "Program"
 STATEMENT_BLOCK_NODE = "StatementBlock"
 STRING_NODE = "String"
 UNIT_BLOCK = "UnitBlock"
+INDEPENDENT_BLOCK_NODE = "IndependentBlock"
 
 # name of variable in prime node which represent order of derivative
 ORDER_VAR_NAME = "order"

--- a/src/language/nodes.py
+++ b/src/language/nodes.py
@@ -60,6 +60,10 @@ class BaseNode:
         return self.class_name == node_info.PRIME_NAME_NODE
 
     @property
+    def is_independent_node(self):
+        return self.class_name == node_info.INDEPENDENT_BLOCK_NODE
+
+    @property
     def is_program_node(self):
         """
         check if current node is main program container node

--- a/src/language/templates/visitors/nmodl_visitor.cpp
+++ b/src/language/templates/visitors/nmodl_visitor.cpp
@@ -89,6 +89,10 @@ using namespace ast;
 
 {%- for node in nodes %}
 void NmodlPrintVisitor::visit_{{ node.class_name|snake_case}}(const {{ node.class_name }}& node) {
+    {% if node.is_independent_node %}
+        printer->add_element(": INDEPENDENT block is deprecated and has no effect in the NEURON model. Skipped!");
+        return;
+    {%- endif %}
     if (is_exclude_type(node.get_node_type())) {
         return;
     }

--- a/src/language/templates/visitors/nmodl_visitor.hpp
+++ b/src/language/templates/visitors/nmodl_visitor.hpp
@@ -32,11 +32,15 @@ namespace visitor {
 /**
  * \class NmodlPrintVisitor
  * \brief %Visitor for printing AST back to NMODL
- * \todo Note that AstNodeType::INDEPENDENT_BLOCK is now trimmed-down
- *       in the AST. So if we need to make provide something like
- *       `nmodl-format` then we should exclude this node type i.e.
- *       add that in the exclude_types.
+ *
+ * \note AstNodeType::INDEPENDENT_BLOCK representation in the AST has
+ *       been trimmed as the `INDEPENDENT {}` block is now deprecated
+ *       and considered an unused construct in MOD files. If a user
+ *       attempts to print a MOD file containing an INDEPENDENT block,
+ *       it will be skipped, and a comment will be added to indicate
+ *       the deprecation.
  */
+
 class NmodlPrintVisitor: public ConstVisitor {
   private:
     std::unique_ptr<printer::NMODLPrinter> printer;

--- a/test/unit/utils/nmodl_constructs.cpp
+++ b/test/unit/utils/nmodl_constructs.cpp
@@ -433,8 +433,7 @@ std::map<std::string, NmodlTestCase> const nmodl_valid_constructs{
                 }
             )",
             R"(
-                INDEPENDENT {
-                t u}
+                : INDEPENDENT block is deprecated and has no effect in the NEURON model. Skipped!
             )"
         }
     },


### PR DESCRIPTION
* As INDEPENDENT is deprecated and has no impact/role in NEURON/NMODL models, we have removed the AST nodes related to this construct.
* When user provide an input with INDEPENDENT {} block then just add a comment and simply skip printing it.
* Update test accordingly

fixes #1123

With this

```console
$ cat test.py

import nmodl
print(nmodl.to_nmodl(nmodl.NmodlDriver().parse_string("NEURON {} INDEPENDENT {t FROM 0 TO 1 WITH 1 (ms)}")))
```

and it will give

```console
NEURON {
}

: INDEPENDENT block is deprecated and has no effect in the NEURON model. Skipped!
```

We can think of alternatives: bring back some part of the old implementation and reproduce the same `INDEPENDENT` block that the user provides. But I am not sure there is any more value to it as the `INDEPENDENT` is not useful in the MOD file.

