### PR TITLE
Added visitor for setting `need_setdata` NmodlType in SymTab

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@
 #include "visitors/local_var_rename_visitor.hpp"
 #include "visitors/localize_visitor.hpp"
 #include "visitors/loop_unroll_visitor.hpp"
+#include "visitors/needsetdata_visitor.hpp"
 #include "visitors/neuron_solve_visitor.hpp"
 #include "visitors/nmodl_visitor.hpp"
 #include "visitors/perf_visitor.hpp"
@@ -548,6 +549,8 @@ int main(int argc, const char* argv[]) {
             }
 
             else if (neuron_code && cpp_backend) {
+                logger->info("Running NeedSetDataVisitor");
+                NeedSetDataVisitor().visit_program(*ast);
                 logger->info("Running C++ backend code generator for NEURON");
                 CodegenNeuronCppVisitor visitor(modfile,
                                                 output_dir,

--- a/src/symtab/symbol_properties.cpp
+++ b/src/symtab/symbol_properties.cpp
@@ -159,6 +159,10 @@ std::vector<std::string> to_string_vector(const NmodlType& obj) {
         properties.emplace_back("codegen_var");
     }
 
+    if (has_property(obj, NmodlType::need_setdata)) {
+        properties.emplace_back("need_setdata");
+    }
+
     return properties;
 }
 

--- a/src/symtab/symbol_properties.hpp
+++ b/src/symtab/symbol_properties.hpp
@@ -217,7 +217,10 @@ enum class NmodlType : enum_type {
     define = 1L << 32,
 
     /// Codegen specific variable
-    codegen_var = 1L << 33
+    codegen_var = 1L << 33,
+
+    /// FUNCTION or PROCEDURE needs setdata check
+    need_setdata = 1L << 34
 };
 
 template <typename T>

--- a/src/visitors/CMakeLists.txt
+++ b/src/visitors/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   local_var_rename_visitor.cpp
   localize_visitor.cpp
   loop_unroll_visitor.cpp
+  needsetdata_visitor.cpp
   neuron_solve_visitor.cpp
   perf_visitor.cpp
   rename_visitor.cpp

--- a/src/visitors/needsetdata_visitor.cpp
+++ b/src/visitors/needsetdata_visitor.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Blue Brain Project, EPFL.
+ * See the top-level LICENSE file for details.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "visitors/needsetdata_visitor.hpp"
+
+#include <utility>
+
+#include "ast/all.hpp"
+
+
+namespace nmodl {
+namespace visitor {
+
+using symtab::Symbol;
+using symtab::syminfo::NmodlType;
+
+void NeedSetDataVisitor::visit_var_name(const ast::VarName& node) {
+    if (function_or_procedure_stack.empty()) {
+        return;
+    }
+    const auto var_sym = psymtab->lookup(node.get_node_name());
+    const auto properties = NmodlType::range_var | NmodlType::pointer_var |
+                            NmodlType::bbcore_pointer_var;
+    if (!var_sym || !var_sym->has_any_property(properties)) {
+        return;
+    }
+    function_proc_need_setdata.insert(function_or_procedure_stack.top());
+    auto func_symbol = psymtab->lookup(function_or_procedure_stack.top()->get_node_name());
+    func_symbol->add_property(NmodlType::need_setdata);
+}
+
+void NeedSetDataVisitor::visit_function_call(const ast::FunctionCall& node) {
+    auto func_symbol = psymtab->lookup(node.get_node_name());
+    // If symbol is not found or there are no AST nodes for it return
+    if (!func_symbol || func_symbol->get_nodes().empty()) {
+        return;
+    }
+    const auto func_block = func_symbol->get_nodes()[0];
+    func_block->accept(*this);
+    if (function_proc_need_setdata.find(dynamic_cast<const ast::Block*>(func_block)) !=
+        function_proc_need_setdata.end()) {
+        function_proc_need_setdata.insert(function_or_procedure_stack.top());
+    }
+    auto caller_func_symbol = psymtab->lookup(function_or_procedure_stack.top()->get_node_name());
+    caller_func_symbol->add_property(NmodlType::need_setdata);
+}
+
+void NeedSetDataVisitor::visit_function_block(const ast::FunctionBlock& node) {
+    function_or_procedure_stack.push(&node);
+    node.visit_children(*this);
+    function_or_procedure_stack.pop();
+}
+
+void NeedSetDataVisitor::visit_procedure_block(const ast::ProcedureBlock& node) {
+    function_or_procedure_stack.push(&node);
+    node.visit_children(*this);
+    function_or_procedure_stack.pop();
+}
+
+void NeedSetDataVisitor::visit_program(const ast::Program& node) {
+    psymtab = node.get_symbol_table();
+    node.visit_children(*this);
+}
+
+}  // namespace visitor
+}  // namespace nmodl

--- a/src/visitors/needsetdata_visitor.hpp
+++ b/src/visitors/needsetdata_visitor.hpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Blue Brain Project, EPFL.
+ * See the top-level LICENSE file for details.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+/**
+ * \file
+ * \brief \copybrief nmodl::visitor::NeedSetDataVisitor
+ */
+
+#include <set>
+#include <stack>
+
+#include "ast/block.hpp"
+#include "symtab/decl.hpp"
+#include "visitors/ast_visitor.hpp"
+
+
+namespace nmodl {
+namespace visitor {
+
+/**
+ * \addtogroup visitor_classes
+ * \{
+ */
+
+/**
+ * \class NeedSetDataVisitor
+ * \brief %Visitor for figuring out if function and procedure need setdata call
+ *
+ */
+class NeedSetDataVisitor: public ConstAstVisitor {
+  private:
+    /// program symbol table
+    symtab::SymbolTable* psymtab = nullptr;
+
+    std::stack<const ast::Block*> function_or_procedure_stack;
+
+    /// function or procedure has RANGE or POINTER variable or calls
+    /// function or procedure that has one of those and needs to throw
+    /// if setdata() is not priorly called
+    std::unordered_set<const ast::Block*> function_proc_need_setdata;
+
+  public:
+
+    void visit_var_name(const ast::VarName& node) override;
+
+    void visit_function_call(const ast::FunctionCall& node) override;
+
+    void visit_function_block(const ast::FunctionBlock& node) override;
+
+    void visit_procedure_block(const ast::ProcedureBlock& node) override;
+
+    void visit_program(const ast::Program& node) override;
+};
+
+/** \} */  // end of visitor_classes
+
+}  // namespace visitor
+}  // namespace nmodl

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(
   visitor/lookup.cpp
   visitor/loop_unroll.cpp
   visitor/misc.cpp
+  visitor/need_setdata.cpp
   visitor/neuron_solve.cpp
   visitor/nmodl.cpp
   visitor/perf.cpp

--- a/test/unit/visitor/need_setdata.cpp
+++ b/test/unit/visitor/need_setdata.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Blue Brain Project, EPFL.
+ * See the top-level LICENSE file for details.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "ast/program.hpp"
+#include "parser/nmodl_driver.hpp"
+#include "test/unit/utils/nmodl_constructs.hpp"
+#include "visitors/needsetdata_visitor.hpp"
+#include "visitors/nmodl_visitor.hpp"
+#include "visitors/symtab_visitor.hpp"
+
+using namespace nmodl;
+using namespace visitor;
+using namespace test_utils;
+
+using nmodl::parser::NmodlDriver;
+using symtab::syminfo::NmodlType;
+
+//=============================================================================
+// GlobalToRange visitor tests
+//=============================================================================
+
+std::shared_ptr<ast::Program> run_NeedSetData_visitor(const std::string& text) {
+    NmodlDriver driver;
+    auto ast = driver.parse_string(text);
+
+    SymtabVisitor().visit_program(*ast);
+    NeedSetDataVisitor().visit_program(*ast);
+    return ast;
+}
+
+SCENARIO("Check whether PROCEDURE and FUNCTION need setdata call", "[visitor][needsetdata]") {
+    GIVEN("mod file with GLOBAL and RANGE variables used in FUNC and PROC") {
+        std::string input_nmodl = R"(
+            NEURON {
+                SUFFIX test
+                RANGE x
+                GLOBAL s
+            }
+            PARAMETER {
+                s = 2
+            }
+            ASSIGNED {
+                x
+            }
+            PROCEDURE a() {
+                x = get_42()
+            }
+            FUNCTION b() {
+                a()
+            }
+            FUNCTION get_42() {
+                get_42 = 42
+            }
+        )";
+        auto ast = run_NeedSetData_visitor(input_nmodl);
+        auto symtab = ast->get_symbol_table();
+        THEN("need_setdata property is added to needed FUNC and PROC") {
+            auto need_setdata_funcs = symtab->get_variables_with_properties(NmodlType::need_setdata);
+            REQUIRE(need_setdata_funcs.size() == 2);
+            const auto a = symtab->lookup("a");
+            REQUIRE(a->has_any_property(NmodlType::need_setdata));
+            const auto b = symtab->lookup("b");
+            REQUIRE(b->has_any_property(NmodlType::need_setdata));
+            const auto get_42 = symtab->lookup("get_42");
+            REQUIRE(!get_42->has_any_property(NmodlType::need_setdata));
+        }
+    }
+}

--- a/test/unit/visitor/need_setdata.cpp
+++ b/test/unit/visitor/need_setdata.cpp
@@ -22,7 +22,7 @@ using nmodl::parser::NmodlDriver;
 using symtab::syminfo::NmodlType;
 
 //=============================================================================
-// GlobalToRange visitor tests
+// NeedSetData visitor tests
 //=============================================================================
 
 std::shared_ptr<ast::Program> run_NeedSetData_visitor(const std::string& text) {


### PR DESCRIPTION
- Second step towards `FUNCTION` and `PROCEDURE` codegen for NEURON
- Added separate visitor to avoid complication with other visitors like `SymtabVisitor` or `CodegenHelperVisitor`
- Follows logic of `func_needs_setdata()` from https://github.com/neuronsimulator/nrn/pull/2475
- Added related unit test
- Requires #1138 