### PR TITLE
Move `print_{function,procedure}` upwards.

### DIFF
--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -454,31 +454,6 @@ void CodegenCoreneuronCppVisitor::print_function_procedure_helper(const ast::Blo
 }
 
 
-void CodegenCoreneuronCppVisitor::print_procedure(const ast::ProcedureBlock& node) {
-    print_function_procedure_helper(node);
-}
-
-
-void CodegenCoreneuronCppVisitor::print_function(const ast::FunctionBlock& node) {
-    auto name = node.get_node_name();
-
-    // name of return variable
-    std::string return_var;
-    if (info.function_uses_table(name)) {
-        return_var = "ret_f_" + name;
-    } else {
-        return_var = "ret_" + name;
-    }
-
-    // first rename return variable name
-    auto block = node.get_statement_block().get();
-    RenameVisitor v(name, return_var);
-    block->accept(v);
-
-    print_function_procedure_helper(node);
-}
-
-
 void CodegenCoreneuronCppVisitor::print_function_tables(const ast::FunctionTableBlock& node) {
     auto name = node.get_node_name();
     const auto& p = node.get_parameters();

--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -372,20 +372,6 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
 
 
     /**
-     * Print NMODL procedure in target backend code
-     * \param node
-     */
-    void print_procedure(const ast::ProcedureBlock& node) override;
-
-
-    /**
-     * Print NMODL function in target backend code
-     * \param node
-     */
-    void print_function(const ast::FunctionBlock& node) override;
-
-
-    /**
      * Print NMODL function_table in target backend code
      * \param node
      */

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -505,6 +505,31 @@ void CodegenCppVisitor::print_function_call(const FunctionCall& node) {
 }
 
 
+void CodegenCppVisitor::print_procedure(const ast::ProcedureBlock& node) {
+    print_function_procedure_helper(node);
+}
+
+
+void CodegenCppVisitor::print_function(const ast::FunctionBlock& node) {
+    auto name = node.get_node_name();
+
+    // name of return variable
+    std::string return_var;
+    if (info.function_uses_table(name)) {
+        return_var = "ret_f_" + name;
+    } else {
+        return_var = "ret_" + name;
+    }
+
+    // first rename return variable name
+    auto block = node.get_statement_block().get();
+    RenameVisitor v(name, return_var);
+    block->accept(v);
+
+    print_function_procedure_helper(node);
+}
+
+
 void CodegenCppVisitor::print_prcellstate_macros() const {
     printer->add_line("#ifndef NRN_PRCELLSTATE");
     printer->add_line("#define NRN_PRCELLSTATE 0");

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -881,14 +881,14 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * Print NMODL procedure in target backend code
      * \param node
      */
-    virtual void print_procedure(const ast::ProcedureBlock& node) = 0;
+    void print_procedure(const ast::ProcedureBlock& node);
 
 
     /**
      * Print NMODL function in target backend code
      * \param node
      */
-    virtual void print_function(const ast::FunctionBlock& node) = 0;
+    void print_function(const ast::FunctionBlock& node);
 
 
     /**

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -291,30 +291,6 @@ void CodegenNeuronCppVisitor::print_function_procedure_helper(const ast::Block& 
 }
 
 
-void CodegenNeuronCppVisitor::print_procedure(const ast::ProcedureBlock& node) {
-    print_function_procedure_helper(node);
-}
-
-
-void CodegenNeuronCppVisitor::print_function(const ast::FunctionBlock& node) {
-    auto name = node.get_node_name();
-
-    // name of return variable
-    std::string return_var;
-    if (info.function_uses_table(name)) {
-        return_var = "ret_f_" + name;
-    } else {
-        return_var = "ret_" + name;
-    }
-
-    // first rename return variable name
-    auto block = node.get_statement_block().get();
-    RenameVisitor v(name, return_var);
-    block->accept(v);
-
-    print_function_procedure_helper(node);
-}
-
 void CodegenNeuronCppVisitor::print_hoc_py_wrapper_function_body(
     const ast::Block* function_or_procedure_block,
     InterpreterWrapper wrapper_type) {

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -236,20 +236,6 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
     void print_function_procedure_helper(const ast::Block& node) override;
 
 
-    /**
-     * Print NMODL procedure in target backend code
-     * \param node
-     */
-    void print_procedure(const ast::ProcedureBlock& node) override;
-
-
-    /**
-     * Print NMODL function in target backend code
-     * \param node
-     */
-    void print_function(const ast::FunctionBlock& node) override;
-
-
     void print_hoc_py_wrapper_function_body(const ast::Block* function_or_procedure_block,
                                             InterpreterWrapper wrapper_type);
 


### PR DESCRIPTION
The code has completely converged and can be moved to the common base.