### PR TITLE
Install pywrapper even as a submodule.

### DIFF
--- a/src/pybind/CMakeLists.txt
+++ b/src/pybind/CMakeLists.txt
@@ -113,7 +113,7 @@ file(COPY ${NMODL_PROJECT_SOURCE_DIR}/python/nmodl/ext DESTINATION ${CMAKE_BINAR
 # things are installed twice with the wheel and in weird places. Let's just
 # move the .so libs
 # ~~~
-if(NOT LINK_AGAINST_PYTHON AND NOT NMODL_AS_SUBPROJECT)
+if(NOT LINK_AGAINST_PYTHON)
   install(TARGETS pywrapper DESTINATION ${NMODL_INSTALL_DIR_SUFFIX}lib)
   if(NMODL_ENABLE_PYTHON_BINDINGS)
     install(TARGETS _nmodl DESTINATION nmodl/)


### PR DESCRIPTION
Should avoid the upstream CMake having to deal with installing NMODL
internals.
