### PR TITLE
Fix RANGE PARAMETER defaults.

### DIFF
--- a/docs/contents/globals.rst
+++ b/docs/contents/globals.rst
@@ -176,6 +176,31 @@ Collection of slightly surprising behaviour:
     the code ``nocmodl`` produces will cause a SEGFAULT.
 
 
+PARAMETER variables
+===================
+
+These can be either RANGE or not RANGE. They can be both read and write. If
+they're written to, they're converted to thread-variables. Therefore, the rest
+of this section will only describe read-only PARAMETERs.
+
+Additionally, parameters optionally have: a) a default value, b) units and c) a
+valid range.
+
+Default Values
+~~~~~~~~~~~~~~
+This section only applies to read-only PARAMETERs.
+
+The behaviour differs for RANGE variables and non-RANGE variables. For RANGE
+variables, default values need to be registered with NEURON for all PARAMETERs
+that are RANGE variables. The function is called ``hoc_register_parm_default``.
+
+Note, that NOCMODL uses it in the ``nrn_alloc`` in the generated `.cpp` files
+and also in ``ndatclas.cpp``. Therefore, it seems registering the values isn't
+optional.
+
+Non-RANGE variables are semantically equivalent to ``static double``. They're
+simply assigned their value in the definition of the global variable.
+
 CONSTANT variables
 ==================
 

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -470,6 +470,9 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
      */
     void print_global_variables_for_hoc() override;
 
+    /** Print global struct with default value of RANGE PARAMETERs.
+     */
+    void print_global_param_default_values();
 
     /**
      * Print the mechanism registration function

--- a/test/usecases/parameter/default_parameter.mod
+++ b/test/usecases/parameter/default_parameter.mod
@@ -1,0 +1,14 @@
+NEURON {
+   SUFFIX default_parameter
+   RANGE x, y, z
+   GLOBAL a
+}
+
+PARAMETER {
+    a
+    b = 0.1
+
+    x
+    y = 2.1
+    z
+}

--- a/test/usecases/parameter/test_default.py
+++ b/test/usecases/parameter/test_default.py
@@ -1,0 +1,55 @@
+from neuron import h
+
+
+def check_defaults(obj, parameters):
+    defaults = {
+        "b": 0.1,
+        "y": 2.1,
+    }
+
+    for p in parameters:
+        actual = getattr(obj, f"{p}_default_parameter")
+        expected = defaults.get(p, 0.0)
+        assert actual == expected
+
+
+def test_default_values():
+    nseg = 10000
+
+    s = h.Section()
+    s.nseg = nseg
+    s.insert("default_parameter")
+
+    static_parameters = ["a", "b"]
+    range_parameters = ["x", "y", "z"]
+
+    check_defaults(h, static_parameters)
+    for seg in s:
+        check_defaults(seg, range_parameters)
+
+    h.finitialize()
+
+    check_defaults(h, static_parameters)
+    for seg in s:
+        check_defaults(seg, range_parameters)
+
+
+def test_parcom_regression():
+    # This is a roundabout way of triggering a codepath leading to
+    # NrnProperyImpl. In NrnProperyImpl we iterate over the std::vector of
+    # default values. Hence, it requires that the default values are registered
+    # correctly.
+
+    nseg = 5
+
+    s = h.Section()
+    s.nseg = nseg
+    s.insert("default_parameter")
+
+    # Caused a SEGFAULT:
+    h.load_file("parcom.hoc")
+
+
+if __name__ == "__main__":
+    test_default_values()
+    test_parcom_regression()


### PR DESCRIPTION
PARAMETERs that are RANGE variables need to register their default
values, because NEURON needs to be able to initialize the parameters
with their default values.

This commits adds the registration code, and sets defaults in
`nrn_alloc` from the same array.