### PR TITLE
Only build min and max Python version wheels on PRs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -201,37 +201,32 @@ stages:
       vmImage: 'ubuntu-20.04'
     steps:
     - task: UsePythonVersion@0
+
     - checkout: self
       submodules: True
       condition: succeeded()
+
     - script: |
         if [[ "$(RELEASEWHEELBUILD)" != "True" ]]; then
-          export TAG="-nightly"
+          echo "##vso[task.setvariable variable=TAG;]-nightly"
         else
-          export TAG=""
+          echo "##vso[task.setvariable variable=TAG;]"
         fi
+      displayName: "Set wheel tag"
+
+    - bash: echo "##vso[task.setvariable variable=CIBW_BUILD;]cp38* cp312*"
+      condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+      displayName: "Set build identifiers"
+
+    - script: |
         python3 -m pip install --upgrade pip
         python3 -m pip install cibuildwheel==2.16.5 tomli tomli-w
         # change the name accordingly
         python3 packaging/change_name.py pyproject.toml "NMODL${TAG}"
         export SETUPTOOLS_SCM_PRETEND_VERSION="$(git describe --tags | cut -d '-' -f 1,2 | tr - .)"
-        CIBW_ENVIRONMENT_PASS_LINUX='SETUPTOOLS_SCM_PRETEND_VERSION' python3 -m cibuildwheel --output-dir wheelhouse
+        CIBW_BUILD="${CIBW_BUILD}" CIBW_ENVIRONMENT_PASS_LINUX='SETUPTOOLS_SCM_PRETEND_VERSION' python3 -m cibuildwheel --output-dir wheelhouse
       condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
       displayName: 'Building ManyLinux Wheels'
-    - script: |
-        if [[ "$(RELEASEWHEELBUILD)" != "True" ]]; then
-          export TAG="-nightly"
-        else
-          export TAG=""
-        fi
-        python3 -m pip install --upgrade pip
-        python3 -m pip install cibuildwheel==2.16.5 tomli tomli-w
-        # change the name accordingly
-        python3 packaging/change_name.py pyproject.toml "NMODL${TAG}"
-        export SETUPTOOLS_SCM_PRETEND_VERSION="$(git describe --tags | cut -d '-' -f 1,2 | tr - .)"
-        CIBW_BUILD="cp38* cp312*" CIBW_ENVIRONMENT_PASS_LINUX='SETUPTOOLS_SCM_PRETEND_VERSION' python3 -m cibuildwheel --output-dir wheelhouse
-      condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-      displayName: 'Building ManyLinux Wheels (min a and max Python versions only)'
 
     - task: PublishBuildArtifacts@1
       inputs:
@@ -252,33 +247,30 @@ stages:
         brew install flex bison cmake ninja
       condition: succeeded()
       displayName: 'Install Dependencies'
-    - task: UsePythonVersion@0
+
     - script: |
         if [[ "$(RELEASEWHEELBUILD)" != "True" ]]; then
-          export NMODL_NIGHTLY_TAG="-nightly"
+          echo "##vso[task.setvariable variable=TAG;]-nightly"
         else
-          export NMODL_NIGHTLY_TAG=""
+          echo "##vso[task.setvariable variable=TAG;]"
         fi
+      displayName: "Set wheel tag"
+
+    - bash: echo "##vso[task.setvariable variable=CIBW_BUILD;]cp38* cp312*"
+      condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+      displayName: "Set build identifiers"
+
+    - task: UsePythonVersion@0
+
+    - script: |
         python3 -m pip install --upgrade pip
         python3 -m pip install cibuildwheel==2.16.5 tomli tomli-w
         # change the name accordingly
         python3 packaging/change_name.py pyproject.toml "NMODL${NMODL_NIGHTLY_TAG}"
-        SETUPTOOLS_SCM_PRETEND_VERSION="$(git describe --tags | cut -d '-' -f 1,2 | tr - .)" python3 -m cibuildwheel --output-dir wheelhouse
+        CIBW_BUILD="${CIBW_BUILD}" SETUPTOOLS_SCM_PRETEND_VERSION="$(git describe --tags | cut -d '-' -f 1,2 | tr - .)" python3 -m cibuildwheel --output-dir wheelhouse
       condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
       displayName: 'Build macos Wheel (x86_64)'
