### PR TITLE
Replace deprecated bison commands

### DIFF
--- a/src/parser/c11.yy
+++ b/src/parser/c11.yy
@@ -49,7 +49,7 @@
 %define api.namespace {nmodl::parser}
 
 /** set the parser's class identifier */
-%define parser_class_name {CParser}
+%define api.parser.class {CParser}
 
 /** keep track of the current position within the input */
 %locations

--- a/src/parser/diffeq.yy
+++ b/src/parser/diffeq.yy
@@ -53,7 +53,7 @@
 %define api.namespace {nmodl::parser}
 
 /** set the parser's class identifier */
-%define parser_class_name {DiffeqParser}
+%define api.parser.class {DiffeqParser}
 
 /** keep track of the current position within the input */
 %locations

--- a/src/parser/nmodl.yy
+++ b/src/parser/nmodl.yy
@@ -61,7 +61,7 @@
 %define api.namespace {nmodl::parser}
 
 /** set the parser's class identifier */
-%define parser_class_name {NmodlParser}
+%define api.parser.class {NmodlParser}
 
 /** keep track of the current position within the input */
 %locations

--- a/src/parser/unit.yy
+++ b/src/parser/unit.yy
@@ -46,7 +46,7 @@
 %define api.namespace {nmodl::parser}
 
 /** set the parser's class identifier */
-%define parser_class_name {UnitParser}
+%define api.parser.class {UnitParser}
 
 /** keep track of the current position within the input */
 %locations


### PR DESCRIPTION
TODO:
- [ ] according to [the docs](https://lists.gnu.org/archive/html/info-gnu/2019-01/msg00016.html), updating `name-prefix` to `api.prefix` is a bit non-trivial, and a naive fix results in compilation errors