### PR TITLE
Simplify `float_variable_name` (NEURON version).

### DIFF
--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -575,21 +575,17 @@ void CodegenNeuronCppVisitor::append_conc_write_statements(
 /// TODO: Edit for NEURON
 std::string CodegenNeuronCppVisitor::float_variable_name(const SymbolType& symbol,
                                                          bool use_instance) const {
+    if (!use_instance) {
+        throw std::runtime_error("Printing non-instance variables is not implemented.");
+    }
+
     auto name = symbol->get_name();
     auto dimension = symbol->get_length();
-    // auto position = position_of_float_var(name);
     if (symbol->is_array()) {
-        if (use_instance) {
-            return fmt::format("(inst.{}+id*{})", name, dimension);
-        }
-        throw std::runtime_error("Printing non-instance variables is not implemented.");
-        // return fmt::format("(data + {}*pnodecount + id*{})", position, dimension);
-    }
-    if (use_instance) {
+        return fmt::format("(inst.{}+id*{})", name, dimension);
+    } else {
         return fmt::format("inst.{}[id]", name);
     }
-    throw std::runtime_error("Not implemented.");
-    // return fmt::format("data[{}*pnodecount + id]", position);
 }
 
 


### PR DESCRIPTION
We now understand better what we need, and can clean up the left over dead code from cloning the CoreNEURON method.