### PR TITLE
Add CMake export infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,9 @@ configure_file(share/nrnunits.lib ${CMAKE_CURRENT_BINARY_DIR}/share/nmodl/nrnuni
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/nmodl/nrnunits.lib
         DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}share/nmodl)
 
+set(nmodl_BINARY ${NMODL_INSTALL_DIR_SUFFIX}bin/nmodl${CMAKE_EXECUTABLE_SUFFIX})
+add_executable(nmodl::nmodl ALIAS nmodl)
+
 install(
   EXPORT nmodlTargets
   FILE nmodlTargets.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,23 @@ configure_file(share/nrnunits.lib ${CMAKE_CURRENT_BINARY_DIR}/share/nmodl/nrnuni
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/nmodl/nrnunits.lib
         DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}share/nmodl)
 
+install(
+  EXPORT nmodlTargets
+  FILE nmodlTargets.cmake
+  NAMESPACE nmodl::
+  DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}lib/cmake/nmodl)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/nmodlConfig.cmake"
+  INSTALL_DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}lib/cmake/nmodl)
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/nmodlConfigVersion.cmake"
+                                 COMPATIBILITY AnyNewerVersion)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/nmodlConfig.cmake"
+              "${CMAKE_CURRENT_BINARY_DIR}/nmodlConfigVersion.cmake"
+        DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}lib/cmake/nmodl)
+
 # to print compiler flags in the build status
 if(CMAKE_BUILD_TYPE)
   string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,7 +243,7 @@ configure_file(share/nrnunits.lib ${CMAKE_CURRENT_BINARY_DIR}/share/nmodl/nrnuni
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/nmodl/nrnunits.lib
         DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}share/nmodl)
 
-set(nmodl_BINARY ${NMODL_INSTALL_DIR_SUFFIX}bin/nmodl${CMAKE_EXECUTABLE_SUFFIX})
+set(nmodl_BINARY bin/nmodl${CMAKE_EXECUTABLE_SUFFIX})
 add_executable(nmodl::nmodl ALIAS nmodl)
 
 install(

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -2,4 +2,6 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/nmodlTargets.cmake")
 
+set(nmodl_BINARY @nmodl_BINARY@)
+
 check_required_components(nmodl)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/nmodlTargets.cmake")
+
+check_required_components(nmodl)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -2,6 +2,6 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/nmodlTargets.cmake")
 
-set(nmodl_BINARY ${PACKAGE_PREFIX_DIR}@nmodl_BINARY@)
+set(nmodl_BINARY ${PACKAGE_PREFIX_DIR}/@nmodl_BINARY@)
 
 check_required_components(nmodl)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -2,6 +2,6 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/nmodlTargets.cmake")
 
-set(nmodl_BINARY @nmodl_BINARY@)
+set(nmodl_BINARY ${PACKAGE_PREFIX_DIR}@nmodl_BINARY@)
 
 check_required_components(nmodl)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,7 @@ include_directories(${PYBIND11_INCLUDE_DIR} ${PYTHON_INCLUDE_DIRS})
 # Add executables
 # =============================================================================
 add_executable(nmodl main.cpp)
+set_target_properties(nmodl PROPERTIES PUBLIC_HEADER nmodl.hpp)
 target_link_libraries(
   nmodl
   CLI11::CLI11
@@ -38,7 +39,7 @@ add_dependencies(nmodl nmodl_copy_python_files nmodl_copy_solver_files)
 cpp_cc_configure_sanitizers(TARGET nmodl)
 
 # =============================================================================
-# Add dependency with nmodl python module (for consumer projects)
+# Add dependency with nmodl Python module (for consumer projects)
 # =============================================================================
 add_dependencies(nmodl pywrapper)
 
@@ -49,4 +50,7 @@ endif()
 # =============================================================================
 # Install executable
 # =============================================================================
-install(TARGETS nmodl DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin)
+install(
+  TARGETS nmodl
+  EXPORT nmodlTargets
+  RUNTIME DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}bin)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,6 @@ include_directories(${PYBIND11_INCLUDE_DIR} ${PYTHON_INCLUDE_DIRS})
 # Add executables
 # =============================================================================
 add_executable(nmodl main.cpp)
-set_target_properties(nmodl PROPERTIES PUBLIC_HEADER nmodl.hpp)
 target_link_libraries(
   nmodl
   CLI11::CLI11


### PR DESCRIPTION
Currently will export a target `nmodl::nmodl` for the NMODL binary, and a `nmodl_BINARY` variable for the filename.