### PR TITLE
Improvements for handling python bindings CMake option

### DIFF
--- a/python/nmodl/__init__.py
+++ b/python/nmodl/__init__.py
@@ -31,11 +31,23 @@ os.environ["NMODLHOME"] = os.environ.get(
 )
 
 
-try:
-    # Try importing but catch exception in case bindings are not available
-    from ._nmodl import NmodlDriver, to_json, to_nmodl  # noqa
-    from ._nmodl import __version__
+import builtins
 
-    __all__ = ["NmodlDriver", "to_json", "to_nmodl"]
-except ImportError:
-    print("[NMODL] [warning] :: Python bindings are not available")
+nmodl_binding_check = True
+
+# attribute is set from `pybind/wrapper.cpp` when nmodl module is used
+# for sympy based solvers
+if hasattr(builtins, "nmodl_python_binding_check"):
+    nmodl_binding_check = builtins.nmodl_python_binding_check
+
+if nmodl_binding_check:
+    try:
+        # Try importing but catch exception in case bindings are not available
+        from ._nmodl import NmodlDriver, to_json, to_nmodl  # noqa
+        from ._nmodl import __version__
+
+        __all__ = ["NmodlDriver", "to_json", "to_nmodl"]
+    except ImportError:
+        print(
+            "[NMODL] [warning] :: Python bindings are not available with this installation"
+        )

--- a/src/language/CMakeLists.txt
+++ b/src/language/CMakeLists.txt
@@ -14,6 +14,10 @@ if(NMODL_CLANG_FORMAT OR NMODL_FORMATTING)
   endforeach()
 endif()
 
+if(NOT NMODL_ENABLE_PYTHON_BINDINGS)
+  list(APPEND CODE_GENERATOR_OPTS "--disable-pybind")
+endif()
+
 add_custom_command(
   OUTPUT ${NMODL_GENERATED_SOURCES}
   COMMAND ${PYTHON_EXECUTABLE} ARGS ${CMAKE_CURRENT_SOURCE_DIR}/code_generator.py

--- a/src/pybind/wrapper.cpp
+++ b/src/pybind/wrapper.cpp
@@ -29,6 +29,8 @@ void SolveLinearSystemExecutor::operator()() {
                                  "function_calls"_a = function_calls,
                                  "tmp_unique_prefix"_a = tmp_unique_prefix);
     py::exec(R"(
+                import builtins
+                builtins.nmodl_python_binding_check = False
                 from nmodl.ode import solve_lin_system
                 exception_message = ""
                 try:
@@ -62,6 +64,8 @@ void SolveNonLinearSystemExecutor::operator()() {
                                  "vars"_a = vars,
                                  "function_calls"_a = function_calls);
     py::exec(R"(
+                import builtins
+                builtins.nmodl_python_binding_check = False
                 from nmodl.ode import solve_non_lin_system
                 exception_message = ""
                 try:
@@ -95,6 +99,8 @@ void DiffeqSolverExecutor::operator()() {
         // with forwards Euler timestep:
         // x = x + f(x) * dt
         py::exec(R"(
+                import builtins
+                builtins.nmodl_python_binding_check = False
                 from nmodl.ode import forwards_euler2c
                 exception_message = ""
                 try:
@@ -111,6 +117,8 @@ void DiffeqSolverExecutor::operator()() {
         // with analytic solution for x(t+dt) in terms of x(t)
         // x = ...
         py::exec(R"(
+                import builtins
+                builtins.nmodl_python_binding_check = False
                 from nmodl.ode import integrate2c
                 exception_message = ""
                 try:
@@ -134,6 +142,8 @@ void DiffeqSolverExecutor::operator()() {
 void AnalyticDiffExecutor::operator()() {
     auto locals = py::dict("expressions"_a = expressions, "vars"_a = used_names_in_block);
     py::exec(R"(
+                            import builtins
+                            builtins.nmodl_python_binding_check = False
                             from nmodl.ode import differentiate2c
                             exception_message = ""
                             try:


### PR DESCRIPTION
- If `-DNMODL_ENABLE_PYTHON_BINDINGS=OFF` then there is no need to generate AST and other wrapper classes for Pybind11.
- Using sympy-based solvers does not require Python bindings to be enabled. Avoid confusing warning when using nmodl binary.
- When someone tries to use the nmodl module via Python, the warning is still preserved.

```console
# before
$ nmodl mod_examples/sparse.mod
[NMODL] [warning] :: Python bindings are not available with this installation
..

# with this PR
$ nmodl mod_examples/sparse.mod
$ python3.11 -c "import nmodl"
[NMODL] [warning] :: Python bindings are not available with this installation
```

Next Step (Independent of this PR): * [disable Python bindings in NRN build](https://github.com/neuronsimulator/nrn/blob/1adc8f5d803183a839e709872f2a590c0ece5620/src/coreneuron/CMakeLists.txt#L267) for normal neuron+coreneuron build

@matz-e / @ohm314: I think this is finally clarified.