### PR TITLE
Use `<nlohmann/json_fwd.hpp>`.

### DIFF
--- a/src/printer/json_printer.cpp
+++ b/src/printer/json_printer.cpp
@@ -8,6 +8,7 @@
 #include "printer/json_printer.hpp"
 #include "utils/logger.hpp"
 
+#include <nlohmann/json.hpp>
 
 namespace nmodl {
 namespace printer {

--- a/src/printer/json_printer.hpp
+++ b/src/printer/json_printer.hpp
@@ -12,7 +12,7 @@
  * \brief \copybrief nmodl::printer::JSONPrinter
  */
 
-#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
 
 #include <fstream>
 #include <iostream>

--- a/src/visitors/perf_visitor.cpp
+++ b/src/visitors/perf_visitor.cpp
@@ -7,6 +7,7 @@
 
 #include "visitors/perf_visitor.hpp"
 
+#include <cassert>
 #include <utility>
 
 #include "ast/all.hpp"

--- a/src/visitors/visitor_utils.cpp
+++ b/src/visitors/visitor_utils.cpp
@@ -9,6 +9,7 @@
 
 #include <map>
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <string>
 
 #include "ast/all.hpp"

--- a/test/unit/visitor/json.cpp
+++ b/test/unit/visitor/json.cpp
@@ -12,6 +12,8 @@
 #include "visitors/json_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
 
+#include <nlohmann/json.hpp>
+
 using json = nlohmann::json;
 
 using namespace nmodl;


### PR DESCRIPTION
We identified recompiling JSON templates to contribute noticably to the compile time:

    **** Templates that took longest to instantiate:
    16889 ms: nlohmann::basic_json<>::parse<const char *> (42 times, avg 402 ms)
    12363 ms: nlohmann::basic_json<>::basic_json (127 times, avg 97 ms)
    10129 ms: nlohmann::detail::parser<nlohmann::basic_json<>, nlohmann::detail::i... (42 times, avg 241 ms)
     7934 ms: nlohmann::detail::parser<nlohmann::basic_json<>, nlohmann::detail::i... (42 times, avg 188 ms)
     6145 ms: nlohmann::basic_json<>::json_value::json_value (211 times, avg 29 ms)

Fortunately, we can avoid the issue by using a forward declaration.