### PR TITLE
Implement simplified expsyn.

### DIFF
--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -15,9 +15,11 @@
 
 #include "ast/all.hpp"
 #include "codegen/codegen_utils.hpp"
+#include "codegen_naming.hpp"
 #include "config/config.h"
 #include "utils/string_utils.hpp"
 #include "visitors/rename_visitor.hpp"
+#include "visitors/var_usage_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
 
 namespace nmodl {
@@ -26,6 +28,7 @@ namespace codegen {
 using namespace ast;
 
 using visitor::RenameVisitor;
+using visitor::VarUsageVisitor;
 
 using symtab::syminfo::NmodlType;
 
@@ -507,7 +510,7 @@ std::string CodegenNeuronCppVisitor::float_variable_name(const SymbolType& symbo
 std::string CodegenNeuronCppVisitor::int_variable_name(const IndexVariableInfo& symbol,
                                                        const std::string& name,
                                                        bool use_instance) const {
-    // auto position = position_of_int_var(name);
+    auto position = position_of_int_var(name);
     if (symbol.is_index) {
         if (use_instance) {
             throw std::runtime_error("Not implemented. [wiejo]");
@@ -518,11 +521,9 @@ std::string CodegenNeuronCppVisitor::int_variable_name(const IndexVariableInfo& 
     }
     if (symbol.is_integer) {
         if (use_instance) {
-            throw std::runtime_error("Not implemented. [cnuoe]");
-            // return fmt::format("inst->{}[{}*pnodecount+id]", name, position);
+            return fmt::format("inst.{}[id]", name);
         }
-        throw std::runtime_error("Not implemented. [u32ow]");
-        // return fmt::format("indexes[{}*pnodecount+id]", position);
+        return fmt::format("_ppvar[{}]", position);
     }
     if (use_instance) {
         return fmt::format("(*inst.{}[id])", name);
@@ -583,9 +584,7 @@ std::string CodegenNeuronCppVisitor::get_variable_name(const std::string& name,
         return std::string("_nt->_") + naming::NTHREAD_DT_VARIABLE;
     }
 
-    // t in net_receive method is an argument to function and hence it should
-    // be used instead of nt->_t which is current time of thread
-    if (varname == naming::NTHREAD_T_VARIABLE && !printing_net_receive) {
+    if (varname == naming::NTHREAD_T_VARIABLE) {
         return std::string("_nt->_") + naming::NTHREAD_T_VARIABLE;
     }
 
@@ -1009,7 +1008,12 @@ void CodegenNeuronCppVisitor::print_mechanism_register() {
             throw std::runtime_error("Broken logic.");
         }
 
-        auto type = (name == naming::POINT_PROCESS_VARIABLE) ? "Point_process*" : "double*";
+        auto type = "double*";
+        if (name == naming::POINT_PROCESS_VARIABLE) {
+            type = "Point_process*";
+        } else if (name == naming::TQITEM_VARIABLE) {
+            type = "void*";
+        }
         mech_register_args.push_back(
             fmt::format("_nrn_mechanism_field<{}>{{\"{}\", \"{}\"}} /* {} */",
                         type,
@@ -1045,6 +1049,10 @@ void CodegenNeuronCppVisitor::print_mechanism_register() {
     printer->add_line("hoc_register_var(hoc_scalar_double, hoc_vector_double, hoc_intfunc);");
     if (!info.point_process) {
         printer->add_line("hoc_register_npy_direct(mech_type, npy_direct_func_proc);");
+    }
+    if (info.net_receive_node) {
+        printer->fmt_line("pnt_receive[mech_type] = nrn_net_receive_{};", info.mod_suffix);
+        printer->fmt_line("pnt_receive_size[mech_type] = {};", info.num_net_receive_parameters);
     }
     printer->pop_block();
 }
@@ -1741,6 +1749,7 @@ void CodegenNeuronCppVisitor::print_compute_functions() {
     print_nrn_cur();
     print_nrn_state();
     print_nrn_jacob();
+    print_net_receive();
 }
 
 
@@ -1765,7 +1774,22 @@ void CodegenNeuronCppVisitor::print_codegen_routines() {
 }
 
 void CodegenNeuronCppVisitor::print_net_send_call(const ast::FunctionCall& node) {
-    throw std::runtime_error("Not implemented.");
+    auto const& arguments = node.get_arguments();
+
+    if (printing_net_receive || printing_net_init) {
+        throw std::runtime_error("Not implemented. [jfiwoei]");
+    }
+
+    std::string weight_pointer = "nullptr";
+    const auto& point_process = get_variable_name("point_process", /* use_instance */ false);
+    const auto& tqitem = get_variable_name("tqitem", /* use_instance */ false);
+
+    printer->fmt_text("net_send(/* tqitem */ &{}, {}, {}.get<Point_process*>(), t + ",
+                      tqitem,
+                      weight_pointer,
+                      point_process);
+    print_vector_elements(arguments, ", ");
+    printer->add_text(')');
 }
 
 void CodegenNeuronCppVisitor::print_net_move_call(const ast::FunctionCall& node) {
@@ -1774,6 +1798,70 @@ void CodegenNeuronCppVisitor::print_net_move_call(const ast::FunctionCall& node)
 
 void CodegenNeuronCppVisitor::print_net_event_call(const ast::FunctionCall& node) {
     throw std::runtime_error("Not implemented.");
+}
+
+/**
+ * Rename arguments to NET_RECEIVE block with corresponding pointer variable
+ *
+ * \code{.mod}
+ *      NET_RECEIVE (weight, R){
+ *            x = R
+ *      }
+ * \endcode
+ *
+ * then generated code should be:
+ *
+ * \code{.cpp}
+ *      x[id] = _args[1];
+ * \endcode
+ *
+ * So, the `R` in AST needs to be renamed with `_args[1]`.
+ */
+static void rename_net_receive_arguments(const ast::NetReceiveBlock& net_receive_node,
+                                         const ast::Node& node) {
+    const auto& parameters = net_receive_node.get_parameters();
+
+    auto n_parameters = parameters.size();
+    for (size_t i = 0; i < n_parameters; ++i) {
+        const auto& name = parameters[i]->get_node_name();
+        auto var_used = VarUsageVisitor().variable_used(node, name);
+        if (var_used) {
+            RenameVisitor vr(name, fmt::format("_args[{}]", i));
+            node.get_statement_block()->visit_children(vr);
+        }
+    }
+}
+
+void CodegenNeuronCppVisitor::print_net_receive() {
+    auto node = info.net_receive_node;
+    if (!node) {
+        return;
+    }
+
+    ParamVector args;
+    args.emplace_back("", "Point_process*", "", "_pnt");
+    args.emplace_back("", "double*", "", "_args");
+    args.emplace_back("", "double", "", "_lflag");
+
+    printer->fmt_push_block("static void nrn_net_receive_{}({})",
+                            info.mod_suffix,
+                            get_parameter_str(args));
+
+    rename_net_receive_arguments(*node, *node);
+
+    printer->add_line("_nrn_mechanism_cache_instance _ml_obj{_pnt->prop};");
+    printer->add_line("auto * _nt = (NrnThread*) _pnt->_vnt;");
+    printer->add_line("auto * _ml = &_ml_obj;");
+
+    printer->fmt_line("auto inst = make_instance_{}(_ml_obj);", info.mod_suffix);
+
+    printer->add_line("size_t id = 0;");
+    printer->add_line("double t = _nt->_t;");
+
+    print_statement_block(*node->get_statement_block(), false, false);
+
+    printer->add_newline();
+    printer->pop_block();
 }
 
 

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -1850,7 +1850,7 @@ void CodegenNeuronCppVisitor::print_net_receive() {
     rename_net_receive_arguments(*node, *node);
 
     printer->add_line("_nrn_mechanism_cache_instance _ml_obj{_pnt->prop};");
-    printer->add_line("auto * _nt = (NrnThread*) _pnt->_vnt;");
+    printer->add_line("auto * _nt = static_cast<NrnThread*>(_pnt->_vnt);");
     printer->add_line("auto * _ml = &_ml_obj;");
 
     printer->fmt_line("auto inst = make_instance_{}(_ml_obj);", info.mod_suffix);

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -157,6 +157,15 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
      */
     void print_net_event_call(const ast::FunctionCall& node) override;
 
+    /**
+     * Print `net_receive` call-back.
+     */
+    void print_net_receive();
+
+    /**
+     * Print code to register the call-back for the NET_RECEIVE block.
+     */
+    void print_net_receive_registration();
 
     /**
      * Print POINT_PROCESS related functions

--- a/test/usecases/CMakeLists.txt
+++ b/test/usecases/CMakeLists.txt
@@ -6,7 +6,8 @@ set(NMODL_USECASE_DIRS
     parameter
     func_proc
     func_proc_pnt
-    nonspecific_current)
+    nonspecific_current
+    net_receive)
 
 file(GLOB NMODL_GOLDEN_REFERENCES "${CMAKE_CURRENT_SOURCE_DIR}/references/*")
 if(NMODL_GOLDEN_REFERENCES STREQUAL "")

--- a/test/usecases/net_receive/simulate.py
+++ b/test/usecases/net_receive/simulate.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+from neuron import h, gui
+from neuron.units import ms
+
+nseg = 1
+
+soma = h.Section()
+soma.nseg = nseg
+soma.cm = 1.0
+
+syn = h.SnapSyn(soma(0.5))
+
+v0 = -65.0
+erev = 10.0
+delay = 0.75
+dg = 0.8
+area = soma(0.5).area()
+rate = dg * 1e5 / area
+
+stim = h.NetStim()
+stim.interval = 1.0
+stim.number = 1
+stim.start = delay
+
+netcon = h.NetCon(stim, syn, 0, 0.0, dg)
+
+v_hoc = h.Vector().record(soma(0.5)._ref_v)
+t_hoc = h.Vector().record(h._ref_t)
+
+h.dt = 0.01
+h.stdinit()
+h.tstop = 10.0 * ms
+h.run()
+
+
+def v(t):
+    v = np.empty_like(t)
+    v[t <= delay] = v0
+    v[t >= delay] = erev + (v0 - erev) * np.exp(-rate * (t[t >= delay] - delay))
+
+    return v
+
+
+t = np.array(t_hoc.as_numpy())
+v_approx = np.array(v_hoc.as_numpy())
+v_exact = v(t)
+
+assert np.all(np.abs(v_approx - v_exact)) < 1e-10

--- a/test/usecases/net_receive/snapsyn.mod
+++ b/test/usecases/net_receive/snapsyn.mod
@@ -1,0 +1,33 @@
+NEURON {
+    POINT_PROCESS SnapSyn
+    RANGE e, i
+    NONSPECIFIC_CURRENT i
+}
+
+UNITS {
+    (nA) = (nanoamp)
+    (mV) = (millivolt)
+    (uS) = (microsiemens)
+}
+
+PARAMETER {
+    e = 10	(mV)
+}
+
+ASSIGNED {
+    v (mV)
+    i (nA)
+    g (uS)
+}
+
+INITIAL {
+    g=0
+}
+
+BREAKPOINT {
+    i = g*(v - e)
+}
+
+NET_RECEIVE(weight (uS)) {
+    g = g + weight
+}


### PR DESCRIPTION
Instead of setting the conductance as:

    g = g + g0 * exp(-(t - t0)/tau)

we set it to

    g += g0

where `g0` is the argument passed to NET_RECEIVE, i.e. the weight.

This allows for an analytic solution, that can be tested.