### PR TITLE
Empty circle ci config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # NOTE this file serves one purpose: to silence Circle CI.
 # Delete at will.
 #
-# Copied from: https://circleci.com/docs/sample-config/
+# Copied&modified from: https://circleci.com/docs/sample-config/
 version: 2.1
 
 # Define the jobs we want to run for this project
@@ -11,15 +11,9 @@ jobs:
       - image: cimg/base:2023.03
     steps:
       - run: echo "this is the build job"
-  test:
-    docker:
-      - image: cimg/base:2023.03
-    steps:
-      - run: echo "this is the test job"
 
 # Orchestrate our job run sequence
 workflows:
   build_and_test:
     jobs:
       - build
-      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,11 @@ jobs:
     docker:
       - image: cimg/base:2023.03
     steps:
-      - checkout
       - run: echo "this is the build job"
   test:
     docker:
       - image: cimg/base:2023.03
     steps:
-      - checkout
       - run: echo "this is the test job"
 
 # Orchestrate our job run sequence

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+# NOTE this file serves one purpose: to silence Circle CI.
+# Delete at will.
+#
+# Copied from: https://circleci.com/docs/sample-config/
+version: 2.1
+
+# Define the jobs we want to run for this project
+jobs:
+  build:
+    docker:
+      - image: cimg/base:2023.03
+    steps:
+      - checkout
+      - run: echo "this is the build job"
+  test:
+    docker:
+      - image: cimg/base:2023.03
+    steps:
+      - checkout
+      - run: echo "this is the test job"
+
+# Orchestrate our job run sequence
+workflows:
+  build_and_test:
+    jobs:
+      - build
+      - test


### PR DESCRIPTION
While https://github.com/BlueBrain/nmodl/pull/1155 is being developed, it would be nice to prevent red CI. The CI for Circle CI goes red because it listens to pushes and then fails because there's no config to run.