### PR TITLE
Fix POINTER variables.

### DIFF
--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -572,6 +572,10 @@ std::string CodegenNeuronCppVisitor::int_variable_name(const IndexVariableInfo& 
         return fmt::format("_ppvar[{}].literal_value<void*>()", position);
     }
 
+    if (info.semantics[position].name == naming::POINTER_SEMANTIC) {
+        return fmt::format("(*_ppvar[{}].get<double*>())", position);
+    }
+
     if (symbol.is_index) {
         if (use_instance) {
             throw std::runtime_error("Not implemented. [wiejo]");
@@ -1134,12 +1138,14 @@ void CodegenNeuronCppVisitor::print_mechanism_register() {
                           method_name(naming::NRN_JACOB_METHOD),
                           nrn_state_required() ? method_name(naming::NRN_STATE_METHOD) : "nullptr")
             : "nullptr, nullptr, nullptr";
+
+
     const auto register_mech_args = fmt::format("{}, {}, {}, {}, {}, {}",
                                                 get_channel_info_var_name(),
                                                 method_name(naming::NRN_ALLOC_METHOD),
                                                 compute_functions_parameters,
                                                 method_name(naming::NRN_INIT_METHOD),
-                                                naming::NRN_POINTERINDEX,
+                                                info.first_pointer_var_index,
                                                 1 + info.thread_data_index);
     if (info.point_process) {
         printer->fmt_line(

--- a/test/usecases/pointer/basic_pointer.mod
+++ b/test/usecases/pointer/basic_pointer.mod
@@ -1,0 +1,38 @@
+: POINTER variables are part of the `dparam` array. They're also "known" to
+: NEURON and it recomputes their index into `dparam`. Naturally, the two don't
+: have to agree, but if they don't it's a bug.
+:
+: These tests check that the index in MOD files agrees with the index used
+: inside of NEURON.
+
+NEURON {
+    SUFFIX basic_pointer
+    RANGE x1, x2, ignore
+    : The ion pointers immediately preceed the POINTER variables
+    : in the dparam array.
+    USEION ca READ ica
+    POINTER p1, p2
+}
+
+ASSIGNED {
+    x1
+    x2
+    p1
+    p2
+    ica
+    ignore
+}
+
+INITIAL {
+    ignore = ica
+    x1 = 0.0
+    x2 = 0.0
+}
+
+FUNCTION read_p1() {
+    read_p1 = p1
+}
+
+FUNCTION read_p2() {
+    read_p2 = p2
+}

--- a/test/usecases/pointer/point_basic.mod
+++ b/test/usecases/pointer/point_basic.mod
@@ -1,0 +1,38 @@
+: POINTER variables are part of the `dparam` array. They're also "known" to
+: NEURON and it recomputes their index into `dparam`. Naturally, the two don't
+: have to agree, but if they don't it's a bug.
+:
+: These tests check that the index in MOD files agrees with the index used
+: inside of NEURON.
+
+NEURON {
+    POINT_PROCESS point_basic
+    RANGE x1, x2, ignore
+    : The ion pointers immediately preceed the POINTER variables
+    : in the dparam array.
+    USEION ca READ ica
+    POINTER p1, p2
+}
+
+ASSIGNED {
+    x1
+    x2
+    p1
+    p2
+    ica
+    ignore
+}
+
+INITIAL {
+    ignore = ica
+    x1 = 0.0
+    x2 = 0.0
+}
+
+FUNCTION read_p1() {
+    read_p1 = p1
+}
+
+FUNCTION read_p2() {
+    read_p2 = p2
+}

--- a/test/usecases/pointer/test_basic_pointer.py
+++ b/test/usecases/pointer/test_basic_pointer.py
@@ -1,0 +1,42 @@
+from neuron import h, gui
+
+
+def check_basic_pointer(make_instance):
+    s = h.Section()
+    s.nseg = 2
+
+    s.insert("basic_pointer")
+
+    s025 = make_instance(s, 0.25)
+    s075 = make_instance(s, 0.75)
+
+    s025._ref_p1 = s025._ref_x1
+    s025._ref_p2 = s025._ref_x2
+
+    s075._ref_p1 = s(0.25)._ref_v
+    s075._ref_p2 = s(0.75)._ref_v
+
+    s025.x1 = 123.0
+    s025.x2 = 0.123
+
+    assert s025.read_p1() == s025.x1
+    assert s025.read_p2() == s025.x2
+
+    s(0.25).v = 83.9
+    s(0.75).v = -83.9
+
+    assert s075.read_p1() == s(0.25).v
+    assert s075.read_p2() == s(0.75).v
+
+
+def test_basic_pointer():
+    check_basic_pointer(lambda s, x: s(x).basic_pointer)
+
+
+def test_point_basic():
+    check_basic_pointer(lambda s, x: h.point_basic(x))
+
+
+if __name__ == "__main__":
+    test_basic_pointer()
+    test_point_basic()


### PR DESCRIPTION
Both the MOD file and NEURON independently number the pointer variables; and then use their respective order to access the `dparam` array. In order to make the two match we must ensure that all pointer variables are consecutive in `dparams` and pass their offset, i.e. the index of the first POINTER variable, to `{point,}_register_mech`.