### PR TITLE
Fix custom function handling in sympy solve visitor

### DIFF
--- a/python/nmodl/ode.py
+++ b/python/nmodl/ode.py
@@ -543,10 +543,12 @@ def integrate2c(diff_string, dt_var, vars, use_pade_approx=False):
         if _a1 == 0 and _a2 == 0:
             solution = _a0
 
+    custom_fcts = {str(f.func): str(f.func) for f in solution.atoms(sp.Function)}
+
     # return result as C code in NEURON format:
     #   - in the lhs x_0 refers to the state var at time (t+dt)
     #   - in the rhs x_0 refers to the state var at time t
-    return f"{sp.ccode(x)} = {sp.ccode(solution.evalf())}"
+    return f"{sp.ccode(x)} = {sp.ccode(solution.evalf(), user_functions=custom_fcts)}"
 
 
 def forwards_euler2c(diff_string, dt_var, vars, function_calls):

--- a/test/unit/ode/test_ode.py
+++ b/test/unit/ode/test_ode.py
@@ -170,6 +170,8 @@ def test_integrate2c():
         ("a", "x + a*dt"),
         ("a*x", "x*exp(a*dt)"),
         ("a*x+b", "(-b + (a*x + b)*exp(a*dt))/a"),
+        # assume custom_function is defined in mod file
+        ("custom_function(a)*x", "x*exp(custom_function(a)*dt)"),
     ]
     for eq, sol in test_cases:
         assert _equivalent(


### PR DESCRIPTION
When running NMODL with NEURON codegen on this file:
https://github.com/neuronsimulator/reduced_dentate/blob/master/mechanisms/tca.mod

we get the following kind of error, but the codegen proceeds:

```plaintext
[NMODL] [info] :: Running sympy solve visitor
[NMODL] [warning] :: SympySolverVisitor :: python exception. (--verbose=info)
[NMODL] [info] :: Traceback (most recent call last):
# a lot of stack trace here...
sympy.printing.codeprinter.PrintMethodNotImplementedError: Unsupported by <class 'sympy.printing.c.C99CodePrinter'>: minf
Set the printer option 'strict' to False in order to generate partially printed code.
```

The problem is that functions defined in mod files are not known to the code generator, so it's complaining it cannot do the codegen for them. A somewhat minimal example of this is the following mod file:

```plaintext
UNITS {(mV) = (millivolt)}
NEURON {SUFFIX test_custom_functions}
STATE {m}
ASSIGNED {v (mV)}
INITIAL {m = minf(v)}
BREAKPOINT {SOLVE states METHOD cnexp}
DERIVATIVE states {m' = minf(v)}
FUNCTION minf(v(mV)) {minf = v}
```