### PR TITLE
Fix rendering of docs

### DIFF
--- a/.github/workflows/nmodl-doc.yml
+++ b/.github/workflows/nmodl-doc.yml
@@ -62,7 +62,6 @@ jobs:
           echo "------- Build Documentation -------";
           bash docs/generate_docs.sh public $(command -v python${PYTHON_VERSION})
           touch public/docs/.nojekyll
-          echo "<meta http-equiv=\"refresh\" content=\"0; url=./html/index.html\" />" > public/docs/index.html
           echo "status=done" >> $GITHUB_OUTPUT
         env:
           CCACHE_DIR: ${{runner.workspace}}/ccache


### PR DESCRIPTION
This should take care of the rendering of the docs, which was caused by a combination of two things:
1. the (now deleted) line was overriding `/index.html` file, and was redirecting it to `/html/index.html` instead
2. where does the `/html/index.html` file come from? I believe the answer is this line here:
https://github.com/BlueBrain/nmodl/blob/3754a71af34180633bb7261fd52648f277fd93f7/.github/workflows/nmodl-doc.yml#L82

At some point I guess the docs were (and still are) under `/html/[file]` instead of just `/[file]`.