### PR TITLE
Homogenize finding our components.

### DIFF
--- a/src/config/config.cpp.in
+++ b/src/config/config.cpp.in
@@ -12,6 +12,14 @@
 #include <fstream>
 #include <sstream>
 
+#if defined(_WIN32)
+#include <stdio.h>
+#elif defined(__APPLE__)
+#include <limits.h>
+#include <mach-o/dyld.h>
+#else
+#endif
+
 namespace fs = std::filesystem;
 
 /// Git version of the project
@@ -40,17 +48,44 @@ std::string maybe_from_env(const std::string& varname) {
     if (value != nullptr) {
         return value;
     }
-    return "";
+
+#if defined(_WIN32)
+    std::vector<wchar_t> buffer;
+    DWORD copied = 0;
+    do {
+        buffer.resize(buffer.size() + MAX_PATH);
+        copied = GetModuleFileName(0, &buffer.at(0), buffer.size());
+    } while (copied >= buffer.size());
+    buffer.resize(copied);
+    fs::path executable(std::wstring(buffer.begin(), buffer.end()));
+#elif defined(__APPLE__)
+    char buffer[PATH_MAX + 1];
+    uint32_t bufsize = PATH_MAX + 1;
+    if( _NSGetExecutablePath(buf, &bufsize) != 0) {
+        return "";
+    }
+    auto executable = fs::read_symlink(buffer);
+#else
+    auto executable = fs::read_symlink("/proc/self/exe");
+#endif
+
+    auto executable_dir = fs::weakly_canonical(executable).parent_path();
+    if (executable_dir.filename() == "bin") {
+        return executable_dir.parent_path();
+    } else {
+        // On Windows, we may find ourselves in the top-level directory without a bin/
+        return executable_dir;
+    }
 }
 
 }
 
