### PR TITLE
Localize kinetic reaction rates.

### DIFF
--- a/src/visitors/kinetic_block_visitor.cpp
+++ b/src/visitors/kinetic_block_visitor.cpp
@@ -488,9 +488,7 @@ class LocalRateNames {
         std::string mangled_name = unmangled_name;
 
         size_t mangle_attempt = 0;
-        while (symtab->lookup_in_scope(mangled_name) ||
-               std::find(local_names.begin(), local_names.end(), mangled_name) !=
-                   local_names.end()) {
+        while (symtab->lookup_in_scope(mangled_name)) {
             mangled_name = fmt::format("{}{:04d}", unmangled_name, mangle_attempt++);
 
             if (mangle_attempt >= 10000) {

--- a/test/unit/visitor/kinetic_block.cpp
+++ b/test/unit/visitor/kinetic_block.cpp
@@ -71,7 +71,9 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         static const std::string output_nmodl_text = R"(
             DERIVATIVE states {
-                x' = (a*c/3.2)
+                LOCAL source0_
+                source0_ = a*c/3.2
+                x' = (source0_)
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -89,7 +91,9 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
-                x'[0] = (a*c/3.2)
+                LOCAL source0_
+                source0_ = a*c/3.2
+                x'[0] = (source0_)
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -109,9 +113,11 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
+                LOCAL source0_
+                source0_ = a*c/3.2
                 f0 = 0*2
                 f1 = 0+0
-                x'[0] = (a*c/3.2)
+                x'[0] = (source0_)
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -143,9 +149,11 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
-                zf = a*x
+                LOCAL kf0_
+                kf0_ = a
+                zf = kf0_*x
                 zb = 0
-                x' = (-1*(a*x))
+                x' = (-1*(kf0_*x))
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -163,8 +171,10 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
-                x' = (-1*(f(v)*x*y))
-                y' = (-1*(f(v)*x*y))
+                LOCAL kf0_
+                kf0_ = f(v)
+                x' = (-1*(kf0_*x*y))
+                y' = (-1*(kf0_*x*y))
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -183,9 +193,11 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
+                LOCAL kf0_
+                kf0_ = f(v)
                 CONSERVE y = 1-x
-                x' = (-1*(f(v)*x*y))
-                y' = (-1*(f(v)*x*y))
+                x' = (-1*(kf0_*x*y))
+                y' = (-1*(kf0_*x*y))
             })";
         THEN("Convert to equivalent DERIVATIVE block, rewrite CONSERVE statement") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -206,9 +218,11 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
+                LOCAL kf0_
+                kf0_ = f(v)
                 CONSERVE y = (1-(a*1*x))/(b*1)
-                x' = ((-1*(f(v)*x*y)))/(a)
-                y' = ((-1*(f(v)*x*y)))/(b)
+                x' = ((-1*(kf0_*x*y)))/(a)
+                y' = ((-1*(kf0_*x*y)))/(b)
             })";
         THEN(
             "Convert to equivalent DERIVATIVE block, rewrite CONSERVE statement inc COMPARTMENT "
@@ -228,8 +242,10 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
-                x'[0] = (-1*(f(v)*x[0]*x[1]))
-                x'[1] = (-1*(f(v)*x[0]*x[1]))
+                LOCAL kf0_
+                kf0_ = f(v)
+                x'[0] = (-1*(kf0_*x[0]*x[1]))
+                x'[1] = (-1*(kf0_*x[0]*x[1]))
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -248,8 +264,10 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
-                x'[0] = ((-1*(f(v)*x[0]*x[1])))/(vol[0])
-                x'[1] = ((-1*(f(v)*x[0]*x[1])))/(vol[1])
+                LOCAL kf0_
+                kf0_ = f(v)
+                x'[0] = ((-1*(kf0_*x[0]*x[1])))/(vol[0])
+                x'[1] = ((-1*(kf0_*x[0]*x[1])))/(vol[1])
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -273,8 +291,11 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
-                c1 = r*x-r*c
-                x' = (-1*(r*x-r*c))
+                LOCAL kf0_, kb0_
+                kb0_ = r
+                kf0_ = r
+                c1 = kf0_*x-kb0_*c
+                x' = (-1*(kf0_*x-kb0_*c))
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -292,8 +313,11 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
-                x' = (-1*(a*x-b*y))
-                y' = (1*(a*x-b*y))
+                LOCAL kf0_, kb0_
+                kb0_ = b
+                kf0_ = a
+                x' = (-1*(kf0_*x-kb0_*y))
+                y' = (1*(kf0_*x-kb0_*y))
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -312,9 +336,12 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
+                LOCAL kf0_, kb0_
+                kb0_ = b
+                kf0_ = a
                 CONSERVE y = 0-x
-                x' = (-1*(a*x-b*y))
-                y' = (1*(a*x-b*y))
+                x' = (-1*(kf0_*x-kb0_*y))
+                y' = (1*(kf0_*x-kb0_*y))
             })";
         THEN("Convert to equivalent DERIVATIVE block, rewrite CONSERVE statement") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -336,11 +363,16 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
