### PR TITLE
Remove POSIX-specific headers

### DIFF
--- a/src/utils/common_utils.cpp
+++ b/src/utils/common_utils.cpp
@@ -16,7 +16,6 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
-#include <sys/stat.h>
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
 #define IS_WINDOWS

--- a/src/utils/common_utils.hpp
+++ b/src/utils/common_utils.hpp
@@ -10,8 +10,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <sys/param.h>
-#include <unistd.h>
 #include <vector>
 
 

--- a/src/utils/file_library.cpp
+++ b/src/utils/file_library.cpp
@@ -9,8 +9,6 @@
 
 #include <cassert>
 #include <filesystem>
-#include <sys/param.h>
-#include <unistd.h>
 
 #include "utils/common_utils.hpp"
 #include "utils/string_utils.hpp"


### PR DESCRIPTION
We don't seem to use them anywhere, and it could be a good step towards implementing #1112 