### PR TITLE
Move POINT_PROCESS and TQITEM code.

### DIFF
--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -667,6 +667,30 @@ void CodegenCoreneuronCppVisitor::print_eigen_linear_solver(const std::string& f
 /*                           Code-specific helper routines                              */
 /****************************************************************************************/
 
+void CodegenCoreneuronCppVisitor::add_variable_tqitem(std::vector<IndexVariableInfo>& variables) {
+    // for non-artificial cell, when net_receive buffering is enabled
+    // then tqitem is an offset
+    if (info.net_send_used) {
+        if (info.artificial_cell) {
+            variables.emplace_back(make_symbol(naming::TQITEM_VARIABLE), true);
+        } else {
+            variables.emplace_back(make_symbol(naming::TQITEM_VARIABLE), false, false, true);
+            variables.back().is_constant = true;
+        }
+        info.tqitem_index = static_cast<int>(variables.size() - 1);
+    }
+}
+
+void CodegenCoreneuronCppVisitor::add_variable_point_process(
+    std::vector<IndexVariableInfo>& variables) {
+    /// note that this variable is not printed in neuron implementation
+    if (info.artificial_cell) {
+        variables.emplace_back(make_symbol(naming::POINT_PROCESS_VARIABLE), true);
+    } else {
+        variables.emplace_back(make_symbol(naming::POINT_PROCESS_VARIABLE), false, false, true);
+        variables.back().is_constant = true;
+    }
+}
 
 std::string CodegenCoreneuronCppVisitor::internal_method_arguments() {
     if (ion_variable_struct_required()) {

--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -414,6 +414,8 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
     /*                             Code-specific helper routines                            */
     /****************************************************************************************/
 
+    void add_variable_tqitem(std::vector<IndexVariableInfo>& variables) override;
+    void add_variable_point_process(std::vector<IndexVariableInfo>& variables) override;
 
     /**
      * Arguments for functions that are defined and used internally.

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -1006,13 +1006,8 @@ std::vector<IndexVariableInfo> CodegenCppVisitor::get_int_variables() {
     if (info.point_process) {
         variables.emplace_back(make_symbol(naming::NODE_AREA_VARIABLE));
         variables.back().is_constant = true;
-        /// note that this variable is not printed in neuron implementation
-        if (info.artificial_cell) {
-            variables.emplace_back(make_symbol(naming::POINT_PROCESS_VARIABLE), true);
-        } else {
-            variables.emplace_back(make_symbol(naming::POINT_PROCESS_VARIABLE), false, false, true);
-            variables.back().is_constant = true;
-        }
+
+        add_variable_point_process(variables);
     }
 
     for (auto& ion: info.ions) {
@@ -1100,17 +1095,7 @@ std::vector<IndexVariableInfo> CodegenCppVisitor::get_int_variables() {
         variables.emplace_back(make_symbol(naming::AREA_VARIABLE));
     }
 
-    // for non-artificial cell, when net_receive buffering is enabled
-    // then tqitem is an offset
-    if (info.net_send_used) {
-        if (info.artificial_cell) {
-            variables.emplace_back(make_symbol(naming::TQITEM_VARIABLE), true);
-        } else {
-            variables.emplace_back(make_symbol(naming::TQITEM_VARIABLE), false, false, true);
-            variables.back().is_constant = true;
-        }
-        info.tqitem_index = static_cast<int>(variables.size() - 1);
-    }
+    add_variable_tqitem(variables);
 
     /**
      * \note Variables for watch statements : there is one extra variable

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -842,6 +842,15 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /*                             Code-specific helper routines                            */
     /****************************************************************************************/
 
+    /**
+     * Add the variable tqitem during `get_int_variables`.
+     */
+    virtual void add_variable_tqitem(std::vector<IndexVariableInfo>& variables) = 0;
+
+    /**
+     * Add the variable point_process during `get_int_variables`.
+     */
+    virtual void add_variable_point_process(std::vector<IndexVariableInfo>& variables) = 0;
 
     /**
      * Arguments for functions that are defined and used internally.

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -386,6 +386,19 @@ void CodegenNeuronCppVisitor::print_hoc_py_wrapper_function_definitions() {
 /*                           Code-specific helper routines                              */
 /****************************************************************************************/
 
+void CodegenNeuronCppVisitor::add_variable_tqitem(std::vector<IndexVariableInfo>& variables) {
+    if (info.net_send_used) {
+        variables.emplace_back(make_symbol(naming::TQITEM_VARIABLE), false, false, true);
+        variables.back().is_constant = true;
+        info.tqitem_index = static_cast<int>(variables.size() - 1);
+    }
+}
+
+void CodegenNeuronCppVisitor::add_variable_point_process(
+    std::vector<IndexVariableInfo>& variables) {
+    variables.emplace_back(make_symbol(naming::POINT_PROCESS_VARIABLE), false, false, true);
+    variables.back().is_constant = true;
+}
 
 std::string CodegenNeuronCppVisitor::internal_method_arguments() {
     return "_ml, inst, id, _ppvar, _thread, _nt";

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -227,6 +227,8 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
     /*                             Code-specific helper routines                            */
     /****************************************************************************************/
 
+    void add_variable_tqitem(std::vector<IndexVariableInfo>& variables) override;
+    void add_variable_point_process(std::vector<IndexVariableInfo>& variables) override;
 
     /**
      * Arguments for functions that are defined and used internally.


### PR DESCRIPTION
This code is shared between NEURON and CoreNEURON. Therefore, it's moved the common base class.