### PR TITLE
Remove pointless check.

### DIFF
--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -772,11 +772,9 @@ void CodegenHelperVisitor::visit_verbatim(const Verbatim& node) {
 
     // check if the token exist in the symbol table
     for (auto& token: tokens) {
-        if (info.variables_in_verbatim.find(token) == info.variables_in_verbatim.end()) {
-            auto symbol = psymtab->lookup(token);
-            if (symbol != nullptr) {
-                info.variables_in_verbatim.insert(token);
-            }
+        auto symbol = psymtab->lookup(token);
+        if (symbol != nullptr) {
+            info.variables_in_verbatim.insert(token);
         }
     }
 }


### PR DESCRIPTION
The container is an `unordered_set`, which means we can insert without causing
duplication. Hence, we can avoid the find code.