### PR TITLE
Prevent inlining VERBATIM.

### DIFF
--- a/src/visitors/inline_visitor.hpp
+++ b/src/visitors/inline_visitor.hpp
@@ -195,7 +195,10 @@ class InlineVisitor: public AstVisitor {
     void visit_wrapped_expression(ast::WrappedExpression& node) override;
 
     void visit_program(ast::Program& node) override;
+
+    static bool is_inlineable(ast::Program& node);
 };
+
 
 /** \} */  // end of visitor_classes
 

--- a/test/unit/visitor/inline.cpp
+++ b/test/unit/visitor/inline.cpp
@@ -663,24 +663,9 @@ SCENARIO("Trying to inline a function with VERBATIM block") {
             }
         )";
 
-        std::string output_nmodl = R"(
-            PROCEDURE verb_1() {
-                VERBATIM
-                    pow(1,2);
-                ENDVERBATIM
-            }
-
-            PROCEDURE verb_2() {
-                {
-                    VERBATIM
-                    pow(1,2);
-                ENDVERBATIM
-                }
-            }
-        )";
-        THEN("It gets inlined") {
+        THEN("It does not get inlined") {
             std::string input = reindent_text(input_nmodl);
-            auto expected_result = reindent_text(output_nmodl);
+            auto expected_result = reindent_text(input_nmodl);
             auto result = run_inline_visitor(input);
             REQUIRE(expected_result == result);
         }


### PR DESCRIPTION
We're banning all VERBATIM blocks because the current solution failed to detect:
```
BREAKPOINT {
   SOLVE getonset
}

PROCEDURE getonset() {
   VERBATIM
   return 0;
   ENDVERBATIM
}
```
must not be inlined as:
```
void nrn_state_synp(...) {
// ...
    for (int id = 0; id < nodecount; id++) {
        // VERBATIM
        return 0; 
        // ENDVERBATIM
    }
}
```