### PR TITLE
Add semantic analysis check for infinite loops with function calls

### DIFF
--- a/src/parser/nmodl.yy
+++ b/src/parser/nmodl.yy
@@ -1328,6 +1328,7 @@ term            :   variable_name
 function_call   :   NAME_PTR "(" expression_list ")"
                     {
                         auto expression = new ast::FunctionCall($1, $3);
+                        expression->set_token(*($1->get_token()));
                         $$ = new ast::WrappedExpression(expression);
                     }
                 ;

--- a/src/visitors/semantic_analysis_visitor.cpp
+++ b/src/visitors/semantic_analysis_visitor.cpp
@@ -108,19 +108,19 @@ void SemanticAnalysisVisitor::visit_function_call(const ast::FunctionCall& node)
 
 void SemanticAnalysisVisitor::visit_procedure_block(const ast::ProcedureBlock& node) {
     /// <-- This code is for check 1
-    visited_function_or_procedure_blocks.push_front(&node);
+    visited_function_or_procedure_blocks.push_back(&node);
     one_arg_in_procedure_function = node.get_parameters().size() == 1;
     node.visit_children(*this);
-    visited_function_or_procedure_blocks.pop_front();
+    visited_function_or_procedure_blocks.pop_back();
     /// -->
 }
 
 void SemanticAnalysisVisitor::visit_function_block(const ast::FunctionBlock& node) {
     /// <-- This code is for check 1
-    visited_function_or_procedure_blocks.push_front(&node);
+    visited_function_or_procedure_blocks.push_back(&node);
     one_arg_in_procedure_function = node.get_parameters().size() == 1;
     node.visit_children(*this);
-    visited_function_or_procedure_blocks.pop_front();
+    visited_function_or_procedure_blocks.pop_back();
     /// -->
 }
 

