### PR TITLE
Initialize _extcall_thread.

### DIFF
--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -1119,6 +1119,13 @@ void CodegenNeuronCppVisitor::print_mechanism_register() {
         printer->fmt_line("register_mech({});", register_mech_args);
     }
 
+    if (info.thread_callback_register) {
+        printer->fmt_line("_extcall_thread.resize({});", info.thread_data_index + 1);
+        printer->fmt_line("thread_mem_init(_extcall_thread.data());");
+        printer->fmt_line("{} = 0;", get_variable_name("thread_data_in_use", false));
+    }
+
+
     /// type related information
     printer->add_newline();
     printer->fmt_line("mech_type = nrn_get_mechtype({}[1]);", get_channel_info_var_name());

--- a/test/usecases/global/test_callables.py
+++ b/test/usecases/global/test_callables.py
@@ -1,0 +1,25 @@
+from neuron import h, gui
+
+
+def test_function():
+    s = h.Section()
+    s.insert("shared_global")
+
+    h.finitialize()
+
+    assert s(0.5).shared_global.sum_arr() == 30.3
+
+
+def test_procedure():
+    s = h.Section()
+    s.insert("shared_global")
+
+    h.finitialize()
+
+    s(0.5).shared_global.set_g_w(44.4)
+    assert h.g_w_shared_global == 44.4
+
+
+if __name__ == "__main__":
+    test_function()
+    test_procedure()


### PR DESCRIPTION
Comparing with NOCMODL, we need `_extcall_thread` to be initialized
early during mechanism registration.

We also need it to share it's memory with the first thread.

When calling functions or procedures from HOC/Python directly, we
need to have access to the `_thread` data that will/is used by thread 0.
The is solved by making `_extcall_thread` hold the required data. Then
the field for thread variable is made to point to the statically allocated
copy that also used for thread 0. This is done by calling `thread_mem_init`.
However, thread 0 also needs to use the statically allocated copy. Therefore,
we need to reset the flags that tracks if we're already using the statically
allocated copy on any thread.
 