### PR TITLE
Add debug logging to parser

### DIFF
--- a/src/parser/nmodl_driver.hpp
+++ b/src/parser/nmodl_driver.hpp
@@ -66,10 +66,10 @@ class NmodlDriver {
     std::unordered_map<std::string, int> defined_var;
 
     /// enable debug output in the flex scanner
-    bool trace_scanner = false;
+    bool trace_scanner = true;
 
     /// enable debug output in the bison parser
-    bool trace_parser = false;
+    bool trace_parser = true;
 
     /// print messages from lexer/parser
     bool verbose = false;


### PR DESCRIPTION
In case of issues like #1217, we get a very short stack trace like the below:

```sh
$ nmodl invalid_name.mod
libc++abi: terminating due to uncaught exception of type std::runtime_error: NMODL Parser Error : syntax error, unexpected ., expecting NAME [Location : 6.11]
    LOCAL _kf
----------^

[1]    40873 abort      nmodl invalid_name.mod
```

With this change, we change this to the more helpful:

```sh
[NMODL] [error] :: Error in parsing the file! Run with verbosity set to `trace` to get the full output.
libc++abi: terminating due to uncaught exception of type std::runtime_error: Error in parsing the file! Run with verbosity set to `trace` to get the full output.
[1]    41314 abort      nmodl invalid_name.mod
```

and if we use the hint from the output, we get:

```sh
[NMODL] [info] :: Processing invalid_name.mod
[NMODL] [trace] :: scanner trace:
--(end of buffer or a NUL)
--accepting rule at line 183("NEURON")
--accepting rule at line 375(" ")
--accepting rule at line 316("{")
--accepting rule at line 390("
    SUFFIX invalid_name")
--accepting rule at line 375(" ")
--accepting rule at line 375(" ")
--accepting rule at line 375(" ")
--accepting rule at line 375(" ")
--accepting rule at line 183("SUFFIX")
--accepting rule at line 375(" ")
--accepting rule at line 183("invalid_name")
--accepting rule at line 390("
}")
--accepting rule at line 320("}")
--accepting rule at line 390("
")
--accepting rule at line 390("
INITIAL {")
--accepting rule at line 183("INITIAL")
--accepting rule at line 375(" ")
--accepting rule at line 316("{")
--accepting rule at line 390("
    LOCAL _kf")
--accepting rule at line 375(" ")
--accepting rule at line 375(" ")
--accepting rule at line 375(" ")
--accepting rule at line 375(" ")
--accepting rule at line 183("LOCAL")
--accepting rule at line 375(" ")
--accepting rule at line 421("_")

[NMODL] [trace] :: parser trace:
Starting parse
Entering state 0
Stack now 0
Reading a token
Next token is token NEURON (1.1-6: )
Reducing stack by rule 3 (line 404):
-> $$ = nterm all (invalid_name.mod:1.1: )
Entering state 3
Stack now 0 3
Next token is token NEURON (1.1-6: )
Shifting token NEURON (1.1-6: )
Entering state 25
Stack now 0 3 25
Reading a token
Next token is token { (1.8: )
Shifting token { (1.8: )
Entering state 94
Stack now 0 3 25 94
Reducing stack by rule 283 (line 1949):
-> $$ = nterm neuron_statement (1.9: )
Entering state 132
Stack now 0 3 25 94 132
Reading a token
Next token is token SUFFIX (2.5-10: )
Shifting token SUFFIX (2.5-10: )
Entering state 230
Stack now 0 3 25 94 132 230
Reading a token
Next token is token NAME (2.12-23: )
Shifting token NAME (2.12-23: )
Entering state 74
Stack now 0 3 25 94 132 230 74
Reducing stack by rule 336 (line 2246):
   $1 = token NAME (2.12-23: )
-> $$ = nterm NAME_PTR (2.12-23: )
Entering state 349
Stack now 0 3 25 94 132 230 349
Reducing stack by rule 284 (line 1952):
   $1 = nterm neuron_statement (1.9: )
   $2 = token SUFFIX (2.5-10: )
   $3 = nterm NAME_PTR (2.12-23: )
-> $$ = nterm neuron_statement (1.9-2.23: )
Entering state 132
Stack now 0 3 25 94 132
Reading a token
Next token is token } (3.1: )
Shifting token } (3.1: )
Entering state 231
Stack now 0 3 25 94 132 231
Reducing stack by rule 282 (line 1936):
   $1 = token NEURON (1.1-6: )
   $2 = token { (1.8: )
   $3 = nterm neuron_statement (1.9-2.23: )
   $4 = token } (3.1: )
-> $$ = nterm neuron_block (1.1-3.1: )
Entering state 61
Stack now 0 3 61
Reducing stack by rule 22 (line 504):
   $1 = nterm neuron_block (1.1-3.1: )
-> $$ = nterm declare (1.1-3.1: )
Entering state 38
Stack now 0 3 38
Reducing stack by rule 7 (line 422):
   $1 = nterm all (invalid_name.mod:1.1: )
   $2 = nterm declare (1.1-3.1: )
-> $$ = nterm all (invalid_name.mod:1.1-3.1: )
Entering state 3
Stack now 0 3
Reading a token
Next token is token INITIAL1 (5.1-7: )
Shifting token INITIAL1 (5.1-7: )
Entering state 19
Stack now 0 3 19
Reading a token
Next token is token { (5.9: )
Shifting token { (5.9: )
Entering state 69
Stack now 0 3 19 69
Reading a token
Next token is token LOCAL (6.5-9: )
Shifting token LOCAL (6.5-9: )
Entering state 22
Stack now 0 3 19 69 22
Reading a token
Next token is token . (6.11: )
Exception caught: cleaning lookahead and stack

[NMODL] [error] :: Error in parsing the file! Run with verbosity set to `trace` to get the full output.
```

Note that the above is the output from the lexer/scanner, but we can also obtain output from the parser if the file is actually valid:

```sh
$ nmodl --verbose trace expsyn.mod
```
as the output is a bit lengthy, I'm attaching it instead.
[parser_log.log](https://github.com/BlueBrain/nmodl/files/14695859/parser_log.log)
