### PR TITLE
Fix bug in `blame`.

### DIFF
--- a/src/printer/code_printer.cpp
+++ b/src/printer/code_printer.cpp
@@ -33,14 +33,14 @@ CodePrinter::CodePrinter(const std::string& filename, size_t blame_line)
 }
 
 void CodePrinter::push_block() {
-    *result << '{';
+    add_text('{');
     add_newline();
     indent_level++;
 }
 
 void CodePrinter::push_block(const std::string& expression) {
     add_indent();
-    *result << expression << " {";
+    add_text(expression, " {");
     add_newline();
     indent_level++;
 }
@@ -48,15 +48,13 @@ void CodePrinter::push_block(const std::string& expression) {
 void CodePrinter::chain_block(std::string const& expression) {
     --indent_level;
     add_indent();
-    *result << "} " << expression << " {";
+    add_text("} ", expression, " {");
     add_newline();
     ++indent_level;
 }
 
 void CodePrinter::add_indent() {
-    for (std::size_t i = 0; i < indent_level * NUM_SPACES; ++i) {
-        *result << ' ';
-    }
+    add_text(std::string(indent_level * NUM_SPACES, ' '));
 }
 
 void CodePrinter::add_multi_line(const std::string& text) {
@@ -94,7 +92,7 @@ void CodePrinter::add_multi_line(const std::string& text) {
 
 void CodePrinter::add_newline(std::size_t n) {
     for (std::size_t i = 0; i < n; ++i) {
-        *result << '\n';
+        add_text('\n');
         ++current_line;
     }
 }
@@ -106,13 +104,13 @@ void CodePrinter::pop_block() {
 void CodePrinter::pop_block_nl(std::size_t num_newlines) {
     indent_level--;
     add_indent();
-    *result << '}';
+    add_text('}');
     add_newline(num_newlines);
 }
 
 void CodePrinter::pop_block(const std::string_view& suffix, std::size_t num_newlines) {
     pop_block_nl(0);
-    *result << suffix;
+    add_text(suffix);
     add_newline(num_newlines);
 }
 


### PR DESCRIPTION
Since the codeprinter often writes to the stream directly, `blame` isn't run when needed.

This commit ensures that CodePrinter always writes via `add_text`.