### PR TITLE
Rename `print_check_table_entrypoint`.

### DIFF
--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -137,7 +137,7 @@ void CodegenNeuronCppVisitor::print_point_process_function_definitions() {
 }
 
 
-void CodegenNeuronCppVisitor::print_check_table_function_prototypes() {
+void CodegenNeuronCppVisitor::print_check_table_entrypoint() {
     if (info.table_count == 0) {
         return;
     }
@@ -231,7 +231,7 @@ void CodegenNeuronCppVisitor::print_function_prototypes() {
 
     print_point_process_function_definitions();
     print_setdata_functions();
-    print_check_table_function_prototypes();
+    print_check_table_entrypoint();
 }
 
 

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -226,7 +226,7 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
     /**
      * Print all `check_*` function declarations
      */
-    void print_check_table_function_prototypes();
+    void print_check_table_entrypoint();
 
 
     void print_function_or_procedure(const ast::Block& node,


### PR DESCRIPTION
Because it doesn't print any prototypes.