### PR TITLE
Refactor `nmodl ... blame --line N`.

### DIFF
--- a/src/printer/CMakeLists.txt
+++ b/src/printer/CMakeLists.txt
@@ -4,8 +4,3 @@
 add_library(printer OBJECT code_printer.cpp json_printer.cpp nmodl_printer.cpp)
 set_property(TARGET printer PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(printer PRIVATE util)
-
-if(NMODL_ENABLE_BACKWARD)
-  target_link_libraries(printer PRIVATE Backward::Interface)
-  target_compile_definitions(printer PUBLIC NMODL_ENABLE_BACKWARD=1)
-endif()

--- a/src/printer/code_printer.cpp
+++ b/src/printer/code_printer.cpp
@@ -6,11 +6,8 @@
  */
 
 #include "printer/code_printer.hpp"
+#include "utils/blame.hpp"
 #include "utils/string_utils.hpp"
-
-#if NMODL_ENABLE_BACKWARD
-#include <backward.hpp>
-#endif
 
 namespace nmodl {
 namespace printer {
@@ -115,18 +112,8 @@ void CodePrinter::pop_block(const std::string_view& suffix, std::size_t num_newl
 }
 
 void CodePrinter::blame() {
-#if NMODL_ENABLE_BACKWARD
-    if (current_line == blame_line) {
-        *result << std::flush;
-
-        std::cout << "\n\n== Blame =======================================================\n";
-
-        backward::StackTrace st;
-        st.load_here(32);
-        backward::Printer p;
-        p.print(st, std::cout);
-    }
-#endif
+    auto blame_printer = utils::make_blame(blame_line);
+    (*blame_printer)(std::cout, current_line);
 }
 
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -3,6 +3,7 @@
 # =============================================================================
 add_library(
   util STATIC
+  blame.cpp
   common_utils.cpp
   file_library.cpp
   logger.cpp
@@ -10,5 +11,11 @@ add_library(
   string_utils.cpp
   table_data.cpp
   ${PROJECT_BINARY_DIR}/src/config/config.cpp)
+
 set_property(TARGET util PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(util PUBLIC fmt::fmt nlohmann_json::nlohmann_json spdlog::spdlog_header_only)
+
+if(NMODL_ENABLE_BACKWARD)
+  target_link_libraries(util PRIVATE Backward::Interface)
+  target_compile_definitions(util PUBLIC NMODL_ENABLE_BACKWARD=1)
+endif()

--- a/src/utils/blame.cpp
+++ b/src/utils/blame.cpp
@@ -1,0 +1,107 @@
+#include "blame.hpp"
+
+#include "string_utils.hpp"
+#include <filesystem>
+#include <fmt/format.h>
+
+#if NMODL_ENABLE_BACKWARD
+#include <backward.hpp>
+#endif
+
+namespace nmodl {
+namespace utils {
+
+class NoBlame: public Blame {
+  public:
+    using Blame::Blame;
+
+  protected:
+    std::string format() const override {
+        return "";
+    }
+};
+
+#if NMODL_ENABLE_BACKWARD
+size_t first_relevant_trace(backward::TraceResolver& tr, const backward::StackTrace& st) {
+    std::vector<std::string> stop_at{"printer/code_printer.cpp", "printer/code_printer.hpp"};
+    int start_from = int(st.size()) - 2;
+    for (int i = start_from; i >= 0; --i) {
+        backward::ResolvedTrace trace = tr.resolve(st[i]);
+        const std::string& filename = trace.source.filename;
+
+        for (const auto& f: stop_at) {
+            if (stringutils::ends_with(filename, f)) {
+                return i + 1;
+            }
+        }
+    }
+
+    throw std::runtime_error("Failed to determine relevant trace.");
+}
+
+class BackwardTracePrinter {
+  public:
+    std::string format(const backward::ResolvedTrace& trace, const std::string& trace_label) const {
+        const std::string& filename = trace.source.filename;
+        size_t linenumber = trace.source.line;
+
+        auto pad = std::string(trace_label.size(), ' ');
+
+        std::stringstream sout;
+
+        sout << fmt::format("{}    Source: \"{}\", line {}, in {}\n",
+                            trace_label,
+                            filename,
+                            linenumber,
+                            trace.source.function);
+
+        if (std::filesystem::exists(trace.source.filename) && trace.source.line != 0) {
+            auto snippet = snippets.get_snippet(filename, linenumber, 3);
+            for (auto line: snippet) {
+                sout << fmt::format("{}    {}{:>5d}:  {}\n",
+                                    pad,
+                                    linenumber == line.first ? ">" : " ",
+                                    line.first,
+                                    line.second);
+            }
+        }
+
+        return sout.str();
+    }
+
+    mutable backward::SnippetFactory snippets;
+};
+
+class ShortBlame: public Blame {
+  public:
+    using Blame::Blame;
+
+  protected:
+    std::string format() const override {
+        backward::StackTrace st;
+        st.load_here(32);
+
+        backward::TraceResolver tr;
+
+        size_t trace_id = first_relevant_trace(tr, st);
+        backward::ResolvedTrace trace = tr.resolve(st[trace_id]);
+
+        std::string trace_label = "";
+        return trace_printer.format(trace, "");
+    }
+
+    BackwardTracePrinter trace_printer;
+};
+#else
+class ShortBlame: public NoBlame {
+  public:
+    using NoBlame::NoBlame;
+};
+#endif
+
+std::unique_ptr<Blame> make_blame(size_t blame_line) {
+    return std::make_unique<ShortBlame>(blame_line);
+}
+
+}  // namespace utils
+}  // namespace nmodl

--- a/src/utils/blame.hpp
+++ b/src/utils/blame.hpp
@@ -1,0 +1,29 @@
+#include <memory>
+#include <string>
+
+namespace nmodl {
+namespace utils {
+
+class Blame {
+  public:
+    Blame(size_t blame_line)
+        : blame_line(blame_line) {}
+
+    template <class OStream>
+    void operator()(OStream& os, size_t current_line) const {
+        if (blame_line == current_line) {
+            os << this->format();
+        }
+    }
+
+  protected:
+    virtual std::string format() const = 0;
+
+  private:
+    size_t blame_line = 0;
+};
+
+std::unique_ptr<Blame> make_blame(size_t blame_line);
+
+}  // namespace utils
+}  // namespace nmodl

--- a/src/utils/string_utils.hpp
+++ b/src/utils/string_utils.hpp
@@ -126,6 +126,27 @@ enum class text_alignment { left, right, center };
     return elements;
 }
 
+
+/**
+ * Check if `haystack` ends with `needle`.
+ *
+ * Every string ends with the empty string.
+ */
+static inline bool ends_with(const std::string& haystack, const std::string& needle) {
+    if (needle.size() == 0) {
+        return true;
+    }
+
+    auto n_chars = needle.size();
+    if (haystack.size() < n_chars) {
+        return false;
+    }
+
+    auto haystack_begin = haystack.begin() + haystack.size() - n_chars;
+    return std::equal(haystack_begin, haystack.end(), needle.begin(), needle.end());
+};
+
+
 ///
 /**
  * Aligns a text within a field of width \a width

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(config STATIC ${PROJECT_BINARY_DIR}/src/config/config.cpp)
 # =============================================================================
 # Test executables
 # =============================================================================
+add_executable(testutils utils/string_utils.cpp)
 add_executable(testmodtoken modtoken/modtoken.cpp)
 add_executable(testlexer lexer/tokens.cpp)
 add_executable(testparser parser/parser.cpp)
@@ -76,6 +77,7 @@ add_executable(
   codegen/transform.cpp
   codegen/codegen_compatibility_visitor.cpp)
 
+target_link_libraries(testutils PRIVATE lexer util)
 target_link_libraries(testmodtoken PRIVATE lexer util)
 target_link_libraries(testlexer PRIVATE lexer util)
 target_link_libraries(
@@ -126,6 +128,7 @@ target_link_libraries(testcodegen PRIVATE Catch2::Catch2)
 target_link_libraries(testvisitor PRIVATE Catch2::Catch2)
 
 # With main from Catch2
+target_link_libraries(testutils PRIVATE Catch2::Catch2WithMain)
 target_link_libraries(testmodtoken PRIVATE Catch2::Catch2WithMain)
 target_link_libraries(testlexer PRIVATE Catch2::Catch2WithMain)
 target_link_libraries(testparser PRIVATE Catch2::Catch2WithMain)
@@ -138,6 +141,7 @@ target_link_libraries(testunitparser PRIVATE Catch2::Catch2WithMain)
 
 foreach(
   test_name
+  testutils
   testcodegen
   testmodtoken
   testlexer

--- a/test/unit/utils/string_utils.cpp
+++ b/test/unit/utils/string_utils.cpp
@@ -1,0 +1,31 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "utils/string_utils.hpp"
+
+using namespace nmodl;
+
+TEST_CASE("ends_with") {
+    SECTION("empty substring") {
+        REQUIRE(stringutils::ends_with("abcde", ""));
+    }
+
+    SECTION("empty str") {
+        REQUIRE(!stringutils::ends_with("", "abc"));
+    }
+
+    SECTION("both empty") {
+        REQUIRE(stringutils::ends_with("", ""));
+    }
+    SECTION("match") {
+        REQUIRE(stringutils::ends_with("abcde", "de"));
+    }
+
+    SECTION("mismatch") {
+        REQUIRE(!stringutils::ends_with("abcde", "d"));
+    }
+
+    SECTION("oversized") {
+        REQUIRE(!stringutils::ends_with("abcde", "--abcde"));
+    }
+}


### PR DESCRIPTION
The revised format only prints the first trace, before entering the `CodePrinter`. The new output (for a particularly verbose case) is:
```
$ nmodl art_toggle.mod blame --line 264
    Source: "/home/lucg/git/bbp/nmodl/src/codegen/codegen_cpp_visitor.cpp", line 546, in print_statement_block
       545:              !statement->is_mutex_unlock() && !statement->is_protect_statement()) {
    >  546:              printer->add_indent();
       547:          }
    Source: "/home/lucg/git/bbp/nmodl/src/codegen/codegen_coreneuron_cpp_visitor.cpp", line 2424, in print_net_send_call
      2423:      if (info.artificial_cell) {
    > 2424:          printer->fmt_text("artcell_net_send(&{}, {}, {}, nt->_t+", tqitem, weight_index, pnt);
      2425:      } else {
    Source: "/home/lucg/git/bbp/nmodl/src/codegen/codegen_cpp_visitor.hpp", line 1387, in print_vector_elements<std::shared_ptr<nmodl::ast::Expression> >
      1386:      for (auto iter = elements.begin(); iter != elements.end(); iter++) {
    > 1387:          printer->add_text(prefix);
      1388:          (*iter)->accept(*this);
    Source: "/home/lucg/git/bbp/nmodl/src/codegen/codegen_cpp_visitor.cpp", line 639, in visit_double
       638:  void CodegenCppVisitor::visit_double(const Double& node) {
    >  639:      printer->add_text(format_double_string(node.get_value()));
       640:  }
    Source: "/home/lucg/git/bbp/nmodl/src/codegen/codegen_cpp_visitor.hpp", line 1390, in print_vector_elements<std::shared_ptr<nmodl::ast::Expression> >
      1389:          if (!separator.empty() && !nmodl::utils::is_last(iter, elements)) {
    > 1390:              printer->add_text(separator);
      1391:          }
    Source: "/home/lucg/git/bbp/nmodl/src/codegen/codegen_cpp_visitor.hpp", line 1387, in print_vector_elements<std::shared_ptr<nmodl::ast::Expression> >
      1386:      for (auto iter = elements.begin(); iter != elements.end(); iter++) {
    > 1387:          printer->add_text(prefix);
      1388:          (*iter)->accept(*this);
    Source: "/home/lucg/git/bbp/nmodl/src/codegen/codegen_cpp_visitor.cpp", line 639, in visit_double
       638:  void CodegenCppVisitor::visit_double(const Double& node) {
    >  639:      printer->add_text(format_double_string(node.get_value()));
       640:  }
    Source: "/home/lucg/git/bbp/nmodl/src/codegen/codegen_coreneuron_cpp_visitor.cpp", line 2433, in print_net_send_call
      2432:      print_vector_elements(arguments, ", ");
    > 2433:      printer->add_text(')');
      2434:  }
    Source: "/home/lucg/git/bbp/nmodl/src/codegen/codegen_cpp_visitor.cpp", line 550, in print_statement_block
       549:          if (need_semicolon(*statement)) {
    >  550:              printer->add_text(';');
       551:          }
    Source: "/home/lucg/git/bbp/nmodl/src/codegen/codegen_cpp_visitor.cpp", line 553, in print_statement_block
       552:          if (!statement->is_mutex_lock() && !statement->is_mutex_unlock()) {
    >  553:              printer->add_newline();
       554:          }
```
It also refactors the code to prepare for injecting a detailed blame printer, when needed.