### PR TITLE
Refactor print_namespace_{start,stop}.

### DIFF
--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -349,7 +349,7 @@ void CodegenCoreneuronCppVisitor::print_top_verbatim_blocks() {
     print_namespace_stop();
 
     printer->add_newline(2);
-    printer->add_line("using namespace coreneuron;");
+    print_using_namespace();
 
     printing_top_verbatim_blocks = true;
 
@@ -767,16 +767,9 @@ void CodegenCoreneuronCppVisitor::print_memb_list_getter() {
 }
 
 
-void CodegenCoreneuronCppVisitor::print_namespace_start() {
-    printer->add_newline(2);
-    printer->push_block("namespace coreneuron");
+std::string CodegenCoreneuronCppVisitor::namespace_name() {
+    return "coreneuron";
 }
-
-
-void CodegenCoreneuronCppVisitor::print_namespace_stop() {
-    printer->pop_block();
-}
-
 
 /**
  * \details There are three types of thread variables currently considered:

--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -501,16 +501,7 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
     void print_memb_list_getter();
 
 
-    /**
-     * Prints the start of the \c coreneuron namespace
-     */
-    void print_namespace_start() override;
-
-
-    /**
-     * Prints the end of the \c coreneuron namespace
-     */
-    void print_namespace_stop() override;
+    virtual std::string namespace_name() override;
 
 
     /**

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -544,6 +544,20 @@ void CodegenCppVisitor::print_mechanism_info() {
     printer->add_line("};");
 }
 
+void CodegenCppVisitor::print_using_namespace() {
+    printer->fmt_line("using namespace {};", namespace_name());
+}
+
+void CodegenCppVisitor::print_namespace_start() {
+    printer->add_newline(2);
+    printer->fmt_push_block("namespace {}", namespace_name());
+}
+
+
+void CodegenCppVisitor::print_namespace_stop() {
+    printer->pop_block();
+}
+
 
 /****************************************************************************************/
 /*                         Printing routines for code generation                        */

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -1072,18 +1072,25 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     /*                  Code-specific printing routines for code generations                */
     /****************************************************************************************/
 
+    /** Name of "our" namespace.
+     */
+    virtual std::string namespace_name() = 0;
 
     /**
      * Prints the start of the simulator namespace
      */
-    virtual void print_namespace_start() = 0;
+    void print_namespace_start();
 
 
     /**
      * Prints the end of the simulator namespace
      */
-    virtual void print_namespace_stop() = 0;
+    void print_namespace_stop();
 
+    /**
+     * Prints f"using namespace {namespace_name()}".
+     */
+    void print_using_namespace();
 
     /****************************************************************************************/
     /*                         Routines for returning variable name                         */

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -535,16 +535,10 @@ std::string CodegenNeuronCppVisitor::py_function_signature(
 /*               Code-specific printing routines for code generation                    */
 /****************************************************************************************/
 
-
-void CodegenNeuronCppVisitor::print_namespace_start() {
-    printer->add_newline(2);
-    printer->push_block("namespace neuron");
+std::string CodegenNeuronCppVisitor::namespace_name() {
+    return "neuron";
 }
 
-
-void CodegenNeuronCppVisitor::print_namespace_stop() {
-    printer->pop_block();
-}
 
 void CodegenNeuronCppVisitor::append_conc_write_statements(
     std::vector<ShadowUseStatement>& statements,

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -357,16 +357,7 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
     /****************************************************************************************/
 
 
-    /**
-     * Prints the start of the \c neuron namespace
-     */
-    void print_namespace_start() override;
-
-
-    /**
-     * Prints the end of the \c neuron namespace
-     */
-    void print_namespace_stop() override;
+    std::string namespace_name() override;
 
 
     /****************************************************************************************/


### PR DESCRIPTION
Since the only thing that differs is the name of the namespace, we're better off adding a virtual method for the namespace name, and devirtualize the printing of `namespace {} {`.