+                LOCAL kf0_, kb0_, kf1_, kb1_
+                kb0_ = b
+                kf0_ = a
+                kb1_ = d
+                kf1_ = c
                 CONSERVE x[2] = 1-y-x[0]-x[1]
-                x'[0] = (-1*(a*x[0]-b*x[1]))
-                x'[1] = (1*(a*x[0]-b*x[1]))
-                x'[2] = (-1*(c*x[2]-d*y))
-                y' = (1*(c*x[2]-d*y))
+                x'[0] = (-1*(kf0_*x[0]-kb0_*x[1]))
+                x'[1] = (1*(kf0_*x[0]-kb0_*x[1]))
+                x'[2] = (-1*(kf1_*x[2]-kb1_*y))
+                y' = (1*(kf1_*x[2]-kb1_*y))
             })";
         THEN(
             "Convert to equivalent DERIVATIVE block, rewrite CONSERVE statement after summing over "
@@ -364,11 +396,16 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
+                LOCAL kf0_, kb0_, kf1_, kb1_
+                kb0_ = b
+                kf0_ = a
+                kb1_ = d
+                kf1_ = c
                 CONSERVE y = 1-x[0]-x[1]-x[2]
-                x'[0] = (-1*(a*x[0]-b*x[1]))
-                x'[1] = (1*(a*x[0]-b*x[1]))
-                x'[2] = (-1*(c*x[2]-d*y))
-                y' = (1*(c*x[2]-d*y))
+                x'[0] = (-1*(kf0_*x[0]-kb0_*x[1]))
+                x'[1] = (1*(kf0_*x[0]-kb0_*x[1]))
+                x'[2] = (-1*(kf1_*x[2]-kb1_*y))
+                y' = (1*(kf1_*x[2]-kb1_*y))
             })";
         THEN(
             "Convert to equivalent DERIVATIVE block, rewrite CONSERVE statement after summing over "
@@ -389,8 +426,11 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
-                x' = ((-1*(a*x-b*y)))/(c-d)
-                y' = ((1*(a*x-b*y)))/(c-d)
+                LOCAL kf0_, kb0_
+                kb0_ = b
+                kf0_ = a
+                x' = ((-1*(kf0_*x-kb0_*y)))/(c-d)
+                y' = ((1*(kf0_*x-kb0_*y)))/(c-d)
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -413,14 +453,21 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE ihkin {
+                LOCAL kf0_, kb0_, kf1_, kb1_, kf2_, kb2_
                 evaluate_fct(v, cai)
+                kb0_ = beta
+                kf0_ = alpha
+                kb1_ = k2
+                kf1_ = k1ca
+                kb2_ = k4
+                kf2_ = k3p
                 CONSERVE p1 = 1-p0
                 CONSERVE o2 = 1-c1-o1
-                c1' = (-1*(alpha*c1-beta*o1))
-                o1' = (1*(alpha*c1-beta*o1))+(-1*(k3p*o1-k4*o2))
-                o2' = (1*(k3p*o1-k4*o2))
-                p0' = (-1*(k1ca*p0-k2*p1))
-                p1' = (1*(k1ca*p0-k2*p1))
+                c1' = (-1*(kf0_*c1-kb0_*o1))
+                o1' = (1*(kf0_*c1-kb0_*o1))+(-1*(kf2_*o1-kb2_*o2))
+                o2' = (1*(kf2_*o1-kb2_*o2))
+                p0' = (-1*(kf1_*p0-kb1_*p1))
+                p1' = (1*(kf1_*p0-kb1_*p1))
             })";
         THEN("Convert to equivalent DERIVATIVE block, re-order both CONSERVE statements") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -440,8 +487,11 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
