### PR TITLE
Lower printing of VERBATIM code.

### DIFF
--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -118,6 +118,21 @@ std::string CodegenCoreneuronCppVisitor::process_verbatim_token(const std::strin
     return get_variable_name(token, use_instance);
 }
 
+void CodegenCoreneuronCppVisitor::visit_verbatim(const Verbatim& node) {
+    const auto& text = node.get_statement()->eval();
+    printer->add_line("// VERBATIM");
+    const auto& result = process_verbatim_text(text);
+
+    const auto& statements = stringutils::split_string(result, '\n');
+    for (const auto& statement: statements) {
+        const auto& trimed_stmt = stringutils::trim_newline(statement);
+        if (trimed_stmt.find_first_not_of(' ') != std::string::npos) {
+            printer->add_line(trimed_stmt);
+        }
+    }
+    printer->add_line("// ENDVERBATIM");
+}
+
 
 /**
  * \details This can be override in the backend. For example, parameters can be constant

--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -425,7 +425,7 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
      * \param text The verbatim code to be processed
      * \return     The code with all variables renamed as needed
      */
-    std::string process_verbatim_text(std::string const& text) override;
+    std::string process_verbatim_text(std::string const& text);
 
 
     /**
@@ -964,6 +964,7 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
 
     void visit_derivimplicit_callback(const ast::DerivimplicitCallback& node) override;
     void visit_for_netcon(const ast::ForNetcon& node) override;
+    void visit_verbatim(const ast::Verbatim& node) override;
     void visit_watch_statement(const ast::WatchStatement& node) override;
 
     ParamVector functor_params() override;

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -1049,22 +1049,6 @@ void CodegenCppVisitor::visit_function_call(const FunctionCall& node) {
 }
 
 
-void CodegenCppVisitor::visit_verbatim(const Verbatim& node) {
-    const auto& text = node.get_statement()->eval();
-    printer->add_line("// VERBATIM");
-    const auto& result = process_verbatim_text(text);
-
-    const auto& statements = stringutils::split_string(result, '\n');
-    for (const auto& statement: statements) {
-        const auto& trimed_stmt = stringutils::trim_newline(statement);
-        if (trimed_stmt.find_first_not_of(' ') != std::string::npos) {
-            printer->add_line(trimed_stmt);
-        }
-    }
-    printer->add_line("// ENDVERBATIM");
-}
-
-
 void CodegenCppVisitor::visit_update_dt(const ast::UpdateDt& node) {
     // dt change statement should be pulled outside already
 }

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -1034,14 +1034,6 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     virtual std::string nrn_thread_internal_arguments() = 0;
 
     /**
-     * Process a verbatim block for possible variable renaming
-     * \param text The verbatim code to be processed
-     * \return     The code with all variables renamed as needed
-     */
-    virtual std::string process_verbatim_text(std::string const& text) = 0;
-
-
-    /**
      * Arguments for register_mech or point_register_mech function
      */
     virtual std::string register_mechanism_arguments() const = 0;
@@ -1480,7 +1472,6 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     void visit_unary_operator(const ast::UnaryOperator& node) override;
     void visit_unit(const ast::Unit& node) override;
     void visit_var_name(const ast::VarName& node) override;
-    void visit_verbatim(const ast::Verbatim& node) override;
     void visit_while_statement(const ast::WhileStatement& node) override;
     void visit_update_dt(const ast::UpdateDt& node) override;
     void visit_protect_statement(const ast::ProtectStatement& node) override;

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -631,9 +631,9 @@ CodegenNeuronCppVisitor::function_table_parameters(const ast::FunctionTableBlock
     return {params, {}};
 }
 
-/// TODO: Write for NEURON
-std::string CodegenNeuronCppVisitor::process_verbatim_text(std::string const& text) {
-    return {};
+
+void CodegenNeuronCppVisitor::visit_verbatim(const Verbatim& node) {
+    // Not implemented yet.
 }
 
 

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -359,14 +359,6 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
 
 
     /**
-     * Process a verbatim block for possible variable renaming
-     * \param text The verbatim code to be processed
-     * \return     The code with all variables renamed as needed
-     */
-    std::string process_verbatim_text(std::string const& text) override;
-
-
-    /**
      * Arguments for register_mech or point_register_mech function
      */
     std::string register_mechanism_arguments() const override;
@@ -768,12 +760,11 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
     /*                            Overloaded visitor routines                               */
     /****************************************************************************************/
 
-
+    void visit_verbatim(const ast::Verbatim& node) override;
     void visit_watch_statement(const ast::WatchStatement& node) override;
     void visit_for_netcon(const ast::ForNetcon& node) override;
     void visit_longitudinal_diffusion_block(const ast::LongitudinalDiffusionBlock& node) override;
     void visit_lon_diffuse(const ast::LonDiffuse& node) override;
-
 
   public:
     /****************************************************************************************/


### PR DESCRIPTION
Lower all of `process_verbatim_text` and the implementation of `visit_verbatim` to the CoreNEURON visitor. The NEURON version will use a different system.