### PR TITLE
Update usecase tests so they compare outputs with NOCMODL

### DIFF
--- a/test/usecases/cnexp_array/simulate.py
+++ b/test/usecases/cnexp_array/simulate.py
@@ -1,6 +1,8 @@
-import numpy as np
+import sys
 
-from neuron import h, gui
+import numpy as np
+from neuron import gui
+from neuron import h
 from neuron.units import ms
 
 nseg = 1
@@ -24,4 +26,8 @@ x_exact = 42.0 * np.exp(rate * t)
 rel_err = np.abs(x - x_exact) / x_exact
 
 assert np.all(rel_err < 1e-12)
+
+if len(sys.argv) > 1:
+    np.savetxt(f"{sys.argv[1]}", np.transpose([t, x]))
+
 print("leonhard: success")

--- a/test/usecases/cnexp_non_trivial/simulate.py
+++ b/test/usecases/cnexp_non_trivial/simulate.py
@@ -1,6 +1,8 @@
-import numpy as np
+import sys
 
-from neuron import h, gui
+import numpy as np
+from neuron import gui
+from neuron import h
 from neuron.units import ms
 
 nseg = 1
@@ -24,4 +26,8 @@ x_exact = 42.0 * np.exp(-t)
 rel_err = np.abs(x - x_exact) / x_exact
 
 assert np.all(rel_err < 1e-12)
+
+if len(sys.argv) > 1:
+    np.savetxt(f"{sys.argv[1]}", np.transpose([t, x]))
+
 print("leonhard: success")

--- a/test/usecases/cnexp_scalar/simulate.py
+++ b/test/usecases/cnexp_scalar/simulate.py
@@ -1,6 +1,8 @@
-import numpy as np
+import sys
 
-from neuron import h, gui
+import numpy as np
+from neuron import gui
+from neuron import h
 from neuron.units import ms
 
 nseg = 1
@@ -24,4 +26,8 @@ x_exact = 42.0 * np.exp(-t)
 rel_err = np.abs(x - x_exact) / x_exact
 
 assert np.all(rel_err < 1e-12)
+
+if len(sys.argv) > 1:
+    np.savetxt(f"{sys.argv[1]}", np.transpose([t, x]))
+
 print("leonhard: success")

--- a/test/usecases/global_breakpoint/simulate.py
+++ b/test/usecases/global_breakpoint/simulate.py
@@ -1,6 +1,8 @@
-import numpy as np
+import sys
 
-from neuron import h, gui
+import numpy as np
+from neuron import gui
+from neuron import h
 from neuron.units import ms
 
 nseg = 1
@@ -24,4 +26,8 @@ x_exact[0] = 42
 abs_err = np.abs(x - x_exact)
 
 assert np.all(abs_err < 1e-12), f"{abs_err=}"
+
+if len(sys.argv) > 1:
+    np.savetxt(f"{sys.argv[1]}", np.transpose([t, x]))
+
 print("leonhard: success")

--- a/test/usecases/ionic/simulate.py
+++ b/test/usecases/ionic/simulate.py
@@ -1,6 +1,8 @@
-import numpy as np
+import sys
 
-from neuron import h, gui
+import numpy as np
+from neuron import gui
+from neuron import h
 from neuron.units import ms
 
 nseg = 1
@@ -25,4 +27,8 @@ x_exact[0] = 0.0
 abs_err = np.abs(x - x_exact)
 
 assert np.all(abs_err < 1e-12), abs_err
+
+if len(sys.argv) > 1:
+    np.savetxt(f"{sys.argv[1]}", np.transpose([t, x]))
+
 print("ionic: success")

--- a/test/usecases/nonspecific_current/simulate.py
+++ b/test/usecases/nonspecific_current/simulate.py
@@ -1,6 +1,8 @@
-import numpy as np
+import sys
 
-from neuron import h, gui
+import numpy as np
+from neuron import gui
+from neuron import h
 from neuron.units import ms
 
 nseg = 1
@@ -26,4 +28,9 @@ v_exact = erev + (v0 - erev) * np.exp(-rate * t)
 rel_err = np.abs(v - v_exact) / np.max(np.abs(v_exact))
 
 assert np.all(rel_err < 1e-1), f"rel_err = {rel_err}"
+
+
+if len(sys.argv) > 1:
+    np.savetxt(f"{sys.argv[1]}", np.transpose([t, v]))
+
 print("leonhard: success")

--- a/test/usecases/nonspecific_current/simulate.py
+++ b/test/usecases/nonspecific_current/simulate.py
@@ -1,8 +1,6 @@
-import sys
-
 import numpy as np
-from neuron import gui
-from neuron import h
+
+from neuron import h, gui
 from neuron.units import ms
 
 nseg = 1
@@ -28,9 +26,4 @@ v_exact = erev + (v0 - erev) * np.exp(-rate * t)
 rel_err = np.abs(v - v_exact) / np.max(np.abs(v_exact))
 
 assert np.all(rel_err < 1e-1), f"rel_err = {rel_err}"
-
-
-if len(sys.argv) > 1:
-    np.savetxt(f"{sys.argv[1]}", np.transpose([t, v]))
-
 print("leonhard: success")

--- a/test/usecases/run_test.sh
+++ b/test/usecases/run_test.sh
@@ -15,11 +15,20 @@ pushd "${usecase_dir}"
 # NRN + nocmodl
 rm -r "${output_dir}" tmp || true
 nrnivmodl
-"$(uname -m)/special" -nogui simulate.py
+python simulate.py nocmodl.txt
 
 # NRN + NMODL
 rm -r "${output_dir}" tmp || true
 nrnivmodl -nmodl "${nmodl}"
-"$(uname -m)/special" -nogui simulate.py
+python simulate.py nmodl.txt
+
+# if files are generated, compare them, then remove them
+
+if [[ -f 'nmodl.txt' ]] && [[ -f 'nocmodl.txt' ]]
+then
+    # diff will report a non-zero exit code if they differ
+    diff nocmodl.txt nmodl.txt
+    rm -fr nocmodl.txt nmodl.txt
+fi
 
 popd


### PR DESCRIPTION
This PR modifies the testing of usecases as follows:

- instead of calling `[arch]/special`, we directly call Python, which allows us to actually parse command-line args (is there some downside/side-effect of doing this?)
- if there is an extra command line argument, _some_ (not all!) of the tests they will create an output file (either `nocmodl.txt` or `nmodl.txt`, depending on which one we use for the codegen) with the relevant quantities of interest (voltage as function of time, etc.)
- if the files differ, the `run_test.sh` script exits with an error code

All of the above should allow us to catch any differences between NEURON + NOCMODL and NEURON + NMODL (with NEURON codegen) a bit more easily.

Note that the nonspecific current test is not modified until #1218 is merged as the test fails.