### PR TITLE
Prepare for deprecating `vectorize`.

### DIFF
--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -59,6 +59,9 @@ std::string CodegenCoreneuronCppVisitor::simulator_name() {
     return "CoreNEURON";
 }
 
+bool CodegenCoreneuronCppVisitor::needs_v_unused() const {
+    return info.vectorize;
+}
 
 /****************************************************************************************/
 /*                     Common helper routines accross codegen functions                 */

--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -93,6 +93,7 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
         return info.vectorize ? (info.thread_data_index + 1) : 0;
     }
 
+    bool needs_v_unused() const override;
 
     /****************************************************************************************/
     /*                     Common helper routines accross codegen functions                 */

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -1272,7 +1272,7 @@ std::vector<CodegenCppVisitor::SymbolType> CodegenCppVisitor::get_float_variable
         }
     }
 
-    if (info.vectorize) {
+    if (needs_v_unused()) {
         variables.push_back(make_symbol(naming::VOLTAGE_UNUSED_VARIABLE));
     }
 

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -731,6 +731,8 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      */
     std::vector<SymbolType> get_float_variables() const;
 
+    virtual bool needs_v_unused() const = 0;
+
 
     /**
      * Determine all \c int variables required during code generation

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -55,6 +55,10 @@ std::string CodegenNeuronCppVisitor::table_thread_function_name() const {
     return "_check_table_thread";
 }
 
+bool CodegenNeuronCppVisitor::needs_v_unused() const {
+    return true;
+}
+
 
 /****************************************************************************************/
 /*                     Common helper routines accross codegen functions                 */

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -124,6 +124,7 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
      */
     std::string table_thread_function_name() const;
 
+    bool needs_v_unused() const override;
 
     /****************************************************************************************/
     /*                     Common helper routines accross codegen functions                 */


### PR DESCRIPTION
Adds virtual methods `needs_v_unused` that returns:
  * true for `--neuron`,
  * and the previous choice for CoreNEURON.

This will make CoreNEURON incompatible with NMODL generated MOD files. However, it will allow NMODL to generate code for NRN that doesn't use globals to handle the voltage `v` (and instead stores a cpoy as a regular range variable).