### PR TITLE
Fix recursive FUNCTION calls

### DIFF
--- a/src/visitors/rename_visitor.cpp
+++ b/src/visitors/rename_visitor.cpp
@@ -47,7 +47,8 @@ std::string RenameVisitor::new_name_generator(const std::string& old_name) {
 /// rename matching variable
 void RenameVisitor::visit_name(const ast::Name& node) {
     const auto& name = node.get_node_name();
-    if (std::regex_match(name, var_name_regex)) {
+    if (std::regex_match(name, var_name_regex) && node.get_parent() &&
+        !node.get_parent()->is_function_call()) {
         std::string new_name = new_name_generator(name);
         node.get_value()->set(new_name);
         std::string token_string = node.get_token() != nullptr

--- a/test/usecases/CMakeLists.txt
+++ b/test/usecases/CMakeLists.txt
@@ -11,7 +11,8 @@ set(NMODL_USECASE_DIRS
     net_send
     point_process
     parameter
-    func_in_breakpoint)
+    func_in_breakpoint
+    recursion)
 
 foreach(usecase ${NMODL_USECASE_DIRS})
   add_test(NAME usecase_${usecase}

--- a/test/usecases/recursion/recursion.mod
+++ b/test/usecases/recursion/recursion.mod
@@ -2,21 +2,6 @@ NEURON {
     SUFFIX recursion
 }
 
-: single recursive call
-FUNCTION f_simple(n) {
-    f_simple = f_simple(n)
-}
-
-: multiple recursive calls
-FUNCTION fc(n) {
-    fc = fc(fc(fc(fc(n))))
-}
-
-: multiple recursive calls with different args
-FUNCTION fd(n) {
-    fd = fd(fc(fd(n) + fc(fd(n))))
-}
-
 FUNCTION myfactorial(n) {
     if (n == 0 || n == 1) {
         myfactorial = 1
@@ -24,11 +9,3 @@ FUNCTION myfactorial(n) {
         myfactorial = n * myfactorial(n - 1)
     }
 } 
-
-FUNCTION myfib(n) {
-    if (n == 0 || n == 1){
-        myfib = n
-    } else {
-        myfib = myfib(n - 1) + myfib(n - 2)
-    }
-}

--- a/test/usecases/recursion/recursion.mod
+++ b/test/usecases/recursion/recursion.mod
@@ -1,0 +1,11 @@
+NEURON {
+        SUFFIX recursion
+}
+
+FUNCTION myfactorial(n) {
+    if (n == 0 || n == 1) {
+        myfactorial = 1
+    } else {
+        myfactorial = n * myfactorial(n - 1)
+    }
+} 

--- a/test/usecases/recursion/recursion.mod
+++ b/test/usecases/recursion/recursion.mod
@@ -1,5 +1,20 @@
 NEURON {
-        SUFFIX recursion
+    SUFFIX recursion
+}
+
+: single recursive call
+FUNCTION f_simple(n) {
+    f_simple = f_simple(n)
+}
+
+: multiple recursive calls
+FUNCTION fc(n) {
+    fc = fc(fc(fc(fc(n))))
+}
+
+: multiple recursive calls with different args
+FUNCTION fd(n) {
+    fd = fd(fc(fd(n) + fc(fd(n))))
 }
 
 FUNCTION myfactorial(n) {
@@ -9,3 +24,11 @@ FUNCTION myfactorial(n) {
         myfactorial = n * myfactorial(n - 1)
     }
 } 
+
+FUNCTION myfib(n) {
+    if (n == 0 || n == 1){
+        myfib = n
+    } else {
+        myfib = myfib(n - 1) + myfib(n - 2)
+    }
+}

--- a/test/usecases/recursion/simulate.py
+++ b/test/usecases/recursion/simulate.py
@@ -5,21 +5,14 @@ from neuron import gui
 from neuron import h
 
 
-def naive_fib(n: int):
-    if n in [0, 1]:
-        return n
-    return naive_fib(n - 1) + naive_fib(n - 2)
-
-
 def simulate():
     s = h.Section(name="soma")
     s.L = 10
     s.diam = 10
     s.insert("recursion")
     fact = s(0.5).recursion.myfactorial
-    fib = s(0.5).recursion.myfib
 
-    return fact, fib
+    return fact
 
 
 def check_solution(f, reference):
@@ -29,6 +22,5 @@ def check_solution(f, reference):
 
 
 if __name__ == "__main__":
-    fact, fib = simulate()
+    fact = simulate()
     check_solution(fact, math.factorial)
-    check_solution(fib, naive_fib)

--- a/test/usecases/recursion/simulate.py
+++ b/test/usecases/recursion/simulate.py
@@ -5,20 +5,30 @@ from neuron import gui
 from neuron import h
 
 
+def naive_fib(n: int):
+    if n in [0, 1]:
+        return n
+    return naive_fib(n - 1) + naive_fib(n - 2)
+
+
 def simulate():
     s = h.Section(name="soma")
     s.L = 10
     s.diam = 10
     s.insert("recursion")
-    return s(0.5).recursion.myfactorial
+    fact = s(0.5).recursion.myfactorial
+    fib = s(0.5).recursion.myfib
+
+    return fact, fib
 
 
-def check_solution(f):
+def check_solution(f, reference):
     for n in range(10):
-        exact, expected = math.factorial(n), f(n)
+        exact, expected = reference(n), f(n)
         assert np.isclose(exact, expected), f"{expected} != {exact}"
 
 
 if __name__ == "__main__":
-    f = simulate()
-    check_solution(f)
+    fact, fib = simulate()
+    check_solution(fact, math.factorial)
+    check_solution(fib, naive_fib)

--- a/test/usecases/recursion/simulate.py
+++ b/test/usecases/recursion/simulate.py
@@ -1,0 +1,24 @@
+import math
+
+import numpy as np
+from neuron import gui
+from neuron import h
+
+
+def simulate():
+    s = h.Section(name="soma")
+    s.L = 10
+    s.diam = 10
+    s.insert("recursion")
+    return s(0.5).recursion.myfactorial
+
+
+def check_solution(f):
+    for n in range(10):
+        exact, expected = math.factorial(n), f(n)
+        assert np.isclose(exact, expected), f"{expected} != {exact}"
+
+
+if __name__ == "__main__":
+    f = simulate()
+    check_solution(f)


### PR DESCRIPTION
The following mod file does not compile under both NEURON and coreNEURON codegen:

```plaintext
NEURON {
    SUFFIX recursion
}
FUNCTION f(n) {
    f = f(n)
}
```
Some more examples are added in `recursion.mod`, which should cover all of the cases of interest (note that only some of them are tested for correctness since the convoluted ones don't have a terminating condition, but they should all at least compile).