### PR TITLE
Fix bug with state named 'is'.

### DIFF
--- a/python/nmodl/ode.py
+++ b/python/nmodl/ode.py
@@ -30,20 +30,15 @@ if not ((major >= 1) and (minor >= 2)):
 # because sympy will try to use its own internal one; or error out for invalid variables.
 # Rename it before and after to a unique name.
 forbidden_var = [
-    # Python keywords
+    # Selected Python keywords
     "is",
     "as",
     "count",
-    "def",
     "del",
     "elif",
-    "finally",
-    "import",
     "in",
     "lambda",
     "pass",
-    "raise",
-    "yield",
     # SymPy functions
     "beta",
     "gamma",

--- a/python/nmodl/ode.py
+++ b/python/nmodl/ode.py
@@ -26,10 +26,27 @@ known_functions["abs"] = "fabs"
 if not ((major >= 1) and (minor >= 2)):
     raise ImportError(f"Requires SympPy version >= 1.2, found {major}.{minor}")
 
-# Some functions are protected inside sympy, if user has declared such a function, it will fail
-# because sympy will try to use its own internal one.
-# Rename it before and after to a single name
+# Some identifiers are protected inside sympy, if user has declared such a function, it will fail
+# because sympy will try to use its own internal one; or error out for invalid variables.
+# Rename it before and after to a unique name.
 forbidden_var = [
+    # Python keywords
+    "is",
+    "be",
+    "as",
+    "count",
+    "def",
+    "del",
+    "elif",
+    "finally",
+    "import",
+    "in",
+    "lambda",
+    "pass",
+    "raise",
+    "yield",
+
+    # SymPy functions
     "beta",
     "gamma",
     "uppergamma",
@@ -41,20 +58,55 @@ forbidden_var = [
 ]
 
 
-def search_and_replace_protected_functions_to_sympy(eqs, function_calls):
+def search_and_replace_protected_identifiers_to_sympy(eqs, vars, function_calls):
+    eqs = _search_and_replace_protected_functions_to_sympy(eqs, function_calls)
+    eqs, vars = _search_and_replace_protected_variables_to_sympy(eqs, vars)
+
+    return eqs, vars
+
+
+def search_and_replace_protected_identifiers_from_sympy(eqs, function_calls):
+    eqs = _search_and_replace_protected_functions_from_sympy(eqs, function_calls)
+    eqs = _search_and_replace_protected_variables_from_sympy(eqs)
+
+    return eqs
+
+
+def _search_and_replace_protected_variables_to_sympy(eqs, vars):
+    for c in forbidden_var:
+        r = re.compile(r"\b{}\b".format(c))
+        f = f"_sympy_{c}_var"
+        eqs = [re.sub(r, f, x) for x in eqs]
+        vars = [re.sub(r, f, x) for x in vars]
+
+    return eqs, vars
+
+
+def _search_and_replace_protected_variables_from_sympy(eqs):
+    for c in forbidden_var:
+        r = re.compile(r"\b_sympy_{}_var\b".format(c))
+        f = c
+        eqs = [re.sub(r, f, x) for x in eqs]
+
+    return eqs
+
+
+def _search_and_replace_protected_functions_to_sympy(eqs, function_calls):
     for c in function_calls:
         if c in forbidden_var:
             r = re.compile(r"\b{}\b\s*\(".format(c))
             f = f"_sympy_{c}_fun("
             eqs = [re.sub(r, f, x) for x in eqs]
+
     return eqs
 
 
-def search_and_replace_protected_functions_from_sympy(eqs, function_calls):
+def _search_and_replace_protected_functions_from_sympy(eqs, function_calls):
     for c in function_calls:
         if c in forbidden_var:
             r = f"_sympy_{c}_fun"
             eqs = [re.sub(r, f"{c}", x) for x in eqs]
+
     return eqs
 
 
@@ -257,8 +309,8 @@ def solve_lin_system(
         vars: list of strings containing new local variables
     """
 
-    eq_strings = search_and_replace_protected_functions_to_sympy(
-        eq_strings, function_calls
+    eq_strings, vars = search_and_replace_protected_identifiers_to_sympy(
+        eq_strings, vars, function_calls
     )
 
     eqs, state_vars, sympy_vars = _sympify_eqs(eq_strings, vars, constants)
@@ -313,7 +365,7 @@ def solve_lin_system(
         # interweave
         code = _interweave_eqs(vecFcode, vecJcode)
 
-    code = search_and_replace_protected_functions_from_sympy(code, function_calls)
+    code = search_and_replace_protected_identifiers_from_sympy(code, function_calls)
 
     return code, new_local_vars
 
@@ -335,8 +387,8 @@ def solve_non_lin_system(eq_strings, vars, constants, function_calls):
         List of strings containing assignment statements
     """
 
-    eq_strings = search_and_replace_protected_functions_to_sympy(
-        eq_strings, function_calls
+    eq_strings, vars = search_and_replace_protected_identifiers_to_sympy(
+        eq_strings, vars, function_calls
     )
 
     eqs, state_vars, sympy_vars = _sympify_eqs(eq_strings, vars, constants)
@@ -365,7 +417,7 @@ def solve_non_lin_system(eq_strings, vars, constants, function_calls):
     # interweave
     code = _interweave_eqs(vecFcode, vecJcode)
 
-    code = search_and_replace_protected_functions_from_sympy(code, function_calls)
+    code = search_and_replace_protected_identifiers_from_sympy(code, function_calls)
 
     return code
 

--- a/python/nmodl/ode.py
+++ b/python/nmodl/ode.py
@@ -32,7 +32,6 @@ if not ((major >= 1) and (minor >= 2)):
 forbidden_var = [
     # Python keywords
     "is",
-    "be",
     "as",
     "count",
     "def",
@@ -45,7 +44,6 @@ forbidden_var = [
     "pass",
     "raise",
     "yield",
-
     # SymPy functions
     "beta",
     "gamma",

--- a/test/integration/mod/variable_names.mod
+++ b/test/integration/mod/variable_names.mod
@@ -34,7 +34,7 @@ STATE {
     nu
     xi
     omicron
-    pi
+    : pi
     chi
     psi
     omega

--- a/test/integration/mod/variable_names.mod
+++ b/test/integration/mod/variable_names.mod
@@ -7,6 +7,7 @@ NEURON {
 STATE {
     is
     be
+    count
     as
     def
     del

--- a/test/integration/mod/variable_names.mod
+++ b/test/integration/mod/variable_names.mod
@@ -59,7 +59,6 @@ KINETIC state {
     ~ iota <-> kappa (1, 1)
     ~ lambda <-> mu (1, 1)
     ~ nu <-> xi (1, 1)
-    ~ omicron <-> pi (1, 1)
-    ~ chi <-> psi (1, 1)
-    ~ omega <-> alpha (1, 1)
+    ~ omicron <-> chi (1, 1)
+    ~ psi <-> omega (1, 1)
 }

--- a/test/integration/mod/variable_names.mod
+++ b/test/integration/mod/variable_names.mod
@@ -9,15 +9,10 @@ STATE {
     be
     count
     as
-    def
     del
     elif
-    finally
-    import
     in
     pass
-    raise
-    yield
 
     alpha
     beta
@@ -46,12 +41,9 @@ BREAKPOINT {
 
 KINETIC state {
     ~ is <-> be (1, 1)
-    ~ as <-> count (1, 1)
-    ~ def <-> del (1, 1)
-    ~ elif <-> finally (1, 1)
-    ~ import <-> in (1, 1)
+    ~ count <-> as (1, 1)
+    ~ elif <-> in (1, 1)
     ~ lambda <-> pass (1, 1)
-    ~ raise <-> yield (1, 1)
     ~ alpha <-> beta (1, 1)
     ~ gamma <-> delta (1, 1)
     ~ epsilon <-> zeta (1, 1)

--- a/test/integration/mod/variable_names.mod
+++ b/test/integration/mod/variable_names.mod
@@ -1,0 +1,64 @@
+: Collection of tricky variable names.
+
+NEURON {
+    SUFFIX variable_names
+}
+
+STATE {
+    is
+    be
+    as
+    def
+    del
+    elif
+    finally
+    import
+    in
+    pass
+    raise
+    yield
+
+    alpha
+    beta
+    gamma
+    delta
+    epsilon
+    zeta
+    eta
+    theta
+    iota
+    kappa
+    lambda
+    mu
+    nu
+    xi
+    omicron
+    pi
+    chi
+    psi
+    omega
+}
+
+BREAKPOINT {
+    SOLVE state METHOD sparse
+}
+
+KINETIC state {
+    ~ is <-> be (1, 1)
+    ~ as <-> count (1, 1)
+    ~ def <-> del (1, 1)
+    ~ elif <-> finally (1, 1)
+    ~ import <-> in (1, 1)
+    ~ lambda <-> pass (1, 1)
+    ~ raise <-> yield (1, 1)
+    ~ alpha <-> beta (1, 1)
+    ~ gamma <-> delta (1, 1)
+    ~ epsilon <-> zeta (1, 1)
+    ~ eta <-> theta (1, 1)
+    ~ iota <-> kappa (1, 1)
+    ~ lambda <-> mu (1, 1)
+    ~ nu <-> xi (1, 1)
+    ~ omicron <-> pi (1, 1)
+    ~ chi <-> psi (1, 1)
+    ~ omega <-> alpha (1, 1)
+}


### PR DESCRIPTION
Sympy doesn't tolerate variable names called `is`.