### PR TITLE
Fix PYTHONPATH for tests when using a venv

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -116,7 +116,13 @@ target_link_libraries(testunitparser PRIVATE lexer test_util config)
 # Use catch_discover instead of add_test for granular test result reporting.
 # =============================================================================
 set(test_env ${NMODL_SANITIZER_ENABLE_ENVIRONMENT})
-set(testvisitor_env "PYTHONPATH=${PROJECT_BINARY_DIR}/lib:$ENV{PYTHONPATH}")
+# workaround for when the user installs all Python dependencies in a virtual env
+execute_process(
+  COMMAND ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('purelib'))"
+  OUTPUT_VARIABLE PYTHON_PURELIB_PATH
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(testvisitor_env "PYTHONPATH=${PROJECT_BINARY_DIR}/lib:${PYTHON_PURELIB_PATH}:$ENV{PYTHONPATH}")
+
 if(NOT LINK_AGAINST_PYTHON)
   list(APPEND testvisitor_env "NMODL_PYLIB=$ENV{NMODL_PYLIB}")
 endif()


### PR DESCRIPTION
When building NMODL with the default flags, it’s possible to get errors like:
```plaintext
/test/unit/visitor/sympy_solver.cpp:2233: FAILED:
  REQUIRE_NOTHROW( result = run_sympy_solver_visitor( nmodl_text, false, false, AstNodeType::DERIVATIVE_BLOCK, true) )
due to unexpected exception with message:
  ModuleNotFoundError: No module named 'find_libpython'

At:
    /build/lib/nmodl/__init__.py(9): <module>
    <frozen importlib._bootstrap>(228): _call_with_frames_removed
    <frozen importlib._bootstrap_external>(850): exec_module
    <frozen importlib._bootstrap>(695): _load_unlocked
    <frozen importlib._bootstrap>(986): _find_and_load_unlocked
    <frozen importlib._bootstrap>(1007): _find_and_load
    <frozen importlib._bootstrap>(228): _call_with_frames_removed
    <frozen importlib._bootstrap>(972): _find_and_load_unlocked
    <frozen importlib._bootstrap>(1007): _find_and_load
    <string>(3): <module>
```
when running `ctest`, even though you may have installed all of the requirements via pip in your virtualenv beforehand (and pip show `find_libpython` finds it). The reason is this line here:
https://github.com/BlueBrain/nmodl/blob/347f786d694fe35ea40696948bf7ecea1daf4fb3/test/unit/CMakeLists.txt#L119

This PR fixes this by using the workaround from [this SO answer](https://stackoverflow.com/a/52638888) to prepend `PYTHONPATH` with the path to where packages are installed in the venv (should work outside of the venv as well).

Note that, as the answer mentions, the Python that comes with Debian is a bit wonky, and I'm not sure if this patch fixes it also on that platform (I tested it on a Debian Bullseye container, aka currently "oldstable", and it seems to work).