### PR TITLE
Fix missing variables when calling functions or procedures

### DIFF
--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -1218,6 +1218,8 @@ void CodegenNeuronCppVisitor::print_global_function_common_code(BlockType type,
     printer->fmt_line("auto node_data = make_node_data_{}(*_nt, *_ml_arg);", info.mod_suffix);
 
     printer->add_line("auto nodecount = _ml_arg->nodecount;");
+    printer->add_line("auto* const _ml = &_lmr;");
+    printer->add_line("auto* _thread = _ml_arg->_thread;");
 }
 
 
@@ -1227,6 +1229,7 @@ void CodegenNeuronCppVisitor::print_nrn_init(bool skip_init_check) {
     print_global_function_common_code(BlockType::Initial);
 
     printer->push_block("for (int id = 0; id < nodecount; id++)");
+    printer->add_line("auto& _ppvar = _ml_arg->pdata[id];");
     print_initial_block(info.initial_node);
     printer->pop_block();
 

--- a/test/usecases/CMakeLists.txt
+++ b/test/usecases/CMakeLists.txt
@@ -6,7 +6,8 @@ set(NMODL_USECASE_DIRS
     parameter
     func_proc
     func_proc_pnt
-    nonspecific_current)
+    nonspecific_current
+    cabpump)
 
 file(GLOB NMODL_GOLDEN_REFERENCES "${CMAKE_CURRENT_SOURCE_DIR}/references/*")
 if(NMODL_GOLDEN_REFERENCES STREQUAL "")

--- a/test/usecases/cabpump/cabpump.mod
+++ b/test/usecases/cabpump/cabpump.mod
@@ -1,0 +1,76 @@
+: simple first-order model of calcium dynamics
+
+DEFINE FOO 1
+
+NEURON {
+        SUFFIX cadyn
+        USEION ca READ cai,ica WRITE cai 
+        RANGE ca 
+        GLOBAL depth,cainf,taur
+        RANGE var
+        RANGE ainf
+}
+
+UNITS {
+        (molar) = (1/liter)		
+        (mM) = (milli/liter)
+	(um)	= (micron) 
+        (mA) = (milliamp)
+	(msM)	= (ms mM)  
+        FARADAY    = (faraday) (coul)
+}
+
+PARAMETER {
+       depth	= .1	(um)		
+        taur =  200 (ms)	: rate of calcium removal for stress conditions
+	cainf	= 50e-6(mM)	:changed oct2
+	cai		(mM)
+}
+
+ASSIGNED {
+	ica		(mA/cm2)
+	drive_channel	(mM/ms)
+    var     (mV)
+    ainf
+}
+
+STATE {
+	ca		(mM) 
+}
+
+ 
+BREAKPOINT {
+	SOLVE state METHOD euler : this comment is terminated by a \r only, and it should not break the parser}
+
+INCLUDE "var_init.inc"
+
+DERIVATIVE state {
+    VERBATIM
+    cai = 2 * _ion_cai;
+    ENDVERBATIM
+	drive_channel =  - (10000) * ica / (2 * FARADAY * depth)
+	if (drive_channel <= 0.) { drive_channel = 0.  }   : cannot pump inward 
+        ca' = drive_channel/18 + (cainf -ca)/taur*11
+	cai = ca
+
+    if (FOO == 0) { }
+}
+
+: to test code generation for TABLE statement
+FUNCTION test_table_f(br) {
+    : TABLE FROM 0 TO FOO WITH 1
+    test_table_f = 1
+}
+
+PROCEDURE test_table_p(br) {
+    : TABLE ainf FROM 0 TO FOO WITH 1
+    ainf = 1
+}
+
+: to test \r only as newlinePROCEDURE test_r(){
+} : add something that will breaks the parser
+
+INITIAL {
+    var_init(var)
+    ca = cainf
+}

--- a/test/usecases/cabpump/simulate.py
+++ b/test/usecases/cabpump/simulate.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from neuron import h, gui
+from neuron.units import ms
+
+nseg = 1
+
+s = h.Section()
+s.insert("cadyn")
+s.nseg = nseg
+
+v_hoc = h.Vector().record(s(0.5)._ref_v)
+t_hoc = h.Vector().record(h._ref_t)
+
+h.stdinit()
+h.tstop = 5.0 * ms
+h.run()
+
+v = np.array(v_hoc.as_numpy())
+t = np.array(t_hoc.as_numpy())
+
+assert np.allclose(v, -65)

--- a/test/usecases/cabpump/var_init.inc
+++ b/test/usecases/cabpump/var_init.inc
@@ -1,0 +1,10 @@
+COMMENT
+    Example file to test INCLUDE keyword
+    in NMODL. This file is included in
+    cabpump.mod and takes care of initializing
+    the dummy variable named "var"
+ENDCOMMENT
+
+FUNCTION var_init(var(mV)) (mV) {
+    var = 1
+}


### PR DESCRIPTION
The variables `_ml`, `_thread`, and `_ppvar` are sometimes needed when calling functions or procedures.