### PR TITLE
Fix indexed COMPARTMENT block.

### DIFF
--- a/src/visitors/kinetic_block_visitor.cpp
+++ b/src/visitors/kinetic_block_visitor.cpp
@@ -179,7 +179,6 @@ void KineticBlockVisitor::compute_indexed_compartment_factor(ast::Compartment& n
     auto index_name = node.get_name()->get_node_name();
 
     auto pattern = fmt::format("^{}\\[([0-9]*)\\]$", array_var_name);
-    std::cout << "pattern = " << pattern << std::endl;
     std::regex re(pattern);
     std::smatch m;
 
@@ -188,7 +187,6 @@ void KineticBlockVisitor::compute_indexed_compartment_factor(ast::Compartment& n
 
         if (matches) {
             int index_value = std::stoi(m[1]);
-            std::cout << "index_value = " << index_value << std::endl;
             auto volume_expr = node.get_expression();
             auto expr = std::shared_ptr<ast::Expression>(node.get_expression()->clone());
             IndexRemover(index_name, index_value).visit_expression(*expr);

--- a/src/visitors/kinetic_block_visitor.cpp
+++ b/src/visitors/kinetic_block_visitor.cpp
@@ -149,16 +149,23 @@ void KineticBlockVisitor::visit_compartment(ast::Compartment& node) {
     std::string expression = to_nmodl(expr);
     logger->debug("KineticBlockVisitor :: COMPARTMENT expr: {}", expression);
     for (const auto& name_ptr: node.get_names()) {
-        const auto& var_name = name_ptr->get_node_name();
-        const auto it = state_var_index.find(var_name);
-        if (it != state_var_index.cend()) {
-            int var_index = it->second;
-            compartment_factors[var_index] = expression;
-            logger->debug(
-                "KineticBlockVisitor :: COMPARTMENT factor {} for state var {} (index {})",
-                expression,
-                var_name,
-                var_index);
+        if (node.get_name() == nullptr) {
+            // COMPARTMENT volume { species }
+            const auto& var_name = name_ptr->get_node_name();
+            std::cout << "var_name = " << var_name << "\n";
+            const auto it = state_var_index.find(var_name);
+            if (it != state_var_index.cend()) {
+                int var_index = it->second;
+                compartment_factors[var_index] = expression;
+                logger->debug(
+                    "KineticBlockVisitor :: COMPARTMENT factor {} for state var {} (index {})",
+                    expression,
+                    var_name,
+                    var_index);
+            }
+        } else {
+            // COMPARTMENT i, volume_expr { species_array }
+            throw std::runtime_error("Not implemented.");
         }
     }
     // add COMPARTMENT state to list of statements to remove

--- a/src/visitors/kinetic_block_visitor.hpp
+++ b/src/visitors/kinetic_block_visitor.hpp
@@ -52,6 +52,9 @@ class KineticBlockVisitor: public AstVisitor {
     /// update CONSERVE statement with reaction var term
     void process_conserve_reac_var(const std::string& varname, int count = 1);
 
+    void set_compartment_factor(int var_index, const std::string& factor);
+    void compute_compartment_factor(ast::Compartment& node, const ast::Name& name);
+
     /// stochiometric matrices nu_L, nu_R
     /// forwards/backwards fluxes k_f, k_b
     /// (see kinetic_schemes.ipynb notebook for details)

--- a/src/visitors/kinetic_block_visitor.hpp
+++ b/src/visitors/kinetic_block_visitor.hpp
@@ -54,6 +54,7 @@ class KineticBlockVisitor: public AstVisitor {
 
     void set_compartment_factor(int var_index, const std::string& factor);
     void compute_compartment_factor(ast::Compartment& node, const ast::Name& name);
+    void compute_indexed_compartment_factor(ast::Compartment& node, const ast::Name& name);
 
     /// stochiometric matrices nu_L, nu_R
     /// forwards/backwards fluxes k_f, k_b

--- a/test/unit/visitor/kinetic_block.cpp
+++ b/test/unit/visitor/kinetic_block.cpp
@@ -239,6 +239,26 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             REQUIRE(result[0] == reindent_text(output_nmodl_text));
         }
     }
+    GIVEN("KINETIC block with -> reaction statement, indexed COMPARTMENT") {
+        std::string input_nmodl_text = R"(
+            STATE {
+                x[2]
+            }
+            KINETIC states {
+                COMPARTMENT i, vol[i] { x }
+                ~ x[0] + x[1] -> (f(v))
+            })";
+        std::string output_nmodl_text = R"(
+            DERIVATIVE states {
+                x'[0] = ((-1*(f(v)*x[0]*x[1])))/(vol[0])
+                x'[1] = ((-1*(f(v)*x[0]*x[1])))/(vol[1])
+            })";
+        THEN("Convert to equivalent DERIVATIVE block") {
+            auto result = run_kinetic_block_visitor(input_nmodl_text);
+            CAPTURE(input_nmodl_text);
+            REQUIRE(result[0] == reindent_text(output_nmodl_text));
+        }
+    }
     GIVEN("KINETIC block with one reaction statement, 1 state var, 1 non-state var, flux vars") {
         // Here c is NOT a state variable
         // see 9.9.2.1 of NEURON book


### PR DESCRIPTION
When encountering an indexed `COMPARTMENT` block:

    COMPARTMENT i, volume_expr { species }

All state variables are searched if they match they match the pattern
`"{species}[%d]"`. For each matching state variables, we obtain the
value of the array index and substitute the name of the array index with
its value in `volume_expr`. This is then stored in the array of
compartment factors.

If multiple species are listed, the above happens for each (array-valued) species.