### PR TITLE
Make sonarcloud checks non-failing

### DIFF
--- a/.github/workflows/sonarsource.yml
+++ b/.github/workflows/sonarsource.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/
       - name: Run sonar-scanner
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
We want sonarcloud runs to just inform developers on the state of their PR rather than stopping them from merging.