### PR TITLE
No more flickering.

### DIFF
--- a/test/usecases/run_test.sh
+++ b/test/usecases/run_test.sh
@@ -10,6 +10,6 @@ pushd "${usecase_dir}"
 rm -r "${output_dir}" tmp || true
 
 nrnivmodl -nmodl "${nmodl}"
-"$(uname -m)/special" simulate.py
+"$(uname -m)/special" -nogui simulate.py
 
 popd


### PR DESCRIPTION
Without `-nogui` running the usecases would cause the screen to flicker. Presumably because a plot opened and was closed within 0.01s, or something similar.