### PR TITLE
Add support for diffing against `sympy.Indexed` instances

### DIFF
--- a/python/nmodl/ode.py
+++ b/python/nmodl/ode.py
@@ -595,6 +595,11 @@ def differentiate2c(
     If the result coincides with one of the vars, or the LHS of one of
     the prev_expressions, then it is simplified to this expression.
 
+    Note that, in order to differentiate against indexed variables (such as
+    ``x[0]``), you must pass an instance of ``sympy.Indexed`` to
+    ``dependent_var`` (_not_ an instance of ``sympy.IndexedBase``), as well as
+    an instance of ``sympy.IndexedBase`` to ``vars``.
+
     Some simple examples of use:
 
     - ``nmodl.ode.differentiate2c ("a*x", "x", {"a"}) == "a"``
@@ -619,7 +624,7 @@ def differentiate2c(
     # every symbol (a.k.a variable) that SymPy
     # is going to manipulate needs to be declared
     # explicitly
-    x = sp.symbols(dependent_var, real=True)
+    x = make_symbol(dependent_var)
     vars = set(vars)
     vars.discard(dependent_var)
     # declare all other supplied variables

--- a/python/nmodl/ode.py
+++ b/python/nmodl/ode.py
@@ -604,6 +604,7 @@ def differentiate2c(
 
     - ``nmodl.ode.differentiate2c ("a*x", "x", {"a"}) == "a"``
     - ``differentiate2c ("cos(y) + b*y**2", "y", {"a","b"}) == "Dy = 2*b*y - sin(y)"``
+    - ``differentiate2c("a * x[0]", sympy.IndexedBase("x", shape=[1])[0], {"a", sympy.IndexedBase("x", shape=[1])}) == "a"``
 
     Args:
         expression: expression to be differentiated e.g. "a*x + b"

--- a/test/unit/ode/test_ode.py
+++ b/test/unit/ode/test_ode.py
@@ -111,6 +111,19 @@ def test_differentiate2c():
         {sp.IndexedBase("s", shape=[1]), sp.IndexedBase("z", shape=[1])},
     )
 
+    # make sure we can diff against indexed vars as well
+    var = sp.IndexedBase("x", shape=[1])
+
+    assert _equivalent(
+        differentiate2c(
+            "a * x[0]",
+            var[0],
+            {"a", var},
+        ),
+        "a",
+        {"a"},
+    )
+
     result = differentiate2c(
         "-f(x)",
         "x",


### PR DESCRIPTION
If we have an expression (string) that contains an indexed variable (like `x[0]`), we should be able to differentiate w.r.t. it as well.
As explained in the updated docstring, the way to do it is to pass a [`sympy.Indexed`](https://docs.sympy.org/latest/modules/tensor/indexed.html#sympy.tensor.indexed.Indexed) instance as the independent variable (not to be confused with an [`sympy.IndexedBase`](https://docs.sympy.org/latest/modules/tensor/indexed.html#sympy.tensor.indexed.IndexedBase) instance!).
Note that we also need to pass an `sympy.IndexedBase` into the SymPy list of known symbols (i.e. as one of `vars`), otherwise the parser breaks.

For reference, we added mod files with indexed vars in #1504.