### PR TITLE
Set strict mode for sympy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = {file = "README.rst", content-type = "text/x-rst"}
 dynamic = ["version"]
 dependencies = [
     "find_libpython",
-    "sympy>=1.3",
+    "sympy>=1.13",
     "importlib-metadata;python_version<'3.9'",
     "importlib-resources;python_version<'3.9'",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Jinja2>=2.9.3
 PyYAML>=3.13
 # runtime dependencies
 find_libpython
-sympy>=1.3
+sympy>=1.13
 importlib-metadata;python_version<'3.9'
 importlib-resources;python_version<'3.9'
 # dependencies for test


### PR DESCRIPTION
Fixes #1129 (or at least it shows a readable error this time).
Raise a proper Python error instead of the mysterious parser error about an unexpexted `/`.
The full error is actually caused by:

```plaintext
/* Not supported in C */
/* <list of symbols/functions> */
```

being part of the output, and NMODL cannot handle it.

Only works in Sympy 1.13 and above, so SymPy has also been bumped.