-    - script: |
-        if [[ "$(RELEASEWHEELBUILD)" != "True" ]]; then
-          export NMODL_NIGHTLY_TAG="-nightly"
-        else
-          export NMODL_NIGHTLY_TAG=""
-        fi
-        python3 -m pip install --upgrade pip
-        python3 -m pip install cibuildwheel==2.16.5 tomli tomli-w
-        # change the name accordingly
-        python3 packaging/change_name.py pyproject.toml "NMODL${NMODL_NIGHTLY_TAG}"
-        CIBW_BUILD="cp38* cp312*" SETUPTOOLS_SCM_PRETEND_VERSION="$(git describe --tags | cut -d '-' -f 1,2 | tr - .)" python3 -m cibuildwheel --output-dir wheelhouse
-      condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
-      displayName: 'Build macos Wheel (x86_64) (min and max Python versions only)'
+
     - task: PublishBuildArtifacts@1
       inputs:
         pathToPublish: '$(Build.SourcesDirectory)/wheelhouse'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -277,7 +277,7 @@ stages:
         # change the name accordingly
         python3 packaging/change_name.py pyproject.toml "NMODL${NMODL_NIGHTLY_TAG}"
         CIBW_BUILD="cp38* cp312*" SETUPTOOLS_SCM_PRETEND_VERSION="$(git describe --tags | cut -d '-' -f 1,2 | tr - .)" python3 -m cibuildwheel --output-dir wheelhouse
-      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
       displayName: 'Build macos Wheel (x86_64) (min and max Python versions only)'
     - task: PublishBuildArtifacts@1
       inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -216,8 +216,23 @@ stages:
         python3 packaging/change_name.py pyproject.toml "NMODL${TAG}"
         export SETUPTOOLS_SCM_PRETEND_VERSION="$(git describe --tags | cut -d '-' -f 1,2 | tr - .)"
         CIBW_ENVIRONMENT_PASS_LINUX='SETUPTOOLS_SCM_PRETEND_VERSION' python3 -m cibuildwheel --output-dir wheelhouse
-      condition: succeeded()
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
       displayName: 'Building ManyLinux Wheels'
+    - script: |
+        if [[ "$(RELEASEWHEELBUILD)" != "True" ]]; then
+          export TAG="-nightly"
+        else
+          export TAG=""
+        fi
+        python3 -m pip install --upgrade pip
+        python3 -m pip install cibuildwheel==2.16.5 tomli tomli-w
+        # change the name accordingly
+        python3 packaging/change_name.py pyproject.toml "NMODL${TAG}"
+        export SETUPTOOLS_SCM_PRETEND_VERSION="$(git describe --tags | cut -d '-' -f 1,2 | tr - .)"
+        CIBW_BUILD="cp38* cp312*" CIBW_ENVIRONMENT_PASS_LINUX='SETUPTOOLS_SCM_PRETEND_VERSION' python3 -m cibuildwheel --output-dir wheelhouse
+      condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
+      displayName: 'Building ManyLinux Wheels (min a and max Python versions only)'
+
     - task: PublishBuildArtifacts@1
       inputs:
         pathToPublish: '$(Build.SourcesDirectory)/wheelhouse'
@@ -249,8 +264,21 @@ stages:
         # change the name accordingly
         python3 packaging/change_name.py pyproject.toml "NMODL${NMODL_NIGHTLY_TAG}"
         SETUPTOOLS_SCM_PRETEND_VERSION="$(git describe --tags | cut -d '-' -f 1,2 | tr - .)" python3 -m cibuildwheel --output-dir wheelhouse
-      condition: succeeded()
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
       displayName: 'Build macos Wheel (x86_64)'
+    - script: |
+        if [[ "$(RELEASEWHEELBUILD)" != "True" ]]; then
+          export NMODL_NIGHTLY_TAG="-nightly"
+        else
+          export NMODL_NIGHTLY_TAG=""
+        fi
+        python3 -m pip install --upgrade pip
+        python3 -m pip install cibuildwheel==2.16.5 tomli tomli-w
+        # change the name accordingly
+        python3 packaging/change_name.py pyproject.toml "NMODL${NMODL_NIGHTLY_TAG}"
+        CIBW_BUILD="cp38* cp312*" SETUPTOOLS_SCM_PRETEND_VERSION="$(git describe --tags | cut -d '-' -f 1,2 | tr - .)" python3 -m cibuildwheel --output-dir wheelhouse
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      displayName: 'Build macos Wheel (x86_64) (min and max Python versions only)'
     - task: PublishBuildArtifacts@1
       inputs:
         pathToPublish: '$(Build.SourcesDirectory)/wheelhouse'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -212,9 +212,12 @@ stages:
         else
           echo "##vso[task.setvariable variable=TAG;]"
         fi
+        echo "Wheel tag: ${TAG}"
       displayName: "Set wheel tag"
 
