### PR TITLE
Remove unnecessary warning messages

### DIFF
--- a/src/symtab/symbol_table.cpp
+++ b/src/symtab/symbol_table.cpp
@@ -206,15 +206,19 @@ void ModelSymbolTable::emit_message(const std::shared_ptr<Symbol>& first,
     }
 
     if (redefinition) {
-        std::string msg = "Re-declaration of " + name + " [" + type + "]";
-        msg += "<" + properties + "> in " + current_symtab->name();
-        msg += " with one in " + second->get_scope();
+        auto msg = fmt::format("Re-declaration of {} [{}] <{}> in {} with one in {}",
+                               name,
+                               type,
+                               properties,
+                               current_symtab->name(),
+                               second->get_scope());
         throw std::runtime_error(msg);
     }
-    std::string msg = "SYMTAB :: " + name + " [" + type + "] in ";
-    msg += current_symtab->name() + " shadows <" + properties;
-    msg += "> definition in " + second->get_scope();
-    logger->debug(msg);
+    logger->debug("SYMTAB :: {} [{}] in {} shadows <{}> definition in {}",
+                 name,
+                 type,
+                 current_symtab->name(),
+                 properties);
 }
 
 

--- a/src/symtab/symbol_table.cpp
+++ b/src/symtab/symbol_table.cpp
@@ -215,10 +215,10 @@ void ModelSymbolTable::emit_message(const std::shared_ptr<Symbol>& first,
         throw std::runtime_error(msg);
     }
     logger->debug("SYMTAB :: {} [{}] in {} shadows <{}> definition in {}",
-                 name,
-                 type,
-                 current_symtab->name(),
-                 properties);
+                  name,
+                  type,
+                  current_symtab->name(),
+                  properties);
 }
 
 

--- a/src/symtab/symbol_table.cpp
+++ b/src/symtab/symbol_table.cpp
@@ -192,10 +192,7 @@ std::shared_ptr<Symbol> ModelSymbolTable::lookup(const std::string& name) {
 }
 
 
-/**
- *  Emit warning message for shadowing definition or throw an exception
- *  if variable is being redefined in the same block.
- */
+//  show symbol table related message for debugging purposes
 void ModelSymbolTable::emit_message(const std::shared_ptr<Symbol>& first,
                                     const std::shared_ptr<Symbol>& second,
                                     bool redefinition) {
@@ -217,7 +214,7 @@ void ModelSymbolTable::emit_message(const std::shared_ptr<Symbol>& first,
     std::string msg = "SYMTAB :: " + name + " [" + type + "] in ";
     msg += current_symtab->name() + " shadows <" + properties;
     msg += "> definition in " + second->get_scope();
-    logger->warn(msg);
+    logger->debug(msg);
 }
 
 

--- a/src/visitors/inline_visitor.cpp
+++ b/src/visitors/inline_visitor.cpp
@@ -132,7 +132,7 @@ bool InlineVisitor::inline_function_call(ast::Block& callee,
 
     /// do nothing if we can't inline given procedure/function
     if (!can_inline_block(*callee.get_statement_block())) {
-        logger->warn("Can not inline function call to {}", function_name);
+        logger->debug("Can not inline function call to {}", function_name);
         return false;
     }
 


### PR DESCRIPTION
- Looking at the typical warnings produced by NMODL, two that I find spurious:

  * Defining a variable of the same name in a new scope ("shadowing").
  * Unable to inline a function or procedure.

- Both of these should not be warnings. The first is perfectly acceptable, and the second can occur in cases where TABLE is used. Emitting these warnings is more misleading than helpful IMO.

- We are converting these two warnings to debug level messages as it might be helpful to know these situations while debugging.

- An example from the Snudda model:

```
[NMODL] [warning] :: SYMTAB :: ca [Argument] in rate shadows <ion> definition in NMODL_GLOBAL
[NMODL] [warning] :: SYMTAB :: ca [Argument] in rate shadows <ion> definition in NMODL_GLOBAL
[NMODL] [warning] :: SYMTAB :: cai [Argument] in h2 shadows <parameter read_ion> definition in NMODL_GLOBAL
[NMODL] [warning] :: SYMTAB :: celsius [Argument] in KTF shadows <parameter extern_neuron_var> definition in NMODL_GLOBAL
[NMODL] [warning] :: SYMTAB :: cai [Argument] in h2 shadows <parameter read_ion> definition in NMODL_GLOBAL
[NMODL] [warning] :: Can not inline function call to alp
[NMODL] [warning] :: Can not inline function call to alp
[NMODL] [warning] :: Can not inline function call to exptable
[NMODL] [warning] :: Can not inline function call to exptable
[NMODL] [warning] :: Can not inline function call to exptable
[NMODL] [warning] :: SYMTAB :: t [Argument] in init_sequence shadows <extern_neuron_var> definition in NMODL_GLOBAL
[NMODL] [warning] :: SYMTAB :: ca [Argument] in rate shadows <ion> definition in NMODL_GLOBAL
[NMODL] [warning] :: SYMTAB :: ca [Argument] in rate shadows <ion> definition in NMODL_GLOBAL
[NMODL] [warning] :: SYMTAB :: ca [Argument] in rate shadows <ion> definition in NMODL_GLOBAL
[NMODL] [warning] :: CVode solver of icur in 64.20-30 replaced with cnexp solver
[NMODL] [warning] :: SYMTAB :: mggate [LocalVar] in StatementBlock1 shadows <range> definition in NMODL_GLOBAL
[NMODL] [warning] :: SYMTAB :: mggate [LocalVar] in StatementBlock18 shadows <range> definition in NMODL_GLOBAL
[NMODL] [warning] :: SYMTAB :: itot_nmda [LocalVar] in StatementBlock1 shadows <range> definition in NMODL_GLOBAL
...
```