### PR TITLE
Fix docstring of `print_function_or_procedure`

### DIFF
--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -821,7 +821,7 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * Print nmodl function or procedure (common code)
      * \param node the AST node representing the function or procedure in NMODL
      * \param name the name of the function or procedure
-     * \param hidden whether the function should be declared `static`
+     * \param specifiers the set of C++ specifiers to apply to the function signature
      */
     virtual void print_function_or_procedure(
         const ast::Block& node,


### PR DESCRIPTION
Forgot to update arg docstring in #1247 