### PR TITLE
Use `ParamVector` everywhere

### DIFF
--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -721,7 +721,7 @@ CodegenCoreneuronCppVisitor::ParamVector CodegenCoreneuronCppVisitor::internal_m
 
 
 const std::string CodegenCoreneuronCppVisitor::external_method_arguments() noexcept {
-    return "id, pnodecount, data, indexes, thread, nt, ml, v";
+    return get_arg_str(external_method_parameters());
 }
 
 

--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -39,6 +39,8 @@ using visitor::RenameVisitor;
 using visitor::SymtabVisitor;
 using visitor::VarUsageVisitor;
 
+using ParamVector = std::vector<std::tuple<std::string, std::string, std::string, std::string>>;
+
 using symtab::syminfo::NmodlType;
 
 extern const std::regex regex_special_chars;
@@ -408,7 +410,7 @@ void CodegenCoreneuronCppVisitor::print_check_table_thread_function() {
 
     printer->add_newline(2);
     auto name = method_name("check_table_thread");
-    auto parameters = external_method_parameters(true);
+    auto parameters = get_parameter_str(external_method_parameters(true));
 
     printer->fmt_push_block("static void {} ({})", name, parameters);
     printer->add_line("setup_instance(nt, ml);");
@@ -725,7 +727,7 @@ const std::string CodegenCoreneuronCppVisitor::external_method_arguments() noexc
 }
 
 
-const std::string CodegenCoreneuronCppVisitor::external_method_parameters(bool table) noexcept {
+const ParamVector CodegenCoreneuronCppVisitor::external_method_parameters(bool table) noexcept {
     ParamVector args = {{"", "int", "", "id"},
                         {"", "int", "", "pnodecount"},
                         {"", "double*", "", "data"},
@@ -738,7 +740,7 @@ const std::string CodegenCoreneuronCppVisitor::external_method_parameters(bool t
     } else {
         args.emplace_back("", "double", "", "v");
     }
-    return get_parameter_str(args);
+    return args;
 }
 
 
@@ -781,7 +783,7 @@ std::string CodegenCoreneuronCppVisitor::replace_if_verbatim_variable(std::strin
         }
     }
     if (name == naming::THREAD_ARGS_PROTO) {
-        name = external_method_parameters();
+        name = get_parameter_str(external_method_parameters());
     }
     return name;
 }
