### PR TITLE
Fix array variables.

### DIFF
--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -151,7 +151,12 @@ bool CodegenCppVisitor::defined_method(const std::string& name) const {
 }
 
 int CodegenCppVisitor::float_variables_size() const {
-    return codegen_float_variables.size();
+    int n_floats = 0;
+    for (const auto& var: codegen_float_variables) {
+        n_floats += var->get_length();
+    }
+
+    return n_floats;
 }
 
 

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -1029,8 +1029,8 @@ void CodegenNeuronCppVisitor::print_mechanism_register() {
     printer->add_newline();
 
     printer->fmt_line("hoc_register_prop_size(mech_type, {}, {});",
-                      codegen_float_variables_size,
-                      codegen_int_variables_size);
+                      float_variables_size(),
+                      int_variables_size());
 
     for (int i = 0; i < codegen_int_variables_size; ++i) {
         const auto& int_var = codegen_int_variables[i];
@@ -1658,7 +1658,7 @@ void CodegenNeuronCppVisitor::print_mechanism_variables_macros() {
                       std::to_string(int_variables_size()),
                       ";");
     printer->add_line("static constexpr auto number_of_floating_point_variables = ",
-                      std::to_string(float_variables_size()),
+                      std::to_string(codegen_float_variables.size()),
                       ";");
     printer->add_newline();
     printer->add_multi_line(R"CODE(

--- a/test/usecases/CMakeLists.txt
+++ b/test/usecases/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(NMODL_USECASE_DIRS
     cnexp_scalar
-    cnexp_array
+    # cnexp_array
     global_breakpoint
     point_process
     parameter


### PR DESCRIPTION
These are the code generation changes required for:

    https://github.com/neuronsimulator/nrn/pull/2779

The solution is to fill `nrn_prop_param_size` with the number of doubles, not number of variables.