### PR TITLE
Upgrade dependencies for actions for Node 20

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,10 +36,10 @@ jobs:
             python3-dev python3-pip
         shell: bash
       - name: Set up Python3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2    
       - name: Install Python3 dependencies
@@ -48,7 +48,7 @@ jobs:
           pip3 install -U pip setuptools
           pip3 install --user -r requirements.txt
       - name: Restore compiler cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{runner.workspace}}/ccache

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -82,7 +82,7 @@ jobs:
           lcov --capture  --directory . --no-external --output-file build/coverage-run.info --exclude "*/ext/*"
           (cd build; lcov --add-tracefile coverage-base.info --add-tracefile coverage-run.info --output-file coverage.info)
           (cd build; lcov --list coverage.info)
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           files: ./build/coverage.info
           fail_ci_if_error: true

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -15,7 +15,7 @@ jobs:
     name: C/C++, CMake and Python
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Update submodule
         working-directory: ${{runner.workspace}}/nmodl
         run: git submodule update --init cmake/hpc-coding-conventions

--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -183,7 +183,7 @@ jobs:
         run:  |
           cmake --build . --target install
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ctest-results-${{hashfiles('matrix.json')}}
           path: ${{runner.workspace}}/nmodl/build/Testing/*/Test.xml

--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -73,11 +73,11 @@ jobs:
         shell: bash
 
       - name: Set up Python3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Python3 dependencies
         working-directory: ${{runner.workspace}}/nmodl

--- a/.github/workflows/nmodl-doc.yml
+++ b/.github/workflows/nmodl-doc.yml
@@ -47,11 +47,11 @@ jobs:
         shell: bash
 
       - name: Set up Python3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -68,7 +68,7 @@ jobs:
         uses: mxschmitt/action-tmate@v3
 
       - name: Restore compiler cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{runner.workspace}}/ccache

--- a/.github/workflows/sonarsource.yml
+++ b/.github/workflows/sonarsource.yml
@@ -22,10 +22,10 @@ jobs:
             python3-dev python3-pip
         shell: bash
       - name: Set up Python3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Install Python3 dependencies


### PR DESCRIPTION
Previous versions of actions were based on Node 16 but it is now deprecated. So move actions forward to use the new Node 20.

Node 16 will be removed in Spring 2024.