### PR TITLE
Use compiled version of spdlog.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,11 +139,11 @@ endif()
 # installation for consistency. This line should be harmless if we use an external spdlog.
 option(SPDLOG_FMT_EXTERNAL "Force to use an external {{fmt}}" ON)
 option(SPDLOG_SYSTEM_INCLUDE "Include spdlog as a system lib" ON)
+cpp_cc_git_submodule(spdlog BUILD PACKAGE spdlog REQUIRED)
 if(NMODL_3RDPARTY_USE_SPDLOG)
   # See above, same logic as fmt
-  option(SPDLOG_BUILD_PIC "Needed to be PIC to be put compiled as a lib" ON)
+  set_target_properties(spdlog PROPERTIES POSITION_INDEPENDENT_CODE ON)
 endif()
-cpp_cc_git_submodule(spdlog BUILD PACKAGE spdlog REQUIRED)
 
 if(NMODL_ENABLE_BACKWARD)
   cpp_cc_git_submodule(backward BUILD EXCLUDE_FROM_ALL PACKAGE backward REQUIRED)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(
   ${PROJECT_BINARY_DIR}/src/config/config.cpp)
 
 set_property(TARGET util PROPERTY POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(util PUBLIC fmt::fmt nlohmann_json::nlohmann_json spdlog::spdlog_header_only)
+target_link_libraries(util PUBLIC fmt::fmt nlohmann_json::nlohmann_json spdlog::spdlog)
 
 if(NMODL_ENABLE_BACKWARD)
   target_link_libraries(util PRIVATE Backward::Interface)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -17,7 +17,7 @@ include_directories(${NMODL_PROJECT_SOURCE_DIR}/ext/eigen)
 # Common input data library
 # =============================================================================
 add_library(test_util STATIC utils/nmodl_constructs.cpp utils/test_utils.cpp)
-target_link_libraries(test_util PUBLIC spdlog::spdlog_header_only)
+target_link_libraries(test_util PUBLIC spdlog::spdlog)
 
 # =============================================================================
 # Common input data library


### PR DESCRIPTION
We see that in NMODL using the header-only version of SPDLOG contributes noticeably to the compile time:
```
**** Template sets that took longest to instantiate:
 52766 ms: spdlog::pattern_formatter::handle_flag_<$> (92 times, avg 573 ms)
```
However, this can be easily avoided by using a non-headeronly version of SPDLOG.

When using an external copy of spdlog it'll pick up the shared library. When built
from the submodule it creates a static library.
