### PR TITLE
Remove `print_backend_namespace_{start,stop}`.

### DIFF
--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -302,16 +302,6 @@ void CodegenCoreneuronCppVisitor::print_global_method_annotation() {
 }
 
 
-void CodegenCoreneuronCppVisitor::print_backend_namespace_start() {
-    // no separate namespace for C++ (cpu) backend
-}
-
-
-void CodegenCoreneuronCppVisitor::print_backend_namespace_stop() {
-    // no separate namespace for C++ (cpu) backend
-}
-
-
 void CodegenCoreneuronCppVisitor::print_backend_includes() {
     // backend specific, nothing for cpu
 }
@@ -2993,12 +2983,10 @@ void CodegenCoreneuronCppVisitor::print_headers_include() {
 
 void CodegenCoreneuronCppVisitor::print_namespace_begin() {
     print_namespace_start();
-    print_backend_namespace_start();
 }
 
 
 void CodegenCoreneuronCppVisitor::print_namespace_end() {
-    print_backend_namespace_stop();
     print_namespace_stop();
 }
 

--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -259,22 +259,6 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
 
 
     /**
-     * Prints the start of namespace for the backend-specific code
-     *
-     * For the C++ backend no additional namespace is required
-     */
-    virtual void print_backend_namespace_start();
-
-
-    /**
-     * Prints the end of namespace for the backend-specific code
-     *
-     * For the C++ backend no additional namespace is required
-     */
-    virtual void print_backend_namespace_stop();
-
-
-    /**
      * Print backend specific includes (none needed for C++ backend)
      */
     virtual void print_backend_includes();


### PR DESCRIPTION
The only backend specialized backend: acc, doesn't use this either.