### PR TITLE
Throw an error when using `derivimplicit` with `PROCEDURE` block

### DIFF
--- a/src/visitors/solve_block_visitor.cpp
+++ b/src/visitors/solve_block_visitor.cpp
@@ -56,7 +56,12 @@ ast::SolutionExpression* SolveBlockVisitor::create_solution_expression(
     if (solve_method == codegen::naming::DERIVIMPLICIT_METHOD &&
         !has_sympy_solution(*node_to_solve)) {
         /// typically derivimplicit is used for derivative block only
-        assert(node_to_solve->get_node_type() == ast::AstNodeType::DERIVATIVE_BLOCK);
+        if (node_to_solve->get_node_type() != ast::AstNodeType::DERIVATIVE_BLOCK) {
+            const std::string node_name = node_to_solve->get_node_name();
+            const std::string node_type = node_to_solve->get_node_type_name();
+            throw std::runtime_error(fmt::format(
+                "Method {} cannot be used for {} {}", solve_method, node_type, node_name));
+        }
         auto derivative_block = dynamic_cast<ast::DerivativeBlock*>(node_to_solve);
         auto callback_expr = new ast::DerivimplicitCallback(derivative_block->clone());
         return new ast::SolutionExpression(solve_block.clone(), callback_expr);

--- a/test/unit/visitor/solve_block.cpp
+++ b/test/unit/visitor/solve_block.cpp
@@ -123,3 +123,24 @@ TEST_CASE("Solve ODEs using legacy NeuronSolveVisitor", "[visitor][solver]") {
         }
     }
 }
+
+TEST_CASE("Throw errors on invalid methods", "[visitor][solver]") {
+    SECTION("PROCEDURE cannot be SOLVEd with derivimplicit METHOD") {
+        GIVEN("Breakpoint block with a PROCEDURE being solved using the derivimplcit METHOD") {
+            std::string nmodl_text = R"(
+            NEURON	{
+                SUFFIX example
+            }
+
+            BREAKPOINT	{
+                SOLVE myfunc METHOD derivimplicit
+            }
+
+            PROCEDURE myfunc() {}
+)";
+            THEN("A runtime error should be thrown") {
+                REQUIRE_THROWS_AS(run_solve_block_visitor(nmodl_text), std::runtime_error);
+            }
+        }
+    }
+}


### PR DESCRIPTION
The following modfile does not work with NOCMODL:

```plaintext
: mwe.mod
NEURON	{
	SUFFIX example
}

BREAKPOINT	{
    SOLVE myfunc METHOD derivimplicit
}

PROCEDURE myfunc() {}
```

With the error:

```plaintext
Error: Method derivimplicit can't be used with Block myfunc at line 10 in file mwe.mod
```

On the other hand, `nmodl --neuron mwe.mod` just segfaults with no useful error; with debugging symbols, I get a slightly more verbose backtrace:

```plaintext
Assertion failed: (node_to_solve->get_node_type() == ast::AstNodeType::DERIVATIVE_BLOCK), function create_solution_expression, file solve_block_visitor.cpp, line 59
```

This PR fixes it so it actually throws a `runtime_error` with the traceback:

```plaintext
terminating due to uncaught exception of type std::runtime_error: Method derivimplicit cannot be used for ProcedureBlock block myfunc
```