-                x' = ((-1*(a*x-b*y)))/(cx)
-                y' = ((1*(a*x-b*y)))/(cy)
+                LOCAL kf0_, kb0_
+                kb0_ = b
+                kf0_ = a
+                x' = ((-1*(kf0_*x-kb0_*y)))/(cx)
+                y' = ((1*(kf0_*x-kb0_*y)))/(cy)
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -460,10 +510,15 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
-                w' = (-1*(c*w-d*z))
-                x' = (-1*(a*x-b*y))
-                y' = (1*(a*x-b*y))
-                z' = (1*(c*w-d*z))
+                LOCAL kf0_, kb0_, kf1_, kb1_
+                kb0_ = b
+                kf0_ = a
+                kb1_ = d
+                kf1_ = c
+                w' = (-1*(kf1_*w-kb1_*z))
+                x' = (-1*(kf0_*x-kb0_*y))
+                y' = (1*(kf0_*x-kb0_*y))
+                z' = (1*(kf1_*w-kb1_*z))
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -482,9 +537,14 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
-                x' = (-1*(a*x-b*y))
-                y' = (1*(a*x-b*y))+(-1*(c*y-d*z))
-                z' = (1*(c*y-d*z))
+                LOCAL kf0_, kb0_, kf1_, kb1_
+                kb0_ = b
+                kf0_ = a
+                kb1_ = d
+                kf1_ = c
+                x' = (-1*(kf0_*x-kb0_*y))
+                y' = (1*(kf0_*x-kb0_*y))+(-1*(kf1_*y-kb1_*z))
+                z' = (1*(kf1_*y-kb1_*z))
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -506,12 +566,17 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
+                LOCAL kf0_, kb0_, kf1_, kb1_
                 c0 = 0
-                c1 = a*x+b*y
-                c2 = c*y-2*d*z
-                x' = (-1*(a*x-b*y))
-                y' = (1*(a*x-b*y))+(-1*(c*y-d*z))
-                z' = (1*(c*y-d*z))
+                kb0_ = b
+                kf0_ = a
+                c1 = kf0_*x+kb0_*y
+                kb1_ = d
+                kf1_ = c
+                c2 = kf1_*y-2*kb1_*z
+                x' = (-1*(kf0_*x-kb0_*y))
+                y' = (1*(kf0_*x-kb0_*y))+(-1*(kf1_*y-kb1_*z))
+                z' = (1*(kf1_*y-kb1_*z))
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -529,8 +594,11 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
-                x' = (-2*(a*x*x-b*y))
-                y' = (1*(a*x*x-b*y))
+                LOCAL kf0_, kb0_
+                kb0_ = b
+                kf0_ = a
+                x' = (-2*(kf0_*x*x-kb0_*y))
+                y' = (1*(kf0_*x*x-kb0_*y))
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -548,8 +616,11 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
-                x' = (-2*(a*x*x-b*y))
-                y' = (1*(a*x*x-b*y))
+                LOCAL kf0_, kb0_
+                kb0_ = b
+                kf0_ = a
+                x' = (-2*(kf0_*x*x-kb0_*y))
+                y' = (1*(kf0_*x*x-kb0_*y))
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -568,8 +639,11 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
-                mc' = (-1*(a(v)*mc-b(v)*m))
-                m' = (1*(a(v)*mc-b(v)*m))
+                LOCAL kf0_, kb0_
+                kb0_ = b(v)
+                kf0_ = a(v)
+                mc' = (-1*(kf0_*mc-kb0_*m))
+                m' = (1*(kf0_*mc-kb0_*m))
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
@@ -589,11 +663,17 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
-                A' = (-2*(k1*A*A*B-k2*C))+(1*(k3*C*D-k4*A*B*B))
-                B' = (-1*(k1*A*A*B-k2*C))+(2*(k3*C*D-k4*A*B*B))
-                C' = (1*(k1*A*A*B-k2*C))+(-1*(k3*C*D-k4*A*B*B))
-                D' = (-1*(k3*C*D-k4*A*B*B))
+                LOCAL kf0_, kb0_, kf1_, kb1_
+                kb0_ = k2
+                kf0_ = k1
+                kb1_ = k4
+                kf1_ = k3
+                A' = (-2*(kf0_*A*A*B-kb0_*C))+(1*(kf1_*C*D-kb1_*A*B*B))
+                B' = (-1*(kf0_*A*A*B-kb0_*C))+(2*(kf1_*C*D-kb1_*A*B*B))
+                C' = (1*(kf0_*A*A*B-kb0_*C))+(-1*(kf1_*C*D-kb1_*A*B*B))
+                D' = (-1*(kf1_*C*D-kb1_*A*B*B))
             })";
