### PR TITLE
Refactor to use `print_function_table_call`.

### DIFF
--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -2249,6 +2249,20 @@ void CodegenCoreneuronCppVisitor::print_net_event_call(const FunctionCall& node)
     printer->add_text(")");
 }
 
+void CodegenCoreneuronCppVisitor::print_function_table_call(const FunctionCall& node) {
+     auto name = node.get_node_name();
+    const auto& arguments = node.get_arguments();
+    printer->add_text(method_name(name), '(');
+
+    printer->add_text(internal_method_arguments());
+    if (!arguments.empty()) {
+        printer->add_text(", ");
+    }
+
+    print_vector_elements(arguments, ", ");
+    printer->add_text(')');
+}
+
 /**
  * Rename arguments to NET_RECEIVE block with corresponding pointer variable
  *

--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -736,6 +736,8 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
      */
     void print_net_event_call(const ast::FunctionCall& node) override;
 
+    void print_function_table_call(const ast::FunctionCall& node) override;
+
 
     /**
      * Print initial block in the net receive block

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -166,6 +166,13 @@ bool CodegenCppVisitor::defined_method(const std::string& name) const {
     return function && function->has_any_property(properties);
 }
 
+bool CodegenCppVisitor::is_function_table_call(const std::string& name) const {
+    auto it = std::find_if(info.function_tables.begin(),
+                           info.function_tables.end(),
+                           [name](const auto& node) { return node->get_node_name() == name; });
+    return it != info.function_tables.end();
+}
+
 int CodegenCppVisitor::float_variables_size() const {
     int n_floats = 0;
     for (const auto& var: codegen_float_variables) {
@@ -489,6 +496,11 @@ void CodegenCppVisitor::print_function_call(const FunctionCall& node) {
 
     if (is_net_event(name)) {
         print_net_event_call(node);
+        return;
+    }
+
+    if (is_function_table_call(name)) {
+        print_function_table_call(node);
         return;
     }
 

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -668,6 +668,9 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     }
 
 
+    bool is_function_table_call(const std::string& name) const;
+
+
     /**
      * Determine the position in the data array for a given float variable
      * \param name The name of a float variable
@@ -851,6 +854,10 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      * \param node The AST node representing the function call
      */
     virtual void print_net_event_call(const ast::FunctionCall& node) = 0;
+
+    /** Print special code when calling FUNCTION_TABLEs.
+     */
+    virtual void print_function_table_call(const ast::FunctionCall& node) = 0;
 
     /**
      * Print function and procedures prototype declaration

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -2278,6 +2278,10 @@ void CodegenNeuronCppVisitor::print_net_event_call(const ast::FunctionCall& /* n
     printer->fmt_text("net_event({}, t)", point_process);
 }
 
+void CodegenNeuronCppVisitor::print_function_table_call(const FunctionCall& node) {
+    throw std::runtime_error("Not implemented.");
+}
+
 /**
  * Rename arguments to NET_RECEIVE block with corresponding pointer variable
  *

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -191,6 +191,8 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
      */
     void print_net_event_call(const ast::FunctionCall& node) override;
 
+    void print_function_table_call(const ast::FunctionCall& node) override;
+
     /**
      * Print `net_receive` call-back.
      */


### PR DESCRIPTION
Introduces a way to customize (CoreNEURON vs. NEURON) calling function tables.