### PR TITLE
Remove print_namespace_{begin,end}.

### DIFF
--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -2981,16 +2981,6 @@ void CodegenCoreneuronCppVisitor::print_headers_include() {
 }
 
 
-void CodegenCoreneuronCppVisitor::print_namespace_begin() {
-    print_namespace_start();
-}
-
-
-void CodegenCoreneuronCppVisitor::print_namespace_end() {
-    print_namespace_stop();
-}
-
-
 void CodegenCoreneuronCppVisitor::print_common_getters() {
     print_first_pointer_var_index_getter();
     print_first_random_var_index_getter();
@@ -3064,7 +3054,7 @@ void CodegenCoreneuronCppVisitor::print_compute_functions() {
 void CodegenCoreneuronCppVisitor::print_codegen_routines() {
     print_backend_info();
     print_headers_include();
-    print_namespace_begin();
+    print_namespace_start();
     print_nmodl_constants();
     print_prcellstate_macros();
     print_mechanism_info();
@@ -3083,7 +3073,7 @@ void CodegenCoreneuronCppVisitor::print_codegen_routines() {
     print_compute_functions();
     print_check_table_thread_function();
     print_mechanism_register();
-    print_namespace_end();
+    print_namespace_stop();
 }
 
 

--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -941,20 +941,6 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
 
 
     /**
-     * Print start of namespaces
-     *
-     */
-    void print_namespace_begin() override;
-
-
-    /**
-     * Print end of namespaces
-     *
-     */
-    void print_namespace_end() override;
-
-
-    /**
      * Print common getters
      *
      */

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -1354,20 +1354,6 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
 
 
     /**
-     * Print start of namespaces
-     *
-     */
-    virtual void print_namespace_begin() = 0;
-
-
-    /**
-     * Print end of namespaces
-     *
-     */
-    virtual void print_namespace_end() = 0;
-
-
-    /**
      * Print all classes
      * \param print_initializers Whether to include default values.
      */

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -2029,16 +2029,6 @@ void CodegenNeuronCppVisitor::print_mechanism_variables_macros() {
 }
 
 
-void CodegenNeuronCppVisitor::print_namespace_begin() {
-    print_namespace_start();
-}
-
-
-void CodegenNeuronCppVisitor::print_namespace_end() {
-    print_namespace_stop();
-}
-
-
 void CodegenNeuronCppVisitor::print_data_structures(bool print_initializers) {
     print_mechanism_global_var_structure(print_initializers);
     print_mechanism_range_var_structure(print_initializers);
@@ -2093,7 +2083,7 @@ void CodegenNeuronCppVisitor::print_codegen_routines() {
     print_headers_include();
     print_macro_definitions();
     print_neuron_global_variable_declarations();
-    print_namespace_begin();
+    print_namespace_start();
     print_nmodl_constants();
     print_prcellstate_macros();
     print_mechanism_info();
@@ -2106,7 +2096,7 @@ void CodegenNeuronCppVisitor::print_codegen_routines() {
     print_compute_functions();  // only nrn_cur and nrn_state
     print_sdlists_init(true);
     print_mechanism_register();
-    print_namespace_end();
+    print_namespace_stop();
 }
 
 void CodegenNeuronCppVisitor::print_ion_variable() {

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -644,20 +644,6 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
 
 
     /**
-     * Print start of namespaces
-     *
-     */
-    void print_namespace_begin() override;
-
-
-    /**
-     * Print end of namespaces
-     *
-     */
-    void print_namespace_end() override;
-
-
-    /**
      * Print all classes
      * \param print_initializers Whether to include default values.
      */


### PR DESCRIPTION
These are new synonyms for `print_namespace_{start,stop}` and
can therefore be removed.