### PR TITLE
Pin pytest to <= 8.1.1 (potential bug with v8.2.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ sympy>=1.3
 importlib-metadata;python_version<'3.9'
 importlib-resources;python_version<'3.9'
 # dependencies for test
-pytest>=3.3.0
+pytest<=8.1.1
 pytest-cov
 numpy
 # dependencies for docs


### PR DESCRIPTION
See for more details: https://github.com/neuronsimulator/nrn/pull/2866