### PR TITLE
Fix CI tag for uploading nightly wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -272,7 +272,7 @@ stages:
         python3 -m pip install --upgrade pip
         python3 -m pip install cibuildwheel==2.16.5 tomli tomli-w
         # change the name accordingly
-        python3 packaging/change_name.py pyproject.toml "NMODL${NMODL_NIGHTLY_TAG}"
+        python3 packaging/change_name.py pyproject.toml "NMODL${TAG}"
         CIBW_BUILD="$(CIBW_BUILD)" SETUPTOOLS_SCM_PRETEND_VERSION="$(git describe --tags | cut -d '-' -f 1,2 | tr - .)" python3 -m cibuildwheel --output-dir wheelhouse
       condition: succeeded()
       displayName: 'Build macos Wheel (x86_64)'


### PR DESCRIPTION
`NMODL_NIGHTLY_TAG` should've been just `TAG`.