### PR TITLE
Pin numpy max version to <2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 scripts = {nmodl = "nmodl._binwrapper:main"}
 requires-python = ">=3.8"
 
-optional-dependencies.test = ["pytest>=3.3.0", "pytest-cov", "numpy", "scipy"]
+optional-dependencies.test = ["pytest>=3.3.0", "pytest-cov", "numpy<2", "scipy"]
 optional-dependencies.docs = [
         "jupyter-client",
         "jupyter",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ importlib-resources;python_version<'3.9'
 # dependencies for test
 pytest<=8.1.1
 pytest-cov
-numpy
+numpy<2
 scipy
 # dependencies for docs
 jupyter-client


### PR DESCRIPTION
NMODL counterpart of https://github.com/neuronsimulator/nrn/pull/2916. Since NEURON first installs its own Python requirements, and only afterwards the requirements of its external dependencies, we need to merge this one first, then update and merge https://github.com/neuronsimulator/nrn/pull/2900, and finally merge https://github.com/neuronsimulator/nrn/pull/2916.