### PR TITLE
Lift shared `print_top_verbatim_blocks` code.

### DIFF
--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -346,28 +346,6 @@ void CodegenCoreneuronCppVisitor::print_abort_routine() const {
 /****************************************************************************************/
 
 
-void CodegenCoreneuronCppVisitor::print_top_verbatim_blocks() {
-    if (info.top_verbatim_blocks.empty()) {
-        return;
-    }
-    print_namespace_stop();
-
-    printer->add_newline(2);
-    print_using_namespace();
-
-    printing_top_verbatim_blocks = true;
-
-    for (const auto& block: info.top_verbatim_blocks) {
-        printer->add_newline(2);
-        block->accept(*this);
-    }
-
-    printing_top_verbatim_blocks = false;
-
-    print_namespace_start();
-}
-
-
 void CodegenCoreneuronCppVisitor::print_function_prototypes() {
     if (info.functions.empty() && info.procedures.empty()) {
         return;

--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -326,12 +326,6 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
 
 
     /**
-     * Print top level (global scope) verbatim blocks
-     */
-    void print_top_verbatim_blocks();
-
-
-    /**
      * Print function and procedures prototype declaration
      */
     void print_function_prototypes() override;

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -640,6 +640,28 @@ void CodegenCppVisitor::print_namespace_stop() {
 }
 
 
+void CodegenCppVisitor::print_top_verbatim_blocks() {
+    if (info.top_verbatim_blocks.empty()) {
+        return;
+    }
+    print_namespace_stop();
+
+    printer->add_newline(2);
+    print_using_namespace();
+
+    printing_top_verbatim_blocks = true;
+
+    for (const auto& block: info.top_verbatim_blocks) {
+        printer->add_newline(2);
+        block->accept(*this);
+    }
+
+    printing_top_verbatim_blocks = false;
+
+    print_namespace_start();
+}
+
+
 /****************************************************************************************/
 /*                         Printing routines for code generation                        */
 /****************************************************************************************/

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -1455,6 +1455,11 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
      */
     void print_nmodl_constants();
 
+    /**
+     * Print top level (global scope) verbatim blocks
+     */
+    void print_top_verbatim_blocks();
+
 
     /****************************************************************************************/
     /*                            Overloaded visitor routines                               */


### PR DESCRIPTION
Both the NEURON and CoreNEURON codegen need the same code for printing all top-level verbatim blocks.