### PR TITLE
Avoid premature segfaults.

### DIFF
--- a/test/usecases/global/global.mod
+++ b/test/usecases/global/global.mod
@@ -1,0 +1,16 @@
+NEURON {
+    SUFFIX global
+    GLOBAL gbl
+}
+
+ASSIGNED {
+    gbl
+}
+
+FUNCTION get_gbl() {
+    get_gbl = gbl
+}
+
+PROCEDURE set_gbl(value) {
+    gbl = value
+}

--- a/test/usecases/global/parameter.mod
+++ b/test/usecases/global/parameter.mod
@@ -1,0 +1,11 @@
+NEURON {
+    SUFFIX parameter
+}
+
+PARAMETER {
+    gbl = 42.0
+}
+
+FUNCTION get_gbl() {
+    get_gbl = gbl
+}

--- a/test/usecases/global/test_without_instance.py
+++ b/test/usecases/global/test_without_instance.py
@@ -1,18 +1,24 @@
 from neuron import h, gui
 
 
-def make_accessors(mech_name):
+def make_accessors(mech_name, read_only):
     get = getattr(h, f"get_gbl_{mech_name}")
-    set = getattr(h, f"set_gbl_{mech_name}")
 
+    if read_only:
+        return get, None
+
+    set = getattr(h, f"set_gbl_{mech_name}")
     return get, set
 
 
-def check_write_read_cycle(mech_name):
-    get, set = make_accessors(mech_name)
+def check_write_read_cycle(mech_name, read_only=False):
+    get, set = make_accessors(mech_name, read_only)
 
-    expected = 278.045
-    set(expected)
+    if read_only:
+        expected = 42.0
+    else:
+        expected = 278.045
+        set(expected)
 
     actual = get()
     assert (
@@ -24,5 +30,15 @@ def test_top_local():
     check_write_read_cycle("top_local")
 
 
+def test_global():
+    check_write_read_cycle("global")
+
+
+def test_parameter():
+    check_write_read_cycle("parameter", True)
+
+
 if __name__ == "__main__":
     test_top_local()
+    test_global()
+    test_parameter()

--- a/test/usecases/global/test_without_instance.py
+++ b/test/usecases/global/test_without_instance.py
@@ -1,0 +1,28 @@
+from neuron import h, gui
+
+
+def make_accessors(mech_name):
+    get = getattr(h, f"get_gbl_{mech_name}")
+    set = getattr(h, f"set_gbl_{mech_name}")
+
+    return get, set
+
+
+def check_write_read_cycle(mech_name):
+    get, set = make_accessors(mech_name)
+
+    expected = 278.045
+    set(expected)
+
+    actual = get()
+    assert (
+        actual == expected
+    ), f"{actual = }, {expected = }, delta = {actual - expected}"
+
+
+def test_top_local():
+    check_write_read_cycle("top_local")
+
+
+if __name__ == "__main__":
+    test_top_local()

--- a/test/usecases/global/top_local.mod
+++ b/test/usecases/global/top_local.mod
@@ -23,3 +23,11 @@ BREAKPOINT {
     y = gbl
     il = 0.0000001 * (v - 10.0)
 }
+
+FUNCTION get_gbl() {
+    get_gbl = gbl
+}
+
+PROCEDURE set_gbl(value) {
+    gbl = value
+}


### PR DESCRIPTION
In NOCMODL functions that only use global data can be called without an instance.