-std::string nmodl::PathHelper::nmodl_home = maybe_from_env("NMODL_HOME");
+const std::string nmodl::PathHelper::NMODL_HOME = maybe_from_env("NMODL_HOME");
 
 std::string nmodl::PathHelper::get_path(const std::string& what, bool add_library_suffix) {
     std::vector<std::string> search_paths = BASE_SEARCH_PATHS;
-    if (!nmodl_home.empty()) {
-        search_paths.emplace(search_paths.begin(), nmodl_home);
+    if (!NMODL_HOME.empty()) {
+        search_paths.emplace(search_paths.begin(), NMODL_HOME);
     }
 
     // check paths in order and return if found
@@ -71,17 +106,4 @@ std::string nmodl::PathHelper::get_path(const std::string& what, bool add_librar
     }
     err_msg << "Please try setting the NMODLHOME environment variable\n";
     throw std::runtime_error(err_msg.str());
-}
-
-void nmodl::PathHelper::setup(const std::string& executable) {
-    // We give precedence to NMODLHOME - don't override if the home is already defined
-    if (nmodl_home.empty()) {
-        auto executable_dir = fs::canonical(fs::path(executable)).parent_path();
-        if (executable_dir.filename() == "bin") {
-            nmodl_home = executable_dir.parent_path();
-        } else {
-            // On Windows, we may find ourselves in the top-level directory without a bin/
-            nmodl_home = executable_dir;
-        }
-    }
 }

--- a/src/config/config.cpp.in
+++ b/src/config/config.cpp.in
@@ -39,6 +39,7 @@ const std::string nmodl::Version::NMODL_VERSION = "@PROJECT_VERSION@";
 const std::vector<std::string> nmodl::PathHelper::BASE_SEARCH_PATHS =
     {"@CMAKE_INSTALL_PREFIX@", "@NMODL_PROJECT_BINARY_DIR@"};
 
+const std::string nmodl::PathHelper::SHARED_LIBRARY_PREFIX = "@CMAKE_SHARED_LIBRARY_PREFIX@";
 const std::string nmodl::PathHelper::SHARED_LIBRARY_SUFFIX = "@CMAKE_SHARED_LIBRARY_SUFFIX@";
 
 namespace {
@@ -71,10 +72,10 @@ std::string maybe_from_env(const std::string& varname) {
 
     auto executable_dir = fs::weakly_canonical(executable).parent_path();
     if (executable_dir.filename() == "bin") {
-        return executable_dir.parent_path();
+        return executable_dir.parent_path().string();
     } else {
         // On Windows, we may find ourselves in the top-level directory without a bin/
-        return executable_dir;
+        return executable_dir.string();
     }
 }
 
@@ -82,7 +83,7 @@ std::string maybe_from_env(const std::string& varname) {
 
 const std::string nmodl::PathHelper::NMODL_HOME = maybe_from_env("NMODL_HOME");
 
-std::string nmodl::PathHelper::get_path(const std::string& what, bool add_library_suffix) {
+std::string nmodl::PathHelper::get_path(const std::string& what, bool is_library) {
     std::vector<std::string> search_paths = BASE_SEARCH_PATHS;
     if (!NMODL_HOME.empty()) {
         search_paths.emplace(search_paths.begin(), NMODL_HOME);
@@ -90,9 +91,11 @@ std::string nmodl::PathHelper::get_path(const std::string& what, bool add_librar
 
     // check paths in order and return if found
     for (const auto& path: search_paths) {
-        auto full_path = fs::path(path) / fs::path(what);
-        if (add_library_suffix) {
-            full_path += SHARED_LIBRARY_SUFFIX;
+        auto full_path = fs::path(path);
+        if (is_library) {
+            full_path /= SHARED_LIBRARY_PREFIX + what + SHARED_LIBRARY_SUFFIX;
+        } else {
+            full_path /= what;
         }
         std::ifstream f(full_path);
         if (f.good()) {

--- a/src/config/config.cpp.in
+++ b/src/config/config.cpp.in
@@ -61,7 +61,7 @@ std::string maybe_from_env(const std::string& varname) {
 #elif defined(__APPLE__)
     char buffer[PATH_MAX + 1];
     uint32_t bufsize = PATH_MAX + 1;
-    if( _NSGetExecutablePath(buf, &bufsize) != 0) {
+    if( _NSGetExecutablePath(buffer, &bufsize) != 0) {
         return "";
     }
     auto executable = fs::read_symlink(buffer);

--- a/src/config/config.cpp.in
+++ b/src/config/config.cpp.in
@@ -49,8 +49,8 @@ std::string nmodl::PathHelper::nmodl_home = maybe_from_env("NMODL_HOME");
 
 std::string nmodl::PathHelper::get_path(const std::string& what, bool add_library_suffix) {
     std::vector<std::string> search_paths = BASE_SEARCH_PATHS;
-    if (!get_home().empty()) {
-        search_paths.emplace(search_paths.begin(), get_home());
+    if (!nmodl_home.empty()) {
+        search_paths.emplace(search_paths.begin(), nmodl_home);
     }
 
     // check paths in order and return if found

--- a/src/config/config.cpp.in
+++ b/src/config/config.cpp.in
@@ -7,13 +7,18 @@
 
 #include "config/config.h"
 
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+namespace fs = std::filesystem;
+
 /// Git version of the project
 const std::string nmodl::Version::GIT_REVISION = "@NMODL_GIT_REVISION@";
 
 /// NMODL version
 const std::string nmodl::Version::NMODL_VERSION = "@PROJECT_VERSION@";
-
-const std::string nmodl::CMakeInfo::SHARED_LIBRARY_SUFFIX = "@CMAKE_SHARED_LIBRARY_SUFFIX@";
 
 /**
  * \brief Path of nrnutils.lib file
@@ -23,5 +28,60 @@ const std::string nmodl::CMakeInfo::SHARED_LIBRARY_SUFFIX = "@CMAKE_SHARED_LIBRA
  * from CMAKE_INSTALL_PREFIX. Note that this use of NMODL_PROJECT_BINARY_DIR
  * will cause ccache misses when the build prefix is changed.
  */
-std::vector<std::string> nmodl::NrnUnitsLib::NRNUNITSLIB_PATH =
-    {"@CMAKE_INSTALL_PREFIX@/share/nmodl/nrnunits.lib", "@NMODL_PROJECT_BINARY_DIR@/share/nmodl/nrnunits.lib"};
+const std::vector<std::string> nmodl::PathHelper::BASE_SEARCH_PATHS =
+    {"@CMAKE_INSTALL_PREFIX@", "@NMODL_PROJECT_BINARY_DIR@"};
+
+const std::string nmodl::PathHelper::SHARED_LIBRARY_SUFFIX = "@CMAKE_SHARED_LIBRARY_SUFFIX@";
+
+namespace {
+
+std::string maybe_from_env(const std::string& varname) {
+    const auto value = std::getenv(varname.c_str());
+    if (value != nullptr) {
+        return value;
+    }
+    return "";
+}
+
+}
+
+std::string nmodl::PathHelper::nmodl_home = maybe_from_env("NMODL_HOME");
+
+std::string nmodl::PathHelper::get_path(const std::string& what, bool add_library_suffix) {
+    std::vector<std::string> search_paths = BASE_SEARCH_PATHS;
+    if (!get_home().empty()) {
+        search_paths.emplace(search_paths.begin(), get_home());
+    }
+
+    // check paths in order and return if found
+    for (const auto& path: search_paths) {
+        auto full_path = fs::path(path) / fs::path(what);
+        if (add_library_suffix) {
+            full_path += SHARED_LIBRARY_SUFFIX;
+        }
+        std::ifstream f(full_path);
+        if (f.good()) {
+            return full_path;
+        }
+    }
+    std::ostringstream err_msg;
+    err_msg << "Could not find '" << what << "' in any of:\n";
+    for (const auto& path: search_paths) {
+        err_msg << "\t" << path << "\n";
+    }
+    err_msg << "Please try setting the NMODLHOME environment variable\n";
+    throw std::runtime_error(err_msg.str());
+}
+
+void nmodl::PathHelper::setup(const std::string& executable) {
+    // We give precedence to NMODLHOME - don't override if the home is already defined
+    if (nmodl_home.empty()) {
+        auto executable_dir = fs::canonical(fs::path(executable)).parent_path();
+        if (executable_dir.filename() == "bin") {
+            nmodl_home = executable_dir.parent_path();
+        } else {
+            // On Windows, we may find ourselves in the top-level directory without a bin/
+            nmodl_home = executable_dir;
+        }
+    }
+}

--- a/src/config/config.cpp.in
+++ b/src/config/config.cpp.in
@@ -13,7 +13,7 @@
 #include <sstream>
 
 #if defined(_WIN32)
-#include <stdio.h>
+#include <windows.h>
 #elif defined(__APPLE__)
 #include <limits.h>
 #include <mach-o/dyld.h>
@@ -50,7 +50,7 @@ std::string maybe_from_env(const std::string& varname) {
     }
 
 #if defined(_WIN32)
-    std::vector<wchar_t> buffer;
+    std::vector<char> buffer;
     DWORD copied = 0;
     do {
         buffer.resize(buffer.size() + MAX_PATH);

--- a/src/config/config.cpp.in
+++ b/src/config/config.cpp.in
@@ -64,7 +64,7 @@ std::string maybe_from_env(const std::string& varname) {
     if( _NSGetExecutablePath(buffer, &bufsize) != 0) {
         return "";
     }
-    auto executable = fs::read_symlink(buffer);
+    auto executable = fs::path(buffer);
 #else
     auto executable = fs::read_symlink("/proc/self/exe");
 #endif

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -49,7 +49,7 @@ class PathHelper {
     const static std::string SHARED_LIBRARY_SUFFIX;
 
     /// base directory of the NMODL installation
-    static std::string nmodl_home;
+    const static std::string NMODL_HOME;
 
     /**
      * Search for a given relative file path
@@ -57,12 +57,6 @@ class PathHelper {
     static std::string get_path(const std::string& what, bool add_library_suffix = false);
 
   public:
-    /**
-     * Set the NMODL base installation directory from the executable if not defined in the
-     * environment
-     */
-    static void setup(const std::string& executable);
-
     /**
      * Return path of units database file
      */

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -64,13 +64,6 @@ class PathHelper {
     static void setup(const std::string& executable);
 
     /**
-     * Return the NMODL base installation directory
-     */
-    static std::string get_home() {
-        return nmodl_home;
-    }
-
-    /**
      * Return path of units database file
      */
     static std::string get_units_path() {

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -54,7 +54,7 @@ class PathHelper {
     /**
      * Search for a given relative file path
      */
-    static std::string get_path(const std::string& what, bool add_library_suffix=false);
+    static std::string get_path(const std::string& what, bool add_library_suffix = false);
 
   public:
     /**

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -15,9 +15,6 @@
  * \brief Version information and units file path
  */
 
-#include <cstdlib>
-#include <fstream>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -44,38 +41,48 @@ struct Version {
 /**
  * \brief Information of units database i.e. `nrnunits.lib`
  */
-struct NrnUnitsLib {
-    /// paths where nrnunits.lib can be found
-    static std::vector<std::string> NRNUNITSLIB_PATH;
+class PathHelper {
+    /// pre-defined paths to search for files
+    const static std::vector<std::string> BASE_SEARCH_PATHS;
+
+    /// suffix to use when looking for libraries
+    const static std::string SHARED_LIBRARY_SUFFIX;
+
+    /// base directory of the NMODL installation
+    static std::string nmodl_home;
+
+    /**
+     * Search for a given relative file path
+     */
+    static std::string get_path(const std::string& what, bool add_library_suffix=false);
+
+  public:
+    /**
+     * Set the NMODL base installation directory from the executable if not defined in the
+     * environment
+     */
+    static void setup(const std::string& executable);
+
+    /**
+     * Return the NMODL base installation directory
+     */
+    static std::string get_home() {
+        return nmodl_home;
+    }
 
     /**
      * Return path of units database file
      */
-    static std::string get_path() {
-        // first look for NMODLHOME env variable
-        if (const char* nmodl_home = std::getenv("NMODLHOME")) {
-            auto path = std::string(nmodl_home) + "/share/nmodl/nrnunits.lib";
-            NRNUNITSLIB_PATH.emplace(NRNUNITSLIB_PATH.begin(), path);
-        }
+    static std::string get_units_path() {
+        return get_path("share/nmodl/nrnunits.lib");
+    };
 
-        // check paths in order and return if found
-        for (const auto& path: NRNUNITSLIB_PATH) {
-            std::ifstream f(path.c_str());
-            if (f.good()) {
-                return path;
-            }
-        }
-        std::ostringstream err_msg;
-        err_msg << "Could not find nrnunits.lib in any of:\n";
-        for (const auto& path: NRNUNITSLIB_PATH) {
-            err_msg << path << "\n";
-        }
-        throw std::runtime_error(err_msg.str());
-    }
-};
-
-struct CMakeInfo {
-    static const std::string SHARED_LIBRARY_SUFFIX;
+    /**
+     * Return path of the python wrapper library
+     */
+    static std::string get_wrapper_path() {
+        return get_path("lib/libpywrapper", true);
+    };
 };
 
 }  // namespace nmodl

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -45,6 +45,9 @@ class PathHelper {
     /// pre-defined paths to search for files
     const static std::vector<std::string> BASE_SEARCH_PATHS;
 
+    /// prefix to use when looking for libraries
+    const static std::string SHARED_LIBRARY_PREFIX;
+
     /// suffix to use when looking for libraries
     const static std::string SHARED_LIBRARY_SUFFIX;
 
@@ -54,7 +57,7 @@ class PathHelper {
     /**
      * Search for a given relative file path
      */
-    static std::string get_path(const std::string& what, bool add_library_suffix = false);
+    static std::string get_path(const std::string& what, bool is_library = false);
 
   public:
     /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,8 +62,6 @@ using nmodl::parser::NmodlDriver;
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 int main(int argc, const char* argv[]) {
-    PathHelper::setup(argv[0]);
-
     CLI::App app{fmt::format("NMODL : Source-to-Source Code Generation Framework [{}]",
                              Version::to_string())};
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,6 +62,8 @@ using nmodl::parser::NmodlDriver;
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 int main(int argc, const char* argv[]) {
+    PathHelper::setup(argv[0]);
+
     CLI::App app{fmt::format("NMODL : Source-to-Source Code Generation Framework [{}]",
                              Version::to_string())};
 
@@ -142,7 +144,7 @@ int main(int argc, const char* argv[]) {
     std::string scratch_dir("tmp");
 
     /// directory where units lib file is located
-    std::string units_dir(NrnUnitsLib::get_path());
+    std::string units_dir(PathHelper::get_units_path());
 
     /// true if ast should be converted to json
     bool json_ast(false);

--- a/src/parser/main_units.cpp
+++ b/src/parser/main_units.cpp
@@ -28,7 +28,7 @@ int main(int argc, const char* argv[]) {
         fmt::format("Unit-Parser : Standalone Parser for Units({})", Version::to_string())};
 
     std::vector<std::string> units_files;
-    units_files.push_back(NrnUnitsLib::get_path());
+    units_files.push_back(PathHelper::get_units_path());
     app.add_option("units_files", units_files, "One or more Units files to process");
 
     CLI11_PARSE(app, argc, argv);

--- a/src/pybind/pyembed.cpp
+++ b/src/pybind/pyembed.cpp
@@ -81,21 +81,15 @@ void EmbeddedPythonLoader::load_libraries() {
 
     assert_compatible_python_versions();
 
-    if (std::getenv("NMODLHOME") == nullptr) {
+    if (PathHelper::get_home().empty()) {
         logger->critical("NMODLHOME environment variable must be set to load embedded python");
         throw std::runtime_error("NMODLHOME not set");
     }
-    auto pybind_wraplib_env = fs::path(std::getenv("NMODLHOME")) / "lib" / "libpywrapper";
-    pybind_wraplib_env.concat(CMakeInfo::SHARED_LIBRARY_SUFFIX);
-    if (!fs::exists(pybind_wraplib_env)) {
-        logger->critical("NMODLHOME doesn't contain libpywrapper{} library",
-                         CMakeInfo::SHARED_LIBRARY_SUFFIX);
-        throw std::runtime_error("NMODLHOME doesn't have lib/libpywrapper library");
-    }
+    auto pybind_wraplib_env = PathHelper::get_wrapper_path();
     pybind_wrapper_handle = dlopen(pybind_wraplib_env.c_str(), dlopen_opts);
     if (!pybind_wrapper_handle) {
         const auto errstr = dlerror();
-        logger->critical("Tried but failed to load {}", pybind_wraplib_env.string());
+        logger->critical("Tried but failed to load {}", pybind_wraplib_env);
         logger->critical(errstr);
         throw std::runtime_error("Failed to dlopen");
     }

--- a/src/pybind/pyembed.cpp
+++ b/src/pybind/pyembed.cpp
@@ -82,8 +82,7 @@ void EmbeddedPythonLoader::load_libraries() {
     assert_compatible_python_versions();
 
     auto pybind_wraplib_env = PathHelper::get_wrapper_path();
-    std::string env_str = pybind_wraplib_env.string();
-    pybind_wrapper_handle = dlopen(env_str.c_str(), dlopen_opts);
+    pybind_wrapper_handle = dlopen(pybind_wraplib_env.c_str(), dlopen_opts);
     if (!pybind_wrapper_handle) {
         const auto errstr = dlerror();
         logger->critical("Tried but failed to load {}", pybind_wraplib_env);

--- a/src/pybind/pyembed.cpp
+++ b/src/pybind/pyembed.cpp
@@ -81,10 +81,6 @@ void EmbeddedPythonLoader::load_libraries() {
 
     assert_compatible_python_versions();
 
-    if (PathHelper::get_home().empty()) {
-        logger->critical("NMODLHOME environment variable must be set to load embedded python");
-        throw std::runtime_error("NMODLHOME not set");
-    }
     auto pybind_wraplib_env = PathHelper::get_wrapper_path();
     pybind_wrapper_handle = dlopen(pybind_wraplib_env.c_str(), dlopen_opts);
     if (!pybind_wrapper_handle) {

--- a/src/visitors/main.cpp
+++ b/src/visitors/main.cpp
@@ -95,7 +95,7 @@ int main(int argc, const char* argv[]) {
          "SympyConductanceVisitor"},
         {std::make_shared<SympySolverVisitor>(), "sympy-solve", "SympySolverVisitor"},
         {std::make_shared<NeuronSolveVisitor>(), "neuron-solve", "NeuronSolveVisitor"},
-        {std::make_shared<UnitsVisitor>(NrnUnitsLib::get_path()), "units", "UnitsVisitor"},
+        {std::make_shared<UnitsVisitor>(PathHelper::get_units_path()), "units", "UnitsVisitor"},
     };
 
     const std::vector<ConstVisitorInfo> const_visitors = {

--- a/test/unit/units/parser.cpp
+++ b/test/unit/units/parser.cpp
@@ -33,7 +33,7 @@ bool is_valid_construct(const std::string& construct) {
 
 std::string parse_string(const std::string& unit_definition) {
     nmodl::parser::UnitDriver correctness_driver;
-    correctness_driver.parse_file(nmodl::NrnUnitsLib::get_path());
+    correctness_driver.parse_file(nmodl::PathHelper::get_units_path());
     correctness_driver.parse_string(unit_definition);
     std::stringstream ss;
     correctness_driver.table->print_units_sorted(ss);

--- a/test/unit/visitor/units.cpp
+++ b/test/unit/visitor/units.cpp
@@ -36,7 +36,7 @@ std::tuple<std::shared_ptr<ast::Program>, std::shared_ptr<units::UnitTable>> run
     const auto& ast = driver.get_ast();
 
     // Parse nrnunits.lib file and the UNITS block of the mod file
-    const std::string units_lib_path(NrnUnitsLib::get_path());
+    const std::string units_lib_path(PathHelper::get_units_path());
     UnitsVisitor units_visitor = UnitsVisitor(units_lib_path);
 
     units_visitor.visit_program(*ast);


### PR DESCRIPTION
We currently rely on two files being present in predefined directories:

* `nrnunits.lib`
* `libpywrapper.so` (or similar)

These are searched for in:

* CMake's binary directory for NMODL
* CMake's install directory for NMODL
* The environment variable `NMODLHOME`

Leading to some acrobatics to always set `NMODLHOME` correctly.  This PR attempts to also find the above files relative to the NMODL executable, in the hope that some use cases of `NMODLHOME` can be removed.

It will now also treat `nrnunits.lib` and `libpywrapper.so` the same, before only the former was looked for in multiple directories, while the latter relied on the environment variable.