### PR TITLE
Don't print `int*` range variables.

### DIFF
--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -1343,8 +1343,7 @@ void CodegenNeuronCppVisitor::print_mechanism_range_var_structure(bool print_ini
         if (name == naming::POINT_PROCESS_VARIABLE) {
             continue;
         } else if (var.is_index || var.is_integer) {
-            auto qualifier = var.is_constant ? "const " : "";
-            printer->fmt_line("{}{}* const* {}{};", qualifier, int_type, name, value_initialize);
+            // In NEURON we don't create caches for `int*`. Hence, do nothing.
         } else {
             auto qualifier = var.is_constant ? "const " : "";
             auto type = var.is_vdata ? "void*" : default_float_data_type();

--- a/test/usecases/useion/style_ion.mod
+++ b/test/usecases/useion/style_ion.mod
@@ -1,0 +1,18 @@
+: This checks for a code-generation bug that resulted in a faulty ctor
+: call. It requires an ion to have a "style", followed by other ions.
+
+NEURON {
+    SUFFIX style_ion
+    USEION ca WRITE cai, eca
+    USEION na READ nai
+}
+
+ASSIGNED {
+  cai
+  eca
+  nai
+}
+
+INITIAL {
+    cai = 42.0
+}


### PR DESCRIPTION
Since `int*` range variables aren't cached (only `double *` are), there's no pointer we can make the `int**` point to. So far we only see these for `style_` variables.