### PR TITLE
Fix (NON)LINEAR block with explicit SOLVEFOR

### DIFF
--- a/src/visitors/sympy_solver_visitor.cpp
+++ b/src/visitors/sympy_solver_visitor.cpp
@@ -52,11 +52,30 @@ void SympySolverVisitor::init_block_data(ast::Node* node) {
     }
 }
 
-void SympySolverVisitor::init_state_vars_vector() {
+void SympySolverVisitor::init_state_vars_vector(const ast::Node* node) {
     state_vars.clear();
     for (const auto& state_var: all_state_vars) {
         if (state_vars_in_block.find(state_var) != state_vars_in_block.cend()) {
             state_vars.push_back(state_var);
+        }
+    }
+
+    // in case we have a SOLVEFOR in the block, we need to set `state_vars` to those instead
+    if (node->is_linear_block()) {
+        const auto& solvefor_vars = dynamic_cast<const ast::LinearBlock*>(node)->get_solvefor();
+        if (!solvefor_vars.empty()) {
+            state_vars.clear();
+            for (const auto& solvefor_var: solvefor_vars) {
+                state_vars.push_back(solvefor_var->get_node_name());
+            }
+        }
+    } else if (node->is_non_linear_block()) {
+        const auto& solvefor_vars = dynamic_cast<const ast::NonLinearBlock*>(node)->get_solvefor();
+        if (!solvefor_vars.empty()) {
+            state_vars.clear();
+            for (const auto& solvefor_var: solvefor_vars) {
+                state_vars.push_back(solvefor_var->get_node_name());
+            }
         }
     }
 }
@@ -283,7 +302,12 @@ void SympySolverVisitor::construct_eigen_solver_block(
 }
 
 
-void SympySolverVisitor::solve_linear_system(const std::vector<std::string>& pre_solve_statements) {
+void SympySolverVisitor::solve_linear_system(const ast::Node& node,
+                                             const std::vector<std::string>& pre_solve_statements
+
+) {
+    // construct ordered vector of state vars used in linear system
+    init_state_vars_vector(&node);
     // call sympy linear solver
     bool small_system = (eq_system.size() <= SMALL_LINEAR_SYSTEM_MAX_STATES);
     auto solver = pywrap::EmbeddedPythonLoader::get_instance().api().solve_linear_system;
@@ -330,9 +354,10 @@ void SympySolverVisitor::solve_linear_system(const std::vector<std::string>& pre
 }
 
 void SympySolverVisitor::solve_non_linear_system(
+    const ast::Node& node,
     const std::vector<std::string>& pre_solve_statements) {
     // construct ordered vector of state vars used in non-linear system
-    init_state_vars_vector();
+    init_state_vars_vector(&node);
 
     auto solver = pywrap::EmbeddedPythonLoader::get_instance().api().solve_nonlinear_system;
     auto [solutions, exception_message] = solver(eq_system, state_vars, vars, function_calls);
@@ -533,7 +558,7 @@ void SympySolverVisitor::visit_derivative_block(ast::DerivativeBlock& node) {
 
         if (solve_method == codegen::naming::SPARSE_METHOD ||
             solve_method == codegen::naming::DERIVIMPLICIT_METHOD) {
-            solve_non_linear_system(pre_solve_statements);
+            solve_non_linear_system(node, pre_solve_statements);
         } else {
             logger->error("SympySolverVisitor :: Solve method {} not supported", solve_method);
         }
@@ -564,19 +589,7 @@ void SympySolverVisitor::visit_linear_block(ast::LinearBlock& node) {
     node.visit_children(*this);
 
     if (eq_system_is_valid && !eq_system.empty()) {
-        // construct ordered vector of state vars used in linear system
-        init_state_vars_vector();
-
-        // in case we have a SOLVEFOR in the block, we need to set `state_vars` to those instead
-        const auto& solvefor_vars = node.get_solvefor();
-        if (!solvefor_vars.empty()) {
-            state_vars.clear();
-            for (const auto& solvefor_var: solvefor_vars) {
-                state_vars.push_back(solvefor_var->get_node_name());
-            }
-        }
-
-        solve_linear_system();
+        solve_linear_system(node);
     }
 }
 
@@ -604,7 +617,7 @@ void SympySolverVisitor::visit_non_linear_block(ast::NonLinearBlock& node) {
     node.visit_children(*this);
 
     if (eq_system_is_valid && !eq_system.empty()) {
-        solve_non_linear_system();
+        solve_non_linear_system(node);
     }
 }
 

--- a/src/visitors/sympy_solver_visitor.hpp
+++ b/src/visitors/sympy_solver_visitor.hpp
@@ -61,7 +61,7 @@ class SympySolverVisitor: public AstVisitor {
     void init_block_data(ast::Node* node);
 
     /// construct vector from set of state vars in correct order
-    void init_state_vars_vector();
+    void init_state_vars_vector(const ast::Node* node);
 
     /// replace binary expression with new expression provided as string
     static void replace_diffeq_expression(ast::DiffEqExpression& expr, const std::string& new_expr);
@@ -79,10 +79,12 @@ class SympySolverVisitor: public AstVisitor {
                                       bool linear);
 
     /// solve linear system (for "LINEAR")
-    void solve_linear_system(const std::vector<std::string>& pre_solve_statements = {});
+    void solve_linear_system(const ast::Node& node,
+                             const std::vector<std::string>& pre_solve_statements = {});
 
     /// solve non-linear system (for "derivimplicit", "sparse" and "NONLINEAR")
-    void solve_non_linear_system(const std::vector<std::string>& pre_solve_statements = {});
+    void solve_non_linear_system(const ast::Node& node,
+                                 const std::vector<std::string>& pre_solve_statements = {});
 
     /// return NMODL string version of node, excluding any units
     static std::string to_nmodl_for_sympy(ast::Ast& node) {

--- a/test/unit/visitor/sympy_solver.cpp
+++ b/test/unit/visitor/sympy_solver.cpp
@@ -2059,6 +2059,28 @@ SCENARIO("LINEAR solve block (SympySolver Visitor)", "[sympy][linear]") {
             compare_blocks(reindent_text(result[0]), reindent_text(expected_text));
         }
     }
+    GIVEN("LINEAR solve block with an explicit SOLVEFOR statement") {
+        std::string nmodl_text = R"(
+            STATE {
+                x
+                y
+                z
+            }
+            LINEAR lin SOLVEFOR x, y {
+                ~ 3 * x = v - y
+                ~ x = z * y - 5
+            })";
+        std::string expected_text = R"(
+            LINEAR lin  SOLVEFOR x,y{
+                y = (v+15.0)/(3.0*z+1.0)
+                x = (v*z-5.0)/(3.0*z+1.0)
+            })";
+        THEN("solve analytically") {
+            auto result =
+                run_sympy_solver_visitor(nmodl_text, false, false, AstNodeType::LINEAR_BLOCK);
+            REQUIRE(reindent_text(result[0]) == reindent_text(expected_text));
+        }
+    }
 }
 
 //=============================================================================


### PR DESCRIPTION
The (NON)LINEAR block in NMODL was not accounting for the SOLVEFOR variables, which means that something like the following would fail (when used with `sympy --analytic`):

```plaintext
STATE {
    x
    y
    z
}
LINEAR lin SOLVEFOR x, y {
    ~ 3 * x = v - y
    ~ x = z * y - 5
}
```

because the SOLVEFOR variables were not accounted for, only the STATE ones, which caused the solver to think this was a nonlinear system due to the presence of the `z * y` term in the second equation (i.e. the solver would try to solve the system for _all_ STATE variables instead of just the ones specified in SOLVEFOR).