### PR TITLE
Add dependency of `generate_references` on `nmodl`.

### DIFF
--- a/test/usecases/CMakeLists.txt
+++ b/test/usecases/CMakeLists.txt
@@ -15,6 +15,7 @@ endif()
 unset(NMODL_GOLDEN_REFERNCES)
 
 add_custom_target(generate_references)
+
 foreach(usecase ${NMODL_USECASE_DIRS})
   # Non-existant dependencies are a way of unconditionally running commands in CMake.
   if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/references/${usecase}/_does_not_exist_weiohbge)
@@ -34,6 +35,7 @@ foreach(usecase ${NMODL_USECASE_DIRS})
 
   add_custom_command(
     OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/references/${usecase}/_does_not_exist_weiohbge
+    DEPENDS nmodl
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/generate_references.sh ${CMAKE_BINARY_DIR}/bin/nmodl
             ${CMAKE_CURRENT_SOURCE_DIR}/${usecase})
 


### PR DESCRIPTION
This can be reproduced by:

    cmake -B build && cmake --build build --target=generate_references

i.e. call `--target=generate_references` without building it first. It would complain about missing `bin/nmodl`.