+
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);
             CAPTURE(input_nmodl_text);
@@ -621,13 +701,24 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             })";
         std::string output_nmodl_text = R"(
             DERIVATIVE kin {
+                LOCAL kf0_, kb0_, kf1_, kb1_, kf2_, kb2_, kf3_, kb3_, source4_, kf5_
+                source4_ = a
                 {
+                    kb0_ = c[0]
+                    kf0_ = b[0]
+                    kb1_ = c[1]
+                    kf1_ = b[1]
+                    kb2_ = c[2]
+                    kf2_ = b[2]
+                    kb3_ = c[3]
+                    kf3_ = b[3]
                 }
-                x'[0] = (a)+(-1*(b[0]*x[0]-c[0]*x[1]))
-                x'[1] = (1*(b[0]*x[0]-c[0]*x[1]))+(-1*(b[1]*x[1]-c[1]*x[2]))
-                x'[2] = (1*(b[1]*x[1]-c[1]*x[2]))+(-1*(b[2]*x[2]-c[2]*x[3]))
-                x'[3] = (1*(b[2]*x[2]-c[2]*x[3]))+(-1*(b[3]*x[3]-c[3]*x[4]))
-                x'[4] = (1*(b[3]*x[3]-c[3]*x[4]))+(-1*(d*x[4]))
+                kf5_ = d
+                x'[0] = (source4_)+(-1*(kf0_*x[0]-kb0_*x[1]))
+                x'[1] = (1*(kf0_*x[0]-kb0_*x[1]))+(-1*(kf1_*x[1]-kb1_*x[2]))
+                x'[2] = (1*(kf1_*x[1]-kb1_*x[2]))+(-1*(kf2_*x[2]-kb2_*x[3]))
+                x'[3] = (1*(kf2_*x[2]-kb2_*x[3]))+(-1*(kf3_*x[3]-kb3_*x[4]))
+                x'[4] = (1*(kf3_*x[3]-kb3_*x[4]))+(-1*(kf5_*x[4]))
             })";
         THEN("Convert to equivalent DERIVATIVE block") {
             auto result = run_kinetic_block_visitor(input_nmodl_text);

--- a/test/unit/visitor/kinetic_block.cpp
+++ b/test/unit/visitor/kinetic_block.cpp
@@ -292,8 +292,8 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
                 LOCAL kf0_, kb0_
-                kb0_ = r
                 kf0_ = r
+                kb0_ = r
                 c1 = kf0_*x-kb0_*c
                 x' = (-1*(kf0_*x-kb0_*c))
             })";
@@ -314,8 +314,8 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
                 LOCAL kf0_, kb0_
-                kb0_ = b
                 kf0_ = a
+                kb0_ = b
                 x' = (-1*(kf0_*x-kb0_*y))
                 y' = (1*(kf0_*x-kb0_*y))
             })";
@@ -337,8 +337,8 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
                 LOCAL kf0_, kb0_
-                kb0_ = b
                 kf0_ = a
+                kb0_ = b
                 CONSERVE y = 0-x
                 x' = (-1*(kf0_*x-kb0_*y))
                 y' = (1*(kf0_*x-kb0_*y))
@@ -364,10 +364,10 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
                 LOCAL kf0_, kb0_, kf1_, kb1_
-                kb0_ = b
                 kf0_ = a
-                kb1_ = d
+                kb0_ = b
                 kf1_ = c
+                kb1_ = d
                 CONSERVE x[2] = 1-y-x[0]-x[1]
                 x'[0] = (-1*(kf0_*x[0]-kb0_*x[1]))
                 x'[1] = (1*(kf0_*x[0]-kb0_*x[1]))
@@ -397,10 +397,10 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
                 LOCAL kf0_, kb0_, kf1_, kb1_
