### PR TITLE
Allow `derivimplicit` to use finite differences.

### DIFF
--- a/python/nmodl/ode.py
+++ b/python/nmodl/ode.py
@@ -358,10 +358,10 @@ def discretize_derivative(expr):
 
 
 def transform_expression(expr, transform):
-    if expr.args is tuple():
+    if not expr:
         return expr
 
-    args = list(transform_expression(transform(arg), transform) for arg in expr.args)
+    args = (transform_expression(transform(arg), transform) for arg in expr.args)
     return expr.func(*args)
 
 
@@ -372,21 +372,6 @@ def transform_matrix_elements(mat, transform):
             for i in range(mat.cols)
         ]
     )
-
-
-def finite_difference_variables(mat):
-    vars = []
-
-    def recurse(expr):
-        for arg in expr.args:
-            if isinstance(arg, sp.Derivative):
-                var = arg.args[1][0]
-                vars.append((var, finite_difference_step_variable(var)))
-
-    for expr in mat:
-        recurse(expr)
-
-    return vars
 
 
 def needs_finite_differences(mat):

--- a/python/nmodl/ode.py
+++ b/python/nmodl/ode.py
@@ -344,6 +344,55 @@ def solve_lin_system(
     return code, new_local_vars
 
 
+def finite_difference_step_variable(sym):
+    return f"{sym}_delta_"
+
+
+def discretize_derivative(expr):
+    if isinstance(expr, sp.Derivative):
+        x = expr.args[1][0]
+        dx = sp.symbols(finite_difference_step_variable(x))
+        return expr.as_finite_difference(dx)
+    else:
+        return expr
+
+
+def transform_expression(expr, transform):
+    if expr.args is tuple():
+        return expr
+
+    args = list(transform_expression(transform(arg), transform) for arg in expr.args)
+    return expr.func(*args)
+
+
+def transform_matrix_elements(mat, transform):
+    return sp.Matrix(
+        [
+            [transform_expression(mat[i, j], transform) for j in range(mat.rows)]
+            for i in range(mat.cols)
+        ]
+    )
+
+
+def finite_difference_variables(mat):
+    vars = []
+
+    def recurse(expr):
+        for arg in expr.args:
+            if isinstance(arg, sp.Derivative):
+                var = arg.args[1][0]
+                vars.append((var, finite_difference_step_variable(var)))
+
+    for expr in mat:
+        recurse(expr)
+
+    return vars
+
+
+def needs_finite_differences(mat):
+    return any(isinstance(expr, sp.Derivative) for expr in sp.preorder_traversal(mat))
+
+
 def solve_non_lin_system(eq_strings, vars, constants, function_calls):
     """Solve non-linear system of equations, return solution as C code.
 
@@ -369,28 +418,31 @@ def solve_non_lin_system(eq_strings, vars, constants, function_calls):
     custom_fcts = _get_custom_functions(function_calls)
 
     jacobian = sp.Matrix(eqs).jacobian(state_vars)
+    if needs_finite_differences(jacobian):
+        jacobian = transform_matrix_elements(jacobian, discretize_derivative)
 
     X_vec_map = {x: sp.symbols(f"X[{i}]") for i, x in enumerate(state_vars)}
+    dX_vec_map = {
+        finite_difference_step_variable(x): sp.symbols(f"dX_[{i}]")
+        for i, x in enumerate(state_vars)
+    }
 
     vecFcode = []
     for i, eq in enumerate(eqs):
-        vecFcode.append(
-            f"F[{i}] = {sp.ccode(eq.simplify().subs(X_vec_map).evalf(), user_functions=custom_fcts)}"
-        )
+        expr = eq.simplify().subs(X_vec_map).evalf()
+        rhs = sp.ccode(expr, user_functions=custom_fcts)
+        vecFcode.append(f"F[{i}] = {rhs}")
 
     vecJcode = []
     for i, j in itertools.product(range(jacobian.rows), range(jacobian.cols)):
         flat_index = i + jacobian.rows * j
 
-        rhs = sp.ccode(
-            jacobian[i, j].simplify().subs(X_vec_map).evalf(),
-            user_functions=custom_fcts,
-        )
+        Jij = jacobian[i, j].simplify().subs({**X_vec_map, **dX_vec_map}).evalf()
+        rhs = sp.ccode(Jij, user_functions=custom_fcts)
         vecJcode.append(f"J[{flat_index}] = {rhs}")
 
     # interweave
     code = _interweave_eqs(vecFcode, vecJcode)
-
     code = search_and_replace_protected_identifiers_from_sympy(code, function_calls)
 
     return code

--- a/python/nmodl/ode.py
+++ b/python/nmodl/ode.py
@@ -358,7 +358,7 @@ def discretize_derivative(expr):
 
 
 def transform_expression(expr, transform):
-    if not expr:
+    if not expr.args:
         return expr
 
     args = (transform_expression(transform(arg), transform) for arg in expr.args)

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -708,6 +708,7 @@ void CodegenCppVisitor::print_functor_definition(const ast::EigenNewtonSolverBlo
 
     printer->fmt_text(
         "void operator()(const Eigen::Matrix<{0}, {1}, 1>& nmodl_eigen_xm, Eigen::Matrix<{0}, {1}, "
+        "1>& nmodl_eigen_dxm, Eigen::Matrix<{0}, {1}, "
         "1>& nmodl_eigen_fm, "
         "Eigen::Matrix<{0}, {1}, {1}>& nmodl_eigen_jm) {2}",
         float_type,
@@ -715,8 +716,15 @@ void CodegenCppVisitor::print_functor_definition(const ast::EigenNewtonSolverBlo
         is_functor_const(variable_block, functor_block) ? "const " : "");
     printer->push_block();
     printer->fmt_line("const {}* nmodl_eigen_x = nmodl_eigen_xm.data();", float_type);
+    printer->fmt_line("{}* nmodl_eigen_dx = nmodl_eigen_dxm.data();", float_type);
     printer->fmt_line("{}* nmodl_eigen_j = nmodl_eigen_jm.data();", float_type);
     printer->fmt_line("{}* nmodl_eigen_f = nmodl_eigen_fm.data();", float_type);
+
+    for (size_t i = 0; i < N; ++i) {
+        printer->fmt_line(
+            "nmodl_eigen_dx[{0}] = std::max(1e-6, 0.02*std::fabs(nmodl_eigen_x[{0}]));", i);
+    }
+
     print_statement_block(functor_block, false, false);
     printer->pop_block();
     printer->add_newline();

--- a/src/pybind/wrapper.cpp
+++ b/src/pybind/wrapper.cpp
@@ -82,14 +82,13 @@ std::tuple<std::vector<std::string>, std::string> call_solve_nonlinear_system(
 exception_message = ""
 try:
     solutions = solve_non_lin_system(equation_strings,
-                                     state_vars,
-                                     vars,
-                                     function_calls)
+                                               state_vars,
+                                               vars,
+                                               function_calls)
 except Exception as e:
     # if we fail, fail silently and return empty string
     import traceback
     solutions = [""]
-    new_local_vars = [""]
     exception_message = traceback.format_exc()
 )";
 

--- a/src/solver/newton/newton.hpp
+++ b/src/solver/newton/newton.hpp
@@ -81,6 +81,8 @@ EIGEN_DEVICE_FUNC int newton_solver(Eigen::Matrix<double, N, 1>& X,
                                     FUNC functor,
                                     double eps = EPS,
                                     int max_iter = MAX_ITER) {
+    // If finite differences are needed, this is stores the stepwidth.
+    Eigen::Matrix<double, N, 1> dX;
     // Vector to store result of function F(X):
     Eigen::Matrix<double, N, 1> F;
     // Matrix to store Jacobian of F(X):
@@ -89,7 +91,7 @@ EIGEN_DEVICE_FUNC int newton_solver(Eigen::Matrix<double, N, 1>& X,
     int iter = -1;
     while (++iter < max_iter) {
         // calculate F, J from X using user-supplied functor
-        functor(X, F, J);
+        functor(X, dX, F, J);
         if (is_converged(X, J, F, eps)) {
             return iter;
         }
@@ -127,10 +129,11 @@ EIGEN_DEVICE_FUNC int newton_solver_small_N(Eigen::Matrix<double, N, 1>& X,
                                             int max_iter) {
     bool invertible;
     Eigen::Matrix<double, N, 1> F;
+    Eigen::Matrix<double, N, 1> dX;
     Eigen::Matrix<double, N, N> J, J_inv;
     int iter = -1;
     while (++iter < max_iter) {
-        functor(X, F, J);
+        functor(X, dX, F, J);
         if (is_converged(X, J, F, eps)) {
             return iter;
         }

--- a/test/unit/newton/newton.cpp
+++ b/test/unit/newton/newton.cpp
@@ -21,6 +21,7 @@ SCENARIO("Non-linear system to solve with Newton Solver", "[analytic][solver]") 
     GIVEN("1 linear eq") {
         struct functor {
             void operator()(const Eigen::Matrix<double, 1, 1>& X,
+                            Eigen::Matrix<double, 1, 1>& /* dX */,
                             Eigen::Matrix<double, 1, 1>& F,
                             Eigen::Matrix<double, 1, 1>& J) const {
                 // Function F(X) to find F(X)=0 solution
@@ -30,15 +31,16 @@ SCENARIO("Non-linear system to solve with Newton Solver", "[analytic][solver]") 
             }
         };
         Eigen::Matrix<double, 1, 1> X{22.2536};
+        Eigen::Matrix<double, 1, 1> dX;
         Eigen::Matrix<double, 1, 1> F;
         Eigen::Matrix<double, 1, 1> J;
         functor fn;
         int iter_newton = newton::newton_solver(X, fn);
-        fn(X, F, J);
+        fn(X, dX, F, J);
         THEN("find the solution") {
             CAPTURE(iter_newton);
             CAPTURE(X);
-            REQUIRE(iter_newton > 0);
+            REQUIRE(iter_newton == 1);
             REQUIRE_THAT(X[0], Catch::Matchers::WithinRel(1.0, 0.01));
             REQUIRE(F.norm() < max_error_norm);
         }
@@ -47,6 +49,7 @@ SCENARIO("Non-linear system to solve with Newton Solver", "[analytic][solver]") 
     GIVEN("1 non-linear eq") {
         struct functor {
             void operator()(const Eigen::Matrix<double, 1, 1>& X,
+                            Eigen::Matrix<double, 1, 1>& /* dX */,
                             Eigen::Matrix<double, 1, 1>& F,
                             Eigen::Matrix<double, 1, 1>& J) const {
                 F[0] = -3.0 * X[0] + std::sin(X[0]) + std::log(X[0] * X[0] + 11.435243) + 3.0;
@@ -54,11 +57,12 @@ SCENARIO("Non-linear system to solve with Newton Solver", "[analytic][solver]") 
             }
         };
         Eigen::Matrix<double, 1, 1> X{-0.21421};
+        Eigen::Matrix<double, 1, 1> dX;
         Eigen::Matrix<double, 1, 1> F;
         Eigen::Matrix<double, 1, 1> J;
         functor fn;
         int iter_newton = newton::newton_solver(X, fn);
-        fn(X, F, J);
+        fn(X, dX, F, J);
         THEN("find the solution") {
             CAPTURE(iter_newton);
             CAPTURE(X);
@@ -71,6 +75,7 @@ SCENARIO("Non-linear system to solve with Newton Solver", "[analytic][solver]") 
     GIVEN("system of 2 non-linear eqs") {
         struct functor {
             void operator()(const Eigen::Matrix<double, 2, 1>& X,
+                            Eigen::Matrix<double, 2, 1>& /* dX */,
                             Eigen::Matrix<double, 2, 1>& F,
                             Eigen::Matrix<double, 2, 2>& J) const {
                 F[0] = -3.0 * X[0] * X[1] + X[0] + 2.0 * X[1] - 1.0;
@@ -82,11 +87,12 @@ SCENARIO("Non-linear system to solve with Newton Solver", "[analytic][solver]") 
             }
         };
         Eigen::Matrix<double, 2, 1> X{0.2, 0.4};
+        Eigen::Matrix<double, 2, 1> dX;
         Eigen::Matrix<double, 2, 1> F;
         Eigen::Matrix<double, 2, 2> J;
         functor fn;
         int iter_newton = newton::newton_solver(X, fn);
-        fn(X, F, J);
+        fn(X, dX, F, J);
         THEN("find a solution") {
             CAPTURE(iter_newton);
             CAPTURE(X);
@@ -107,6 +113,7 @@ SCENARIO("Non-linear system to solve with Newton Solver", "[analytic][solver]") 
             double e = 0.01;
             double z = 0.99;
             void operator()(const Eigen::Matrix<double, 3, 1>& X,
+                            Eigen::Matrix<double, 3, 1>& /* dX */,
                             Eigen::Matrix<double, 3, 1>& F,
                             Eigen::Matrix<double, 3, 3>& J) const {
                 F(0) = -(-_x_old - dt * (a * std::pow(X[0], 2) + X[1]) + X[0]);
@@ -124,11 +131,12 @@ SCENARIO("Non-linear system to solve with Newton Solver", "[analytic][solver]") 
             }
         };
         Eigen::Matrix<double, 3, 1> X{0.21231, 0.4435, -0.11537};
+        Eigen::Matrix<double, 3, 1> dX;
         Eigen::Matrix<double, 3, 1> F;
         Eigen::Matrix<double, 3, 3> J;
         functor fn;
         int iter_newton = newton::newton_solver(X, fn);
-        fn(X, F, J);
+        fn(X, dX, F, J);
         THEN("find a solution") {
             CAPTURE(iter_newton);
             CAPTURE(X);
@@ -145,6 +153,7 @@ SCENARIO("Non-linear system to solve with Newton Solver", "[analytic][solver]") 
             double X3_old = 1.2345;
             double dt = 0.2;
             void operator()(const Eigen::Matrix<double, 4, 1>& X,
+                            Eigen::Matrix<double, 4, 1>& /* dX */,
                             Eigen::Matrix<double, 4, 1>& F,
                             Eigen::Matrix<double, 4, 4>& J) const {
                 F[0] = -(-3.0 * X[0] * X[2] * dt + X[0] - X0_old + 2.0 * dt / X[1]);
@@ -170,11 +179,12 @@ SCENARIO("Non-linear system to solve with Newton Solver", "[analytic][solver]") 
             }
         };
         Eigen::Matrix<double, 4, 1> X{0.21231, 0.4435, -0.11537, -0.8124312};
+        Eigen::Matrix<double, 4, 1> dX;
         Eigen::Matrix<double, 4, 1> F;
         Eigen::Matrix<double, 4, 4> J;
         functor fn;
         int iter_newton = newton::newton_solver(X, fn);
-        fn(X, F, J);
+        fn(X, dX, F, J);
         THEN("find a solution") {
             CAPTURE(iter_newton);
             CAPTURE(X);
@@ -186,6 +196,7 @@ SCENARIO("Non-linear system to solve with Newton Solver", "[analytic][solver]") 
     GIVEN("system of 5 non-linear eqs") {
         struct functor {
             void operator()(const Eigen::Matrix<double, 5, 1>& X,
+                            Eigen::Matrix<double, 5, 1>& /* dX */,
                             Eigen::Matrix<double, 5, 1>& F,
                             Eigen::Matrix<double, 5, 5>& J) const {
                 F[0] = -3.0 * X[0] * X[2] + X[0] + 2.0 / X[1];
@@ -224,11 +235,12 @@ SCENARIO("Non-linear system to solve with Newton Solver", "[analytic][solver]") 
         };
         Eigen::Matrix<double, 5, 1> X;
         X << 8.234, -245.46, 123.123, 0.8343, 5.555;
+        Eigen::Matrix<double, 5, 1> dX;
         Eigen::Matrix<double, 5, 1> F;
         Eigen::Matrix<double, 5, 5> J;
         functor fn;
         int iter_newton = newton::newton_solver<5, functor>(X, fn);
-        fn(X, F, J);
+        fn(X, dX, F, J);
         THEN("find a solution") {
             CAPTURE(iter_newton);
             CAPTURE(X);
@@ -240,6 +252,7 @@ SCENARIO("Non-linear system to solve with Newton Solver", "[analytic][solver]") 
     GIVEN("system of 10 non-linear eqs") {
         struct functor {
             void operator()(const Eigen::Matrix<double, 10, 1>& X,
+                            Eigen::Matrix<double, 10, 1>& /* dX */,
                             Eigen::Matrix<double, 10, 1>& F,
                             Eigen::Matrix<double, 10, 10>& J) const {
                 F[0] = -3.0 * X[0] * X[1] + X[0] + 2.0 * X[1];
@@ -360,11 +373,12 @@ SCENARIO("Non-linear system to solve with Newton Solver", "[analytic][solver]") 
 
         Eigen::Matrix<double, 10, 1> X;
         X << 8.234, -5.46, 1.123, 0.8343, 5.555, 18.234, -2.46, 0.123, 10.8343, -4.685;
+        Eigen::Matrix<double, 10, 1> dX;
         Eigen::Matrix<double, 10, 1> F;
         Eigen::Matrix<double, 10, 10> J;
         functor fn;
         int iter_newton = newton::newton_solver<10, functor>(X, fn);
-        fn(X, F, J);
+        fn(X, dX, F, J);
         THEN("find a solution") {
             CAPTURE(iter_newton);
             CAPTURE(X);

--- a/test/usecases/solve/finite_difference.mod
+++ b/test/usecases/solve/finite_difference.mod
@@ -1,0 +1,30 @@
+NEURON {
+    SUFFIX finite_difference
+    GLOBAL a
+    THREADSAFE
+}
+
+ASSIGNED {
+  a
+}
+
+STATE {
+  x
+}
+
+INITIAL {
+    x = 42.0
+    a = 0.1
+}
+
+BREAKPOINT {
+    SOLVE dX METHOD derivimplicit
+}
+
+DERIVATIVE dX {
+    x' = -f(x)
+}
+
+FUNCTION f(x) {
+    f = a*x
+}

--- a/test/usecases/solve/test_finite_difference.py
+++ b/test/usecases/solve/test_finite_difference.py
@@ -10,7 +10,7 @@ def test_finite_difference():
     s.insert("finite_difference")
     s.nseg = nseg
 
-    x_hoc = h.Vector().record(getattr(s(0.5), f"_ref_x_finite_difference"))
+    x_hoc = h.Vector().record(s(0.5)._ref_x_finite_difference)
     t_hoc = h.Vector().record(h._ref_t)
 
     h.stdinit()

--- a/test/usecases/solve/test_finite_difference.py
+++ b/test/usecases/solve/test_finite_difference.py
@@ -1,0 +1,30 @@
+import numpy as np
+from neuron import h, gui
+from neuron.units import ms
+
+
+def test_finite_difference():
+    nseg = 1
+
+    s = h.Section()
+    s.insert("finite_difference")
+    s.nseg = nseg
+
+    x_hoc = h.Vector().record(getattr(s(0.5), f"_ref_x_finite_difference"))
+    t_hoc = h.Vector().record(h._ref_t)
+
+    h.stdinit()
+    h.dt = 0.001
+    h.tstop = 5.0 * ms
+    h.run()
+
+    x = np.array(x_hoc.as_numpy())
+    t = np.array(t_hoc.as_numpy())
+
+    a = h.a_finite_difference
+    x_exact = 42.0 * np.exp(-a * t)
+    np.testing.assert_allclose(x, x_exact, rtol=1e-4)
+
+
+if __name__ == "__main__":
+    test_finite_difference()


### PR DESCRIPTION
In NOCMODL `derivimplicit` uses finite differences to compute each
element of the Jacobian. In stead we try to use SymPy, however, if it
fails, e.g. because it encounters an opaque function, we allow it to use
a finite difference instead.

When SymPy can't compute a derivative analytically, it replaces it
with a `Derivative({func}, ({variable}, {n}))`, which represents the
`n`th derivative of `func` w.r.t. `variable`.

In this PR we crawl SymPy's AST to find `Derivative` objects, and
replace them with a finite difference. The step-with is the same
as used in NEURON for computing the elements of the Jacobian.

Additionally, there's some code to enable computing the `\Delta x`.