### PR TITLE
Implement trivial cases of reading/writing ions. 

### DIFF
--- a/test/unit/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/test/unit/codegen/codegen_neuron_cpp_visitor.cpp
@@ -194,9 +194,9 @@ void _nrn_mechanism_register_data_fields(Args&&... args) {
         double* Ds{};
         double* v_unused{};
         double* g_unused{};
-        const double* ion_ena{};
-        double* ion_ina{};
-        double* ion_dinadv{};
+        const double* const* ion_ena{};
+        double* const* ion_ina{};
+        double* const* ion_dinadv{};
         pas_test_Store* global{&pas_test_global};
     };)";
 
@@ -259,9 +259,16 @@ void _nrn_mechanism_register_data_fields(Args&&... args) {
             _nrn_mechanism_field<double>{"ina"} /* 6 */,
             _nrn_mechanism_field<double>{"Ds"} /* 7 */,
             _nrn_mechanism_field<double>{"v_unused"} /* 8 */,
-            _nrn_mechanism_field<double>{"g_unused"} /* 9 */
+            _nrn_mechanism_field<double>{"g_unused"} /* 9 */,
+            _nrn_mechanism_field<double*>{"ion_ena", "na_ion"} /* 0 */,
+            _nrn_mechanism_field<double*>{"ion_ina", "na_ion"} /* 1 */,
+            _nrn_mechanism_field<double*>{"ion_dinadv", "na_ion"} /* 2 */
         );
 
+        hoc_register_prop_size(mech_type, 10, 3);
+        hoc_register_dparam_semantics(mech_type, 0, "na_ion");
+        hoc_register_dparam_semantics(mech_type, 1, "na_ion");
+        hoc_register_dparam_semantics(mech_type, 2, "na_ion");
     })CODE";
 
             REQUIRE_THAT(generated,

--- a/test/usecases/ionic/ionic.mod
+++ b/test/usecases/ionic/ionic.mod
@@ -1,0 +1,13 @@
+NEURON {
+        SUFFIX ionic
+        USEION na READ ina WRITE ena
+}
+
+ASSIGNED {
+        ina (mA/cm2)
+        ena (mV)
+}
+
+BREAKPOINT {
+        ena = 42.0
+}

--- a/test/usecases/ionic/simulate.py
+++ b/test/usecases/ionic/simulate.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from neuron import h, gui
+from neuron.units import ms
+
+nseg = 1
+
+s = h.Section()
+s.insert("ionic")
+s.nseg = nseg
+
+x_hoc = h.Vector().record(s(0.5)._ref_ena)
+t_hoc = h.Vector().record(h._ref_t)
+
+h.stdinit()
+h.tstop = 5.0 * ms
+h.run()
+
+x = np.array(x_hoc.as_numpy())
+t = np.array(t_hoc.as_numpy())
+
+x_exact = np.full(t.shape, 42.0)
+x_exact[0] = 0.0
+
+abs_err = np.abs(x - x_exact)
+
+assert np.all(abs_err < 1e-12), abs_err
+print("ionic: success")


### PR DESCRIPTION
This implements a trivial case of reading an ion variable `ena` and writing `42.0` to `ina`; along with the functionality required to be able to record `ina`.