-                kb0_ = b
                 kf0_ = a
-                kb1_ = d
+                kb0_ = b
                 kf1_ = c
+                kb1_ = d
                 CONSERVE y = 1-x[0]-x[1]-x[2]
                 x'[0] = (-1*(kf0_*x[0]-kb0_*x[1]))
                 x'[1] = (1*(kf0_*x[0]-kb0_*x[1]))
@@ -427,8 +427,8 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
                 LOCAL kf0_, kb0_
-                kb0_ = b
                 kf0_ = a
+                kb0_ = b
                 x' = ((-1*(kf0_*x-kb0_*y)))/(c-d)
                 y' = ((1*(kf0_*x-kb0_*y)))/(c-d)
             })";
@@ -455,12 +455,12 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             DERIVATIVE ihkin {
                 LOCAL kf0_, kb0_, kf1_, kb1_, kf2_, kb2_
                 evaluate_fct(v, cai)
-                kb0_ = beta
                 kf0_ = alpha
-                kb1_ = k2
+                kb0_ = beta
                 kf1_ = k1ca
-                kb2_ = k4
+                kb1_ = k2
                 kf2_ = k3p
+                kb2_ = k4
                 CONSERVE p1 = 1-p0
                 CONSERVE o2 = 1-c1-o1
                 c1' = (-1*(kf0_*c1-kb0_*o1))
@@ -514,8 +514,8 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
                 LOCAL kf0_, kb0_
-                kb0_ = b
                 kf0_ = a
+                kb0_ = b
                 x' = ((-1*(kf0_*x-kb0_*y)))/(cx)
                 y' = ((1*(kf0_*x-kb0_*y)))/(cy)
             })";
@@ -537,10 +537,10 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
                 LOCAL kf0_, kb0_, kf1_, kb1_
-                kb0_ = b
                 kf0_ = a
-                kb1_ = d
+                kb0_ = b
                 kf1_ = c
+                kb1_ = d
                 w' = (-1*(kf1_*w-kb1_*z))
                 x' = (-1*(kf0_*x-kb0_*y))
                 y' = (1*(kf0_*x-kb0_*y))
@@ -564,10 +564,10 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
                 LOCAL kf0_, kb0_, kf1_, kb1_
-                kb0_ = b
                 kf0_ = a
-                kb1_ = d
+                kb0_ = b
                 kf1_ = c
+                kb1_ = d
                 x' = (-1*(kf0_*x-kb0_*y))
                 y' = (1*(kf0_*x-kb0_*y))+(-1*(kf1_*y-kb1_*z))
                 z' = (1*(kf1_*y-kb1_*z))
@@ -594,11 +594,11 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             DERIVATIVE states {
                 LOCAL kf0_, kb0_, kf1_, kb1_
                 c0 = 0
-                kb0_ = b
                 kf0_ = a
+                kb0_ = b
                 c1 = kf0_*x+kb0_*y
-                kb1_ = d
                 kf1_ = c
+                kb1_ = d
                 c2 = kf1_*y-2*kb1_*z
                 x' = (-1*(kf0_*x-kb0_*y))
                 y' = (1*(kf0_*x-kb0_*y))+(-1*(kf1_*y-kb1_*z))
@@ -621,8 +621,8 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
                 LOCAL kf0_, kb0_
-                kb0_ = b
                 kf0_ = a
+                kb0_ = b
                 x' = (-2*(kf0_*x*x-kb0_*y))
                 y' = (1*(kf0_*x*x-kb0_*y))
             })";
@@ -643,8 +643,8 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
                 LOCAL kf0_, kb0_
-                kb0_ = b
                 kf0_ = a
+                kb0_ = b
                 x' = (-2*(kf0_*x*x-kb0_*y))
                 y' = (1*(kf0_*x*x-kb0_*y))
             })";
@@ -666,8 +666,8 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
                 LOCAL kf0_, kb0_
-                kb0_ = b(v)
                 kf0_ = a(v)
+                kb0_ = b(v)
                 mc' = (-1*(kf0_*mc-kb0_*m))
                 m' = (1*(kf0_*mc-kb0_*m))
             })";
