### PR TITLE
Turn off Sanitizer CI.

### DIFF
--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -35,19 +35,9 @@ jobs:
               os: macos-12
           - config:
               os: macos-13
-          # TODO: might be interesting to add the thread sanitizer too
-          - config:
-              os: ubuntu-22.04
-              # Hyphens here will be replaced with commas before the value is
-              # passed to NMODL_SANITIZERS
-              sanitizer: address-leak
           - config:
               os: ubuntu-22.04
               enable_usecases: On
-          - config:
-              flag_warnings: ON
-              os: ubuntu-22.04
-              sanitizer: undefined
       fail-fast: true
     steps:
       - name: Setup cmake


### PR DESCRIPTION
Recent changes to Github mean that these runs are cancelled for no apparent reason.

We're turning off these runs, to be able to investigate/fix the issue without blocking other work.