### PR TITLE
Use target fmt::fmt instead of fmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,13 +112,13 @@ if(NOT TARGET CLI11::CLI11)
   cpp_cc_git_submodule(cli11 BUILD PACKAGE CLI11 REQUIRED)
 endif()
 # We could have fmt incoming from NEURON
-if(NOT TARGET fmt)
+if(NOT TARGET fmt::fmt)
   cpp_cc_git_submodule(fmt BUILD EXCLUDE_FROM_ALL PACKAGE fmt REQUIRED)
 endif()
 # If we're building from the submodule, make sure we pass -fPIC so that we can link the code into a
 # shared library later.
 if(NMODL_3RDPARTY_USE_FMT)
-  set_property(TARGET fmt PROPERTY POSITION_INDEPENDENT_CODE ON)
+  set_property(TARGET fmt::fmt PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 if(NOT NMODL_3RDPARTY_USE_FMT
    AND ((NMODL_PGI_COMPILER AND CMAKE_CXX_COMPILER_VERSION LESS_EQUAL 22.3.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ endif()
 # If we're building from the submodule, make sure we pass -fPIC so that we can link the code into a
 # shared library later.
 if(NMODL_3RDPARTY_USE_FMT)
-  set_property(TARGET fmt::fmt PROPERTY POSITION_INDEPENDENT_CODE ON)
+  set_property(TARGET fmt PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()
 if(NOT NMODL_3RDPARTY_USE_FMT
    AND ((NMODL_PGI_COMPILER AND CMAKE_CXX_COMPILER_VERSION LESS_EQUAL 22.3.0)


### PR DESCRIPTION
The target that should really be used is fmt::fmt or fmt::fmt_header_only.