### PR TITLE
Remove generation of INCLUDE file in the tests

### DIFF
--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -167,6 +167,10 @@ foreach(
                        "${_environment_vars_list}")
 endforeach()
 
+# Generate include files used in test input, see test/unit/utils/nmodl_constructs.cpp
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/Unit.inc" "UNITSON \n UNITSOFF \n UNITSON \n UNITSOFF")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/included.file" "TITLE")
+
 # =============================================================================
 # pybind11 tests
 # =============================================================================

--- a/test/unit/parser/parser.cpp
+++ b/test/unit/parser/parser.cpp
@@ -133,7 +133,6 @@ SCENARIO("NMODL parser accepts empty unit specification") {
 }
 
 SCENARIO("NMODL parser running number of valid NMODL constructs") {
-    TempFile unit("Unit.inc", nmodl_valid_constructs.at("unit_statement_1").input);
     for (const auto& construct: nmodl_valid_constructs) {
         auto test_case = construct.second;
         GIVEN(test_case.name) {
@@ -172,7 +171,6 @@ SCENARIO("Check that the parser doesn't crash when passing invalid INCLUDE const
     }
 
     GIVEN("An invalid included file") {
-        TempFile included("included.file", nmodl_invalid_constructs.at("title_1").input);
         REQUIRE_THROWS_WITH(is_valid_construct("INCLUDE \"included.file\""),
                             Catch::Matchers::ContainsSubstring("unexpected End of file"));
     }
@@ -199,7 +197,6 @@ SCENARIO("NEURON block can add CURIE information", "[parser][represents]") {
 
 SCENARIO("Check parents in valid NMODL constructs") {
     nmodl::parser::NmodlDriver driver;
-    TempFile unit("Unit.inc", nmodl_valid_constructs.at("unit_statement_1").input);
     for (const auto& construct: nmodl_valid_constructs) {
         // parse the string and get the ast
         const auto ast = driver.parse_string(construct.second.input);

--- a/test/unit/utils/test_utils.cpp
+++ b/test/unit/utils/test_utils.cpp
@@ -10,8 +10,6 @@
 #include "utils/string_utils.hpp"
 
 #include <cassert>
-#include <filesystem>
-#include <fstream>
 
 namespace fs = std::filesystem;
 
@@ -83,21 +81,6 @@ std::string reindent_text(const std::string& text) {
         }
     }
     return indented_text;
-}
-
-TempFile::TempFile(fs::path path, const std::string& content)
-    : path_(std::move(path)) {
-    std::ofstream output(path_);
-    output << content;
-}
-
-TempFile::~TempFile() {
-    try {
-        fs::remove(path_);
-    } catch (...) {
-        // TODO: remove .string() once spdlog use fmt 9.1.0
-        logger->error("Cannot delete temporary file {}", path_.string());
-    }
 }
 
 }  // namespace test_utils

--- a/test/unit/utils/test_utils.cpp
+++ b/test/unit/utils/test_utils.cpp
@@ -11,8 +11,6 @@
 
 #include <cassert>
 
-namespace fs = std::filesystem;
-
 namespace nmodl {
 namespace test_utils {
 

--- a/test/unit/utils/test_utils.hpp
+++ b/test/unit/utils/test_utils.hpp
@@ -7,24 +7,12 @@
 
 #pragma once
 
-#include <filesystem>
 #include <string>
 
 namespace nmodl {
 namespace test_utils {
 
 std::string reindent_text(const std::string& text);
-
-/**
- * \brief Create an empty file which is then removed when the C++ object is destructed
- */
-struct TempFile {
-    TempFile(std::filesystem::path path, const std::string& content);
-    ~TempFile();
-
-  private:
-    std::filesystem::path path_;
-};
 
 }  // namespace test_utils
 }  // namespace nmodl

--- a/test/unit/visitor/nmodl.cpp
+++ b/test/unit/visitor/nmodl.cpp
@@ -41,7 +41,6 @@ std::string run_nmodl_visitor(const std::string& text) {
 }
 
 SCENARIO("Convert AST back to NMODL form", "[visitor][nmodl]") {
-    TempFile unit("Unit.inc", nmodl_valid_constructs.at("unit_statement_1").input);
     for (const auto& construct: nmodl_valid_constructs) {
         auto test_case = construct.second;
         const std::string& input_nmodl_text = reindent_text(test_case.input);


### PR DESCRIPTION
- include mod files generation cause race condition with parallel tests, see #1290
- the included files are trivial examples and they don't need to be generated from the code
  - could be copied via configure_file
  - cmake could generate those at a configure time

Considering the use case and it's triviality, I thought 2nd option is better. That also allows removal of some extra code/logic.