### PR TITLE
Use forward declaration for nmodl lexer.

### DIFF
--- a/src/parser/nmodl_driver.hpp
+++ b/src/parser/nmodl_driver.hpp
@@ -16,7 +16,7 @@
 #include <string>
 #include <unordered_map>
 
-#include "ast/ast.hpp"
+#include "ast/include.hpp"
 #include "utils/file_library.hpp"
 
 
@@ -25,8 +25,11 @@ namespace nmodl {
 /// encapsulate lexer and parsers implementations
 namespace parser {
 
-// Declared in <lexer/nmodl_lexer.hpp>
+// Declared in: lexer/nmodl_lexer.hpp
 class NmodlLexer;
+
+// Declared in generated file: ${BUILD_DIR}/src/parser/nmodl/location.hh
+class location;
 
 /**
  * \defgroup parser Parser Implementation

--- a/src/parser/nmodl_driver.hpp
+++ b/src/parser/nmodl_driver.hpp
@@ -17,8 +17,6 @@
 #include <unordered_map>
 
 #include "ast/ast.hpp"
-#include "lexer/nmodl_lexer.hpp"
-#include "parser/nmodl_driver.hpp"
 #include "utils/file_library.hpp"
 
 
@@ -26,6 +24,9 @@
 namespace nmodl {
 /// encapsulate lexer and parsers implementations
 namespace parser {
+
+// Declared in <lexer/nmodl_lexer.hpp>
+class NmodlLexer;
 
 /**
  * \defgroup parser Parser Implementation

--- a/test/unit/visitor/implicit_argument.cpp
+++ b/test/unit/visitor/implicit_argument.cpp
@@ -11,6 +11,7 @@
 #include "visitors/nmodl_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
+#include "ast/program.hpp"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/test/unit/visitor/implicit_argument.cpp
+++ b/test/unit/visitor/implicit_argument.cpp
@@ -5,13 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "ast/program.hpp"
 #include "parser/nmodl_driver.hpp"
 #include "test/unit/utils/test_utils.hpp"
 #include "visitors/implicit_argument_visitor.hpp"
 #include "visitors/nmodl_visitor.hpp"
 #include "visitors/symtab_visitor.hpp"
 #include "visitors/visitor_utils.hpp"
-#include "ast/program.hpp"
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>

--- a/test/unit/visitor/rename_function_arguments.cpp
+++ b/test/unit/visitor/rename_function_arguments.cpp
@@ -1,10 +1,10 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
+#include "ast/program.hpp"
 #include "parser/nmodl_driver.hpp"
 #include "visitors/rename_function_arguments.hpp"
 #include "visitors/visitor_utils.hpp"
-#include "ast/program.hpp"
 
 using namespace nmodl;
 using namespace visitor;

--- a/test/unit/visitor/rename_function_arguments.cpp
+++ b/test/unit/visitor/rename_function_arguments.cpp
@@ -4,6 +4,7 @@
 #include "parser/nmodl_driver.hpp"
 #include "visitors/rename_function_arguments.hpp"
 #include "visitors/visitor_utils.hpp"
+#include "ast/program.hpp"
 
 using namespace nmodl;
 using namespace visitor;


### PR DESCRIPTION
We identified `nmodl_lexer.hpp` and `nmodl_driver.hpp` to be expensive to parse.

    **** Expensive headers:

    37155 ms: src/lexer/nmodl_lexer.hpp (included 47 times, avg 790 ms), included via:
      41x: nmodl_driver.hpp
      6x: <direct include>

    34970 ms: src/parser/nmodl_driver.hpp (included 47 times, avg 744 ms), included via:
      47x: <direct include>

The problem is easily avoided by using a forward declaration.