### PR TITLE
Remove `hoc_nrnpointerindex`.

### DIFF
--- a/src/codegen/codegen_naming.hpp
+++ b/src/codegen/codegen_naming.hpp
@@ -179,10 +179,6 @@ static constexpr char THREAD_ARGS_PROTO[] = "_threadargsproto_";
 /// prefix for ion variable
 static constexpr char ION_VARNAME_PREFIX[] = "ion_";
 
-/// hoc_nrnpointerindex name
-static constexpr char NRN_POINTERINDEX[] = "hoc_nrnpointerindex";
-
-
 /// commonly used variables in verbatim block and how they
 /// should be mapped to new code generation backends
 // clang-format off

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -867,12 +867,6 @@ void CodegenNeuronCppVisitor::print_mechanism_global_var_structure(bool print_in
         static _nrn_non_owning_id_without_container _prop_id{};)CODE");
     }
 
-    printer->fmt_line("static int {} = {};",
-                      naming::NRN_POINTERINDEX,
-                      info.pointer_variables.size() > 0
-                          ? static_cast<int>(info.pointer_variables.size())
-                          : -1);
-
     printer->add_line("static _nrn_mechanism_std_vector<Datum> _extcall_thread;");
 
     // Start printing the CNRN-style global variables.


### PR DESCRIPTION
The implementation of `hoc_nrnpointerindex` is incorrect; and wont be needed anymore after merging #1462. 