### PR TITLE
Fix `net_send` and `net_move` for ARTIFICIAL_CELLs.

### DIFF
--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -2160,7 +2160,8 @@ void CodegenNeuronCppVisitor::print_net_send_call(const ast::FunctionCall& node)
     }
     const auto& tqitem = get_variable_name("tqitem", /* use_instance */ false);
 
-    printer->fmt_text("net_send(/* tqitem */ &{}, {}, {}, {} + ",
+    printer->fmt_text("{}(/* tqitem */ &{}, {}, {}, {} + ",
+                      info.artificial_cell ? "artcell_net_send" : "net_send",
                       tqitem,
                       weight_pointer,
                       point_process,

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -2174,7 +2174,10 @@ void CodegenNeuronCppVisitor::print_net_move_call(const ast::FunctionCall& node)
     const auto& point_process = get_variable_name("point_process", /* use_instance */ false);
     const auto& tqitem = get_variable_name("tqitem", /* use_instance */ false);
 
-    printer->fmt_text("net_move(/* tqitem */ &{}, {}, ", tqitem, point_process);
+    printer->fmt_text("{}(/* tqitem */ &{}, {}, ",
+                      info.artificial_cell ? "artcell_net_move" : "net_move",
+                      tqitem,
+                      point_process);
 
     print_vector_elements(node.get_arguments(), ", ");
     printer->add_text(')');

--- a/test/unit/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/test/unit/codegen/codegen_neuron_cpp_visitor.cpp
@@ -209,3 +209,39 @@ SCENARIO("Read `eca`.", "[codegen]") {
         }
     }
 }
+
+SCENARIO("ARTIFICIAL_CELL with `net_send`") {
+    GIVEN("a mod file") {
+        std::string nmodl = R"(
+            NEURON {
+                ARTIFICIAL_CELL test
+            }
+            NET_RECEIVE(w) {
+                net_send(t+1, 1)
+            }
+        )";
+        std::string cpp = transpile(nmodl);
+
+        THEN("it contains") {
+            REQUIRE_THAT(cpp, ContainsSubstring("artcell_net_send"));
+        }
+    }
+}
+
+SCENARIO("ARTIFICIAL_CELL with `net_move`") {
+    GIVEN("a mod file") {
+        std::string nmodl = R"(
+            NEURON {
+                ARTIFICIAL_CELL test
+            }
+            NET_RECEIVE(w) {
+                net_move(t+1)
+            }
+        )";
+        std::string cpp = transpile(nmodl);
+
+        THEN("it contains") {
+            REQUIRE_THAT(cpp, ContainsSubstring("artcell_net_move"));
+        }
+    }
+}


### PR DESCRIPTION
For `net_send` and `net_move` we need to call `artcell_*`. This enables using a
self queue. Since this is an optimization it's hard to test functionally. Hence, we
only perform a crude check that `artcell_*` exist in the generated C++ file.