### PR TITLE
Print tracebacks of Python exceptions.

### DIFF
--- a/src/pybind/wrapper.cpp
+++ b/src/pybind/wrapper.cpp
@@ -51,9 +51,10 @@ try:
                                                  do_cse)
 except Exception as e:
     # if we fail, fail silently and return empty string
+    import traceback
     solutions = [""]
     new_local_vars = [""]
-    exception_message = str(e)
+    exception_message = traceback.format_exc()
 )";
 
     py::exec(nmodl::pybind_wrappers::ode_py + script, locals);
@@ -86,9 +87,10 @@ try:
                                      function_calls)
 except Exception as e:
     # if we fail, fail silently and return empty string
+    import traceback
     solutions = [""]
     new_local_vars = [""]
-    exception_message = str(e)
+    exception_message = traceback.format_exc()
 )";
 
     py::exec(nmodl::pybind_wrappers::ode_py + script, locals);
@@ -123,8 +125,9 @@ try:
     solution = forwards_euler2c(equation_string, dt_var, vars, function_calls)
 except Exception as e:
     # if we fail, fail silently and return empty string
+    import traceback
     solution = ""
-    exception_message = str(e)
+    exception_message = traceback.format_exc()
 )";
 
         py::exec(nmodl::pybind_wrappers::ode_py + script, locals);
@@ -139,8 +142,9 @@ try:
                            use_pade_approx)
 except Exception as e:
     # if we fail, fail silently and return empty string
+    import traceback
     solution = ""
-    exception_message = str(e)
+    exception_message = traceback.format_exc()
 )";
 
         py::exec(nmodl::pybind_wrappers::ode_py + script, locals);
@@ -170,8 +174,9 @@ try:
                )
 except Exception as e:
     # if we fail, fail silently and return empty string
+    import traceback
     solution = ""
-    exception_message = str(e)
+    exception_message = traceback.format_exc()
 )";
 
     py::exec(nmodl::pybind_wrappers::ode_py + script, locals);

--- a/src/visitors/sympy_solver_visitor.cpp
+++ b/src/visitors/sympy_solver_visitor.cpp
@@ -321,8 +321,10 @@ void SympySolverVisitor::solve_linear_system(const ast::Node& node,
         eq_system, state_vars, vars, small_system, elimination, tmp_unique_prefix, function_calls);
 
     if (!exception_message.empty()) {
-        logger->warn("SympySolverVisitor :: solve_lin_system python exception: " +
-                     exception_message);
+        logger->warn(
+            "SympySolverVisitor :: solve_lin_system python exception occured. (--verbose=info)");
+        logger->info(exception_message +
+                     "\n (Note: line numbers are of by a few compared to `ode.py`.)");
         return;
     }
     // find out where to insert solutions in statement block
@@ -363,8 +365,10 @@ void SympySolverVisitor::solve_non_linear_system(
     auto [solutions, exception_message] = solver(eq_system, state_vars, vars, function_calls);
 
     if (!exception_message.empty()) {
-        logger->warn("SympySolverVisitor :: solve_non_lin_system python exception: " +
-                     exception_message);
+        logger->warn(
+            "SympySolverVisitor :: solve_non_lin_system python exception. (--verbose=info)");
+        logger->info(exception_message +
+                     "\n (Note: line numbers are of by a few compared to `ode.py`.)");
         return;
     }
     logger->debug("SympySolverVisitor :: Constructing eigen newton solve block");
@@ -449,7 +453,9 @@ void SympySolverVisitor::visit_diff_eq_expression(ast::DiffEqExpression& node) {
     logger->debug("SympySolverVisitor :: -> solution: {}", solution);
 
     if (!exception_message.empty()) {
-        logger->warn("SympySolverVisitor :: python exception: " + exception_message);
+        logger->warn("SympySolverVisitor :: python exception. (--verbose=info)");
+        logger->info(exception_message +
+                     "\n (Note: line numbers are of by a few compared to `ode.py`.)");
         return;
     }
 


### PR DESCRIPTION
The SymPy solvers are meant to be run again on code that has already been transformed. However, since the output of the SymPy solvers isn't valid input for the SymPy solver they crash the second time around.

Failure is interpreted as: "it already ran" and not considered a failure.

Naturally, this is rarely the case while developing and it's always a bug.

The workaround here is to print the traceback as a separate log message of severity "info". Unfortunately, `pybind11` injects a line:

    # -*- coding: utf-8 -*-

Hence, all line numbers are off by two; because `ode_py` starts with an empty line.

Old output:

    [NMODL] [warning] :: SympySolverVisitor :: solve_non_lin_system python exception: name 'x' is not defined

New output:

    [NMODL] [warning] :: SympySolverVisitor :: solve_non_lin_system python exception. (--verbose=info)
    [NMODL] [info] :: Traceback (most recent call last):
      File "<string>", line 691, in <module>
      File "<string>", line 416, in solve_non_lin_system
      File "<string>", line 385, in finite_difference_variables
      File "<string>", line 382, in recurse
      File "<string>", line 352, in finite_difference_step_variable
    NameError: name 'x' is not defined