### PR TITLE
Bug fix for NEURON wheel creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ add_custom_target(
 # =============================================================================
 # Adjust install prefix for wheel
 # =============================================================================
-if(NOT LINK_AGAINST_PYTHON)
+if(NOT LINK_AGAINST_PYTHON AND NOT NMODL_AS_SUBPROJECT)
   set(NMODL_INSTALL_DIR_SUFFIX "nmodl/.data/")
 endif()
 

--- a/packaging/test_wheel.bash
+++ b/packaging/test_wheel.bash
@@ -24,7 +24,11 @@ test_wheel () {
     TEST_DIR="$(mktemp -d)"
     OUTPUT_DIR="$(mktemp -d)"
     cp "${this_dir}/../python/nmodl/ext/example/"*.mod "$TEST_DIR/"
-    cp "${this_dir}/../test/integration/mod/cabpump.mod" "${this_dir}/../test/integration/mod/var_init.inc" "$TEST_DIR/"
+    cp "${this_dir}/../test/integration/mod/cabpump.mod" \
+       "${this_dir}/../test/integration/mod/var_init.inc" \
+       "${this_dir}/../test/integration/mod/glia_sparse.mod" \
+       "$TEST_DIR/"
+
     for mod in "${TEST_DIR}/"*.mod
     do
         nmodl -o "${OUTPUT_DIR}" "${mod}" sympy --analytic

--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -89,7 +89,7 @@ file(COPY ${NMODL_PROJECT_SOURCE_DIR}/python/nmodl/ext DESTINATION ${CMAKE_BINAR
 # things are installed twice with the wheel and in weird places. Let's just
 # move the .so libs
 # ~~~
-if(NOT LINK_AGAINST_PYTHON)
+if(NOT LINK_AGAINST_PYTHON AND NOT NMODL_AS_SUBPROJECT)
   install(TARGETS pywrapper DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}lib)
   if(NMODL_ENABLE_PYTHON_BINDINGS)
     install(TARGETS _nmodl DESTINATION nmodl/)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -11,7 +11,7 @@ file(GLOB modfiles CONFIGURE_DEPENDS "${NMODL_PROJECT_SOURCE_DIR}/test/integrati
 foreach(modfile ${modfiles})
   get_filename_component(modfile_name "${modfile}" NAME)
   add_test(NAME ${modfile_name} COMMAND ${CMAKE_BINARY_DIR}/bin/nmodl ${modfile})
-  set_tests_properties(${modfile_name} PROPERTIES ENVIRONMENT
-                                                  PYTHONPATH=${PROJECT_BINARY_DIR}/lib:$ENV{PYTHONPATH})
+  set_tests_properties(${modfile_name}
+                       PROPERTIES ENVIRONMENT PYTHONPATH=${PROJECT_BINARY_DIR}/lib:$ENV{PYTHONPATH})
   cpp_cc_configure_sanitizers(TEST ${modfile_name})
 endforeach()

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -11,5 +11,7 @@ file(GLOB modfiles CONFIGURE_DEPENDS "${NMODL_PROJECT_SOURCE_DIR}/test/integrati
 foreach(modfile ${modfiles})
   get_filename_component(modfile_name "${modfile}" NAME)
   add_test(NAME ${modfile_name} COMMAND ${CMAKE_BINARY_DIR}/bin/nmodl ${modfile})
+  set_tests_properties(${modfile_name} PROPERTIES ENVIRONMENT
+                                                  PYTHONPATH=${PROJECT_BINARY_DIR}/lib:$ENV{PYTHONPATH})
   cpp_cc_configure_sanitizers(TEST ${modfile_name})
 endforeach()

--- a/test/integration/mod/glia_sparse.mod
+++ b/test/integration/mod/glia_sparse.mod
@@ -1,9 +1,4 @@
 : Example of MOD file using sparse solver
-: Note that this file with path `test/integration/mod/glia_sparse.mod`
-:      is used in NEURON for integration testing. If you change path
-:      or remove it then you need to also change `test_wheels.sh` in
-:      NEURON.
-
 
 NEURON {
     SUFFIX glia

--- a/test/integration/mod/glia_sparse.mod
+++ b/test/integration/mod/glia_sparse.mod
@@ -1,0 +1,38 @@
+: Example of MOD file using sparse solver
+
+NEURON {
+    SUFFIX glia
+    RANGE alfa, beta
+    RANGE Aalfa, Valfa, Abeta, Vbeta
+}
+
+PARAMETER {
+    Aalfa = 353.91 ( /ms)
+    Valfa = 13.99 ( /mV)
+    Abeta = 1.272  ( /ms)
+    Vbeta = 13.99 ( /mV)
+    n1 = 5.422
+    n4 = 0.738
+}
+
+STATE {
+    C1
+    C2
+}
+
+BREAKPOINT {
+    SOLVE kstates METHOD sparse
+}
+
+FUNCTION alfa(v(mV)) {
+    alfa = Q10*Aalfa*exp(v/Valfa)
+}
+
+FUNCTION beta(v(mV)) {
+    beta = Q10*Abeta*exp(-v/Vbeta)
+}
+
+KINETIC kstates {
+    ~ C1 <-> C2 (n1*alfa(v),n4*beta(v))
+}
+

--- a/test/integration/mod/glia_sparse.mod
+++ b/test/integration/mod/glia_sparse.mod
@@ -30,11 +30,11 @@ BREAKPOINT {
 }
 
 FUNCTION alfa(v(mV)) {
-    alfa = Q10*Aalfa*exp(v/Valfa)
+    alfa = Aalfa*exp(v/Valfa)
 }
 
 FUNCTION beta(v(mV)) {
-    beta = Q10*Abeta*exp(-v/Vbeta)
+    beta = Abeta*exp(-v/Vbeta)
 }
 
 KINETIC kstates {

--- a/test/integration/mod/glia_sparse.mod
+++ b/test/integration/mod/glia_sparse.mod
@@ -1,4 +1,9 @@
 : Example of MOD file using sparse solver
+: Note that this file with path `test/integration/mod/glia_sparse.mod`
+:      is used in NEURON for integration testing. If you change path
+:      or remove it then you need to also change `test_wheels.sh` in
+:      NEURON.
+
 
 NEURON {
     SUFFIX glia


### PR DESCRIPTION
- when neuron is built with nmodl then nmodl related files should be installed in `<prefix>/` and not in `<prefix>/nmodl/.data`
  - `<prefix>/nmodl/.data` is used when we build standalone wheels
- add one mod file using sparse solver - nmodl will automatically use `sympy` solver

This was the root cause for neuronsimulator/nrn/issues/2494!