### PR TITLE
Update `clang-format == 19.1.3`.

### DIFF
--- a/.bbp-project.yaml
+++ b/.bbp-project.yaml
@@ -1,7 +1,7 @@
 tools:
   ClangFormat:
     enable: True
-    version: ~=13.0
+    version: == 19.1.3
     exclude:
       match:
       - ext/.*

--- a/src/lexer/modtoken.hpp
+++ b/src/lexer/modtoken.hpp
@@ -68,7 +68,7 @@ class ModToken {
     /// \{
 
     ModToken()
-        : pos(nullptr, 0){};
+        : pos(nullptr, 0) {};
 
     explicit ModToken(bool ext)
         : pos(nullptr, 0)

--- a/src/visitors/sympy_solver_visitor.hpp
+++ b/src/visitors/sympy_solver_visitor.hpp
@@ -170,7 +170,7 @@ class SympySolverVisitor: public AstVisitor {
                                 int SMALL_LINEAR_SYSTEM_MAX_STATES = 3)
         : use_pade_approx(use_pade_approx)
         , elimination(elimination)
-        , SMALL_LINEAR_SYSTEM_MAX_STATES(SMALL_LINEAR_SYSTEM_MAX_STATES){};
+        , SMALL_LINEAR_SYSTEM_MAX_STATES(SMALL_LINEAR_SYSTEM_MAX_STATES) {};
 
     void visit_var_name(ast::VarName& node) override;
     void visit_diff_eq_expression(ast::DiffEqExpression& node) override;


### PR DESCRIPTION
Fixes a bug in clang-format that would reorder multi-line string literals according to the rules for `#include` directives.