### PR TITLE
Refactor printing setup code in entrypoints.

### DIFF
--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -507,8 +507,8 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
     /**
      * Prints setup code for entrypoints NEURON.
      *
-     * See `print_entrypoint_setup_code`. This variation should be used when one only has
-     * access to a `Prop`, but not the full `Memb_list`.
+     * See `print_entrypoint_setup_code_from_memb_list`. This variation should be used when one only
+     * has access to a `Prop`, but not the full `Memb_list`.
      */
     void print_entrypoint_setup_code_from_prop();
 

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -492,6 +492,26 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
     void print_global_function_common_code(BlockType type,
                                            const std::string& function_name = "") override;
 
+    /**
+     * Prints setup code for entrypoints from NEURON.
+     *
+     * The entrypoints typically receive a `sorted_token` and a bunch of other things, which then
+     * need to be converted into the default arguments for functions called (recursively) from the
+     * entrypoint.
+     *
+     * This variation prints the fast entrypoint, where NEURON is fully initialized and setup.
+     */
+    void print_entrypoint_setup_code_from_memb_list();
+
+
+    /**
+     * Prints setup code for entrypoints NEURON.
+     *
+     * See `print_entrypoint_setup_code`. This variation should be used when one only has
+     * access to a `Prop`, but not the full `Memb_list`.
+     */
+    void print_entrypoint_setup_code_from_prop();
+
 
     /**
      * Print the \c nrn\_init function definition
@@ -508,11 +528,6 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
      */
     void print_nrn_constructor() override;
     void print_nrn_constructor_declaration();
-
-    /**
-     * Print the set of common variables from a `Prop` only.
-     */
-    void print_callable_preamble_from_prop();
 
     /**
      * Print nrn_destructor function definition


### PR DESCRIPTION
The entrypoints into the MOD file from NEURON typically require setting up some variable, e.g. `_lmr`, `inst`, `node_data`, `_thread_vars`, etc.

The code has roughly two favours:

* From fully initialized NEURON, i.e. a Memb_list exists and the model is sorted. All the compute function have this type of entrypoint.

* From a `Prop`. Usually this happens when we don't know that the model is sorted, or that initialization has happened. The HOC/Python bindings of FUNCTION/PROCEDUREs use this type of entrypoint.