### PR TITLE
Remove ARM-based MacOS from CI

### DIFF
--- a/.github/workflows/nmodl-ci.yml
+++ b/.github/workflows/nmodl-ci.yml
@@ -35,8 +35,6 @@ jobs:
           - config:
               os: macos-13
           - config:
-              os: macos-14
-          - config:
               os: windows-latest
           # TODO: might be interesting to add the thread sanitizer too
           - config:


### PR DESCRIPTION
It keeps failing with complaints of wrong arch being used (see for instance https://github.com/BlueBrain/nmodl/actions/runs/11142396798/job/30965250232?pr=1484). I don't have MacOS 14 yet so I can't debug it properly, hence I would like to leave it out for now.