### PR TITLE
Remove unused variable in NEURON codegen

### DIFF
--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -1033,7 +1033,6 @@ void CodegenNeuronCppVisitor::print_mechanism_register() {
                       int_variables_size());
 
     for (int i = 0; i < codegen_int_variables_size; ++i) {
-        const auto& int_var = codegen_int_variables[i];
         if (i != info.semantics[i].index) {
             throw std::runtime_error("Broken logic.");
         }


### PR DESCRIPTION
This is to fix the annoying warning which appears in every PR involving NEURON codegen.