### PR TITLE
Fix rendering LaTeX in documentation.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,6 +185,10 @@ latex_documents = [
     (master_doc, "nmodl.tex", "nmodl Documentation", "BlueBrain HPC team", "manual")
 ]
 
+imgmath_image_format = 'svg'
+imgmath_embed = True
+imgmath_font_size = 14
+
 
 # -- Options for manual page output ---------------------------------------
 


### PR DESCRIPTION
Use `imgmath_embed = True` to work around a path bug for files/notebooks located in subfolders.

Use `imgmath_image_format = 'svg'` because PNG results in pixalated images.