### PR TITLE
Bump MacOS versions in CI

### DIFF
--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -72,7 +72,7 @@ jobs:
           brew install python@3.12 || true
           brew link --overwrite python@3.12
           brew install ccache coreutils bison boost flex ninja
-          echo /usr/local/opt/flex/bin:/usr/local/opt/bison/bin >> $GITHUB_PATH
+          echo /usr/local/opt/flex/bin:/usr/local/opt/bison/bin:/opt/homebrew/opt/flex/bin:/opt/homebrew/opt/bison/bin >> $GITHUB_PATH
           # Taken from https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
           echo CMAKE_BUILD_PARALLEL_LEVEL=3 >> $GITHUB_ENV
         shell: bash

--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -33,9 +33,9 @@ jobs:
               glibc_asserts: ON
               os: ubuntu-22.04
           - config:
-              os: macos-12
-          - config:
               os: macos-13
+          - config:
+              os: macos-14
           - config:
               os: windows-latest
           # TODO: might be interesting to add the thread sanitizer too


### PR DESCRIPTION
MacOS 12 is unsupported as of 16/09/2024.