@@ -690,10 +690,10 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
         std::string output_nmodl_text = R"(
             DERIVATIVE states {
                 LOCAL kf0_, kb0_, kf1_, kb1_
-                kb0_ = k2
                 kf0_ = k1
-                kb1_ = k4
+                kb0_ = k2
                 kf1_ = k3
+                kb1_ = k4
                 A' = (-2*(kf0_*A*A*B-kb0_*C))+(1*(kf1_*C*D-kb1_*A*B*B))
                 B' = (-1*(kf0_*A*A*B-kb0_*C))+(2*(kf1_*C*D-kb1_*A*B*B))
                 C' = (1*(kf0_*A*A*B-kb0_*C))+(-1*(kf1_*C*D-kb1_*A*B*B))
@@ -730,14 +730,14 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
                 LOCAL kf0_, kb0_, kf1_, kb1_, kf2_, kb2_, kf3_, kb3_, source4_, kf5_
                 source4_ = a
                 {
-                    kb0_ = c[0]
                     kf0_ = b[0]
-                    kb1_ = c[1]
+                    kb0_ = c[0]
                     kf1_ = b[1]
-                    kb2_ = c[2]
+                    kb1_ = c[1]
                     kf2_ = b[2]
-                    kb3_ = c[3]
+                    kb2_ = c[2]
                     kf3_ = b[3]
+                    kb3_ = c[3]
                 }
                 kf5_ = d
                 x'[0] = (source4_)+(-1*(kf0_*x[0]-kb0_*x[1]))

--- a/test/unit/visitor/kinetic_block.cpp
+++ b/test/unit/visitor/kinetic_block.cpp
@@ -475,6 +475,32 @@ SCENARIO("Convert KINETIC to DERIVATIVE using KineticBlock visitor", "[kinetic][
             REQUIRE(result[0] == reindent_text(output_nmodl_text));
         }
     }
