### PR TITLE
Refactor HOC/Python wrapper printing.

### DIFF
--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -285,7 +285,6 @@ void CodegenNeuronCppVisitor::print_function_procedure_helper(const ast::Block& 
 void CodegenNeuronCppVisitor::print_hoc_py_wrapper_call_impl(
     const ast::Block* function_or_procedure_block,
     InterpreterWrapper wrapper_type) {
-
     const auto block_name = function_or_procedure_block->get_node_name();
 
     const auto get_func_call_str = [&]() {
@@ -298,7 +297,6 @@ void CodegenNeuronCppVisitor::print_hoc_py_wrapper_call_impl(
         func_call.append(")");
         return func_call;
     };
-
 
     printer->add_line("double _r = 0.0;");
     if (function_or_procedure_block->is_function_block()) {
@@ -391,19 +389,25 @@ void CodegenNeuronCppVisitor::print_hoc_py_wrapper_setup(
     }
 }
 
+
+std::string CodegenNeuronCppVisitor::hoc_py_wrapper_signature(
+    const ast::Block* function_or_procedure_block,
+    InterpreterWrapper wrapper_type) {
+    const auto block_name = function_or_procedure_block->get_node_name();
+    if (wrapper_type == InterpreterWrapper::HOC) {
+        return hoc_function_signature(block_name);
+    } else {
+        return py_function_signature(block_name);
+    }
+}
+
 void CodegenNeuronCppVisitor::print_hoc_py_wrapper(const ast::Block* function_or_procedure_block,
                                                    InterpreterWrapper wrapper_type) {
     if (info.point_process && wrapper_type == InterpreterWrapper::Python) {
         return;
     }
-    const auto block_name = function_or_procedure_block->get_node_name();
-    if (info.point_process) {
-        printer->fmt_push_block("static double _hoc_{}(void* _vptr)", block_name);
-    } else if (wrapper_type == InterpreterWrapper::HOC) {
-        printer->fmt_push_block("static void _hoc_{}(void)", block_name);
-    } else {
-        printer->fmt_push_block("static double _npy_{}(Prop* _prop)", block_name);
-    }
+
+    printer->push_block(hoc_py_wrapper_signature(function_or_procedure_block, wrapper_type));
 
     print_hoc_py_wrapper_setup(function_or_procedure_block, wrapper_type);
     print_hoc_py_wrapper_call_impl(function_or_procedure_block, wrapper_type);

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -298,6 +298,9 @@ void CodegenNeuronCppVisitor::print_hoc_py_wrapper_call_impl(
         func_call.append(")");
         return func_call;
     };
+
+
+    printer->add_line("double _r = 0.0;");
     if (function_or_procedure_block->is_function_block()) {
         printer->add_indent();
         printer->fmt_text("_r = {};", get_func_call_str());
@@ -318,7 +321,6 @@ void CodegenNeuronCppVisitor::print_hoc_py_wrapper_setup(
     InterpreterWrapper wrapper_type) {
     const auto block_name = function_or_procedure_block->get_node_name();
     printer->add_multi_line(R"CODE(
-        double _r{};
         Datum* _ppvar;
         Datum* _thread;
         NrnThread* nt;

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -391,9 +391,8 @@ void CodegenNeuronCppVisitor::print_hoc_py_wrapper_setup(
     }
 }
 
-void CodegenNeuronCppVisitor::print_hoc_py_wrapper_function_body(
-    const ast::Block* function_or_procedure_block,
-    InterpreterWrapper wrapper_type) {
+void CodegenNeuronCppVisitor::print_hoc_py_wrapper(const ast::Block* function_or_procedure_block,
+                                                   InterpreterWrapper wrapper_type) {
     if (info.point_process && wrapper_type == InterpreterWrapper::Python) {
         return;
     }
@@ -416,8 +415,8 @@ void CodegenNeuronCppVisitor::print_hoc_py_wrapper_function_body(
 void CodegenNeuronCppVisitor::print_hoc_py_wrapper_function_definitions() {
     auto print_wrappers = [this](const auto& callables) {
         for (const auto& callable: callables) {
-            print_hoc_py_wrapper_function_body(callable, InterpreterWrapper::HOC);
-            print_hoc_py_wrapper_function_body(callable, InterpreterWrapper::Python);
+            print_hoc_py_wrapper(callable, InterpreterWrapper::HOC);
+            print_hoc_py_wrapper(callable, InterpreterWrapper::Python);
         }
     };
 

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -282,19 +282,41 @@ void CodegenNeuronCppVisitor::print_function_procedure_helper(const ast::Block& 
     }
 }
 
-
-void CodegenNeuronCppVisitor::print_hoc_py_wrapper_function_body(
+void CodegenNeuronCppVisitor::print_hoc_py_wrapper_call_impl(
     const ast::Block* function_or_procedure_block,
     InterpreterWrapper wrapper_type) {
-    if (info.point_process && wrapper_type == InterpreterWrapper::Python) {
-        return;
-    }
+
     const auto block_name = function_or_procedure_block->get_node_name();
-    if (wrapper_type == InterpreterWrapper::HOC) {
-        printer->fmt_push_block("{}", hoc_function_signature(block_name));
+
+    const auto get_func_call_str = [&]() {
+        const auto& params = function_or_procedure_block->get_parameters();
+        const auto func_proc_name = block_name + "_" + info.mod_suffix;
+        auto func_call = fmt::format("{}({}", func_proc_name, internal_method_arguments());
+        for (int i = 0; i < params.size(); ++i) {
+            func_call.append(fmt::format(", *getarg({})", i + 1));
+        }
+        func_call.append(")");
+        return func_call;
+    };
+    if (function_or_procedure_block->is_function_block()) {
+        printer->add_indent();
+        printer->fmt_text("_r = {};", get_func_call_str());
+        printer->add_newline();
     } else {
-        printer->fmt_push_block("{}", py_function_signature(block_name));
+        printer->add_line("_r = 1.;");
+        printer->fmt_line("{};", get_func_call_str());
     }
+    if (info.point_process || wrapper_type != InterpreterWrapper::HOC) {
+        printer->add_line("return(_r);");
+    } else if (wrapper_type == InterpreterWrapper::HOC) {
+        printer->add_line("hoc_retpushx(_r);");
+    }
+}
+
+void CodegenNeuronCppVisitor::print_hoc_py_wrapper_setup(
+    const ast::Block* function_or_procedure_block,
+    InterpreterWrapper wrapper_type) {
+    const auto block_name = function_or_procedure_block->get_node_name();
     printer->add_multi_line(R"CODE(
         double _r{};
         Datum* _ppvar;
@@ -365,29 +387,26 @@ void CodegenNeuronCppVisitor::print_hoc_py_wrapper_function_body(
                           table_update_function_name(block_name),
                           internal_method_arguments());
     }
-    const auto get_func_call_str = [&]() {
-        const auto& params = function_or_procedure_block->get_parameters();
-        const auto func_proc_name = block_name + "_" + info.mod_suffix;
-        auto func_call = fmt::format("{}({}", func_proc_name, internal_method_arguments());
-        for (int i = 0; i < params.size(); ++i) {
-            func_call.append(fmt::format(", *getarg({})", i + 1));
-        }
-        func_call.append(")");
-        return func_call;
-    };
-    if (function_or_procedure_block->is_function_block()) {
-        printer->add_indent();
-        printer->fmt_text("_r = {};", get_func_call_str());
-        printer->add_newline();
-    } else {
-        printer->add_line("_r = 1.;");
-        printer->fmt_line("{};", get_func_call_str());
+}
+
+void CodegenNeuronCppVisitor::print_hoc_py_wrapper_function_body(
+    const ast::Block* function_or_procedure_block,
+    InterpreterWrapper wrapper_type) {
+    if (info.point_process && wrapper_type == InterpreterWrapper::Python) {
+        return;
     }
-    if (info.point_process || wrapper_type != InterpreterWrapper::HOC) {
-        printer->add_line("return(_r);");
+    const auto block_name = function_or_procedure_block->get_node_name();
+    if (info.point_process) {
+        printer->fmt_push_block("static double _hoc_{}(void* _vptr)", block_name);
     } else if (wrapper_type == InterpreterWrapper::HOC) {
-        printer->add_line("hoc_retpushx(_r);");
+        printer->fmt_push_block("static void _hoc_{}(void)", block_name);
+    } else {
+        printer->fmt_push_block("static double _npy_{}(Prop* _prop)", block_name);
     }
+
+    print_hoc_py_wrapper_setup(function_or_procedure_block, wrapper_type);
+    print_hoc_py_wrapper_call_impl(function_or_procedure_block, wrapper_type);
+
     printer->pop_block();
 }
 

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -244,8 +244,25 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
     void print_function_procedure_helper(const ast::Block& node) override;
 
 
+    /** Print the wrapper for calling FUNCION/PROCEDURES from HOC/Py.
+     *
+     *  Usually the function is made up of the following parts:
+     *    * Print setup code `inst`, etc.
+     *    * Print code to call the function and return.
+     */
     void print_hoc_py_wrapper_function_body(const ast::Block* function_or_procedure_block,
                                             InterpreterWrapper wrapper_type);
+
+    /** Print the setup code for HOC/Py wrapper.
+     */
+    void print_hoc_py_wrapper_setup(const ast::Block* function_or_procedure_block,
+                                    InterpreterWrapper wrapper_type);
+
+
+    /** Print the code that calls the impl from the HOC/Py wrapper.
+     */
+    void print_hoc_py_wrapper_call_impl(const ast::Block* function_or_procedure_block,
+                                        InterpreterWrapper wrapper_type);
 
 
     void print_hoc_py_wrapper_function_definitions();

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -266,7 +266,12 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
 
     /** Return the wrapper signature.
      *
-     * Everything without the { or ;.
+     * Everything without the { or ; as an example:
+            return_type function_name(<internal_args>, <args>)
+            
+       were `<internal_args> is the list of arguments required by the
+       code to be passed along, while <args> are the arguments in of
+       function as they appear in the MOD file.
      */
     std::string hoc_py_wrapper_signature(const ast::Block* function_or_procedure_block,
                                          InterpreterWrapper wrapper_type);

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -250,8 +250,8 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
      *    * Print setup code `inst`, etc.
      *    * Print code to call the function and return.
      */
-    void print_hoc_py_wrapper_function_body(const ast::Block* function_or_procedure_block,
-                                            InterpreterWrapper wrapper_type);
+    void print_hoc_py_wrapper(const ast::Block* function_or_procedure_block,
+                              InterpreterWrapper wrapper_type);
 
     /** Print the setup code for HOC/Py wrapper.
      */

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -264,6 +264,12 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
     void print_hoc_py_wrapper_call_impl(const ast::Block* function_or_procedure_block,
                                         InterpreterWrapper wrapper_type);
 
+    /** Return the wrapper signature.
+     *
+     * Everything without the { or ;.
+     */
+    std::string hoc_py_wrapper_signature(const ast::Block* function_or_procedure_block,
+                                         InterpreterWrapper wrapper_type);
 
     void print_hoc_py_wrapper_function_definitions();
 

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -266,12 +266,12 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
 
     /** Return the wrapper signature.
      *
-     * Everything without the { or ; as an example:
-            return_type function_name(<internal_args>, <args>)
-            
-       were `<internal_args> is the list of arguments required by the
-       code to be passed along, while <args> are the arguments in of
-       function as they appear in the MOD file.
+     * Everything without the `{` or `;`. Roughly, as an example:
+     *      <return_type> <function_name>(<internal_args>, <args>)
+     *
+     * were `<internal_args> is the list of arguments required by the
+     * codegen to be passed along, while <args> are the arguments of
+     * of the function as they appear in the MOD file.
      */
     std::string hoc_py_wrapper_signature(const ast::Block* function_or_procedure_block,
                                          InterpreterWrapper wrapper_type);


### PR DESCRIPTION
The method is first split into three parts:
* determining the signature,
* printing the setup code,
* calling the implementation.

Additionally we rename the function, because it doesn't print the function body, it prints the whole wrapper function.