### PR TITLE
Initial attempt at implementing VERBATIM.

### DIFF
--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -123,7 +123,6 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
      */
     std::string process_verbatim_token(const std::string& token);
 
-
     /**
      * Check if variable is qualified as constant
      * \param name The name of variable

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -13,6 +13,7 @@
 #include "ast/all.hpp"
 #include "codegen/codegen_helper_visitor.hpp"
 #include "codegen/codegen_utils.hpp"
+#include "utils/string_utils.hpp"
 #include "visitors/defuse_analyze_visitor.hpp"
 #include "visitors/rename_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -169,6 +169,10 @@ struct ShadowUseStatement {
     std::string rhs;
 };
 
+inline std::string get_name(ast::Ast const* sym) {
+    return sym->get_node_name();
+}
+
 inline std::string get_name(const std::shared_ptr<symtab::Symbol>& sym) {
     return sym->get_name();
 }

--- a/src/codegen/codegen_naming.hpp
+++ b/src/codegen/codegen_naming.hpp
@@ -176,8 +176,26 @@ static constexpr char NRN_WATCH_CHECK_METHOD[] = "nrn_watch_check";
 /// verbatim name of the variable for nrn thread arguments
 static constexpr char THREAD_ARGS[] = "_threadargs_";
 
+/// verbatim name of the variable for nrn thread arguments, sometimes with trailing comma
+static constexpr char THREAD_ARGS_COMMA[] = "_threadargscomma_";
+
 /// verbatim name of the variable for nrn thread arguments in prototype
 static constexpr char THREAD_ARGS_PROTO[] = "_threadargsproto_";
+
+/// verbatim name of the variable for nrn thread arguments in prototype and a comma
+static constexpr char THREAD_ARGS_PROTO_COMMA[] = "_threadargsprotocomma_";
+
+/// variation of `_threadargs_` for "internal" functions.
+static constexpr char INTERNAL_THREAD_ARGS[] = "_internalthreadargs_";
+
+/// variation of `_threadargs_` for "internal" functions, with comma (maybe).
+static constexpr char INTERNAL_THREAD_ARGS_COMMA[] = "_internalthreadargscomma_";
+
+/// variation of `_threadargsproto_` for "internal" functions.
+static constexpr char INTERNAL_THREAD_ARGS_PROTO[] = "_internalthreadargsproto_";
+
+/// variation of `_threadargsproto_` for "internal" functions, possibly with comma.
+static constexpr char INTERNAL_THREAD_ARGS_PROTO_COMMA[] = "_internalthreadargsprotocomma_";
 
 /// prefix for ion variable
 static constexpr char ION_VARNAME_PREFIX[] = "ion_";

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -739,7 +739,7 @@ std::vector<std::string> CodegenNeuronCppVisitor::print_verbatim_setup(
         print_macro(fmt::format("_l{}", mod_name), get_variable_name(current_name));
     }
 
-    print_macro("t", "nt->_t");
+    print_macro(naming::NTHREAD_T_VARIABLE, "nt->_t");
     print_macro("_nt", "nt");
     print_macro("_tqitem", "tqitem");
 

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -669,9 +669,11 @@ std::vector<std::string> CodegenNeuronCppVisitor::print_verbatim_setup(
         print_macro(name, get_variable_name(name));
     }
 
-    for (const auto& var: codegen_int_variables) {
+    for (size_t i = 0; i < codegen_int_variables.size(); ++i) {
+        const auto& var = codegen_int_variables[i];
         auto name = get_name(var);
-        print_macro(name, get_variable_name(name));
+        std::string macro_value = get_variable_name(name);
+        print_macro(name, macro_value);
         if (verbatim.find("_p_" + name) != std::string::npos) {
             print_macro("_p_" + name, get_pointer_name(name));
         }
@@ -680,6 +682,7 @@ std::vector<std::string> CodegenNeuronCppVisitor::print_verbatim_setup(
     for (const auto& func: info.functions) {
         auto name = get_name(func);
         print_macro(name, method_name(name));
+        print_macro(fmt::format("_l{}", name), fmt::format("ret_{}", name));
     }
 
     for (const auto& proc: info.procedures) {

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -2546,6 +2546,7 @@ void CodegenNeuronCppVisitor::print_codegen_routines_regular() {
     print_point_process_function_definitions();
     print_setdata_functions();
     print_check_table_entrypoint();
+    print_top_verbatim_blocks();
     print_functors_definitions();
     print_global_variables_for_hoc();
     print_thread_memory_callbacks();

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -678,6 +678,16 @@ std::vector<std::string> CodegenNeuronCppVisitor::print_verbatim_setup(
         }
     }
 
+    for (const auto& var : codegen_global_variables) {
+        auto name = get_name(var);
+        print_macro(name, get_variable_name(name));
+    }
+
+    for (const auto& var : codegen_thread_variables) {
+        auto name = get_name(var);
+        print_macro(name, get_variable_name(name));
+    }
+
     for (const auto& func: info.functions) {
         auto name = get_name(func);
         print_macro(name, method_name(name));

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -647,22 +647,25 @@ CodegenNeuronCppVisitor::function_table_parameters(const ast::FunctionTableBlock
 }
 
 
-std::unordered_map<std::string, std::string> get_nonglobal_local_variable_names(const symtab::SymbolTable& symtab) {
-    if(symtab.global_scope()) {
+std::unordered_map<std::string, std::string> get_nonglobal_local_variable_names(
+    const symtab::SymbolTable& symtab) {
+    if (symtab.global_scope()) {
         return {};
     }
 
     auto local_variables = symtab.get_variables(NmodlType::local_var);
     auto parent_symtab = symtab.get_parent_table();
-    if(parent_symtab == nullptr) {
-        throw std::runtime_error("Internal NMODL error: non top-level symbol table doesn't have a parent.");
+    if (parent_symtab == nullptr) {
+        throw std::runtime_error(
+            "Internal NMODL error: non top-level symbol table doesn't have a parent.");
     }
 
     auto variable_names = get_nonglobal_local_variable_names(*parent_symtab);
 
-    for(const auto& symbol : local_variables) {
+    for (const auto& symbol: local_variables) {
         auto status = symbol->get_status();
-        bool is_renamed = (status & symtab::syminfo::Status::renamed) != symtab::syminfo::Status::empty;
+        bool is_renamed = (status & symtab::syminfo::Status::renamed) !=
+                          symtab::syminfo::Status::empty;
         auto current_name = symbol->get_name();
         auto mod_name = is_renamed ? symbol->get_original_name() : current_name;
 
@@ -671,7 +674,6 @@ std::unordered_map<std::string, std::string> get_nonglobal_local_variable_names(
 
     return variable_names;
 }
-
 
 
 std::vector<std::string> CodegenNeuronCppVisitor::print_verbatim_setup(
@@ -707,12 +709,12 @@ std::vector<std::string> CodegenNeuronCppVisitor::print_verbatim_setup(
         }
     }
 
-    for (const auto& var : codegen_global_variables) {
+    for (const auto& var: codegen_global_variables) {
         auto name = get_name(var);
         print_macro(name, get_variable_name(name));
     }
 
-    for (const auto& var : codegen_thread_variables) {
+    for (const auto& var: codegen_thread_variables) {
         auto name = get_name(var);
         print_macro(name, get_variable_name(name));
     }

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -779,10 +779,10 @@ std::string CodegenNeuronCppVisitor::process_verbatim_text(const std::string& ve
         // function is defined in the same mod file
         if (program_symtab->is_method_defined(token) && tokens[i + 1] == "(") {
             result += token + "(";
-            if (tokens[i + 2] == "_threadargs_") {
-                result += "_internalthreadargs_";
-            } else if (tokens[i + 2] == "_threadargscomma_") {
-                result += "_internalthreadargscomma_";
+            if (tokens[i + 2] == naming::THREAD_ARGS) {
+                result += naming::INTERNAL_THREAD_ARGS;
+            } else if (tokens[i + 2] == naming::THREAD_ARGS_COMMA) {
+                result += naming::INTERNAL_THREAD_ARGS_COMMA;
             } else {
                 result += tokens[i + 2];
             }

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -655,8 +655,6 @@ std::vector<std::string> CodegenNeuronCppVisitor::print_verbatim_setup(
     // essentially what NOCMODL does. Therefore, the logic isn't sharp (and
     // doesn't have to be).
 
-    auto symtab = node.get_symbol_table();
-
     std::vector<std::string> macros_defined;
     auto print_macro = [this, &verbatim, &macros_defined](const std::string& macro_name,
                                                           const std::string& macro_value) {
@@ -701,6 +699,15 @@ std::vector<std::string> CodegenNeuronCppVisitor::print_verbatim_setup(
         auto name = get_name(proc);
         print_macro(name, method_name(name));
     }
+
+
+    auto symtab = node.get_parent()->get_symbol_table();
+    auto locals = symtab->get_variables(/* with= */ NmodlType::local_var);
+    for (const auto& local: locals) {
+        std::string name = local->get_name();
+        print_macro(fmt::format("_l{}", name), get_variable_name(name));
+    }
+
 
     print_macro("t", "nt->_t");
     print_macro("_nt", "nt");

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -671,6 +671,10 @@ std::vector<std::string> CodegenNeuronCppVisitor::print_verbatim_setup(
         print_macro(name, "::neuron::" + method_name(name));
     }
 
