### PR TITLE
Fail for invalid `<<` reaction equation.

### DIFF
--- a/src/visitors/kinetic_block_visitor.cpp
+++ b/src/visitors/kinetic_block_visitor.cpp
@@ -222,10 +222,10 @@ void KineticBlockVisitor::visit_reaction_statement(ast::ReactionStatement& node)
             }
         }
         if (!lhs->is_react_var_name() || !single_state_var) {
-            logger->warn(
+            throw std::runtime_error(fmt::format(
                 "KineticBlockVisitor :: LHS of \"<<\" reaction statement must be a single state "
                 "var, but instead found {}: ignoring this statement",
-                to_nmodl(lhs));
+                to_nmodl(lhs)));
             return;
         }
         const auto& rhs = node.get_expression1();

--- a/test/unit/visitor/kinetic_block.cpp
+++ b/test/unit/visitor/kinetic_block.cpp
@@ -129,13 +129,8 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             KINETIC states {
                 ~ x + y << (2*z)
             })";
-        std::string output_nmodl_text = R"(
-            DERIVATIVE states {
-            })";
-        THEN("Emit warning & do not process statement") {
-            auto result = run_kinetic_block_visitor(input_nmodl_text);
-            CAPTURE(input_nmodl_text);
-            REQUIRE(result[0] == reindent_text(output_nmodl_text));
+        THEN("Fail by throwing an error.") {
+            CHECK_THROWS(run_kinetic_block_visitor(input_nmodl_text));
         }
     }
     GIVEN("KINETIC block with -> reaction statement, 1 state var, flux vars") {


### PR DESCRIPTION
The previous behaviour for

    KINETIC states {
         ~ x + y << 42.0
    }

was to print a warning and continue as if the line didn't exist. The new behaviour is to throw an error, because it's unclear why ignoring the line could ever lead to a correct translation of the MOD file.