### PR TITLE
Fix thread variables with Newton code.

### DIFF
--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -817,11 +817,17 @@ void CodegenNeuronCppVisitor::print_sdlists_init([[maybe_unused]] bool print_ini
 }
 
 CodegenCppVisitor::ParamVector CodegenNeuronCppVisitor::functor_params() {
-    return ParamVector{{"", "NrnThread*", "", "nt"},
-                       {"", fmt::format("{}&", instance_struct()), "", "inst"},
-                       {"", "int", "", "id"},
-                       {"", "double", "", "v"},
-                       {"", "Datum*", "", "_thread"}};
+    auto params = ParamVector{};
+    params.push_back({"", "NrnThread*", "", "nt"});
+    params.push_back({"", fmt::format("{}&", instance_struct()), "", "inst"});
+    params.push_back({"", "int", "", "id"});
+    params.push_back({"", "double", "", "v"});
+    params.push_back({"", "Datum*", "", "_thread"});
+    if (!codegen_thread_variables.empty()) {
+        params.push_back({"", fmt::format("{}&", thread_variables_struct()), "", "_thread_vars"});
+    }
+
+    return params;
 }
 
 void CodegenNeuronCppVisitor::print_mechanism_global_var_structure(bool print_initializers) {

--- a/test/usecases/global/test_thread_newton.py
+++ b/test/usecases/global/test_thread_newton.py
@@ -1,0 +1,26 @@
+import numpy as np
+from neuron import gui
+from neuron import h
+
+
+def simulate():
+    s = h.Section()
+    s.insert("thread_newton")
+
+    t_hoc = h.Vector().record(h._ref_t)
+    x_hoc = h.Vector().record(s(0.5).thread_newton._ref_x)
+
+    h.stdinit()
+    h.run()
+
+    t = np.array(t_hoc.as_numpy())
+    x = h.Vector(x_hoc.as_numpy())
+
+    # The ODE for X is `dX/dt = 42.0`:
+    x_exact = 42.0 * t
+
+    assert np.all(np.abs(x - x_exact) < 1e-10)
+
+
+if __name__ == "__main__":
+    simulate()

--- a/test/usecases/global/thread_newton.mod
+++ b/test/usecases/global/thread_newton.mod
@@ -1,0 +1,29 @@
+NEURON {
+    SUFFIX thread_newton
+    RANGE x
+    GLOBAL c
+    THREADSAFE
+}
+
+ASSIGNED {
+    c
+    x
+}
+
+STATE {
+    X
+}
+
+INITIAL {LOCAL total
+    X = 0.0
+    c = 42.0
+}
+
+BREAKPOINT {
+    SOLVE state METHOD sparse
+    x = X
+}
+
+KINETIC state {
+    ~ X << (c)
+}


### PR DESCRIPTION
Solving non-linear system causes a function object to be present in the generated code. This function object was missing the required code to handle thread-variables.