### PR TITLE
Blame NMODL for lines it's generating.

### DIFF
--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -127,6 +127,7 @@ jobs:
           fi
           cmake_args+=(-DCMAKE_CXX_COMPILER=${CXX} \
                        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache)
+          cmake_args+=(-DNMODL_ENABLE_BACKWARD=On)
           cmake .. "${cmake_args[@]}"
         env:
           INSTALL_DIR: ${{ runner.workspace }}/install

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "ext/catch2"]
 	path = ext/catch2
 	url = https://github.com/catchorg/Catch2.git
+[submodule "ext/backward"]
+	path = ext/backward
+	url = https://github.com/bombela/backward-cpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(NMODL_ENABLE_PYTHON_BINDINGS "Enable pybind11 based python bindings" ON)
 option(NMODL_ENABLE_TESTS "Enable build of tests" ON)
 option(NMODL_ENABLE_USECASES
        "If building tests, additionally enable build of usecase tests. Requires neuron." OFF)
+option(NMODL_ENABLE_BACKWARD "Use backward, enables blame." OFF)
 set(NMODL_EXTRA_CXX_FLAGS
     ""
     CACHE STRING "Add extra compile flags for NMODL sources")
@@ -130,6 +131,10 @@ if(NMODL_3RDPARTY_USE_SPDLOG)
   set(SPDLOG_BUILD_PIC ON)
 endif()
 cpp_cc_git_submodule(spdlog BUILD PACKAGE spdlog REQUIRED)
+
+if(NMODL_ENABLE_BACKWARD)
+  cpp_cc_git_submodule(backward BUILD PACKAGE backward REQUIRED)
+endif()
 
 # =============================================================================
 # Format & execute ipynb notebooks in place (pip install nbconvert clean-ipynb)

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -198,8 +198,10 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     CodegenCppVisitor(std::string mod_filename,
                       const std::string& output_dir,
                       std::string float_type,
-                      const bool optimize_ionvar_copies)
-        : printer(std::make_unique<CodePrinter>(output_dir + "/" + mod_filename + ".cpp"))
+                      const bool optimize_ionvar_copies,
+                      size_t blame_line = 0)
+        : printer(
+              std::make_unique<CodePrinter>(output_dir + "/" + mod_filename + ".cpp", blame_line))
         , mod_filename(std::move(mod_filename))
         , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}
@@ -224,8 +226,9 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     CodegenCppVisitor(std::string mod_filename,
                       std::ostream& stream,
                       std::string float_type,
-                      const bool optimize_ionvar_copies)
-        : printer(std::make_unique<CodePrinter>(stream))
+                      const bool optimize_ionvar_copies,
+                      size_t blame_line = 0)
+        : printer(std::make_unique<CodePrinter>(stream, blame_line))
         , mod_filename(std::move(mod_filename))
         , float_type(std::move(float_type))
         , optimize_ionvar_copies(optimize_ionvar_copies) {}

--- a/src/printer/CMakeLists.txt
+++ b/src/printer/CMakeLists.txt
@@ -4,3 +4,8 @@
 add_library(printer OBJECT code_printer.cpp json_printer.cpp nmodl_printer.cpp)
 set_property(TARGET printer PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(printer PRIVATE util)
+
+if(NMODL_ENABLE_BACKWARD)
+  target_link_libraries(printer PRIVATE Backward::Interface)
+  target_compile_definitions(printer PUBLIC NMODL_ENABLE_BACKWARD=1)
+endif()

--- a/src/printer/code_printer.hpp
+++ b/src/printer/code_printer.hpp
@@ -44,17 +44,21 @@ class CodePrinter {
     std::ofstream ofs;
     std::streambuf* sbuf = nullptr;
     std::unique_ptr<std::ostream> result;
+    size_t current_line = 1;
+    size_t blame_line = 0;
     size_t indent_level = 0;
     const size_t NUM_SPACES = 4;
 
   public:
-    CodePrinter()
-        : result(std::make_unique<std::ostream>(std::cout.rdbuf())) {}
+    CodePrinter(size_t blame_line = 0)
+        : result(std::make_unique<std::ostream>(std::cout.rdbuf()))
+        , blame_line(blame_line) {}
 
-    CodePrinter(std::ostream& stream)
-        : result(std::make_unique<std::ostream>(stream.rdbuf())) {}
+    CodePrinter(std::ostream& stream, size_t blame_line = 0)
+        : result(std::make_unique<std::ostream>(stream.rdbuf()))
+        , blame_line(blame_line) {}
 
-    CodePrinter(const std::string& filename);
+    CodePrinter(const std::string& filename, size_t blame_line = 0);
 
     ~CodePrinter() {
         ofs.close();
@@ -74,6 +78,7 @@ class CodePrinter {
 
     template <typename... Args>
     void add_text(Args&&... args) {
+        blame();
         (operator<<(*result, args), ...);
     }
 
@@ -127,6 +132,10 @@ class CodePrinter {
     int indent_spaces() {
         return NUM_SPACES * indent_level;
     }
+
+  private:
+    /// Blame when on the requested line.
+    void blame();
 };
 
 /** @} */  // end of printer


### PR DESCRIPTION
Adds

    nmodl MOD_FILE blame --line LINE

which will cause NMODL to print a backtrace every time it writes to line `LINE`.

This is very helpful when trying to find the NMODL code responsible for printing a (faulty) line of code.