### PR TITLE
Fix typo in pybind CMakeLists

### DIFF
--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -25,7 +25,7 @@ set_property(
   APPEND
   PROPERTY CMAKE_CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../../python/nmodl/ode.py)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ode_py.hpp.inc ${CMAKE_CURRENT_BINARY_DIR}/ode_py.hpp
-               @ONLY@)
+               @ONLY)
 
 add_library(pyembed pyembed.cpp)
 set_property(TARGET pyembed PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Was getting a warning:

```plaintext
CMake Warning (dev) at src/pybind/CMakeLists.txt:27 (configure_file):
  configure_file called with unknown argument(s):

   @ONLY@
```

should be `@ONLY`.