+    GIVEN("KINETIC block with one reaction statement & clashing local") {
+        std::string input_nmodl_text = R"(
+            ASSIGNED {
+                kf0_
+            }
+            STATE {
+                x y
+            }
+            KINETIC states {
+                LOCAL kf0_0000, kb0_0000
+                ~ x <-> y (kf0_, b)
+            })";
+        std::string output_nmodl_text = R"(
+            DERIVATIVE states {
+                LOCAL kf0_0000, kb0_0000, kf0_0001, kb0_
+                kf0_0001 = kf0_
+                kb0_ = b
+                x' = (-1*(kf0_0001*x-kb0_*y))
+                y' = (1*(kf0_0001*x-kb0_*y))
+            })";
+        THEN("Convert to equivalent DERIVATIVE block") {
+            auto result = run_kinetic_block_visitor(input_nmodl_text);
+            CAPTURE(input_nmodl_text);
+            REQUIRE(result[0] == reindent_text(output_nmodl_text));
+        }
+    }
     GIVEN("KINETIC block with one reaction statement & 2 COMPARTMENT statements") {
         std::string input_nmodl_text = R"(
             STATE {

--- a/test/unit/visitor/sympy_solver.cpp
+++ b/test/unit/visitor/sympy_solver.cpp
@@ -2159,20 +2159,22 @@ SCENARIO("Solve KINETIC block using SympySolver Visitor", "[visitor][solver][sym
         std::string expected_text = R"(
             DERIVATIVE kstates {
                 EIGEN_NEWTON_SOLVE[2]{
-                    LOCAL old_C1, old_C2
+                    LOCAL kf0_, kb0_, old_C1, old_C2
                 }{
+                    kb0_ = alfa(v)
+                    kf0_ = alfa(v)
                     old_C1 = C1
                     old_C2 = C2
                 }{
                     nmodl_eigen_x[0] = C1
                     nmodl_eigen_x[1] = C2
                 }{
-                    nmodl_eigen_f[0] = -nmodl_eigen_x[0]*dt*alfa(v)-nmodl_eigen_x[0]+nmodl_eigen_x[1]*dt*alfa(v)+old_C1
-                    nmodl_eigen_j[0] = -dt*alfa(v)-1.0
-                    nmodl_eigen_j[2] = dt*alfa(v)
-                    nmodl_eigen_f[1] = nmodl_eigen_x[0]*dt*alfa(v)-nmodl_eigen_x[1]*dt*alfa(v)-nmodl_eigen_x[1]+old_C2
-                    nmodl_eigen_j[1] = dt*alfa(v)
-                    nmodl_eigen_j[3] = -dt*alfa(v)-1.0
+                    nmodl_eigen_f[0] = -nmodl_eigen_x[0]*dt*kf0_-nmodl_eigen_x[0]+nmodl_eigen_x[1]*dt*kb0_+old_C1
+                    nmodl_eigen_j[0] = -dt*kf0_-1.0
+                    nmodl_eigen_j[2] = dt*kb0_
+                    nmodl_eigen_f[1] = nmodl_eigen_x[0]*dt*kf0_-nmodl_eigen_x[1]*dt*kb0_-nmodl_eigen_x[1]+old_C2
+                    nmodl_eigen_j[1] = dt*kf0_
+                    nmodl_eigen_j[3] = -dt*kb0_-1.0
                 }{
                     C1 = nmodl_eigen_x[0]
                     C2 = nmodl_eigen_x[1]
@@ -2207,20 +2209,22 @@ SCENARIO("Solve KINETIC block using SympySolver Visitor", "[visitor][solver][sym
         std::string expected_text = R"(
             DERIVATIVE kstates {
                 EIGEN_NEWTON_SOLVE[2]{
-                    LOCAL old_C1, old_C2
+                    LOCAL kf0_, kb0_, old_C1, old_C2
                 }{
+                    kb0_ = lowergamma(v)
+                    kf0_ = beta(v)
                     old_C1 = C1
                     old_C2 = C2
                 }{
                     nmodl_eigen_x[0] = C1
                     nmodl_eigen_x[1] = C2
                 }{
-                    nmodl_eigen_f[0] = -nmodl_eigen_x[0]*dt*beta(v)-nmodl_eigen_x[0]+nmodl_eigen_x[1]*dt*lowergamma(v)+old_C1
-                    nmodl_eigen_j[0] = -dt*beta(v)-1.0
-                    nmodl_eigen_j[2] = dt*lowergamma(v)
-                    nmodl_eigen_f[1] = nmodl_eigen_x[0]*dt*beta(v)-nmodl_eigen_x[1]*dt*lowergamma(v)-nmodl_eigen_x[1]+old_C2
-                    nmodl_eigen_j[1] = dt*beta(v)
-                    nmodl_eigen_j[3] = -dt*lowergamma(v)-1.0
+                    nmodl_eigen_f[0] = -nmodl_eigen_x[0]*dt*kf0_-nmodl_eigen_x[0]+nmodl_eigen_x[1]*dt*kb0_+old_C1
+                    nmodl_eigen_j[0] = -dt*kf0_-1.0
+                    nmodl_eigen_j[2] = dt*kb0_
+                    nmodl_eigen_f[1] = nmodl_eigen_x[0]*dt*kf0_-nmodl_eigen_x[1]*dt*kb0_-nmodl_eigen_x[1]+old_C2
+                    nmodl_eigen_j[1] = dt*kf0_
+                    nmodl_eigen_j[3] = -dt*kb0_-1.0
                 }{
                     C1 = nmodl_eigen_x[0]
                     C2 = nmodl_eigen_x[1]


### PR DESCRIPTION
If assignments and reaction equations are interspersed the ODE might use incorrect reaction rates. Example:
```
rate = 42.0
~ a <-> b (1.0*rate, 2.0*rate)
rate = 43.0
~ c <-> d (3.0*rate, 4.0*rate)
```
was equivalent to:
```
rate = 42.0
rate = 43.0
~ a <-> b (1.0*rate, 2.0*rate)
~ c <-> d (3.0*rate, 4.0*rate)
```
This PR solves the issue by localizing the rates, i.e. it'll produce:
```
LOCAL kf0_, kb0_, kf1_, kb1_
rate = 42.0
kf0_ = 1.0*rate
kb0_ = 2.0*rate
~ a <-> b (kf0_, kb0_)
rate = 43.0
kf1_ = 3.0*rate
kb1_ = 4.0*rate
~ c <-> d (kf1_, kb1_)
```
Which can then be safely shuffled into:
```
LOCAL kf0_, kb0_, kf1_, kb1_
rate = 42.0
kf0_ = 1.0*rate
kb0_ = 2.0*rate

rate = 43.0
kf1_ = 3.0*rate
kb1_ = 4.0*rate

~ a <-> b (kf0_, kb0_)
~ c <-> d (kf1_, kb1_)
```
and from there transformed as usual.