### PR TITLE
Avoid name collisions.

### DIFF
--- a/test/unit/units/parser.cpp
+++ b/test/unit/units/parser.cpp
@@ -27,6 +27,7 @@ using Catch::Matchers::ContainsSubstring;
 // able to define complex units based on base units
 nmodl::parser::UnitDriver driver;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
+namespace {
 bool is_valid_construct(const std::string& construct) {
     return driver.parse_string(construct);
 }
@@ -40,6 +41,7 @@ std::string parse_string(const std::string& unit_definition) {
     correctness_driver.table->print_base_units(ss);
     return ss.str();
 }
+}  // namespace
 
 SCENARIO("Unit parser accepting valid units definition", "[unit][parser]") {
     GIVEN("A base unit") {


### PR DESCRIPTION
These are generic function names with generic arguments. During testing i was definitely getting errors related to a second copy of these somewhere else. In my case its:
```
include/c++/14.2.1/bits/basic_string.h
```