@@ -2787,7 +2789,7 @@ void CodegenCoreneuronCppVisitor::print_net_receive() {
  */
 void CodegenCoreneuronCppVisitor::print_derivimplicit_kernel(const Block& block) {
     auto ext_args = external_method_arguments();
-    auto ext_params = external_method_parameters();
+    auto ext_params = get_parameter_str(external_method_parameters());
     auto suffix = info.mod_suffix;
     auto list_num = info.derivimplicit_list_num;
     auto block_name = block.get_node_name();
@@ -2798,7 +2800,7 @@ void CodegenCoreneuronCppVisitor::print_derivimplicit_kernel(const Block& block)
 
     printer->push_block("namespace");
             printer->fmt_push_block("struct _newton_{}_{}", block_name, info.mod_suffix);
-            printer->fmt_push_block("int operator()({}) const", external_method_parameters());
+            printer->fmt_push_block("int operator()({}) const", get_parameter_str(external_method_parameters()));
     auto const instance = fmt::format("auto* const inst = static_cast<{0}*>(ml->instance);",
                                       instance_struct());
     auto const slist1 = fmt::format("auto const& slist{} = {};",

--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -697,8 +697,7 @@ void CodegenCoreneuronCppVisitor::add_variable_point_process(
 }
 
 std::string CodegenCoreneuronCppVisitor::internal_method_arguments() {
-    const auto& args = internal_method_parameters();
-    return get_arg_str(args);
+    return get_arg_str(internal_method_parameters());
 }
 
 

--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -39,8 +39,6 @@ using visitor::RenameVisitor;
 using visitor::SymtabVisitor;
 using visitor::VarUsageVisitor;
 
-using ParamVector = std::vector<std::tuple<std::string, std::string, std::string, std::string>>;
-
 using symtab::syminfo::NmodlType;
 
 extern const std::regex regex_special_chars;

--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -696,7 +696,7 @@ void CodegenCoreneuronCppVisitor::add_variable_point_process(
 
 std::string CodegenCoreneuronCppVisitor::internal_method_arguments() {
     const auto& args = internal_method_parameters();
-    return get_parameter_str(args);
+    return get_arg_str(args);
 }
 
 
@@ -727,6 +727,7 @@ const std::string CodegenCoreneuronCppVisitor::external_method_arguments() noexc
 
 const std::string CodegenCoreneuronCppVisitor::external_method_parameters(bool table) noexcept {
     ParamVector args = {{"", "int", "", "id"},
+                        {"", "int", "", "pnodecount"},
                         {"", "double*", "", "data"},
                         {"", "Datum*", "", "indexes"},
                         {"", "ThreadDatum*", "", "thread"},

--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -2751,10 +2751,10 @@ void CodegenCoreneuronCppVisitor::print_net_receive() {
     printing_net_receive = true;
     if (!info.artificial_cell) {
         const auto& name = method_name("net_receive");
-        ParamVector params;
-        params.emplace_back("", "Point_process*", "", "pnt");
-        params.emplace_back("", "int", "", "weight_index");
-        params.emplace_back("", "double", "", "flag");
+        ParamVector params = {
+            {"", "Point_process*", "", "pnt"},
+            {"", "int", "", "weight_index"},
+            {"", "double", "", "flag"}};
         printer->add_newline(2);
         printer->fmt_push_block("static void {}({})", name, get_parameter_str(params));
         printer->add_line("NrnThread* nt = nrn_threads + pnt->_tid;");

--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -724,7 +724,8 @@ const std::string CodegenCoreneuronCppVisitor::external_method_arguments() noexc
 }
 
 
-const ParamVector CodegenCoreneuronCppVisitor::external_method_parameters(bool table) noexcept {
+const CodegenCppVisitor::ParamVector CodegenCoreneuronCppVisitor::external_method_parameters(
+    bool table) noexcept {
     ParamVector args = {{"", "int", "", "id"},
                         {"", "int", "", "pnodecount"},
                         {"", "double*", "", "data"},

--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -695,10 +695,8 @@ void CodegenCoreneuronCppVisitor::add_variable_point_process(
 }
 
 std::string CodegenCoreneuronCppVisitor::internal_method_arguments() {
-    if (ion_variable_struct_required()) {
-        return "id, pnodecount, inst, ionvar, data, indexes, thread, nt, v";
-    }
-    return "id, pnodecount, inst, data, indexes, thread, nt, v";
+    const auto& args = internal_method_parameters();
+    return get_parameter_str(args);
 }
 
 
@@ -706,34 +704,40 @@ std::string CodegenCoreneuronCppVisitor::internal_method_arguments() {
  * @todo: figure out how to correctly handle qualifiers
  */
 CodegenCoreneuronCppVisitor::ParamVector CodegenCoreneuronCppVisitor::internal_method_parameters() {
-    ParamVector params;
-    params.emplace_back("", "int", "", "id");
-    params.emplace_back("", "int", "", "pnodecount");
-    params.emplace_back("", fmt::format("{}*", instance_struct()), "", "inst");
+    ParamVector params = {{"", "int", "", "id"},
+                          {"", "int", "", "pnodecount"},
+                          {"", fmt::format("{}*", instance_struct()), "", "inst"}};
     if (ion_variable_struct_required()) {
         params.emplace_back("", "IonCurVar&", "", "ionvar");
     }
-    params.emplace_back("", "double*", "", "data");
-    params.emplace_back("const ", "Datum*", "", "indexes");
-    params.emplace_back("", "ThreadDatum*", "", "thread");
-    params.emplace_back("", "NrnThread*", "", "nt");
-    params.emplace_back("", "double", "", "v");
+    ParamVector other_params = {{"", "double*", "", "data"},
+                                {"const ", "Datum*", "", "indexes"},
+                                {"", "ThreadDatum*", "", "thread"},
+                                {"", "NrnThread*", "", "nt"},
+                                {"", "double", "", "v"}};
+    params.insert(params.end(), other_params.begin(), other_params.end());
     return params;
 }
 
 
-const char* CodegenCoreneuronCppVisitor::external_method_arguments() noexcept {
+const std::string CodegenCoreneuronCppVisitor::external_method_arguments() noexcept {
     return "id, pnodecount, data, indexes, thread, nt, ml, v";
 }
 
 
-const char* CodegenCoreneuronCppVisitor::external_method_parameters(bool table) noexcept {
+const std::string CodegenCoreneuronCppVisitor::external_method_parameters(bool table) noexcept {
+    ParamVector args = {{"", "int", "", "id"},
+                        {"", "double*", "", "data"},
+                        {"", "Datum*", "", "indexes"},
+                        {"", "ThreadDatum*", "", "thread"},
+                        {"", "NrnThread*", "", "nt"},
+                        {"", "Memb_list*", "", "ml"}};
     if (table) {
-        return "int id, int pnodecount, double* data, Datum* indexes, "
-               "ThreadDatum* thread, NrnThread* nt, Memb_list* ml, int tml_id";
+        args.emplace_back("", "int", "", "tml_id");
+    } else {
+        args.emplace_back("", "double", "", "v");
     }
-    return "int id, int pnodecount, double* data, Datum* indexes, "
-           "ThreadDatum* thread, NrnThread* nt, Memb_list* ml, double v";
+    return get_parameter_str(args);
 }
 
 
@@ -750,10 +754,7 @@ std::string CodegenCoreneuronCppVisitor::nrn_thread_arguments() const {
  * same mod file itself
  */
 std::string CodegenCoreneuronCppVisitor::nrn_thread_internal_arguments() {
-    if (ion_variable_struct_required()) {
-        return "id, pnodecount, inst, ionvar, data, indexes, thread, nt, v";
-    }
-    return "id, pnodecount, inst, data, indexes, thread, nt, v";
+    return get_arg_str(internal_method_parameters());
 }
 
 

--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -433,7 +433,7 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
      * Arguments for external functions called from generated code
      * \return A string representing the arguments passed to an external function
      */
-    const char* external_method_arguments() noexcept override;
+    const std::string external_method_arguments() noexcept override;
 
 
     /**
@@ -445,7 +445,7 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
      * \param table
      * \return      A string representing the parameters of the function
      */
-    const char* external_method_parameters(bool table = false) noexcept override;
+    const std::string external_method_parameters(bool table = false) noexcept override;
 
 
     /**

--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -443,7 +443,7 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
      * calling convention. This method generates the string representing the function parameters for
      * these externally called functions.
      * \param table
-     * \return      A string representing the parameters of the function
+     * \return      A ParamVector representing the parameters of the function
      */
     const ParamVector external_method_parameters(bool table = false) noexcept override;
 

--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -64,7 +64,6 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
     using CodegenCppVisitor::CodegenCppVisitor;
 
   protected:
-    using ParamVector = std::vector<std::tuple<std::string, std::string, std::string, std::string>>;
     /****************************************************************************************/
     /*                                    Member variables                                  */
     /****************************************************************************************/

--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -64,6 +64,7 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
     using CodegenCppVisitor::CodegenCppVisitor;
 
   protected:
+    using ParamVector = std::vector<std::tuple<std::string, std::string, std::string, std::string>>;
     /****************************************************************************************/
     /*                                    Member variables                                  */
     /****************************************************************************************/

--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -445,7 +445,7 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
      * \param table
      * \return      A string representing the parameters of the function
      */
-    const std::string external_method_parameters(bool table = false) noexcept override;
+    const ParamVector external_method_parameters(bool table = false) noexcept override;
 
 
     /**

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -32,6 +32,20 @@ bool CodegenCppVisitor::ion_variable_struct_required() const {
     return optimize_ion_variable_copies() && info.ion_has_write_variable();
 }
 
+std::string CodegenCppVisitor::get_arg_str(const ParamVector& params) {
+    std::string str;
+    bool is_first = true;
+    for (const auto& param: params) {
+        if (is_first) {
+            is_first = false;
+        } else {
+            str += ", ";
+        }
+        str += std::get<3>(param);
+    }
+    return str;
+}
+
 
 std::string CodegenCppVisitor::get_parameter_str(const ParamVector& params) {
     std::string str;

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -33,36 +33,24 @@ bool CodegenCppVisitor::ion_variable_struct_required() const {
 }
 
 std::string CodegenCppVisitor::get_arg_str(const ParamVector& params) {
-    std::string str;
-    bool is_first = true;
+    std::vector<std::string> variables;
     for (const auto& param: params) {
-        if (is_first) {
-            is_first = false;
-        } else {
-            str += ", ";
-        }
-        str += std::get<3>(param);
+        variables.push_back(std::get<3>(param));
     }
-    return str;
+    return fmt::format("{}", fmt::join(variables, ", "));
 }
 
 
 std::string CodegenCppVisitor::get_parameter_str(const ParamVector& params) {
-    std::string str;
-    bool is_first = true;
+    std::vector<std::string> variables;
     for (const auto& param: params) {
-        if (is_first) {
-            is_first = false;
-        } else {
-            str += ", ";
-        }
-        str += fmt::format("{}{} {}{}",
-                           std::get<0>(param),
-                           std::get<1>(param),
-                           std::get<2>(param),
-                           std::get<3>(param));
+        variables.push_back(fmt::format("{}{} {}{}",
+                                        std::get<0>(param),
+                                        std::get<1>(param),
+                                        std::get<2>(param),
+                                        std::get<3>(param)));
     }
-    return str;
+    return fmt::format("{}", fmt::join(variables, ", "));
 }
 
 

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -908,7 +908,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * \param table
      * \return      A string representing the parameters of the function
      */
-    virtual const std::string external_method_parameters(bool table = false) noexcept = 0;
+    virtual const ParamVector external_method_parameters(bool table = false) noexcept = 0;
 
 
     /**

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -507,6 +507,16 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      */
     static std::string get_parameter_str(const ParamVector& params);
 
+
+    /**
+     * Generate the string representing the parameters in a function call
+     *
+     * The procedure parameters are stored in a vector of 4-tuples each representing a parameter.
+     *
+     * \param params The parameters that should be concatenated into the function parameter
+     * declaration
+     * \return The string representing the function call parameters
+     */
     static std::string get_arg_str(const ParamVector& params);
 
 

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -507,6 +507,8 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      */
     static std::string get_parameter_str(const ParamVector& params);
 
+    static std::string get_arg_str(const ParamVector& params);
+
 
     /**
      * Check if function or procedure node has parameter with given name
@@ -894,7 +896,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * Arguments for external functions called from generated code
      * \return A string representing the arguments passed to an external function
      */
-    virtual const char* external_method_arguments() noexcept = 0;
+    virtual const std::string external_method_arguments() noexcept = 0;
 
 
     /**
@@ -906,7 +908,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * \param table
      * \return      A string representing the parameters of the function
      */
-    virtual const char* external_method_parameters(bool table = false) noexcept = 0;
+    virtual const std::string external_method_parameters(bool table = false) noexcept = 0;
 
 
     /**

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -456,30 +456,30 @@ void CodegenNeuronCppVisitor::add_variable_point_process(
 }
 
 std::string CodegenNeuronCppVisitor::internal_method_arguments() {
-    return "_ml, inst, id, _ppvar, _thread, _nt";
+    const auto& args = internal_method_parameters();
+    return get_arg_str(args);
 }
 
 
 CodegenNeuronCppVisitor::ParamVector CodegenNeuronCppVisitor::internal_method_parameters() {
-    ParamVector params;
-    params.emplace_back("", "_nrn_mechanism_cache_range*", "", "_ml");
-    params.emplace_back("", fmt::format("{}&", instance_struct()), "", "inst");
-    params.emplace_back("", "size_t", "", "id");
-    params.emplace_back("", "Datum*", "", "_ppvar");
-    params.emplace_back("", "Datum*", "", "_thread");
-    params.emplace_back("", "NrnThread*", "", "_nt");
+    ParamVector params = {{"", "_nrn_mechanism_cache_range*", "", "_ml"},
+                          {"", fmt::format("{}&", instance_struct()), "", "inst"},
+                          {"", "size_t", "", "id"},
+                          {"", "Datum*", "", "_ppvar"},
+                          {"", "Datum*", "", "_thread"},
+                          {"", "NrnThread*", "", "_nt"}};
     return params;
 }
 
 
 /// TODO: Edit for NEURON
-const char* CodegenNeuronCppVisitor::external_method_arguments() noexcept {
+const std::string CodegenNeuronCppVisitor::external_method_arguments() noexcept {
     return {};
 }
 
 
 /// TODO: Edit for NEURON
-const char* CodegenNeuronCppVisitor::external_method_parameters(bool table) noexcept {
+const std::string CodegenNeuronCppVisitor::external_method_parameters(bool table) noexcept {
     return {};
 }
 
@@ -1366,12 +1366,11 @@ void CodegenNeuronCppVisitor::print_make_node_data() const {
                             node_data_struct(),
                             info.mod_suffix);
 
-    std::vector<std::string> make_node_data_args;
-    make_node_data_args.push_back("_ml_arg.nodeindices");
-    make_node_data_args.push_back("_nt.node_voltage_storage()");
-    make_node_data_args.push_back("_nt.node_d_storage()");
-    make_node_data_args.push_back("_nt.node_rhs_storage()");
-    make_node_data_args.push_back("_ml_arg.nodecount");
+    std::vector<std::string> make_node_data_args = {"_ml_arg.nodeindices",
+                                                    "_nt.node_voltage_storage()",
+                                                    "_nt.node_d_storage()",
+                                                    "_nt.node_rhs_storage()",
+                                                    "_ml_arg.nodecount"};
 
     printer->fmt_push_block("return {}", node_data_struct());
     printer->add_multi_line(fmt::format("{}", fmt::join(make_node_data_args, ",\n")));
@@ -1437,10 +1436,11 @@ void CodegenNeuronCppVisitor::print_initial_block(const InitialBlock* node) {
 void CodegenNeuronCppVisitor::print_global_function_common_code(BlockType type,
                                                                 const std::string& function_name) {
     std::string method = function_name.empty() ? compute_method_name(type) : function_name;
-    std::string args =
-        "_nrn_model_sorted_token const& _sorted_token, NrnThread* _nt, Memb_list* _ml_arg, int "
-        "_type";
-    printer->fmt_push_block("void {}({})", method, args);
+    ParamVector args = {{"", "const _nrn_model_sorted_token&", "", "_sorted_token"},
+                        {"", "NrnThread*", "", "_nt"},
+                        {"", "Memb_list*", "", "_ml_arg"},
+                        {"", "int", "", "_type"}};
+    printer->fmt_push_block("void {}({})", method, get_parameter_str(args));
 
     printer->add_line("_nrn_mechanism_cache_range _lmr{_sorted_token, *_nt, *_ml_arg, _type};");
     printer->fmt_line("auto inst = make_instance_{}(_lmr);", info.mod_suffix);
@@ -1480,10 +1480,15 @@ void CodegenNeuronCppVisitor::print_nrn_init(bool skip_init_check) {
 void CodegenNeuronCppVisitor::print_nrn_jacob() {
     printer->add_newline(2);
 
-    printer->fmt_push_block(
-        "static void {}(_nrn_model_sorted_token const& _sorted_token, NrnThread* "
-        "_nt, Memb_list* _ml_arg, int _type)",
-        method_name(naming::NRN_JACOB_METHOD));  // begin function
+    ParamVector args = {{"", "const _nrn_model_sorted_token&", "", "_sorted_token"},
+                        {"", "NrnThread*", "", "_nt"},
+                        {"", "Memb_list*", "", "_ml_arg"},
+                        {"", "int", "", "_type"}};
+
+    printer->fmt_push_block("static void {}({})",
+                            method_name(naming::NRN_JACOB_METHOD),
+                            get_parameter_str(args));  // begin function
+
 
     printer->add_multi_line(
         "_nrn_mechanism_cache_range _lmr{_sorted_token, *_nt, *_ml_arg, _type};");
@@ -1689,11 +1694,10 @@ CodegenNeuronCppVisitor::ParamVector CodegenNeuronCppVisitor::nrn_current_parame
         throw std::runtime_error("Not implemented.");
     }
 
-    ParamVector params;
-    params.emplace_back("", "_nrn_mechanism_cache_range*", "", "_ml");
-    params.emplace_back("", "NrnThread*", "", "_nt");
-    params.emplace_back("", "Datum*", "", "_ppvar");
-    params.emplace_back("", "Datum*", "", "_thread");
+    ParamVector params = {{"", "_nrn_mechanism_cache_range*", "", "_ml"},
+                          {"", "NrnThread*", "", "_nt"},
+                          {"", "Datum*", "", "_ppvar"},
+                          {"", "Datum*", "", "_thread"}};
 
     if (info.thread_callback_register) {
         auto type_name = fmt::format("{}&", thread_variables_struct());
@@ -2116,10 +2120,9 @@ void CodegenNeuronCppVisitor::print_net_receive() {
         return;
     }
 
-    ParamVector args;
-    args.emplace_back("", "Point_process*", "", "_pnt");
-    args.emplace_back("", "double*", "", "_args");
-    args.emplace_back("", "double", "", "flag");
+    ParamVector args = {{"", "Point_process*", "", "_pnt"},
+                        {"", "double*", "", "_args"},
+                        {"", "double", "", "flag"}};
 
     printer->fmt_push_block("static void nrn_net_receive_{}({})",
                             info.mod_suffix,

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -461,7 +461,7 @@ std::string CodegenNeuronCppVisitor::internal_method_arguments() {
 }
 
 
-CodegenNeuronCppVisitor::ParamVector CodegenNeuronCppVisitor::internal_method_parameters() {
+CodegenCppVisitor::ParamVector CodegenNeuronCppVisitor::internal_method_parameters() {
     ParamVector params = {{"", "_nrn_mechanism_cache_range*", "", "_ml"},
                           {"", fmt::format("{}&", instance_struct()), "", "inst"},
                           {"", "size_t", "", "id"},
@@ -479,7 +479,8 @@ const std::string CodegenNeuronCppVisitor::external_method_arguments() noexcept 
 
 
 /// TODO: Edit for NEURON
-const ParamVector CodegenNeuronCppVisitor::external_method_parameters(bool table) noexcept {
+const CodegenCppVisitor::ParamVector CodegenNeuronCppVisitor::external_method_parameters(
+    bool table) noexcept {
     return {};
 }
 

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -31,6 +31,7 @@ using visitor::RenameVisitor;
 using visitor::VarUsageVisitor;
 
 using symtab::syminfo::NmodlType;
+using ParamVector = std::vector<std::tuple<std::string, std::string, std::string, std::string>>;
 
 
 /****************************************************************************************/
@@ -479,7 +480,7 @@ const std::string CodegenNeuronCppVisitor::external_method_arguments() noexcept 
 
 
 /// TODO: Edit for NEURON
-const std::string CodegenNeuronCppVisitor::external_method_parameters(bool table) noexcept {
+const ParamVector CodegenNeuronCppVisitor::external_method_parameters(bool table) noexcept {
     return {};
 }
 

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -31,7 +31,6 @@ using visitor::RenameVisitor;
 using visitor::VarUsageVisitor;
 
 using symtab::syminfo::NmodlType;
-using ParamVector = std::vector<std::tuple<std::string, std::string, std::string, std::string>>;
 
 
 /****************************************************************************************/

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -289,7 +289,7 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
      * \param table
      * \return      A string representing the parameters of the function
      */
-    const std::string external_method_parameters(bool table = false) noexcept override;
+    const ParamVector external_method_parameters(bool table = false) noexcept override;
 
 
     /**

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -87,7 +87,6 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
     using CodegenCppVisitor::CodegenCppVisitor;
 
   protected:
-    using ParamVector = std::vector<std::tuple<std::string, std::string, std::string, std::string>>;
     /****************************************************************************************/
     /*                                    Member variables                                  */
     /****************************************************************************************/

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -277,7 +277,7 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
      * Arguments for external functions called from generated code
      * \return A string representing the arguments passed to an external function
      */
-    const char* external_method_arguments() noexcept override;
+    const std::string external_method_arguments() noexcept override;
 
 
     /**
@@ -289,7 +289,7 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
      * \param table
      * \return      A string representing the parameters of the function
      */
-    const char* external_method_parameters(bool table = false) noexcept override;
+    const std::string external_method_parameters(bool table = false) noexcept override;
 
 
     /**

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -87,6 +87,7 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
     using CodegenCppVisitor::CodegenCppVisitor;
 
   protected:
+    using ParamVector = std::vector<std::tuple<std::string, std::string, std::string, std::string>>;
     /****************************************************************************************/
     /*                                    Member variables                                  */
     /****************************************************************************************/


### PR DESCRIPTION
Also refactored some functions so they don't use `char*` but a `std::string` instead.