### PR TITLE
Fix FUNCTION_TABLE with POINT_PROCESS/ARTIFICIAL_CELL.

### DIFF
--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -1219,16 +1219,26 @@ void CodegenNeuronCppVisitor::print_global_variables_for_hoc() {
     printer->add_line("{nullptr, nullptr}");
     printer->decrease_indent();
     printer->add_line("};");
+
+
+    auto print_py_callable_reg = [this](const auto& callables, auto get_name) {
+        for (const auto& callable: callables) {
+            const auto name = get_name(callable);
+            printer->fmt_line("{{\"{}\", {}}},", name, py_function_name(name));
+        }
+    };
+
     if (!info.point_process) {
         printer->push_block("static NPyDirectMechFunc npy_direct_func_proc[] =");
-        for (const auto& procedure: info.procedures) {
-            const auto proc_name = procedure->get_node_name();
-            printer->fmt_line("{{\"{}\", {}}},", proc_name, py_function_name(proc_name));
-        }
-        for (const auto& function: info.functions) {
-            const auto func_name = function->get_node_name();
-            printer->fmt_line("{{\"{}\", {}}},", func_name, py_function_name(func_name));
-        }
+        print_py_callable_reg(info.procedures,
+                              [](const auto& callable) { return callable->get_node_name(); });
+        print_py_callable_reg(info.functions,
+                              [](const auto& callable) { return callable->get_node_name(); });
+        print_py_callable_reg(info.function_tables,
+                              [](const auto& callable) { return callable->get_node_name(); });
+        print_py_callable_reg(info.function_tables, [](const auto& callable) {
+            return "table_" + callable->get_node_name();
+        });
         printer->add_line("{nullptr, nullptr}");
         printer->pop_block(";");
     }

--- a/test/usecases/function_table/art_function_table.mod
+++ b/test/usecases/function_table/art_function_table.mod
@@ -1,5 +1,5 @@
 NEURON {
-    SUFFIX function_table
+    ARTIFICIAL_CELL art_function_table
 }
 
 INCLUDE "function_table.inc"

--- a/test/usecases/function_table/function_table.inc
+++ b/test/usecases/function_table/function_table.inc
@@ -1,0 +1,8 @@
+FUNCTION_TABLE cnst1(v)
+FUNCTION_TABLE cnst2(v, x)
+FUNCTION_TABLE tau1(v)
+FUNCTION_TABLE tau2(v, x)
+
+FUNCTION use_tau2(v, x) {
+    use_tau2 = tau2(v, x)
+}

--- a/test/usecases/function_table/point_function_table.mod
+++ b/test/usecases/function_table/point_function_table.mod
@@ -1,5 +1,5 @@
 NEURON {
-    SUFFIX function_table
+    POINT_PROCESS point_function_table
 }
 
 INCLUDE "function_table.inc"

--- a/test/usecases/function_table/test_function_table.py
+++ b/test/usecases/function_table/test_function_table.py
@@ -72,6 +72,11 @@ def check_2d(make_inst, mech_name):
 
     inst = make_inst(s)
     set_table, eval_table = make_callbacks(inst, "tau2", mech_name)
+    eval_use_table = make_callable(inst, "use_tau2", mech_name)
+
+    if inst is None:
+        setdata = getattr(h, f"setdata_{mech_name}")
+        setdata(s(0.5))
 
     v = np.array([0.0, 1.0])
     x = np.array([1.0, 2.0, 3.0])
@@ -88,27 +93,10 @@ def check_2d(make_inst, mech_name):
         for xx in np.linspace(x[0], x[-1], 20):
             expected = scipy.interpolate.interpn((v, x), tau2, (vv, xx))
             actual = eval_table(vv, xx)
+            actual_indirect = eval_use_table(vv, xx)
 
             np.testing.assert_approx_equal(actual, expected, significant=11)
-
-
-def check_use_table(make_inst, mech_name):
-    s = h.Section()
-    s.insert("function_table")
-
-    inst = make_inst(s)
-    _, eval_table = make_callbacks(inst, "tau2", mech_name)
-    eval_use_table = make_callable(inst, "use_tau2", mech_name)
-
-    if inst is None:
-        setdata = getattr(h, f"setdata_{mech_name}")
-        setdata(s(0.5))
-
-    vv, xx = 0.33, 2.24
-
-    expected = eval_table(vv, xx)
-    actual = eval_use_table(vv, xx)
-    np.testing.assert_approx_equal(actual, expected, significant=11)
+            np.testing.assert_approx_equal(actual_indirect, expected, significant=11)
 
 
 if __name__ == "__main__":
@@ -125,7 +113,3 @@ if __name__ == "__main__":
 
         check_1d(make_instance, mech_name)
         check_2d(make_instance, mech_name)
-
-        # Must run after `check_2d`, because it assumes the table
-        # has been initialized.
-        check_use_table(make_instance, mech_name)

--- a/test/usecases/function_table/test_function_table.py
+++ b/test/usecases/function_table/test_function_table.py
@@ -99,7 +99,7 @@ def check_2d(make_inst, mech_name):
             np.testing.assert_approx_equal(actual_indirect, expected, significant=11)
 
 
-if __name__ == "__main__":
+def test_function_table():
     variations = [
         (lambda s: None, "function_table"),
         (lambda s: s(0.5).function_table, "function_table"),
@@ -113,3 +113,7 @@ if __name__ == "__main__":
 
         check_1d(make_instance, mech_name)
         check_2d(make_instance, mech_name)
+
+
+if __name__ == "__main__":
+    test_function_table()

--- a/test/usecases/function_table/test_function_table.py
+++ b/test/usecases/function_table/test_function_table.py
@@ -4,43 +4,75 @@ import numpy as np
 import scipy
 
 
-def test_constant_1d():
+def make_callable(inst, name, mech_name):
+    if inst is None:
+        return getattr(h, f"{name}_{mech_name}")
+    else:
+        return getattr(inst, f"{name}")
+
+
+def make_callbacks(inst, name, mech_name):
+    set_table = make_callable(inst, f"table_{name}", mech_name)
+    eval_table = make_callable(inst, name, mech_name)
+
+    return set_table, eval_table
+
+
+def check_constant_1d(make_inst, mech_name):
     s = h.Section()
     s.insert("function_table")
 
+    inst = make_inst(s)
+    set_table, eval_table = make_callbacks(inst, "cnst1", mech_name)
+
     c = 42.0
-    h.table_cnst1_function_table(c)
+    set_table(c)
 
     for vv in np.linspace(-10.0, 10.0, 14):
-        np.testing.assert_equal(h.cnst1_function_table(vv), c)
+        np.testing.assert_equal(eval_table(vv), c)
 
 
-def test_constant_2d():
+def check_constant_2d(make_inst, mech_name):
     s = h.Section()
     s.insert("function_table")
 
+    inst = make_inst(s)
+    set_table, eval_table = make_callbacks(inst, "cnst2", mech_name)
+
     c = 42.0
-    h.table_cnst2_function_table(c)
+    set_table(c)
 
     for vv in np.linspace(-10.0, 10.0, 7):
         for xx in np.linspace(-20.0, 10.0, 9):
-            np.testing.assert_equal(h.cnst2_function_table(vv, xx), c)
+            np.testing.assert_equal(eval_table(vv, xx), c)
 
 
-def test_1d():
+def check_1d(make_inst, mech_name):
+    s = h.Section()
+    s.insert("function_table")
+
+    inst = make_inst(s)
+    set_table, eval_table = make_callbacks(inst, "tau1", mech_name)
+
     v = np.array([0.0, 1.0])
     tau1 = np.array([1.0, 2.0])
 
-    h.table_tau1_function_table(h.Vector(tau1), h.Vector(v))
+    set_table(h.Vector(tau1), h.Vector(v))
 
     for vv in np.linspace(v[0], v[-1], 20):
         expected = np.interp(vv, v, tau1)
-        actual = h.tau1_function_table(vv)
+        actual = eval_table(vv)
 
         np.testing.assert_approx_equal(actual, expected, significant=11)
 
 
-def test_2d():
+def check_2d(make_inst, mech_name):
+    s = h.Section()
+    s.insert("function_table")
+
+    inst = make_inst(s)
+    set_table, eval_table = make_callbacks(inst, "tau2", mech_name)
+
     v = np.array([0.0, 1.0])
     x = np.array([1.0, 2.0, 3.0])
 
@@ -50,36 +82,50 @@ def test_2d():
     hoc_tau2 = h.Matrix(*tau2.shape)
     hoc_tau2.from_vector(h.Vector(tau2.transpose().reshape(-1)))
 
-    h.table_tau2_function_table(
-        hoc_tau2._ref_x[0][0], v.size, v[0], v[-1], x.size, x[0], x[-1]
-    )
+    set_table(hoc_tau2._ref_x[0][0], v.size, v[0], v[-1], x.size, x[0], x[-1])
 
     for vv in np.linspace(v[0], v[-1], 20):
         for xx in np.linspace(x[0], x[-1], 20):
             expected = scipy.interpolate.interpn((v, x), tau2, (vv, xx))
-            actual = h.tau2_function_table(vv, xx)
+            actual = eval_table(vv, xx)
 
             np.testing.assert_approx_equal(actual, expected, significant=11)
 
 
-def test_use_table():
+def check_use_table(make_inst, mech_name):
     s = h.Section()
     s.insert("function_table")
 
-    h.setdata_function_table(s(0.5))
+    inst = make_inst(s)
+    _, eval_table = make_callbacks(inst, "tau2", mech_name)
+    eval_use_table = make_callable(inst, "use_tau2", mech_name)
+
+    if inst is None:
+        setdata = getattr(h, f"setdata_{mech_name}")
+        setdata(s(0.5))
 
     vv, xx = 0.33, 2.24
 
-    expected = h.tau2_function_table(vv, xx)
-    actual = h.use_tau2_function_table(vv, xx)
+    expected = eval_table(vv, xx)
+    actual = eval_use_table(vv, xx)
     np.testing.assert_approx_equal(actual, expected, significant=11)
 
 
 if __name__ == "__main__":
-    test_constant_1d()
-    test_constant_2d()
+    variations = [
+        (lambda s: None, "function_table"),
+        (lambda s: s(0.5).function_table, "function_table"),
+        (lambda s: h.point_function_table(s(0.5)), "point_function_table"),
+        (lambda s: h.art_function_table(s(0.5)), "art_function_table"),
+    ]
 
-    test_1d()
-    test_2d()
+    for make_instance, mech_name in variations:
+        check_constant_1d(make_instance, mech_name)
+        check_constant_2d(make_instance, mech_name)
 
-    test_use_table()
+        check_1d(make_instance, mech_name)
+        check_2d(make_instance, mech_name)
+
+        # Must run after `check_2d`, because it assumes the table
+        # has been initialized.
+        check_use_table(make_instance, mech_name)


### PR DESCRIPTION
There's three bugs that are fixed:
* make printing the function signature more consistent. This then results in the correct signature for POINT_PROCESSES.
* while we did register the "HOC" variation, i.e. `h.tau2_{mech_name}` would work, we didn't register the Python variations meaning `s(0.5).{mech_name}.tau2` didn't work.
* the `use_tau2` test had an implicit dependency on a previous test to set the dependency. After the first test ran the last instance of the mechanism went out of scope and the mechanism itself got collected. Leading to invalid memory access.