### PR TITLE
Hide most functions/global variables.

### DIFF
--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -462,7 +462,7 @@ void CodegenCppVisitor::print_global_var_struct_assertions() const {
 
 
 void CodegenCppVisitor::print_global_var_struct_decl() {
-    printer->add_line(global_struct(), ' ', global_struct_instance(), ';');
+    printer->fmt_line("static {} {};", global_struct(), global_struct_instance());
 }
 
 

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -1547,8 +1547,8 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     template <typename T>
     void print_function_declaration(const T& node,
                                     const std::string& name,
-                                    const std::unordered_set<CppObjectSpecifier>& = {
-                                        CppObjectSpecifier::Inline});
+                                    const std::unordered_set<CppObjectSpecifier>& =
+                                        {CppObjectSpecifier::Static, CppObjectSpecifier::Inline});
 
     void print_rename_state_vars() const;
 };

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -1709,7 +1709,7 @@ void CodegenNeuronCppVisitor::print_global_function_common_code(BlockType type,
                         {"", "NrnThread*", "", "nt"},
                         {"", "Memb_list*", "", "_ml_arg"},
                         {"", "int", "", "_type"}};
-    printer->fmt_push_block("void {}({})", method, get_parameter_str(args));
+    printer->fmt_push_block("static void {}({})", method, get_parameter_str(args));
     print_entrypoint_setup_code_from_memb_list();
     printer->add_line("auto nodecount = _ml_arg->nodecount;");
 }
@@ -1780,13 +1780,15 @@ void CodegenNeuronCppVisitor::print_nrn_jacob() {
 
 void CodegenNeuronCppVisitor::print_nrn_constructor_declaration() {
     if (info.constructor_node) {
-        printer->fmt_line("void {}(Prop* prop);", method_name(naming::NRN_CONSTRUCTOR_METHOD));
+        printer->fmt_line("static void {}(Prop* prop);",
+                          method_name(naming::NRN_CONSTRUCTOR_METHOD));
     }
 }
 
 void CodegenNeuronCppVisitor::print_nrn_constructor() {
     if (info.constructor_node) {
-        printer->fmt_push_block("void {}(Prop* prop)", method_name(naming::NRN_CONSTRUCTOR_METHOD));
+        printer->fmt_push_block("static void {}(Prop* prop)",
+                                method_name(naming::NRN_CONSTRUCTOR_METHOD));
 
         print_entrypoint_setup_code_from_prop();
 
@@ -1799,11 +1801,12 @@ void CodegenNeuronCppVisitor::print_nrn_constructor() {
 
 
 void CodegenNeuronCppVisitor::print_nrn_destructor_declaration() {
-    printer->fmt_line("void {}(Prop* prop);", method_name(naming::NRN_DESTRUCTOR_METHOD));
+    printer->fmt_line("static void {}(Prop* prop);", method_name(naming::NRN_DESTRUCTOR_METHOD));
 }
 
 void CodegenNeuronCppVisitor::print_nrn_destructor() {
-    printer->fmt_push_block("void {}(Prop* prop)", method_name(naming::NRN_DESTRUCTOR_METHOD));
+    printer->fmt_push_block("static void {}(Prop* prop)",
+                            method_name(naming::NRN_DESTRUCTOR_METHOD));
     print_entrypoint_setup_code_from_prop();
 
     for (const auto& rv: info.random_variables) {
@@ -2039,7 +2042,7 @@ void CodegenNeuronCppVisitor::print_nrn_current(const BreakpointBlock& node) {
     const auto& args = nrn_current_parameters();
     const auto& block = node.get_statement_block();
     printer->add_newline(2);
-    printer->fmt_push_block("inline double nrn_current_{}({})",
+    printer->fmt_push_block("static inline double nrn_current_{}({})",
                             info.mod_suffix,
                             get_parameter_str(args));
     printer->add_line("double current = 0.0;");


### PR DESCRIPTION
Global struct instance must be `static`. One reason is `SUFFIX nothing` which would otherwise cause symbols to clash.

Similarly, any function that isn't `dlsym`ed or eligible for `EXTERNAL` should have internal linkage.