### PR TITLE
Run Sonar in parallel.

### DIFF
--- a/.github/workflows/sonarsource.yml
+++ b/.github/workflows/sonarsource.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Run build-wrapper
         working-directory: ${{runner.workspace}}/nmodl
         run: |
-          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/ --verbose
+          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build --verbose --parallel
       - name: Run sonar-scanner
         continue-on-error: true
         env:


### PR DESCRIPTION
Cuts build time in half; analysis time could be another 8 minutes, depending on how many files it can use a cached analysis for.