### PR TITLE
Fix parsing directories

### DIFF
--- a/src/parser/nmodl_driver.cpp
+++ b/src/parser/nmodl_driver.cpp
@@ -35,6 +35,10 @@ std::shared_ptr<ast::Program> NmodlDriver::parse_stream(std::istream& in) {
 
 std::shared_ptr<ast::Program> NmodlDriver::parse_file(const fs::path& filename,
                                                       const location* loc) {
+    if (fs::is_directory(filename)) {
+        throw std::runtime_error("NMODL Parser Error : path " + filename.string() +
+                                 " appears to be a directory, please provide a file instead");
+    }
     std::ifstream in(filename);
     if (!in.good()) {
         std::ostringstream oss;

--- a/test/unit/pybind/test_parser.py
+++ b/test/unit/pybind/test_parser.py
@@ -1,0 +1,12 @@
+import nmodl
+from pathlib import Path
+import pytest
+
+
+def test_parse_directory():
+    """
+    Make sure we raise an error when parsing a directory instead of a file
+    """
+
+    with pytest.raises(RuntimeError):
+        nmodl.NmodlDriver().parse_file(str(Path(__file__).parent))


### PR DESCRIPTION
* throw a runtime error if we pass a directory to `parse_file` (fixes #1113)
* add test to make sure it works