### PR TITLE
Lower PROTECT related code.

### DIFF
--- a/src/codegen/codegen_coreneuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.cpp
@@ -3038,5 +3038,15 @@ void CodegenCoreneuronCppVisitor::visit_watch_statement(const ast::WatchStatemen
                                   current_watch_statement++));
 }
 
+
+void CodegenCoreneuronCppVisitor::visit_protect_statement(const ast::ProtectStatement& node) {
+    print_atomic_reduction_pragma();
+    printer->add_indent();
+    node.get_expression()->accept(*this);
+    printer->add_text(";");
+}
+
+
+
 }  // namespace codegen
 }  // namespace nmodl

--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -942,6 +942,7 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
     void visit_for_netcon(const ast::ForNetcon& node) override;
     void visit_verbatim(const ast::Verbatim& node) override;
     void visit_watch_statement(const ast::WatchStatement& node) override;
+    void visit_protect_statement(const ast::ProtectStatement& node) override;
 
     ParamVector functor_params() override;
 

--- a/src/codegen/codegen_coreneuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_coreneuron_cpp_visitor.hpp
@@ -230,7 +230,7 @@ class CodegenCoreneuronCppVisitor: public CodegenCppVisitor {
     /**
      * Print atomic update pragma for reduction statements
      */
-    void print_atomic_reduction_pragma() override;
+    virtual void print_atomic_reduction_pragma();
 
 
     /**

--- a/src/codegen/codegen_cpp_visitor.cpp
+++ b/src/codegen/codegen_cpp_visitor.cpp
@@ -1106,14 +1106,6 @@ void CodegenCppVisitor::visit_update_dt(const ast::UpdateDt& node) {
 }
 
 
-void CodegenCppVisitor::visit_protect_statement(const ast::ProtectStatement& node) {
-    print_atomic_reduction_pragma();
-    printer->add_indent();
-    node.get_expression()->accept(*this);
-    printer->add_text(";");
-}
-
-
 void CodegenCppVisitor::visit_mutex_lock(const ast::MutexLock& node) {
     printer->fmt_line("#pragma omp critical ({})", info.mod_suffix);
     printer->add_indent();

--- a/src/codegen/codegen_cpp_visitor.hpp
+++ b/src/codegen/codegen_cpp_visitor.hpp
@@ -803,12 +803,6 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
 
 
     /**
-     * Print atomic update pragma for reduction statements
-     */
-    virtual void print_atomic_reduction_pragma() = 0;
-
-
-    /**
      * Instantiate global var instance
      *
      * For C++ code generation this is empty
@@ -1485,7 +1479,6 @@ class CodegenCppVisitor: public visitor::ConstAstVisitor {
     void visit_var_name(const ast::VarName& node) override;
     void visit_while_statement(const ast::WhileStatement& node) override;
     void visit_update_dt(const ast::UpdateDt& node) override;
-    void visit_protect_statement(const ast::ProtectStatement& node) override;
     void visit_mutex_lock(const ast::MutexLock& node) override;
     void visit_mutex_unlock(const ast::MutexUnlock& node) override;
     void visit_solution_expression(const ast::SolutionExpression& node) override;

--- a/src/codegen/codegen_neuron_cpp_visitor.cpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.cpp
@@ -80,12 +80,6 @@ int CodegenNeuronCppVisitor::position_of_int_var(const std::string& name) const 
 /*                                Backend specific routines                             */
 /****************************************************************************************/
 
-
-/// TODO: Edit for NEURON
-void CodegenNeuronCppVisitor::print_atomic_reduction_pragma() {
-    return;
-}
-
 bool CodegenNeuronCppVisitor::optimize_ion_variable_copies() const {
     if (optimize_ionvar_copies) {
         throw std::runtime_error("Not implemented.");

--- a/src/codegen/codegen_neuron_cpp_visitor.hpp
+++ b/src/codegen/codegen_neuron_cpp_visitor.hpp
@@ -153,13 +153,6 @@ class CodegenNeuronCppVisitor: public CodegenCppVisitor {
     /*                                Backend specific routines                             */
     /****************************************************************************************/
 
-
-    /**
-     * Print atomic update pragma for reduction statements
-     */
-    void print_atomic_reduction_pragma() override;
-
-
     /**
      * Check if ion variable copies should be avoided
      */


### PR DESCRIPTION
* Lower visit_protected_statement.

The code is lowered into the CoreNEURON side, because
NEURON can't use the same OpenMP system.

* Lower print_atomic_reduction_pragma.

This method is specific to the CoreNEURON implementation of
`visit_protected_statement`.