+    if (verbatim.find("t") != std::string::npos) {
+        print_macro("t", "nt->_t");
+    }
+
     if (verbatim.find("_nt") != std::string::npos) {
         print_macro("_nt", "nt");
     }
@@ -871,12 +875,7 @@ std::string CodegenNeuronCppVisitor::get_pointer_name(const std::string& name) c
         throw std::runtime_error("Only integer variables have a 'pointer name'.");
     }
     auto position = position_of_int_var(name);
-
-    if (info.semantics[position].name == naming::RANDOM_SEMANTIC) {
-        return fmt::format("_ppvar[{}].literal_value<void*>()", position);
-    }
-
-    throw std::runtime_error(fmt::format("Unsupported variable: {}. [loicw]", name));
+    return fmt::format("_ppvar[{}].literal_value<void*>()", position);
 }
 
 

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -646,6 +646,34 @@ CodegenNeuronCppVisitor::function_table_parameters(const ast::FunctionTableBlock
     return {params, {}};
 }
 
+
+std::unordered_map<std::string, std::string> get_nonglobal_local_variable_names(const symtab::SymbolTable& symtab) {
+    if(symtab.global_scope()) {
+        return {};
+    }
+
+    auto local_variables = symtab.get_variables(NmodlType::local_var);
+    auto parent_symtab = symtab.get_parent_table();
+    if(parent_symtab == nullptr) {
+        throw std::runtime_error("Internal NMODL error: non top-level symbol table doesn't have a parent.");
+    }
+
+    auto variable_names = get_nonglobal_local_variable_names(*parent_symtab);
+
+    for(const auto& symbol : local_variables) {
+        auto status = symbol->get_status();
+        bool is_renamed = (status & symtab::syminfo::Status::renamed) != symtab::syminfo::Status::empty;
+        auto current_name = symbol->get_name();
+        auto mod_name = is_renamed ? symbol->get_original_name() : current_name;
+
+        variable_names[mod_name] = current_name;
+    }
+
+    return variable_names;
+}
+
+
+
 std::vector<std::string> CodegenNeuronCppVisitor::print_verbatim_setup(
     const ast::Verbatim& node,
     const std::string& verbatim) {
@@ -702,12 +730,10 @@ std::vector<std::string> CodegenNeuronCppVisitor::print_verbatim_setup(
 
 
     auto symtab = node.get_parent()->get_symbol_table();
-    auto locals = symtab->get_variables(/* with= */ NmodlType::local_var);
-    for (const auto& local: locals) {
-        std::string name = local->get_name();
-        print_macro(fmt::format("_l{}", name), get_variable_name(name));
+    auto locals = get_nonglobal_local_variable_names(*symtab);
+    for (const auto& [mod_name, current_name]: locals) {
+        print_macro(fmt::format("_l{}", mod_name), get_variable_name(current_name));
     }
-
 
     print_macro("t", "nt->_t");
     print_macro("_nt", "nt");

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -616,6 +616,7 @@ CodegenCppVisitor::ParamVector CodegenNeuronCppVisitor::internalthreadargs_param
     return internal_method_parameters();
 }
 
+
 CodegenCppVisitor::ParamVector CodegenNeuronCppVisitor::threadargs_parameters() {
     return {{"", "Memb_list*", "", "_ml"},
             {"", "size_t", "", "_iml"},
@@ -624,6 +625,7 @@ CodegenCppVisitor::ParamVector CodegenNeuronCppVisitor::threadargs_parameters() 
             {"", "double*", "", "_globals"},
             {"", "NrnThread*", "", "_nt"}};
 }
+
 
 /// TODO: Edit for NEURON
 std::string CodegenNeuronCppVisitor::nrn_thread_arguments() const {
@@ -755,6 +757,7 @@ std::vector<std::string> CodegenNeuronCppVisitor::print_verbatim_setup(
     return macros_defined;
 }
 
+
 void CodegenNeuronCppVisitor::print_verbatim_cleanup(
     const std::vector<std::string>& macros_defined) {
     for (const auto& macro: macros_defined) {
@@ -762,6 +765,7 @@ void CodegenNeuronCppVisitor::print_verbatim_cleanup(
     }
     printer->add_line("// End of cleanup for VERBATIM");
 }
+
 
 std::string CodegenNeuronCppVisitor::process_verbatim_text(const std::string& verbatim) {
     parser::CDriver driver;

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -2677,6 +2677,7 @@ void CodegenNeuronCppVisitor::print_codegen_routines_nothing() {
     print_headers_include();
     print_namespace_start();
     print_function_prototypes();
+    print_top_verbatim_blocks();
     print_global_variables_for_hoc();
     print_function_definitions();
     print_mechanism_register();

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -669,8 +669,7 @@ std::vector<std::string> CodegenNeuronCppVisitor::print_verbatim_setup(
         print_macro(name, get_variable_name(name));
     }
 
-    for (size_t i = 0; i < codegen_int_variables.size(); ++i) {
-        const auto& var = codegen_int_variables[i];
+    for (const auto& var: codegen_int_variables) {
         auto name = get_name(var);
         std::string macro_value = get_variable_name(name);
         print_macro(name, macro_value);

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -16,10 +16,12 @@
 #include <stdexcept>
 
 #include "ast/all.hpp"
+#include "ast/procedure_block.hpp"
 #include "codegen/codegen_cpp_visitor.hpp"
 #include "codegen/codegen_utils.hpp"
 #include "codegen_naming.hpp"
 #include "config/config.h"
+#include "parser/c11_driver.hpp"
 #include "solver/solver.hpp"
 #include "utils/string_utils.hpp"
 #include "visitors/rename_visitor.hpp"
@@ -610,6 +612,19 @@ const CodegenCppVisitor::ParamVector CodegenNeuronCppVisitor::external_method_pa
 }
 
 
+CodegenCppVisitor::ParamVector CodegenNeuronCppVisitor::internalthreadargs_parameters() {
+    return internal_method_parameters();
+}
+
+CodegenCppVisitor::ParamVector CodegenNeuronCppVisitor::threadargs_parameters() {
+    return {{"", "Memb_list*", "", "_ml"},
+            {"", "size_t", "", "_iml"},
+            {"", "Datum*", "", "_ppvar"},
+            {"", "Datum*", "", "_thread"},
+            {"", "double*", "", "_globals"},
+            {"", "NrnThread*", "", "_nt"}};
+}
+
 /// TODO: Edit for NEURON
 std::string CodegenNeuronCppVisitor::nrn_thread_arguments() const {
     return {};
@@ -633,10 +648,11 @@ CodegenNeuronCppVisitor::function_table_parameters(const ast::FunctionTableBlock
 
 std::vector<std::string> CodegenNeuronCppVisitor::print_verbatim_setup(
     const std::string& verbatim) {
-    // Note, the logic for reducing the number of macros printed, is aims to
+    // Note, the logic for reducing the number of macros printed, aims to
     // improve legibility of the generated code by reducing number of lines of
-    // code. It would be correct to print all macros, because that's essentially
-    // what NOCMODL does. Therefore, the logic isn't sharp.
+    // code. It would be correct to print all macros, because that's
+    // essentially what NOCMODL does. Therefore, the logic isn't sharp (and
+    // doesn't have to be).
 
     std::vector<std::string> macros_defined;
     auto print_macro = [this, &verbatim, &macros_defined](const std::string& macro_name,
@@ -663,25 +679,28 @@ std::vector<std::string> CodegenNeuronCppVisitor::print_verbatim_setup(
 
     for (const auto& func: info.functions) {
         auto name = get_name(func);
-        print_macro(name, "::neuron::" + method_name(name));
+        print_macro(name, method_name(name));
     }
 
     for (const auto& proc: info.procedures) {
         auto name = get_name(proc);
-        print_macro(name, "::neuron::" + method_name(name));
+        print_macro(name, method_name(name));
     }
 
-    if (verbatim.find("t") != std::string::npos) {
-        print_macro("t", "nt->_t");
-    }
+    print_macro("t", "nt->_t");
+    print_macro("_nt", "nt");
+    print_macro("_tqitem", "tqitem");
 
-    if (verbatim.find("_nt") != std::string::npos) {
-        print_macro("_nt", "nt");
-    }
+    auto print_args_macro = [this, print_macro](const std::string& macro_basename,
+                                                const ParamVector& params) {
+        print_macro("_" + macro_basename + "_", get_arg_str(params));
+        print_macro("_" + macro_basename + "comma_", get_arg_str(params) + ",");
+        print_macro("_" + macro_basename + "proto_", get_parameter_str(params));
+        print_macro("_" + macro_basename + "protocomma_", get_parameter_str(params) + ",");
+    };
 
-    if (verbatim.find("_tqitem") != std::string::npos) {
-        print_macro("_tqitem", "tqitem");
-    }
+    print_args_macro("internalthreadargs", internalthreadargs_parameters());
+    print_args_macro("threadargs", threadargs_parameters());
 
     return macros_defined;
 }
@@ -694,13 +713,42 @@ void CodegenNeuronCppVisitor::print_verbatim_cleanup(
     printer->add_line("// End of cleanup for VERBATIM");
 }
 
+std::string CodegenNeuronCppVisitor::process_verbatim_text(const std::string& verbatim) {
+    parser::CDriver driver;
+    driver.scan_string(verbatim);
+    auto tokens = driver.all_tokens();
+    std::string result;
+    for (size_t i = 0; i < tokens.size(); i++) {
+        auto token = tokens[i];
+
+        // check if we have function call in the verbatim block where
+        // function is defined in the same mod file
+        if (program_symtab->is_method_defined(token) && tokens[i + 1] == "(") {
+            result += token + "(";
+            if (tokens[i + 2] == "_threadargs_") {
+                result += "_internalthreadargs_";
+            } else if (tokens[i + 2] == "_threadargscomma_") {
+                result += "_internalthreadargscomma_";
+            } else {
+                result += tokens[i + 2];
+            }
+
+            i += 2;
+        } else {
+            result += token;
+        }
+    }
+    return result;
+}
+
 
 void CodegenNeuronCppVisitor::visit_verbatim(const Verbatim& node) {
     const auto& verbatim_code = node.get_statement()->eval();
+    auto massaged_verbatim = process_verbatim_text(verbatim_code);
 
-    auto macros_defined = print_verbatim_setup(verbatim_code);
+    auto macros_defined = print_verbatim_setup(massaged_verbatim);
     printer->add_line("// Begin VERBATIM");
-    const auto& lines = stringutils::split_string(verbatim_code, '\n');
+    const auto& lines = stringutils::split_string(massaged_verbatim, '\n');
     for (const auto& line: lines) {
         printer->add_line(line);
     }

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -649,6 +649,17 @@ CodegenNeuronCppVisitor::function_table_parameters(const ast::FunctionTableBlock
 }
 
 
+/** Map of the non-(global/top-local) LOCAL variables.
+ *
+ *  The map associates the name in the MOD file, e.g. `a` with
+ *  the current name of that LOCAL variable, e.g. `a_r_4`.
+ *
+ *      auto map = get_nonglobal_local_variable_names();
+ *      assert map["a"] == "a_r_4";
+ *
+ *  The two names can differ, because an early pass makes all
+ *  names unique by renaming local variables.
+ */
 std::unordered_map<std::string, std::string> get_nonglobal_local_variable_names(
     const symtab::SymbolTable& symtab) {
     if (symtab.global_scope()) {

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -647,12 +647,15 @@ CodegenNeuronCppVisitor::function_table_parameters(const ast::FunctionTableBlock
 }
 
 std::vector<std::string> CodegenNeuronCppVisitor::print_verbatim_setup(
+    const ast::Verbatim& node,
     const std::string& verbatim) {
     // Note, the logic for reducing the number of macros printed, aims to
     // improve legibility of the generated code by reducing number of lines of
     // code. It would be correct to print all macros, because that's
     // essentially what NOCMODL does. Therefore, the logic isn't sharp (and
     // doesn't have to be).
+
+    auto symtab = node.get_symbol_table();
 
     std::vector<std::string> macros_defined;
     auto print_macro = [this, &verbatim, &macros_defined](const std::string& macro_name,
@@ -758,7 +761,7 @@ void CodegenNeuronCppVisitor::visit_verbatim(const Verbatim& node) {
     const auto& verbatim_code = node.get_statement()->eval();
     auto massaged_verbatim = process_verbatim_text(verbatim_code);
 
-    auto macros_defined = print_verbatim_setup(massaged_verbatim);
+    auto macros_defined = print_verbatim_setup(node, massaged_verbatim);
     printer->add_line("// Begin VERBATIM");
     const auto& lines = stringutils::split_string(massaged_verbatim, '\n');
     for (const auto& line: lines) {

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -368,11 +368,6 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
         const ast::FunctionTableBlock& /* node */) override;
 
 
-    void print_verbatim_overload(const std::string& return_type, const ast::Ast& node);
-    void print_procedure_verbatim_overload(const ast::ProcedureBlock& procedure);
-    void print_function_verbatim_overload(const ast::FunctionBlock& function);
-
-
     /** Print compatibility macros required for VERBATIM blocks.
      *
      *  Returns the names of all macros introduced.

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -377,7 +377,8 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
      *
      *  Returns the names of all macros introduced.
      */
-    std::vector<std::string> print_verbatim_setup(const ast::Verbatim& node, const std::string& verbatim);
+    std::vector<std::string> print_verbatim_setup(const ast::Verbatim& node,
+                                                  const std::string& verbatim);
 
 
     /** Print `#undef`s to erase all compatibility macros.

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -377,7 +377,7 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
      *
      *  Returns the names of all macros introduced.
      */
-    std::vector<std::string> print_verbatim_setup(const std::string& verbatim);
+    std::vector<std::string> print_verbatim_setup(const ast::Verbatim& node, const std::string& verbatim);
 
 
     /** Print `#undef`s to erase all compatibility macros.

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -358,6 +358,17 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
         const ast::FunctionTableBlock& /* node */) override;
 
 
+    /** Print compatibility macros required for VERBATIM blocks.
+     *
+     *  Returns the names of all macros introduced.
+     */
+    std::vector<std::string> print_verbatim_setup(const std::string& verbatim);
+
+    /** Print `#undef`s to erase all compatibility macros.
+     */
+    void print_verbatim_cleanup(const std::vector<std::string>& macros_defined);
+
+
     /**
      * Arguments for register_mech or point_register_mech function
      */
@@ -462,7 +473,10 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
 
 
     /**
-     * Determine variable name in the structure of mechanism properties
+     * Determine the C++ string to replace variable names with.
+     *
+     * Given a variable name such as `ion_cai` or `v`, return the C++ code
+     * required to get the value.
      *
      * \param name         Variable name that is being printed
      * \param use_instance Should the variable be accessed via instance or data array
@@ -470,6 +484,18 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
      * thread structure
      */
     std::string get_variable_name(const std::string& name, bool use_instance = true) const override;
+
+    /**
+     * Determine the C++ string to replace pointer names with.
+     *
+     * Given a variable name such as `_p_ptr` or `_p_rng`, return the C++ code
+     * required to get a pointer to `ptr` (or `rng`).
+     *
+     * \param name         Variable name that is being printed
+     * \return             The C++ string representing the variable.
+     * thread structure
+     */
+    std::string get_pointer_name(const std::string& name) const;
 
 
     /****************************************************************************************/

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -24,6 +24,8 @@
 #include <string_view>
 #include <utility>
 
+#include "ast/function_block.hpp"
+#include "ast/procedure_block.hpp"
 #include "codegen/codegen_cpp_visitor.hpp"
 #include "codegen/codegen_info.hpp"
 #include "codegen/codegen_naming.hpp"
@@ -343,6 +345,14 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
     const ParamVector external_method_parameters(bool table = false) noexcept override;
 
 
+    /** The parameters for the four macros `_internalthreadargs*_`. */
+    ParamVector internalthreadargs_parameters();
+
+
+    /** The parameters for the four macros `_threadargs*_`. */
+    ParamVector threadargs_parameters();
+
+
     /**
      * Arguments for "_threadargs_" macro in neuron implementation
      */
@@ -358,11 +368,17 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
         const ast::FunctionTableBlock& /* node */) override;
 
 
+    void print_verbatim_overload(const std::string& return_type, const ast::Ast& node);
+    void print_procedure_verbatim_overload(const ast::ProcedureBlock& procedure);
+    void print_function_verbatim_overload(const ast::FunctionBlock& function);
+
+
     /** Print compatibility macros required for VERBATIM blocks.
      *
      *  Returns the names of all macros introduced.
      */
     std::vector<std::string> print_verbatim_setup(const std::string& verbatim);
+
 
     /** Print `#undef`s to erase all compatibility macros.
      */
@@ -786,6 +802,7 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
     /*                            Overloaded visitor routines                               */
     /****************************************************************************************/
 
+    std::string process_verbatim_text(const std::string& verbatim);
     void visit_verbatim(const ast::Verbatim& node) override;
     void visit_watch_statement(const ast::WatchStatement& node) override;
     void visit_for_netcon(const ast::ForNetcon& node) override;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -294,6 +294,7 @@ int run_nmodl(int argc, const char* argv[]) {
     CLI11_PARSE(app, argc, argv);
 
     std::string simulator_name = neuron_code ? "neuron" : "coreneuron";
+    verbatim_rename = neuron_code ? false : verbatim_rename;
 
     fs::create_directories(output_dir);
     fs::create_directories(scratch_dir);

--- a/src/symtab/symbol_table.cpp
+++ b/src/symtab/symbol_table.cpp
@@ -116,7 +116,6 @@ std::vector<std::shared_ptr<Symbol>> SymbolTable::get_variables(NmodlType with,
     return result;
 }
 
-
 std::vector<std::shared_ptr<Symbol>> SymbolTable::get_variables_with_status(Status status,
                                                                             bool all) const {
     std::vector<std::shared_ptr<Symbol>> variables;

--- a/test/usecases/CMakeLists.txt
+++ b/test/usecases/CMakeLists.txt
@@ -30,7 +30,8 @@ set(NMODL_USECASE_DIRS
     steady_state
     suffix
     table
-    useion)
+    useion
+    verbatim)
 
 foreach(usecase ${NMODL_USECASE_DIRS})
   add_test(NAME usecase_${usecase}

--- a/test/usecases/verbatim/globals.mod
+++ b/test/usecases/verbatim/globals.mod
@@ -1,0 +1,14 @@
+NEURON {
+  SUFFIX globals
+  GLOBAL gbl
+}
+
+ASSIGNED {
+  gbl
+}
+
+FUNCTION get_gbl() {
+VERBATIM
+_lget_gbl = gbl;
+ENDVERBATIM
+}

--- a/test/usecases/verbatim/internal_function.mod
+++ b/test/usecases/verbatim/internal_function.mod
@@ -1,0 +1,14 @@
+NEURON	{ 
+    SUFFIX internal_function
+    THREADSAFE
+}
+
+FUNCTION f() {
+VERBATIM
+  return g(_threadargs_);
+ENDVERBATIM
+}
+
+FUNCTION g() {
+  g = 42.0
+}

--- a/test/usecases/verbatim/internal_function.mod
+++ b/test/usecases/verbatim/internal_function.mod
@@ -1,4 +1,4 @@
-NEURON	{ 
+NEURON {
     SUFFIX internal_function
     THREADSAFE
 }

--- a/test/usecases/verbatim/locals.mod
+++ b/test/usecases/verbatim/locals.mod
@@ -1,0 +1,26 @@
+NEURON {
+    SUFFIX locals
+}
+
+PARAMETER {
+    a = -1.0
+}
+
+FUNCTION get_a() { LOCAL a
+    a = 32.0
+VERBATIM
+    _lget_a = _la;
+ENDVERBATIM
+}
+
+FUNCTION get_b() { LOCAL a, b
+    a = -1.0
+    b = 32.0
+    { LOCAL a
+        a = 100.0
+        b = b + a
+        VERBATIM
+        _lget_b = _lb;
+        ENDVERBATIM
+    }
+}

--- a/test/usecases/verbatim/nothing.mod
+++ b/test/usecases/verbatim/nothing.mod
@@ -1,0 +1,11 @@
+NEURON { SUFFIX nothing }
+
+VERBATIM
+double foo = 42.0;
+ENDVERBATIM
+
+FUNCTION get_foo() {
+VERBATIM
+    return foo;
+ENDVERBATIM
+}

--- a/test/usecases/verbatim/pointer_in_double.mod
+++ b/test/usecases/verbatim/pointer_in_double.mod
@@ -1,0 +1,36 @@
+NEURON {
+    SUFFIX pointer_in_double
+    THREADSAFE
+}
+
+ASSIGNED {
+  ptr
+}
+
+VERBATIM
+struct SomeDouble {
+  SomeDouble(double _value) : _value(_value) {}
+
+  double value() const {
+    return _value;
+  }
+
+  double _value;
+};
+
+static std::vector<SomeDouble> some_doubles;
+ENDVERBATIM
+
+INITIAL {
+VERBATIM
+  some_doubles.reserve(10);
+  some_doubles.push_back(SomeDouble(double(some_doubles.size())));
+  *reinterpret_cast<SomeDouble**>(&ptr) = &some_doubles.back();
+ENDVERBATIM
+}
+
+FUNCTION use_pointer() {
+VERBATIM
+  return (*reinterpret_cast<SomeDouble**>(&ptr))->value();
+ENDVERBATIM
+}

--- a/test/usecases/verbatim/test_globals.py
+++ b/test/usecases/verbatim/test_globals.py
@@ -1,0 +1,13 @@
+from neuron import h, gui
+
+def test_globals():
+    s = h.Section()
+    s.insert("globals")
+
+    h.gbl_globals = 654.0
+
+    assert h.globals.get_gbl() == h.gbl
+
+
+if __name__ == "__main__":
+    test_globals()

--- a/test/usecases/verbatim/test_globals.py
+++ b/test/usecases/verbatim/test_globals.py
@@ -6,7 +6,7 @@ def test_globals():
 
     h.gbl_globals = 654.0
 
-    assert h.globals.get_gbl() == h.gbl
+    assert s(0.5).globals.get_gbl() == h.gbl_globals
 
 
 if __name__ == "__main__":

--- a/test/usecases/verbatim/test_globals.py
+++ b/test/usecases/verbatim/test_globals.py
@@ -1,5 +1,6 @@
 from neuron import h, gui
 
+
 def test_globals():
     s = h.Section()
     s.insert("globals")

--- a/test/usecases/verbatim/test_internal_function.py
+++ b/test/usecases/verbatim/test_internal_function.py
@@ -1,0 +1,11 @@
+from neuron import h
+
+
+def test_internal_function():
+    s = h.Section()
+    s.nseg = 4
+
+    s.insert("internal_function")
+
+    assert s.internal_function.g() == 42.0
+    assert s.internal_function.f() == 42.0

--- a/test/usecases/verbatim/test_locals.py
+++ b/test/usecases/verbatim/test_locals.py
@@ -1,0 +1,12 @@
+from neuron import h, gui
+
+def test_locals():
+    s = h.Section()
+    s.insert("locals")
+
+    assert s(0.5).locals.get_a() == 32.0
+    assert s(0.5).locals.get_b() == 132.0
+
+
+if __name__ == "__main__":
+    test_locals()

--- a/test/usecases/verbatim/test_locals.py
+++ b/test/usecases/verbatim/test_locals.py
@@ -1,5 +1,6 @@
 from neuron import h, gui
 
+
 def test_locals():
     s = h.Section()
     s.insert("locals")

--- a/test/usecases/verbatim/test_nothing.py
+++ b/test/usecases/verbatim/test_nothing.py
@@ -1,0 +1,9 @@
+from neuron import h, gui
+
+
+def test_nothing():
+    assert h.get_foo() == 42.0
+
+
+if __name__ == "__main__":
+    test_nothing()

--- a/test/usecases/verbatim/test_pointer_in_double.py
+++ b/test/usecases/verbatim/test_pointer_in_double.py
@@ -6,6 +6,7 @@ from neuron import h, gui
 #
 # The pattern is found in the builtin mod file: `apcount.mod`.
 
+
 def test_pointer_in_double():
     s = h.Section()
     s.nseg = 3

--- a/test/usecases/verbatim/test_pointer_in_double.py
+++ b/test/usecases/verbatim/test_pointer_in_double.py
@@ -1,0 +1,22 @@
+from neuron import h, gui
+
+# Since a double is 64-bits and a pointer is also 32 or 64-bits, we can store
+# the bits of a pointer in the memory that was allocated for use as doubles.
+# Concretely, we, using VERBATIM, safe pointers in ASSIGNED or RANGE variables.
+#
+# The pattern is found in the builtin mod file: `apcount.mod`.
+
+def test_pointer_in_double():
+    s = h.Section()
+    s.nseg = 3
+    s.insert("pointer_in_double")
+
+    h.finitialize()
+    for i, x in enumerate([0.25, 0.5, 0.75]):
+        actual = s(x).pointer_in_double.use_pointer()
+        expected = i
+        assert actual == expected, f"{actual} != {expected}"
+
+
+if __name__ == "__main__":
+    test_pointer_in_double()


### PR DESCRIPTION
Edit the idea is to temporarily print the NOCMODL macros, e.g. the MOD file:
```
VERBATIM
_lget_gbl = gbl;
ENDVERBATIM
```
generates:
```
        // Setup for VERBATIM
        #define gbl inst.global->gbl
        #define get_gbl get_gbl_globals
        #define _lget_gbl ret_get_gbl
        #define t nt->_t
        // Begin VERBATIM

        _lget_gbl = gbl;
        // End VERBATIM
        #undef gbl
        #undef get_gbl
        #undef _lget_gbl
        #undef t
        // End of cleanup for VERBATIM
```
One can see the following happening:
``` 
       // Translate `gbl` to the correct C++ code:
       #define gbl inst.global->gbl

       // Because the substring `get_gbl` is present we print the
       // full name of the function `get_gbl` (even though it's not
       // needed).
       #define get_gbl get_gbl_globals

       // Same translation logic for the return type.
       #define _lget_gbl ret_get_gbl
```

There's one more twist relates to `threadargs` in both NOCMODL and NMODL there's two variations of prototypes: one `internalthreadargsproto` and `threadargsproto`. In NOCMODL the number and order of the arguments are the same (their types differ slightly). Therefore, in NOCMODL a single macro is sufficient to call both types, i.e. `threadargs` works for both types of functions. There is no `internalthreadargs`. In NMODL the two signatures differ significantly and for this reason we need to massage VERBATIM code to determine which string to substitute for `threadargs`.