### PR TITLE
Not vectorized MOD files don't have thread data.

### DIFF
--- a/src/codegen/codegen_helper_visitor.cpp
+++ b/src/codegen/codegen_helper_visitor.cpp
@@ -249,7 +249,7 @@ void CodegenHelperVisitor::find_non_range_variables() {
 
     auto vars = psymtab->get_variables_with_properties(NmodlType::global_var);
     for (auto& var: vars) {
-        if (info.thread_safe && var->get_write_count() > 0) {
+        if (info.vectorize && info.thread_safe && var->get_write_count() > 0) {
             var->mark_thread_safe();
             info.thread_variables.push_back(var);
             info.thread_var_data_size += var->get_length();
@@ -287,7 +287,7 @@ void CodegenHelperVisitor::find_non_range_variables() {
 
         // if model is thread safe and if parameter is being written then
         // those variables should be promoted to thread safe variable
-        if (info.thread_safe && var->get_write_count() > 0) {
+        if (info.vectorize && info.thread_safe && var->get_write_count() > 0) {
             var->mark_thread_safe();
             info.thread_variables.push_back(var);
             info.thread_var_data_size += var->get_length();

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -835,6 +835,11 @@ void CodegenNeuronCppVisitor::print_mechanism_global_var_structure(bool print_in
     }
 
     if (!codegen_thread_variables.empty()) {
+        if (!info.vectorize) {
+            // MOD files that aren't "VECTORIZED" don't have thread data.
+            throw std::runtime_error("Found thread variables with `vectorize == false`.");
+        }
+
         codegen_global_variables.push_back(make_symbol("thread_data_in_use"));
 
         auto symbol = make_symbol("thread_data");


### PR DESCRIPTION
When the MOD file is not thread safe or not vectorized, then global
variables should be implemented as static variables and never promoted
to thread variables.