-    - bash: echo "##vso[task.setvariable variable=CIBW_BUILD;]cp38* cp312*"
+    - script: |
+        echo "##vso[task.setvariable variable=CIBW_BUILD;]cp38* cp312*"
+        echo "Build identifiers: ${CIBW_BUILD}"
       condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
       displayName: "Set build identifiers"
 
@@ -254,9 +257,12 @@ stages:
         else
           echo "##vso[task.setvariable variable=TAG;]"
         fi
+        echo "Wheel tag: ${TAG}"
       displayName: "Set wheel tag"
 
-    - bash: echo "##vso[task.setvariable variable=CIBW_BUILD;]cp38* cp312*"
+    - script: |
+        echo "##vso[task.setvariable variable=CIBW_BUILD;]cp38* cp312*"
+        echo "Build identifiers: ${CIBW_BUILD}"
       condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
       displayName: "Set build identifiers"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -217,7 +217,6 @@ stages:
 
     - script: |
         echo "##vso[task.setvariable variable=CIBW_BUILD;]cp38* cp312*"
-        echo "Build identifiers: ${CIBW_BUILD}"
       condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
       displayName: "Set build identifiers"
 
@@ -227,8 +226,8 @@ stages:
         # change the name accordingly
         python3 packaging/change_name.py pyproject.toml "NMODL${TAG}"
         export SETUPTOOLS_SCM_PRETEND_VERSION="$(git describe --tags | cut -d '-' -f 1,2 | tr - .)"
-        CIBW_BUILD="${CIBW_BUILD}" CIBW_ENVIRONMENT_PASS_LINUX='SETUPTOOLS_SCM_PRETEND_VERSION' python3 -m cibuildwheel --output-dir wheelhouse
-      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+        CIBW_BUILD="$(CIBW_BUILD)" CIBW_ENVIRONMENT_PASS_LINUX='SETUPTOOLS_SCM_PRETEND_VERSION' python3 -m cibuildwheel --output-dir wheelhouse
+      condition: succeeded()
       displayName: 'Building ManyLinux Wheels'
 
     - task: PublishBuildArtifacts@1
@@ -257,12 +256,10 @@ stages:
         else
           echo "##vso[task.setvariable variable=TAG;]"
         fi
-        echo "Wheel tag: ${TAG}"
       displayName: "Set wheel tag"
 
     - script: |
         echo "##vso[task.setvariable variable=CIBW_BUILD;]cp38* cp312*"
-        echo "Build identifiers: ${CIBW_BUILD}"
       condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
       displayName: "Set build identifiers"
 
@@ -273,8 +270,8 @@ stages:
         python3 -m pip install cibuildwheel==2.16.5 tomli tomli-w
         # change the name accordingly
         python3 packaging/change_name.py pyproject.toml "NMODL${NMODL_NIGHTLY_TAG}"
-        CIBW_BUILD="${CIBW_BUILD}" SETUPTOOLS_SCM_PRETEND_VERSION="$(git describe --tags | cut -d '-' -f 1,2 | tr - .)" python3 -m cibuildwheel --output-dir wheelhouse
-      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+        CIBW_BUILD="$(CIBW_BUILD)" SETUPTOOLS_SCM_PRETEND_VERSION="$(git describe --tags | cut -d '-' -f 1,2 | tr - .)" python3 -m cibuildwheel --output-dir wheelhouse
+      condition: succeeded()
       displayName: 'Build macos Wheel (x86_64)'
 
     - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -212,11 +212,12 @@ stages:
         else
           echo "##vso[task.setvariable variable=TAG;]"
         fi
-        echo "Wheel tag: ${TAG}"
+        echo "Wheel tag: $TAG"
       displayName: "Set wheel tag"
 
     - script: |
         echo "##vso[task.setvariable variable=CIBW_BUILD;]cp38* cp312*"
+        echo "Build identifiers: $CIBW_BUILD"
       condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
       displayName: "Set build identifiers"
 
@@ -256,10 +257,12 @@ stages:
         else
           echo "##vso[task.setvariable variable=TAG;]"
         fi
+        echo "Wheel tag: $TAG"
       displayName: "Set wheel tag"
 
     - script: |
         echo "##vso[task.setvariable variable=CIBW_BUILD;]cp38* cp312*"
+        echo "Build identifiers: $CIBW_BUILD"
       condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
       displayName: "Set build identifiers"
 


### PR DESCRIPTION
To speed-up the CI on PRs, we only build wheels for the min (currently 3.8) and max (currently 3.12) versions of Python.