--- a/src/visitors/semantic_analysis_visitor.cpp
+++ b/src/visitors/semantic_analysis_visitor.cpp
@@ -23,6 +23,8 @@
 namespace nmodl {
 namespace visitor {
 
+using symtab::syminfo::NmodlType;
+
 bool SemanticAnalysisVisitor::check(const ast::Program& node) {
     check_fail = false;
 
@@ -93,8 +95,10 @@ void SemanticAnalysisVisitor::visit_function_call(const ast::FunctionCall& node)
         return;
     }
     auto func_symbol = psymtab->lookup(func_name);
-    // If symbol is not found or there are no AST nodes for it return
-    if (!func_symbol || func_symbol->get_nodes().empty()) {
+    // If symbol is not found or there are no AST nodes for it or it's not a function or procedure
+    // return
+    if (!func_symbol || func_symbol->get_nodes().empty() ||
+        !func_symbol->has_any_property(NmodlType::function_block | NmodlType::procedure_block)) {
         return;
     }
     const auto func_block = func_symbol->get_nodes()[0];

--- a/src/visitors/semantic_analysis_visitor.hpp
+++ b/src/visitors/semantic_analysis_visitor.hpp
@@ -52,8 +52,8 @@ class SemanticAnalysisVisitor: public ConstAstVisitor {
     bool accel_backend = false;
     /// true if the procedure or the function contains only one argument
     bool one_arg_in_procedure_function = false;
-    /// list of visited Function or Procedure Blocks
-    std::forward_list<const ast::Block*> visited_function_or_procedure_blocks;
+    /// vector of visited Function or Procedure Blocks (used as a searchable stack)
+    std::vector<const ast::Block*> visited_function_or_procedure_blocks;
     /// true if the mod file is of type point process
     bool is_point_process = false;
     /// true if we are inside a mutex locked part

--- a/src/visitors/semantic_analysis_visitor.hpp
+++ b/src/visitors/semantic_analysis_visitor.hpp
@@ -52,7 +52,7 @@ class SemanticAnalysisVisitor: public ConstAstVisitor {
     bool accel_backend = false;
     /// true if the procedure or the function contains only one argument
     bool one_arg_in_procedure_function = false;
-    /// set of visited Function or Procedure Blocks
+    /// list of visited Function or Procedure Blocks
     std::forward_list<const ast::Block*> visited_function_or_procedure_blocks;
     /// true if the mod file is of type point process
     bool is_point_process = false;

--- a/src/visitors/semantic_analysis_visitor.hpp
+++ b/src/visitors/semantic_analysis_visitor.hpp
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <forward_list>
+
 /**
  * \file
  * \brief \copybrief nmodl::visitor::SemanticAnalysisVisitor
@@ -32,6 +34,7 @@
  * 6. Check that mutex are not badly use
  * 7. Check than function table got at least one argument.
  * 8. Check that at most one derivative block is present.
+ * 9. Check that there are no infinite loops with function calls
  */
 #include "ast/ast.hpp"
 #include "visitors/ast_visitor.hpp"
@@ -43,14 +46,14 @@ class SemanticAnalysisVisitor: public ConstAstVisitor {
   private:
     bool check_fail = false;
 
+    /// program symbol table
+    symtab::SymbolTable* psymtab = nullptr;
     /// true if accelerator backend is used for code generation
     bool accel_backend = false;
     /// true if the procedure or the function contains only one argument
     bool one_arg_in_procedure_function = false;
-    /// true if we are in a procedure block
-    bool in_procedure = false;
-    /// true if we are in a function block
-    bool in_function = false;
+    /// set of visited Function or Procedure Blocks
+    std::forward_list<const ast::Block*> visited_function_or_procedure_blocks;
     /// true if the mod file is of type point process
     bool is_point_process = false;
     /// true if we are inside a mutex locked part
@@ -59,10 +62,13 @@ class SemanticAnalysisVisitor: public ConstAstVisitor {
     /// Check number of DERIVATIVE blocks
     void visit_program(const ast::Program& node) override;
 
-    /// Store if we are in a procedure and if the arity of this is 1
+    /// Check whether there is an infinite loop with function calls
+    void visit_function_call(const ast::FunctionCall& node) override;
+
+    /// Store nodes to the \c visited_function_or_procedure_blocks
     void visit_procedure_block(const ast::ProcedureBlock& node) override;
 
-    /// Store if we are in a function and if the arity of this is 1
+    /// Store nodes to the \c visited_function_or_procedure_blocks
     void visit_function_block(const ast::FunctionBlock& node) override;
 
     /// Visit a table statement and check that the arity of the block were 1

--- a/test/unit/visitor/semantic_analysis.cpp
+++ b/test/unit/visitor/semantic_analysis.cpp
@@ -192,3 +192,19 @@ SCENARIO("At most one DERIVATIVE block", "[visitor][semantic_analysis]") {
         }
     }
 }
+
+SCENARIO("Recursive function calls", "[visitor][semantic_analysis]") {
+    GIVEN("A file with recursive function calls") {
+        std::string nmodl_text = R"(
+            FUNCTION a() {
+                b()
+            }
+            PROCEDURE b() {
+                a()
+            }
+        )";
+        THEN("Semantic analysis should fail") {
+            REQUIRE(run_semantic_analysis_visitor(nmodl_text));
+        }
+    }
+}

--- a/test/unit/visitor/semantic_analysis.cpp
+++ b/test/unit/visitor/semantic_analysis.cpp
@@ -198,9 +198,11 @@ SCENARIO("Recursive function calls", "[visitor][semantic_analysis]") {
         std::string nmodl_text = R"(
             FUNCTION a() {
                 b()
+                a = 42
             }
             PROCEDURE b() {
-                a()
+                LOCAL x
+                x = a()
             }
         )";
         THEN("Semantic analysis should fail") {


### PR DESCRIPTION
- First step towards support in NEURON code generation for `FUNCTION` and `PROCEDURE`
- Related to the changes in https://github.com/neuronsimulator/nrn/pull/2475 that require that there is no loop between functions and procedures
- Added token in `ast::FunctionCall` parsing for printing nice error
- Added unit test
- Improved a bit the error for other semantic checks to show the problematic function/procedure name
- The usage of this feature can be seen in https://github.com/BlueBrain/nmodl/compare/magkanar/nrn_proc_func
