### PR TITLE
Make non-thread-safe warnings more specific

### DIFF
--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -1359,11 +1359,6 @@ void CodegenCppVisitor::setup(const Program& node) {
     }
     info.rsuffix = info.point_process ? "" : "_" + info.mod_suffix;
 
-    if (!info.vectorize) {
-        logger->warn(
-            "CodegenCoreneuronCppVisitor : MOD file uses non-thread safe constructs of NMODL");
-    }
-
     codegen_float_variables = get_float_variables();
     codegen_int_variables = get_int_variables();
 

--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -13,8 +13,8 @@
 #include "ast/all.hpp"
 #include "codegen/codegen_naming.hpp"
 #include "parser/c11_driver.hpp"
+#include "utils/logger.hpp"
 #include "visitors/visitor_utils.hpp"
-
 
 namespace nmodl {
 namespace codegen {
@@ -738,14 +738,19 @@ CodegenInfo CodegenHelperVisitor::analyze(const ast::Program& node) {
 
 void CodegenHelperVisitor::visit_linear_block(const ast::LinearBlock& /* node */) {
     info.vectorize = false;
+    logger->warn("CodegenHelperVisitor : MOD file uses non-thread safe construct of NMODL: LINEAR");
 }
 
 void CodegenHelperVisitor::visit_non_linear_block(const ast::NonLinearBlock& /* node */) {
     info.vectorize = false;
+    logger->warn(
+        "CodegenHelperVisitor : MOD file uses non-thread safe construct of NMODL: NONLINEAR");
 }
 
 void CodegenHelperVisitor::visit_discrete_block(const ast::DiscreteBlock& /* node */) {
     info.vectorize = false;
+    logger->warn(
+        "CodegenHelperVisitor : MOD file uses non-thread safe construct of NMODL: DISCRETE");
 }
 
 void CodegenHelperVisitor::visit_update_dt(const ast::UpdateDt& node) {


### PR DESCRIPTION
The warning `MOD file uses non-thread safe constructs of NMODL` does not really tell me which ones are not thread-safe, so this PR makes it more specific and now outputs a warning with about the ones which are not safe. More of a UX improvement than anything else.