### PR TITLE
Fix `nrn_ghk`.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -291,6 +291,8 @@ int main(int argc, const char* argv[]) {
 
     CLI11_PARSE(app, argc, argv);
 
+    std::string simulator_name = neuron_code ? "neuron" : "coreneuron";
+
     fs::create_directories(output_dir);
     fs::create_directories(scratch_dir);
 
@@ -383,8 +385,7 @@ int main(int argc, const char* argv[]) {
             // run perfvisitor to update read/write counts
             PerfVisitor().visit_program(*ast);
 
-            auto compatibility_visitor = CodegenCompatibilityVisitor(neuron_code ? "neuron"
-                                                                                 : "coreneuron");
+            auto compatibility_visitor = CodegenCompatibilityVisitor(simulator_name);
             // If we want to just check compatibility we return the result
             if (only_check_compatibility) {
                 return compatibility_visitor.find_unhandled_ast_nodes(*ast);
@@ -556,7 +557,7 @@ int main(int argc, const char* argv[]) {
 
         // Add implicit arguments (like celsius, nt) to NEURON functions (like
         // nrn_ghk, at_time) whose signatures we have to massage.
-        ImplicitArgumentVisitor{}.visit_program(*ast);
+        ImplicitArgumentVisitor{simulator_name}.visit_program(*ast);
         SymtabVisitor(update_symtab).visit_program(*ast);
 
         {

--- a/src/visitors/implicit_argument_visitor.cpp
+++ b/src/visitors/implicit_argument_visitor.cpp
@@ -19,6 +19,9 @@ void ImplicitArgumentVisitor::visit_function_call(ast::FunctionCall& node) {
     auto function_name = node.get_node_name();
     auto const& arguments = node.get_arguments();
     if (function_name == "nrn_ghk") {
+        if(simulator == "neuron") {
+            return;
+        }
         // This function is traditionally used in MOD files with four arguments, but
         // its value also depends on the global celsius variable so the real
         // function in CoreNEURON has a 5th argument for that.

--- a/src/visitors/implicit_argument_visitor.cpp
+++ b/src/visitors/implicit_argument_visitor.cpp
@@ -19,7 +19,7 @@ void ImplicitArgumentVisitor::visit_function_call(ast::FunctionCall& node) {
     auto function_name = node.get_node_name();
     auto const& arguments = node.get_arguments();
     if (function_name == "nrn_ghk") {
-        if(simulator == "neuron") {
+        if (simulator == "neuron") {
             return;
         }
         // This function is traditionally used in MOD files with four arguments, but

--- a/src/visitors/implicit_argument_visitor.hpp
+++ b/src/visitors/implicit_argument_visitor.hpp
@@ -35,7 +35,8 @@ namespace visitor {
  * that they can be pure functions.
  */
 struct ImplicitArgumentVisitor: public AstVisitor {
-    ImplicitArgumentVisitor(const std::string& simulator = "coreneuron") : simulator(simulator) {}
+    ImplicitArgumentVisitor(const std::string& simulator = "coreneuron")
+        : simulator(simulator) {}
 
     void visit_function_call(ast::FunctionCall& node) override;
 

--- a/src/visitors/implicit_argument_visitor.hpp
+++ b/src/visitors/implicit_argument_visitor.hpp
@@ -14,6 +14,8 @@
 
 #include "visitors/ast_visitor.hpp"
 
+#include <string>
+
 
 namespace nmodl {
 namespace visitor {
@@ -33,7 +35,12 @@ namespace visitor {
  * that they can be pure functions.
  */
 struct ImplicitArgumentVisitor: public AstVisitor {
+    ImplicitArgumentVisitor(const std::string& simulator = "coreneuron") : simulator(simulator) {}
+
     void visit_function_call(ast::FunctionCall& node) override;
+
+  private:
+    std::string simulator;
 };
 
 /** \} */  // end of visitor_classes

--- a/test/usecases/CMakeLists.txt
+++ b/test/usecases/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(NMODL_USECASE_DIRS
     solve
+    builtin_functions
     constant
     electrode_current
     constructor

--- a/test/usecases/builtin_functions/compile_only.mod
+++ b/test/usecases/builtin_functions/compile_only.mod
@@ -1,0 +1,7 @@
+NEURON {
+  SUFFIX compile_only
+}
+
+FUNCTION call_nrn_ghk() {
+  call_nrn_ghk = nrn_ghk(1.0, 2.0, 3.0, 4.0)
+}


### PR DESCRIPTION
The NEURON version of `nrn_ghk` has four arguments, unlike the
CoreNEURON variation which as five.